### PR TITLE
Upgrade CI actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.21'
+          cache: false
 
       - name: Compile Go benchmarks
         run: cd safere-benchmarks/go && go build -o regexp_benchmark .


### PR DESCRIPTION
Upgrades deprecated GitHub Actions to their latest major versions to fix CI warnings:

- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5
- `actions/setup-go` v5 → v6