### PR TITLE
Match JDK: ^ in MULTILINE does not match at pos 0 of empty string

### DIFF
--- a/safere/src/main/java/dev/eaftan/safere/Nfa.java
+++ b/safere/src/main/java/dev/eaftan/safere/Nfa.java
@@ -449,8 +449,13 @@ final class Nfa {
     // BEGIN_LINE is set at the start of text and after '\n', but NOT at end-of-text after a final
     // '\n'. JDK's MULTILINE ^ does not match at the position past the last '\n' when that position
     // is the end of the string. For example, "a\n" has BEGIN_LINE at pos 0 but NOT at pos 2.
+    // Also, JDK's MULTILINE ^ does not match at position 0 of an empty string — the empty string
+    // has no lines for ^ to match at. BEGIN_TEXT is still set (for \A). See #41.
     if (pos == 0) {
-      flags |= EmptyOp.BEGIN_TEXT | EmptyOp.BEGIN_LINE;
+      flags |= EmptyOp.BEGIN_TEXT;
+      if (!text.isEmpty()) {
+        flags |= EmptyOp.BEGIN_LINE;
+      }
     } else if (pos < text.length() && text.charAt(pos - 1) == '\n') {
       flags |= EmptyOp.BEGIN_LINE;
     }

--- a/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
@@ -148,16 +148,6 @@ final class ExhaustiveUtils {
       return 0;
     }
 
-    // Skip empty text with MULTILINE + ^ anchor — JDK bug: ^ in MULTILINE mode doesn't
-    // match at position 0 of an empty string, but does match at position 0 of any non-empty
-    // string. SafeRE correctly considers ^ to always match at the start of text regardless
-    // of text length. We keep our correct behavior. See https://github.com/eaftan/safere/issues/41
-    if (text.isEmpty()
-        && (flags & java.util.regex.Pattern.MULTILINE) != 0
-        && regexp.contains("^")) {
-      return 0;
-    }
-
     // Try to compile with JDK first — if JDK rejects it, skip
     java.util.regex.Pattern jdkPat;
     try {


### PR DESCRIPTION
JDK treats an empty string as having no lines, so MULTILINE `^` does not match at position 0. This differs from `\A` (BEGIN_TEXT), which still matches.

**Fix:** In `Nfa.emptyFlags()`, only set `BEGIN_LINE` at pos 0 when text is non-empty.

Removes the exhaustive test skip for this case — SafeRE now matches JDK behavior.

Fixes #41