### PR TITLE
Remove Pull Requests section from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,10 +145,6 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
 - When referencing an issue in a commit message, use `Fixes #N` only if the
   commit fully resolves the issue. Otherwise use `Refs #N` or `Part of #N`.
 
-## Pull Requests
-
-- Always use **merge commits** (not squash or rebase) when merging PRs.
-
 ## Key Constraints
 
 - **Linear time**: No backreferences, no lookahead/lookbehind, no possessive


### PR DESCRIPTION
Remove the merge commit policy added in #36 — PR merging will be handled manually by the project owner.