### PR TITLE
Treat \r, \u0085, \u2028, \u2029 as line terminators to match JDK

### DIFF
--- a/safere/src/main/java/dev/eaftan/safere/BitState.java
+++ b/safere/src/main/java/dev/eaftan/safere/BitState.java
@@ -358,7 +358,7 @@ final class BitState {
         }
 
         case InstOp.OP_EMPTY_WIDTH -> {
-          int curFlags = Nfa.emptyFlags(text, pos);
+          int curFlags = Nfa.emptyFlags(text, pos, prog.unixLines());
           if ((ip.arg & ~curFlags) == 0) {
             if (shouldVisit(ip.out, pos)) {
               push(ip.out, pos);
@@ -392,14 +392,11 @@ final class BitState {
 
         case InstOp.OP_MATCH -> {
           if (endMatch && pos != endPos) {
-            // $ (dollarAnchorEnd) allows ending before a trailing \n at the actual text end.
-            // Use text.length() (not endPos) because dollarAnchorEnd is a property of the
-            // text boundary, not the search range. When resolveCaptures() narrows the search
-            // range (endPos < text.length()), checking against endPos would wrongly accept
-            // matches at endPos-1 that aren't at the real text boundary.
-            int textLen = text.length();
-            if (!prog.dollarAnchorEnd() || pos != textLen - 1
-                || textLen == 0 || text.charAt(textLen - 1) != '\n') {
+            // $ (dollarAnchorEnd) allows ending before a trailing line terminator at the actual
+            // text end. Use text.length() (not endPos) because dollarAnchorEnd is a property of
+            // the text boundary, not the search range.
+            if (!prog.dollarAnchorEnd()
+                || !Nfa.isAtTrailingLineTerminator(text, pos, prog.unixLines())) {
               break; // must match at the end boundary
             }
           }

--- a/safere/src/main/java/dev/eaftan/safere/Dfa.java
+++ b/safere/src/main/java/dev/eaftan/safere/Dfa.java
@@ -241,14 +241,18 @@ final class Dfa {
       }
     }
     if (hasLineBoundary) {
-      // '\n' triggers BEGIN_LINE (at the position after it) and END_LINE (at the position
-      // of it). Give '\n' its own equivalence class so the DFA can cache different
-      // transitions for newline vs other characters in the same range.
+      // Line terminator characters trigger BEGIN_LINE (at the position after them) and
+      // END_LINE (at their position). Give each its own equivalence class so the DFA can
+      // cache different transitions for line terminators vs other characters.
       bounds.add(0x0A);   // '\n'
       bounds.add(0x0B);   // '\n' + 1
-      // '\r' also needs its own class: END_LINE fires before '\r' when '\r\n' follows.
       bounds.add(0x0D);   // '\r'
       bounds.add(0x0E);   // '\r' + 1
+      // Additional JDK line terminators: \u0085, \u2028, \u2029
+      bounds.add(0x0085); // NEXT LINE
+      bounds.add(0x0086); // NEXT LINE + 1
+      bounds.add(0x2028); // LINE SEPARATOR
+      bounds.add(0x202A); // PARAGRAPH SEPARATOR + 1 (covers both \u2028 and \u2029)
     }
     if (hasWordBoundary) {
       // Add boundaries at the edges of word-character ranges [0-9A-Za-z_].
@@ -468,7 +472,7 @@ final class Dfa {
     if (startInst == 0) {
       return deadState;
     }
-    int emptyFlags = Nfa.emptyFlags(text, pos);
+    int emptyFlags = Nfa.emptyFlags(text, pos, prog.unixLines());
 
     // Determine word-character context for \b/\B support.
     boolean lastWord;
@@ -512,20 +516,48 @@ final class Dfa {
    *
    * <ul>
    *   <li>END_TEXT is set at {@code pos == text.length()}.
-   *   <li>DOLLAR_END is set at {@code pos == text.length()} and also at
-   *       {@code pos == text.length() - 1} when the text ends with {@code '\n'}.
+   *   <li>DOLLAR_END is set at {@code pos == text.length()} and also before the trailing line
+   *       terminator at end of text. For {@code \r\n} this can be up to 2 characters back.
    * </ul>
    *
-   * <p>For most of the text, transitions are cached normally. Only the last 1–2 character
+   * <p>For most of the text, transitions are cached normally. Only the last 1–3 character
    * transitions (near end-of-text) bypass the cache. The end-of-text sentinel ({@code cp < 0})
    * is always safe to cache because it always represents "at text end".
    */
-  private static int positionDependentThreshold(String text) {
-    int textLen = text.length();
-    if (textLen > 0 && text.charAt(textLen - 1) == '\n') {
-      return textLen - 1;
+  private int positionDependentThreshold(String text) {
+    int len = text.length();
+    if (prog.unixLines()) {
+      return (len > 0 && text.charAt(len - 1) == '\n') ? len - 1 : len;
     }
-    return textLen;
+    if (len >= 2 && text.charAt(len - 2) == '\r' && text.charAt(len - 1) == '\n') {
+      return len - 2;
+    }
+    if (len > 0 && Nfa.isLineTerminator(text.charAt(len - 1))) {
+      return len - 1;
+    }
+    return len;
+  }
+
+  /**
+   * Returns the start position of the trailing line terminator at the end of text, or
+   * {@code text.length()} if no trailing line terminator exists. This is the earliest position
+   * where non-multiline {@code $} can match before a trailing line terminator.
+   */
+  private int trailingLineTermStart(String text) {
+    int len = text.length();
+    if (len == 0) {
+      return len;
+    }
+    if (prog.unixLines()) {
+      return (text.charAt(len - 1) == '\n') ? len - 1 : len;
+    }
+    if (len >= 2 && text.charAt(len - 2) == '\r' && text.charAt(len - 1) == '\n') {
+      return len - 2;
+    }
+    if (Nfa.isLineTerminator(text.charAt(len - 1))) {
+      return len - 1;
+    }
+    return len;
   }
 
   /**
@@ -540,7 +572,7 @@ final class Dfa {
     // This allows empty-width assertions like $ and \b to fire.
     if (cp < 0) {
       // Compute empty flags for end-of-text, but override word boundary using state context.
-      int emptyFlags = Nfa.emptyFlags(text, nextPos);
+      int emptyFlags = Nfa.emptyFlags(text, nextPos, prog.unixLines());
       // At end-of-text the "current" character is not a word char.
       boolean wasWord = (s.flags & FLAG_LAST_WORD) != 0;
       if (wasWord) {
@@ -577,11 +609,11 @@ final class Dfa {
     //
     //   (a) Word boundary (\b, \B): depends on whether cp is a word character, combined
     //       with the previous character (FLAG_LAST_WORD in the state).
-    //   (b) END_LINE ($): fires when cp == '\n' (or '\r' before '\n'). The DFA caches
-    //       transitions per (state, char-class). END_LINE at position P depends on
-    //       text[P] == '\n', but two positions with the same (state, char-class) may have
+    //   (b) END_LINE ($): fires when cp is a line terminator. The DFA caches transitions
+    //       per (state, char-class). END_LINE at position P depends on whether text[P] is
+    //       a line terminator, but two positions with the same (state, char-class) may have
     //       different characters at P. So END_LINE is deferred and re-expanded here when
-    //       the current character is '\n'.
+    //       the current character is a line terminator.
     //
     // Both are re-expanded before consuming the character so that MATCH instructions
     // reached through these assertions are detected at the correct position.
@@ -589,7 +621,7 @@ final class Dfa {
     boolean wasWord = (s.flags & FLAG_LAST_WORD) != 0;
     int wordBeforeFlags = (isWord != wasWord) ? EmptyOp.WORD_BOUNDARY
         : EmptyOp.NON_WORD_BOUNDARY;
-    boolean endLineHere = (cp == '\n');
+    boolean endLineHere = prog.unixLines() ? (cp == '\n') : Nfa.isLineTerminator(cp);
 
     // Collect successors of unsatisfied EMPTY_WIDTH instructions whose deferred flags
     // are now satisfiable and that have no other unsatisfied flags.
@@ -678,7 +710,7 @@ final class Dfa {
     // word boundary (depends on the next character) and END_LINE (depends on what's at
     // nextPos, not deterministic for cache). Unsatisfied EMPTY_WIDTH instructions will
     // remain in the frontier for re-evaluation when the next character arrives.
-    int emptyFlags = Nfa.emptyFlags(text, nextPos);
+    int emptyFlags = Nfa.emptyFlags(text, nextPos, prog.unixLines());
     emptyFlags &= ~(EmptyOp.WORD_BOUNDARY | EmptyOp.NON_WORD_BOUNDARY | EmptyOp.END_LINE);
 
     int[] nextInsts = expand(computeBuf, successorCount, emptyFlags);
@@ -809,12 +841,13 @@ final class Dfa {
     // If the compiled program requires end-of-text matching (stripped $ or \z), enforce it.
     boolean needEndMatch = prog.anchorEnd();
     boolean dollarEnd = prog.dollarAnchorEnd();
-    // $ allows matching before a trailing \n at end of text (JDK default $ behavior).
-    boolean trailingNewline = dollarEnd && textLen > 0 && text.charAt(textLen - 1) == '\n';
+    // $ allows matching before a trailing line terminator at end of text (JDK default $ behavior).
+    // Compute the start position of the trailing line terminator for dollarAnchorEnd matching.
+    int trailingTermStart = dollarEnd ? trailingLineTermStart(text) : textLen;
 
     // Position-dependent flag threshold: emptyFlags at positions >= this threshold contain
-    // text-length-dependent flags (END_TEXT at textLen, DOLLAR_END at textLen or textLen-1
-    // when text ends with '\n'). Transitions computed at such positions must NOT be cached
+    // text-length-dependent flags (END_TEXT at textLen, DOLLAR_END near the end when text ends
+    // with a line terminator). Transitions computed at such positions must NOT be cached
     // because the same (state, character-class) pair at a different position (in the same or
     // a different text) would produce a different result. See the class-level comment on
     // DFA caching invariants.
@@ -831,7 +864,7 @@ final class Dfa {
     // Check if start state is already a match (e.g., empty pattern or .*? prefix).
     if (s.isMatch()) {
       if (!needEndMatch || textLen == startPos
-          || (trailingNewline && textLen - 1 == startPos)) {
+          || (trailingTermStart < textLen && trailingTermStart == startPos)) {
         matched = true;
         matchEnd = startPos;
         if (!longest && (!needEndMatch || startPos == textLen)) {
@@ -906,7 +939,7 @@ final class Dfa {
         if ((s.flags & FLAG_MATCH_BEFORE) != 0) {
           int endPos = pos;
           if (!needEndMatch || endPos == textLen
-              || (trailingNewline && endPos == textLen - 1)) {
+              || (trailingTermStart < textLen && endPos >= trailingTermStart)) {
             matched = true;
             matchEnd = endPos;
             if (!longest && (!needEndMatch || endPos == textLen)) {
@@ -921,7 +954,7 @@ final class Dfa {
             || (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0) {
           int endPos = Math.min(nextPos, textLen);
           if (!needEndMatch || endPos == textLen
-              || (trailingNewline && endPos == textLen - 1)) {
+              || (trailingTermStart < textLen && endPos >= trailingTermStart)) {
             matched = true;
             matchEnd = endPos;
             if (!longest && (!needEndMatch || endPos == textLen)) {
@@ -1109,7 +1142,7 @@ final class Dfa {
     int textLen = text.length();
     boolean needEndMatch = prog.anchorEnd();
     boolean dollarEnd = prog.dollarAnchorEnd();
-    boolean trailingNewline = dollarEnd && textLen > 0 && text.charAt(textLen - 1) == '\n';
+    int trailingTermStart = dollarEnd ? trailingLineTermStart(text) : textLen;
 
     // Position-dependent threshold: same invariant as doSearch.
     int posDepThreshold = positionDependentThreshold(text);
@@ -1125,7 +1158,7 @@ final class Dfa {
     // Check if start state is already a match.
     if (s.isMatch()) {
       if (!needEndMatch || textLen == 0
-          || (trailingNewline && textLen - 1 == 0)) {
+          || (trailingTermStart < textLen && trailingTermStart == 0)) {
         for (int id : collectMatchIds(s.insts)) {
           seen.set(id);
         }
@@ -1187,7 +1220,7 @@ final class Dfa {
           int endPos = (s.flags & FLAG_MATCH_BEFORE) != 0
               ? pos : Math.min(nextPos, textLen);
           if (!needEndMatch || endPos == textLen
-              || (trailingNewline && endPos == textLen - 1)) {
+              || (trailingTermStart < textLen && endPos >= trailingTermStart)) {
             // Collect match IDs from the state's instructions.
             for (int id : collectMatchIds(s.insts)) {
               seen.set(id);

--- a/safere/src/main/java/dev/eaftan/safere/Matcher.java
+++ b/safere/src/main/java/dev/eaftan/safere/Matcher.java
@@ -844,18 +844,34 @@ public final class Matcher implements MatchResult {
             int matchStart = revResult.pos();
 
             // For dollarAnchorEnd patterns, the forward DFA's earlyEnd is always textLen
-            // (it can't return early at textLen-1). But the correct leftmost match may end
-            // at textLen-1 (before trailing '\n'). The reverse DFA from textLen only finds
-            // starts for matches ending AT textLen, potentially missing an earlier-starting
-            // match that ends at textLen-1. Check both possibilities and use the leftmost.
-            if (prog.dollarAnchorEnd() && earlyEnd == text.length()
-                && text.length() > 0 && text.charAt(text.length() - 1) == '\n') {
-              Dfa.SearchResult altRevResult =
-                  revDfa.doSearchReverse(
-                      text, earlyEnd - 1, effectiveStart, true, true);
-              if (altRevResult != null && altRevResult.matched()
-                  && altRevResult.pos() < matchStart) {
-                matchStart = altRevResult.pos();
+            // (it can't return early). But the correct leftmost match may end before the
+            // trailing line terminator. The reverse DFA from textLen only finds starts for
+            // matches ending AT textLen, potentially missing an earlier-starting match that
+            // ends before the trailing line terminator. Check all dollar positions.
+            if (prog.dollarAnchorEnd() && earlyEnd == text.length()) {
+              int len = text.length();
+              boolean ul = prog.unixLines();
+              // Try position before trailing \n (or standalone line terminator)
+              if (len > 0 && (ul ? text.charAt(len - 1) == '\n'
+                  : Nfa.isLineTerminator(text.charAt(len - 1)))) {
+                Dfa.SearchResult altRevResult =
+                    revDfa.doSearchReverse(
+                        text, earlyEnd - 1, effectiveStart, true, true);
+                if (altRevResult != null && altRevResult.matched()
+                    && altRevResult.pos() < matchStart) {
+                  matchStart = altRevResult.pos();
+                }
+                // For \r\n, also try position before \r
+                if (!ul && len >= 2 && text.charAt(len - 1) == '\n'
+                    && text.charAt(len - 2) == '\r') {
+                  Dfa.SearchResult altRevResult2 =
+                      revDfa.doSearchReverse(
+                          text, earlyEnd - 2, effectiveStart, true, true);
+                  if (altRevResult2 != null && altRevResult2.matched()
+                      && altRevResult2.pos() < matchStart) {
+                    matchStart = altRevResult2.pos();
+                  }
+                }
               }
             }
 

--- a/safere/src/main/java/dev/eaftan/safere/Nfa.java
+++ b/safere/src/main/java/dev/eaftan/safere/Nfa.java
@@ -328,7 +328,7 @@ final class Nfa {
           break;
 
         case EMPTY_WIDTH:
-          int flags = emptyFlags(text, pos);
+          int flags = emptyFlags(text, pos, prog.unixLines());
           if ((ip.arg & ~flags) == 0) {
             stack.add(new int[]{ip.out, -1});
             captureStack.add(null);
@@ -386,9 +386,9 @@ final class Nfa {
 
         case MATCH: {
           if (endmatch && matchPos != text.length()) {
-            // $ (dollarAnchorEnd) allows ending before a trailing \n at text end.
-            if (!prog.dollarAnchorEnd() || matchPos != text.length() - 1
-                || text.isEmpty() || text.charAt(text.length() - 1) != '\n') {
+            // $ (dollarAnchorEnd) allows ending before a trailing line terminator at text end.
+            if (!prog.dollarAnchorEnd()
+                || !isAtTrailingLineTerminator(text, matchPos, prog.unixLines())) {
               break;
             }
           }
@@ -436,46 +436,102 @@ final class Nfa {
   // ---------------------------------------------------------------------------
 
   /**
+   * Returns true if the code point is a JDK line terminator character: {@code '\n'}, {@code '\r'},
+   * {@code '\u0085'} (NEXT LINE), {@code '\u2028'} (LINE SEPARATOR), or {@code '\u2029'}
+   * (PARAGRAPH SEPARATOR).
+   */
+  static boolean isLineTerminator(int cp) {
+    return cp == '\n' || cp == '\r' || cp == '\u0085' || cp == '\u2028' || cp == '\u2029';
+  }
+
+  /**
+   * Returns true if {@code pos} is at the start of a trailing line terminator sequence that extends
+   * to the end of the text. Used for non-multiline {@code $} (dollarAnchorEnd) matching.
+   *
+   * @param unixLines if true, only {@code '\n'} is recognized as a line terminator
+   */
+  static boolean isAtTrailingLineTerminator(String text, int pos, boolean unixLines) {
+    int len = text.length();
+    if (pos < 0 || pos >= len) {
+      return false;
+    }
+    char ch = text.charAt(pos);
+    if (unixLines) {
+      return ch == '\n' && pos + 1 == len;
+    }
+    if (ch == '\n' && pos + 1 == len) {
+      return true;
+    }
+    if (ch == '\r') {
+      return pos + 1 == len || (pos + 2 == len && text.charAt(pos + 1) == '\n');
+    }
+    return (ch == '\u0085' || ch == '\u2028' || ch == '\u2029') && pos + 1 == len;
+  }
+
+  /**
    * Computes which empty-width assertions hold at the given position in the text.
    *
    * @param text the input text
    * @param pos the position (char index) to check
+   * @param unixLines if true, only {@code '\n'} is recognized as a line terminator; otherwise all
+   *     JDK line terminators are recognized
    * @return a bitmask of {@link EmptyOp} flags
    */
-  static int emptyFlags(String text, int pos) {
+  static int emptyFlags(String text, int pos, boolean unixLines) {
     int flags = 0;
 
     // ^ and \A
-    // BEGIN_LINE is set at the start of text and after '\n', but NOT at end-of-text after a final
-    // '\n'. JDK's MULTILINE ^ does not match at the position past the last '\n' when that position
-    // is the end of the string. For example, "a\n" has BEGIN_LINE at pos 0 but NOT at pos 2.
-    // Also, JDK's MULTILINE ^ does not match at position 0 of an empty string — the empty string
-    // has no lines for ^ to match at. BEGIN_TEXT is still set (for \A). See #41.
+    // BEGIN_LINE is set at the start of text and after a line terminator, but NOT at
+    // end-of-text after a final line terminator. JDK's MULTILINE ^ does not match at the
+    // position past the last line terminator when that position is the end of the string.
+    // For example, "a\n" has BEGIN_LINE at pos 0 but NOT at pos 2.
+    // Also, JDK's MULTILINE ^ does not match at position 0 of an empty string — the empty
+    // string has no lines for ^ to match at. BEGIN_TEXT is still set (for \A). See #41.
     if (pos == 0) {
       flags |= EmptyOp.BEGIN_TEXT;
       if (!text.isEmpty()) {
         flags |= EmptyOp.BEGIN_LINE;
       }
-    } else if (pos < text.length() && text.charAt(pos - 1) == '\n') {
-      flags |= EmptyOp.BEGIN_LINE;
+    } else if (pos < text.length()) {
+      char prev = text.charAt(pos - 1);
+      if (unixLines) {
+        if (prev == '\n') {
+          flags |= EmptyOp.BEGIN_LINE;
+        }
+      } else {
+        // After \n: always a new line (whether standalone or part of \r\n).
+        // After \r: new line only if NOT followed by \n (standalone \r).
+        // After \u0085, \u2028, \u2029: always a new line.
+        if (prev == '\n' || prev == '\u0085' || prev == '\u2028' || prev == '\u2029') {
+          flags |= EmptyOp.BEGIN_LINE;
+        } else if (prev == '\r' && text.charAt(pos) != '\n') {
+          flags |= EmptyOp.BEGIN_LINE;
+        }
+      }
     }
 
     // $ and \z
-    // END_LINE is set before any '\n' or '\r\n' and at end of text (used by MULTILINE $).
+    // END_LINE is set before any line terminator and at end of text (used by MULTILINE $).
     // END_TEXT is set only at end of text (used by \z).
-    // DOLLAR_END is set at end of text and also before the final trailing '\n' at end of text
-    // (used by $ without MULTILINE — JDK's default $ behavior).
+    // DOLLAR_END is set at end of text and also before the trailing line terminator at end of
+    // text (used by $ without MULTILINE — JDK's default $ behavior).
     if (pos == text.length()) {
       flags |= EmptyOp.END_TEXT | EmptyOp.END_LINE | EmptyOp.DOLLAR_END;
-    } else if (text.charAt(pos) == '\n') {
-      flags |= EmptyOp.END_LINE;
-      // Set DOLLAR_END if this '\n' is the last character in text.
-      if (pos + 1 == text.length()) {
-        flags |= EmptyOp.DOLLAR_END;
+    } else {
+      char ch = text.charAt(pos);
+      if (unixLines) {
+        if (ch == '\n') {
+          flags |= EmptyOp.END_LINE;
+          if (pos + 1 == text.length()) {
+            flags |= EmptyOp.DOLLAR_END;
+          }
+        }
+      } else if (isLineTerminator(ch)) {
+        flags |= EmptyOp.END_LINE;
+        if (isAtTrailingLineTerminator(text, pos, false)) {
+          flags |= EmptyOp.DOLLAR_END;
+        }
       }
-    } else if (text.charAt(pos) == '\r' && pos + 1 < text.length()
-        && text.charAt(pos + 1) == '\n') {
-      flags |= EmptyOp.END_LINE;
     }
 
     // \b and \B

--- a/safere/src/main/java/dev/eaftan/safere/OnePass.java
+++ b/safere/src/main/java/dev/eaftan/safere/OnePass.java
@@ -86,18 +86,22 @@ final class OnePass {
 
   /**
    * When true, the end anchor was {@code $} (not {@code \z}), meaning the match may end before a
-   * trailing {@code \n} at end of text. Only meaningful when {@link #anchorEnd} is true.
+   * trailing line terminator at end of text. Only meaningful when {@link #anchorEnd} is true.
    */
   private final boolean dollarAnchorEnd;
 
+  /** When true, only {@code '\n'} is recognized as a line terminator. */
+  private final boolean unixLines;
+
   private OnePass(long[][] actions, long[] matchAction, int[] boundaries, boolean anchorEnd,
-      boolean dollarAnchorEnd) {
+      boolean dollarAnchorEnd, boolean unixLines) {
     this.actions = actions;
     this.matchAction = matchAction;
     this.boundaries = boundaries;
     this.asciiClassMap = buildAsciiClassMap(boundaries);
     this.anchorEnd = anchorEnd;
     this.dollarAnchorEnd = dollarAnchorEnd;
+    this.unixLines = unixLines;
   }
 
   // -------------------------------------------------------------------------
@@ -273,7 +277,7 @@ final class OnePass {
     long[][] trimmedActions = Arrays.copyOf(actions, stateCount);
     long[] trimmedMatch = Arrays.copyOf(matchActions, stateCount);
     return new OnePass(trimmedActions, trimmedMatch, boundaries, prog.anchorEnd(),
-        prog.dollarAnchorEnd());
+        prog.dollarAnchorEnd(), prog.unixLines());
   }
 
   /** Builds sorted code point boundaries from all CHAR_RANGE and CHAR_CLASS instructions. */
@@ -349,7 +353,7 @@ final class OnePass {
       long matchAct = matchAction[state];
       if (matchAct != NO_ACTION) {
         int reqEmpty = (int) (matchAct & EMPTY_MASK);
-        if (reqEmpty == 0 || (reqEmpty & ~Nfa.emptyFlags(text, pos)) == 0) {
+        if (reqEmpty == 0 || (reqEmpty & ~Nfa.emptyFlags(text, pos, unixLines)) == 0) {
           applyCaptures(matchAct, pos, cap);
           if (cap.length > 1) {
             cap[1] = pos;
@@ -391,7 +395,7 @@ final class OnePass {
 
       int reqEmpty = (int) (action & EMPTY_MASK);
       if (reqEmpty != 0) {
-        int curEmpty = Nfa.emptyFlags(text, pos);
+        int curEmpty = Nfa.emptyFlags(text, pos, unixLines);
         if ((reqEmpty & ~curEmpty) != 0) {
           break;
         }
@@ -409,9 +413,9 @@ final class OnePass {
       return null;
     }
     if (anchorEnd && bestCap[1] != endPos) {
-      // $ (dollarAnchorEnd) allows the match to end before a trailing \n at end of text.
-      if (!dollarAnchorEnd || bestCap[1] != endPos - 1
-          || endPos == 0 || text.charAt(endPos - 1) != '\n') {
+      // $ (dollarAnchorEnd) allows the match to end before a trailing line terminator.
+      if (!dollarAnchorEnd
+          || !Nfa.isAtTrailingLineTerminator(text, bestCap[1], unixLines)) {
         return null;
       }
     }

--- a/safere/src/main/java/dev/eaftan/safere/ParseFlags.java
+++ b/safere/src/main/java/dev/eaftan/safere/ParseFlags.java
@@ -81,8 +81,16 @@ final class ParseFlags {
    */
   public static final int WAS_DOLLAR = 1 << 13;
 
+  /**
+   * Unix lines mode: only {@code '\n'} is recognized as a line terminator in the behavior of
+   * {@code .}, {@code ^}, and {@code $}. Without this flag, all JDK line terminators are
+   * recognized: {@code '\n'}, {@code '\r'}, {@code "\r\n"}, {@code '\u0085'}, {@code '\u2028'},
+   * and {@code '\u2029'}.
+   */
+  public static final int UNIX_LINES = 1 << 14;
+
   /** Mask of all valid parse flags. */
-  public static final int ALL_FLAGS = (1 << 14) - 1;
+  public static final int ALL_FLAGS = (1 << 15) - 1;
 
   private ParseFlags() {} // Non-instantiable.
 }

--- a/safere/src/main/java/dev/eaftan/safere/Parser.java
+++ b/safere/src/main/java/dev/eaftan/safere/Parser.java
@@ -373,11 +373,22 @@ final class Parser {
   private void pushDot() {
     if ((flags & ParseFlags.DOT_NL) != 0 && (flags & ParseFlags.NEVER_NL) == 0) {
       pushSimpleOp(RegexpOp.ANY_CHAR);
-    } else {
-      // Rewrite . into [^\n]
+    } else if ((flags & ParseFlags.UNIX_LINES) != 0) {
+      // UNIX_LINES: . matches everything except \n
       CharClassBuilder ccb = new CharClassBuilder();
       ccb.addRange(0, '\n' - 1);
       ccb.addRange('\n' + 1, runeMax);
+      Regexp re = Regexp.charClass(ccb.build(), flags & ~ParseFlags.FOLD_CASE);
+      pushRegexp(re);
+    } else {
+      // Default JDK behavior: . matches everything except line terminators
+      // (\n, \r, \u0085, \u2028, \u2029)
+      CharClassBuilder ccb = new CharClassBuilder();
+      ccb.addRange(0, '\n' - 1);             // 0x00–0x09
+      ccb.addRange('\n' + 1, '\r' - 1);      // 0x0B–0x0C
+      ccb.addRange('\r' + 1, '\u0085' - 1);  // 0x0E–0x0084
+      ccb.addRange('\u0085' + 1, '\u2028' - 1); // 0x0086–0x2027
+      ccb.addRange('\u2029' + 1, runeMax);    // 0x202A–max
       Regexp re = Regexp.charClass(ccb.build(), flags & ~ParseFlags.FOLD_CASE);
       pushRegexp(re);
     }

--- a/safere/src/main/java/dev/eaftan/safere/Pattern.java
+++ b/safere/src/main/java/dev/eaftan/safere/Pattern.java
@@ -218,6 +218,7 @@ public final class Pattern implements Serializable {
     int parseFlags = toParseFlags(flags);
     Regexp re = Parser.parse(regex, parseFlags);
     Prog compiled = Compiler.compile(re);
+    compiled.setUnixLines((flags & UNIX_LINES) != 0);
     Map<String, Integer> named = extractNamedGroups(re);
     PrefixResult prefixResult = extractPrefix(re);
     String prefix = prefixResult.prefix();
@@ -755,6 +756,9 @@ public final class Pattern implements Serializable {
     }
     if ((flags & UNICODE_CHARACTER_CLASS) != 0) {
       pf |= ParseFlags.UNICODE_GROUPS;
+    }
+    if ((flags & UNIX_LINES) != 0) {
+      pf |= ParseFlags.UNIX_LINES;
     }
 
     return pf;

--- a/safere/src/main/java/dev/eaftan/safere/Prog.java
+++ b/safere/src/main/java/dev/eaftan/safere/Prog.java
@@ -30,6 +30,7 @@ final class Prog {
    */
   private boolean dollarAnchorEnd;
   private boolean reversed;
+  private boolean unixLines;
 
   /** Creates an empty program. */
   public Prog() {}
@@ -147,6 +148,19 @@ final class Prog {
   /** Sets whether this program runs in reverse. */
   public void setReversed(boolean reversed) {
     this.reversed = reversed;
+  }
+
+  /**
+   * Returns true if Unix lines mode is active. When true, only {@code '\n'} is recognized as a
+   * line terminator. When false (default), all JDK line terminators are recognized.
+   */
+  public boolean unixLines() {
+    return unixLines;
+  }
+
+  /** Sets whether Unix lines mode is active. */
+  public void setUnixLines(boolean unixLines) {
+    this.unixLines = unixLines;
   }
 
   /**

--- a/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
@@ -126,11 +126,6 @@ final class ExhaustiveUtils {
   static int testPair(String regexp, String text, int flags, List<TestResult> failures) {
     int tests = 0;
 
-    // Skip text with standalone \r (not \r\n) — known JDK vs RE2 behavioral difference
-    if (hasStandaloneCarriageReturn(text)) {
-      return 0;
-    }
-
     // Skip patterns with zero-width assertions (\b, \B) inside quantified groups —
     // known RE2 vs JDK semantic difference in zero-width repetition handling
     if (ZERO_WIDTH_IN_REPETITION.matcher(regexp).find()) {
@@ -445,16 +440,6 @@ final class ExhaustiveUtils {
       generateStringsRecursive(result, current, maxLen, alphabet);
       current.delete(current.length() - ch.length(), current.length());
     }
-  }
-
-  /**
-   * Returns true if the text contains any {@code \r} character. JDK treats {@code \r} (both
-   * standalone and in {@code \r\n}) specially — dot doesn't match it, {@code $} matches before it,
-   * etc. SafeRE (like RE2) only gives special treatment to {@code \n}. This is a known design
-   * difference, not a bug.
-   */
-  private static boolean hasStandaloneCarriageReturn(String text) {
-    return text.indexOf('\r') >= 0;
   }
 
   /**

--- a/safere/src/test/java/dev/eaftan/safere/NfaTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/NfaTest.java
@@ -483,41 +483,73 @@ class NfaTest {
   class EmptyFlags {
     @Test
     void beginOfText() {
-      int flags = Nfa.emptyFlags("abc", 0);
+      int flags = Nfa.emptyFlags("abc", 0, false);
       assertThat(flags & EmptyOp.BEGIN_TEXT).isNotZero();
       assertThat(flags & EmptyOp.BEGIN_LINE).isNotZero();
     }
 
     @Test
     void endOfText() {
-      int flags = Nfa.emptyFlags("abc", 3);
+      int flags = Nfa.emptyFlags("abc", 3, false);
       assertThat(flags & EmptyOp.END_TEXT).isNotZero();
       assertThat(flags & EmptyOp.END_LINE).isNotZero();
     }
 
     @Test
     void midText() {
-      int flags = Nfa.emptyFlags("abc", 1);
+      int flags = Nfa.emptyFlags("abc", 1, false);
       assertThat(flags & EmptyOp.BEGIN_TEXT).isZero();
       assertThat(flags & EmptyOp.END_TEXT).isZero();
     }
 
     @Test
     void afterNewline() {
-      int flags = Nfa.emptyFlags("a\nb", 2);
+      int flags = Nfa.emptyFlags("a\nb", 2, false);
       assertThat(flags & EmptyOp.BEGIN_LINE).isNotZero();
     }
 
     @Test
     void wordBoundary() {
-      int flags = Nfa.emptyFlags("foo bar", 3);
+      int flags = Nfa.emptyFlags("foo bar", 3, false);
       assertThat(flags & EmptyOp.WORD_BOUNDARY).isNotZero();
     }
 
     @Test
     void nonWordBoundary() {
-      int flags = Nfa.emptyFlags("foo", 1);
+      int flags = Nfa.emptyFlags("foo", 1, false);
       assertThat(flags & EmptyOp.NON_WORD_BOUNDARY).isNotZero();
+    }
+
+    @Test
+    @DisplayName("BEGIN_LINE after standalone \\r")
+    void beginLineAfterCr() {
+      int flags = Nfa.emptyFlags("a\rb", 2, false);
+      assertThat(flags & EmptyOp.BEGIN_LINE).isNotZero();
+    }
+
+    @Test
+    @DisplayName("BEGIN_LINE NOT between \\r and \\n in \\r\\n")
+    void noBeginLineBetweenCrLf() {
+      int flags = Nfa.emptyFlags("a\r\nb", 2, false);
+      assertThat(flags & EmptyOp.BEGIN_LINE).isZero();
+    }
+
+    @Test
+    @DisplayName("END_LINE before standalone \\r")
+    void endLineBeforeCr() {
+      int flags = Nfa.emptyFlags("a\rb", 1, false);
+      assertThat(flags & EmptyOp.END_LINE).isNotZero();
+    }
+
+    @Test
+    @DisplayName("UNIX_LINES: \\r is not a line terminator")
+    void unixLinesCrNotLineTerm() {
+      // After \r: no BEGIN_LINE in UNIX_LINES mode
+      int flags = Nfa.emptyFlags("a\rb", 2, true);
+      assertThat(flags & EmptyOp.BEGIN_LINE).isZero();
+      // Before \r: no END_LINE in UNIX_LINES mode
+      int flags2 = Nfa.emptyFlags("a\rb", 1, true);
+      assertThat(flags2 & EmptyOp.END_LINE).isZero();
     }
   }
 }

--- a/safere/src/test/java/dev/eaftan/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/ParseFlagsTest.java
@@ -48,7 +48,7 @@ class ParseFlagsTest {
 
   @Test
   void allFlagsCoversAllBits() {
-    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 14) - 1);
+    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 15) - 1);
   }
 
   @Test

--- a/safere/src/test/java/dev/eaftan/safere/PatternTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/PatternTest.java
@@ -453,9 +453,68 @@ class PatternTest {
           Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
       Matcher m = p.matcher(header);
       assertThat(m.find()).isTrue();
-      // SafeRE's . matches \r (only \n is excluded), so the capture includes trailing \r.
-      // JDK's . excludes both \r and \n. Use trim() in real code.
+      // . now excludes all line terminators including \r (matching JDK behavior).
       assertThat(m.group(1).trim()).isEqualTo("abc123");
+    }
+
+    @Test
+    @DisplayName(". does not match \\r (issue #54)")
+    void dotDoesNotMatchCr() {
+      // Regression for #54: . should not match \r, matching JDK behavior.
+      Pattern p = Pattern.compile(".");
+      Matcher m = p.matcher("a\rb");
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("a");
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("b");
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("$ matches before \\r in MULTILINE mode (issue #54)")
+    void multilineEolStandaloneCr() {
+      // Regression for #54: $ in MULTILINE should match before standalone \r.
+      Pattern p = Pattern.compile("$", Pattern.MULTILINE);
+      Matcher m = p.matcher("a\rb");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(3);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("^ matches after \\r in MULTILINE mode (issue #54)")
+    void multilineBolStandaloneCr() {
+      // Regression for #54: ^ in MULTILINE should match after standalone \r.
+      Pattern p = Pattern.compile("^", Pattern.MULTILINE);
+      Matcher m = p.matcher("a\rb");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("UNIX_LINES restores \\n-only line terminator behavior (issue #54)")
+    void unixLinesFlag() {
+      // With UNIX_LINES, only \n is a line terminator — \r is treated as ordinary char.
+      Pattern dotPat = Pattern.compile(".", Pattern.UNIX_LINES);
+      Matcher dm = dotPat.matcher("a\rb");
+      assertThat(dm.find()).isTrue();
+      assertThat(dm.group()).isEqualTo("a");
+      assertThat(dm.find()).isTrue();
+      assertThat(dm.group()).isEqualTo("\r");
+      assertThat(dm.find()).isTrue();
+      assertThat(dm.group()).isEqualTo("b");
+
+      Pattern dollarPat = Pattern.compile("$", Pattern.MULTILINE | Pattern.UNIX_LINES);
+      Matcher mm = dollarPat.matcher("a\rb");
+      // $ should only match at end of text, not before \r
+      assertThat(mm.find()).isTrue();
+      assertThat(mm.start()).isEqualTo(3);
+      assertThat(mm.find()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #54. SafeRE now treats all JDK line terminators (`\r`, `\r\n`, `\u0085`, `\u2028`, `\u2029`) as line terminators, matching JDK behavior.

## Changes

**Core**: `Nfa.emptyFlags()` now recognizes all JDK line terminators for `BEGIN_LINE`, `END_LINE`, and `DOLLAR_END` assertions. Added `isLineTerminator()` and `isAtTrailingLineTerminator()` helpers.

**Parser**: `." (dot) now excludes all line terminators, not just `\n`.

**Engines**: Updated DFA inline `endLineHere` check, equivalence class boundaries (`\u0085`, `\u2028`, `\u2029`), position-dependent threshold, and trailing terminator checks. Updated BitState, OnePass, NFA, and Matcher `dollarAnchorEnd` checks.

**UNIX_LINES**: Added `ParseFlags.UNIX_LINES` and `Prog.unixLines()` to thread the flag through all engines. When set, reverts to `\n`-only behavior (previous SafeRE default).

**Tests**: Removed the `hasStandaloneCarriageReturn()` skip in exhaustive tests. Added regression tests for `.`, `^`, `$` with `\r`, and UNIX_LINES flag. All 6444 tests pass including >10M exhaustive cross-engine comparisons.