### PR TITLE
Fix DFA skipping earlier deferred-assertion matches (#42 bugs 1 & 3)

### DIFF
--- a/safere/src/main/java/dev/eaftan/safere/Dfa.java
+++ b/safere/src/main/java/dev/eaftan/safere/Dfa.java
@@ -50,6 +50,14 @@ final class Dfa {
    */
   private static final int FLAG_MATCH_BEFORE = 1 << 10;
 
+  /**
+   * Flag bit: when {@link #FLAG_MATCH_BEFORE} is set, indicates that an after-consume match ALSO
+   * exists (from character transitions reaching MATCH). The search loop should try the
+   * before-consume match first (earlier position) and fall back to the after-consume match if the
+   * before-consume match is rejected (e.g., by {@code needEndMatch} requiring end-of-text).
+   */
+  private static final int FLAG_MATCH_AFTER_DEFERRED = 1 << 11;
+
   /** Maximum number of DFA states before bailing out to NFA. */
   private static final int DEFAULT_MAX_STATES = 10_000;
 
@@ -685,10 +693,21 @@ final class Dfa {
     }
 
     int flags = emptyFlags & 0xFF;
-    if (hasMatch(nextInsts)) {
-      flags |= FLAG_MATCH;
-    } else if (hasMatchFromDeferred) {
+    if (hasMatchFromDeferred) {
+      // A deferred assertion (\b, \B, or multiline $) fired before consuming the current
+      // character and reached a MATCH instruction. This match is at position `pos` (before
+      // the character), which is earlier than any match at `nextPos` (after consuming).
+      // FLAG_MATCH_BEFORE ensures doSearch records the match end at `pos`, preserving
+      // leftmost-first semantics.
       flags |= FLAG_MATCH | FLAG_MATCH_BEFORE;
+      if (hasMatch(nextInsts)) {
+        // Character transitions also reach MATCH (match at nextPos). Record this so doSearch
+        // can fall back to the after-consume match when the before-consume match is rejected
+        // (e.g., patterns ending with $ require the match to end at text length).
+        flags |= FLAG_MATCH_AFTER_DEFERRED;
+      }
+    } else if (hasMatch(nextInsts)) {
+      flags |= FLAG_MATCH;
     }
     if (isWord) {
       flags |= FLAG_LAST_WORD;
@@ -881,16 +900,33 @@ final class Dfa {
       }
 
       if (s.isMatch()) {
-        // FLAG_MATCH_BEFORE indicates the match was triggered by a word-boundary assertion
-        // before consuming the current character. Record the match at pos, not nextPos.
-        int endPos = (s.flags & FLAG_MATCH_BEFORE) != 0
-            ? pos : Math.min(nextPos, textLen);
-        if (!needEndMatch || endPos == textLen
-            || (trailingNewline && endPos == textLen - 1)) {
-          matched = true;
-          matchEnd = endPos;
-          if (!longest && (!needEndMatch || endPos == textLen)) {
-            return new SearchResult(true, matchEnd);
+        // FLAG_MATCH_BEFORE indicates a deferred assertion (\b, multiline $) fired before
+        // consuming the current character and reached MATCH. Try the before-consume position
+        // first (it's at an earlier position, preserving leftmost-first semantics).
+        if ((s.flags & FLAG_MATCH_BEFORE) != 0) {
+          int endPos = pos;
+          if (!needEndMatch || endPos == textLen
+              || (trailingNewline && endPos == textLen - 1)) {
+            matched = true;
+            matchEnd = endPos;
+            if (!longest && (!needEndMatch || endPos == textLen)) {
+              return new SearchResult(true, matchEnd);
+            }
+          }
+        }
+        // Try the after-consume position: either no before-consume match exists, or it was
+        // rejected (e.g., needEndMatch but pos != textLen) and an after-consume match also
+        // exists (FLAG_MATCH_AFTER_DEFERRED).
+        if ((s.flags & FLAG_MATCH_BEFORE) == 0
+            || (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0) {
+          int endPos = Math.min(nextPos, textLen);
+          if (!needEndMatch || endPos == textLen
+              || (trailingNewline && endPos == textLen - 1)) {
+            matched = true;
+            matchEnd = endPos;
+            if (!longest && (!needEndMatch || endPos == textLen)) {
+              return new SearchResult(true, matchEnd);
+            }
           }
         }
       }

--- a/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
@@ -137,26 +137,22 @@ final class ExhaustiveUtils {
       return 0;
     }
 
-    // Skip patterns with $ and \b/\B in the same pattern — known bug #42 (bug 1).
-    // SafeRE's unanchored search misses earlier \b positions, finding $ at end instead.
-    if (DOLLAR_ASSERTION_ALT.matcher(regexp).find()) {
-      return 0;
-    }
-
-    // Skip patterns with ^ and $ in the same alternation — known bug #42 (bug 3).
-    // SafeRE's findAll misses $ before \n when ^ is also an alternative in the pattern.
-    if (CARET_DOLLAR_ALT.matcher(regexp).find()) {
-      return 0;
-    }
-
-    // Skip patterns with nested repetition and capture groups — known bug #42.
-    // SafeRE and JDK disagree on which iteration's capture to report.
+    // Skip patterns with nested repetition and capture groups — known behavioral difference.
+    // NFA engines start a fresh thread at each position with captures initialized to -1.
+    // When a {0,}/*  repetition matches zero times, captures from earlier (failed) starting
+    // positions are not preserved. JDK's backtracking engine leaks captures from failed attempts
+    // (and is itself inconsistent: `(a)*$` vs `(?:(a))*$` give different g1 results).
+    // This is an inherent NFA vs backtracking difference, not a SafeRE bug.
+    // See https://github.com/eaftan/safere/issues/42 (bug 2).
     if (NESTED_REP_CAPTURE.matcher(regexp).find()) {
       return 0;
     }
 
-    // Skip patterns with $ alternated with \n inside repetition — known bug #42.
-    // SafeRE's zero-width $ + consuming \n in a * loop disagrees with JDK on findAll boundaries.
+    // Skip patterns with $ alternated with \n inside repetition — known behavioral difference.
+    // In `(?:$|\n)+` on "a\n\n", SafeRE's NFA greedily matches $ then \n in a single iteration
+    // of the + loop, consuming both \n characters in one match [1,3). JDK treats $ as zero-width
+    // before each \n individually, producing two matches [1,2) and [2,2). This is a difference in
+    // how zero-width assertions interact with consuming alternatives inside repetition.
     if (regexp.contains("$") && regexp.contains("\\n") && regexp.matches(".*[*+].*")) {
       return 0;
     }
@@ -477,36 +473,20 @@ final class ExhaustiveUtils {
       java.util.regex.Pattern.compile("\\\\[bB].*[*+]|[*+].*\\\\[bB]");
 
   /**
-   * Pattern detecting `$` and `\b` (or `\B`) in the same pattern. SafeRE has a known bug where
-   * unanchored search for `$|\b` (or `\b|$`) skips positions where only `\b` matches, finding `$`
-   * at end-of-text instead of `\b` at an earlier word boundary.
-   * See <a href="https://github.com/eaftan/safere/issues/42">issue #42</a> (bug 1).
-   */
-  private static final java.util.regex.Pattern DOLLAR_ASSERTION_ALT =
-      java.util.regex.Pattern.compile(
-          "\\$.*\\\\[bB]|\\\\[bB].*\\$");
-
-  /**
    * Pattern detecting capture groups inside zero-or-more repetition ({@code *}, {@code +?},
-   * {@code {N,}}, etc.) anchored by `$`. SafeRE has a known bug where capture groups are not
-   * preserved when the repetition matches zero times at the `$` anchor position, and where nested
-   * repetitions disagree on which iteration's capture to report.
-   * See <a href="https://github.com/eaftan/safere/issues/42">issue #42</a>.
+   * {@code {N,}}, etc.) anchored by {@code $}. NFA engines start a fresh thread at each position
+   * with captures initialized to -1. When a {@code {0,}}/{@code *} repetition matches zero times,
+   * captures from earlier (failed) starting positions are not preserved. JDK's backtracking engine
+   * leaks captures from failed attempts (and is itself inconsistent: {@code (a)*$} vs
+   * {@code (?:(a))*$} give different g1 results). This is an inherent NFA vs backtracking
+   * difference, not a SafeRE bug.
+   *
+   * <p>See <a href="https://github.com/eaftan/safere/issues/42">issue #42</a> (bug 2).
    */
   private static final java.util.regex.Pattern NESTED_REP_CAPTURE =
       java.util.regex.Pattern.compile(
           "\\([^)]*\\)[^)]*(?:\\{\\d+[,}]|[*+?]).*(?:\\{\\d+[,}]|[*+?])|"
               + "\\([^)]*\\)[^)]*(?:[*+?]|\\{\\d+[,}]).*\\$");
-
-  /**
-   * Pattern detecting `^`/`\A` and `$` as alternatives within a group (e.g., {@code (?:^|$)} or
-   * {@code (?:$|\A)}). SafeRE has a known bug where findAll misses `$` before `\n` when `^` or
-   * `\A` is also an alternative.
-   * See <a href="https://github.com/eaftan/safere/issues/42">issue #42</a> (bug 3).
-   */
-  private static final java.util.regex.Pattern CARET_DOLLAR_ALT =
-      java.util.regex.Pattern.compile(
-          "\\(\\?*:?(?:\\^|\\\\A)\\).*\\|.*\\$|\\$.*\\|.*\\(\\?*:?(?:\\^|\\\\A)\\)");
 
   /** Escape non-printable characters for error messages. */
   static String escape(String s) {

--- a/safere/src/test/java/dev/eaftan/safere/Issue42RegressionTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/Issue42RegressionTest.java
@@ -1,0 +1,142 @@
+// Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
+// See LICENSE file in the project root for details.
+
+package dev.eaftan.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for <a href="https://github.com/eaftan/safere/issues/42">issue #42</a>: three
+ * pre-existing bugs found by CrossEngineExhaustiveTest.
+ */
+class Issue42RegressionTest {
+
+  // ---------------------------------------------------------------------------
+  // Bug 1: $|\b alternation — SafeRE must find the leftmost \b match
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Bug 1: $|\\b alternation leftmost match")
+  class Bug1WordBoundary {
+
+    @Test
+    @DisplayName("(?:$|\\b) on \" a\" finds \\b at [1,1)")
+    void dollarOrWordBoundary() {
+      Matcher m = Pattern.compile("(?:$|\\b)").matcher(" a");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.end()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("(?:\\b|$) on \" a\" finds \\b at [1,1)")
+    void wordBoundaryOrDollar() {
+      Matcher m = Pattern.compile("(?:\\b|$)").matcher(" a");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.end()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("$|\\b on longer text finds leftmost \\b")
+    void dollarOrWordBoundaryLongText() {
+      Matcher m = Pattern.compile("(?:$|\\b)").matcher("hello world");
+      assertThat(m.find()).isTrue();
+      // \b at position 0 (start of "hello") is leftmost
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.end()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("findAll with $|\\b finds all positions")
+    void dollarOrWordBoundaryFindAll() {
+      Matcher m = Pattern.compile("(?:$|\\b)").matcher(" a");
+      List<int[]> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(new int[]{m.start(), m.end()});
+      }
+      // Expected: [0,0) (non-word boundary? no — space at 0 is non-word, start of text is
+      // non-word, so no \b. $ doesn't match either). Actually at pos 0: $ at pos 0? No.
+      // \b at pos 0: prev is start-of-text (non-word), next is ' ' (non-word) → no boundary.
+      // Position 1: \b matches (space→a). Position 2: $ matches (end of text).
+      // Also \b at position 2: prev='a' (word), next=end (non-word) → \b matches.
+      // So both \b and $ match at position 2, but that's one match.
+      assertThat(matches).hasSize(2);
+      assertThat(matches.get(0)).containsExactly(1, 1); // \b at space→a
+      assertThat(matches.get(1)).containsExactly(2, 2); // \b and/or $ at end
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bug 3: Multiline ^|$ findAll must find $ before \n
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Bug 3: Multiline ^|$ findAll")
+  class Bug3MultilineDollar {
+
+    @Test
+    @DisplayName("(?:^|$) on \"aa\\na\" with MULTILINE finds all four positions")
+    void caretOrDollarMultiline() {
+      Matcher m = Pattern.compile("(?:^|$)", Pattern.MULTILINE).matcher("aa\na");
+      List<int[]> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(new int[]{m.start(), m.end()});
+      }
+      // ^ at pos 0, $ at pos 2 (before \n), ^ at pos 3 (after \n), $ at pos 4 (end)
+      assertThat(matches).hasSize(4);
+      assertThat(matches.get(0)).containsExactly(0, 0); // ^ at start
+      assertThat(matches.get(1)).containsExactly(2, 2); // $ before \n
+      assertThat(matches.get(2)).containsExactly(3, 3); // ^ after \n
+      assertThat(matches.get(3)).containsExactly(4, 4); // $ at end
+    }
+
+    @Test
+    @DisplayName("(?:$|^) on \"aa\\na\" with MULTILINE (reversed order)")
+    void dollarOrCaretMultiline() {
+      Matcher m = Pattern.compile("(?:$|^)", Pattern.MULTILINE).matcher("aa\na");
+      List<int[]> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(new int[]{m.start(), m.end()});
+      }
+      assertThat(matches).hasSize(4);
+      assertThat(matches.get(0)).containsExactly(0, 0);
+      assertThat(matches.get(1)).containsExactly(2, 2);
+      assertThat(matches.get(2)).containsExactly(3, 3);
+      assertThat(matches.get(3)).containsExactly(4, 4);
+    }
+
+    @Test
+    @DisplayName("(?:^|$) on \"a\\nb\\nc\" with MULTILINE")
+    void caretOrDollarMultipleLines() {
+      Matcher m = Pattern.compile("(?:^|$)", Pattern.MULTILINE).matcher("a\nb\nc");
+      List<int[]> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(new int[]{m.start(), m.end()});
+      }
+      // ^ at 0, $ at 1 (before \n), ^ at 2 (after \n), $ at 3 (before \n), ^ at 4, $ at 5
+      assertThat(matches).hasSize(6);
+      assertThat(matches.get(0)).containsExactly(0, 0);
+      assertThat(matches.get(1)).containsExactly(1, 1);
+      assertThat(matches.get(2)).containsExactly(2, 2);
+      assertThat(matches.get(3)).containsExactly(3, 3);
+      assertThat(matches.get(4)).containsExactly(4, 4);
+      assertThat(matches.get(5)).containsExactly(5, 5);
+    }
+
+    @Test
+    @DisplayName("First find() still works correctly for multiline ^|$")
+    void firstFindMultiline() {
+      Matcher m = Pattern.compile("(?:^|$)", Pattern.MULTILINE).matcher("aa\na");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.end()).isEqualTo(0);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two of the three bugs reported in #42:

**Bug 1**: `(?:$|\b)` on `" a"` — DFA skipped the earlier `\b` match at position 1, finding `$` at end instead.

**Bug 3**: `(?:^|$)` with MULTILINE on `"aa\na"` — `findAll` missed `$` before `\n` when `^` was also an alternative.

**Root cause**: In `Dfa.computeNext()`, when both a deferred assertion match (before-consume, at `pos`) and a character transition match (after-consume, at `nextPos`) existed, the code always prioritized the after-consume match. This violates leftmost-first semantics.

**Fix**: Added `FLAG_MATCH_AFTER_DEFERRED` to track dual matches. `doSearch()` now tries the before-consume match first (leftmost), falling back to after-consume if rejected (e.g., by `needEndMatch` requiring `endPos==textLen`).

**Bug 2** (capture groups lost in zero-width repetitions) is an inherent NFA vs backtracking semantic difference — JDK itself is inconsistent (`(a)*$` vs `(?:(a))*$` give different g1 results). The test exclusion is preserved with updated documentation.

## Changes

- **Dfa.java**: Added `FLAG_MATCH_AFTER_DEFERRED`, modified `computeNext()` and `doSearch()` for dual-match tracking
- **ExhaustiveUtils.java**: Removed bug 1 and 3 exclusions; updated bug 2 comment; restored `$`+`\n`+repetition exclusion
- **Issue42RegressionTest.java**: New regression tests for bugs 1 and 3

Part of #42