### PR TITLE
Remove 22 dead MATCH_DIFFERS annotations and fix split() for zero-width matches

### DIFF
--- a/safere/src/main/java/dev/eaftan/safere/Pattern.java
+++ b/safere/src/main/java/dev/eaftan/safere/Pattern.java
@@ -345,9 +345,21 @@ public final class Pattern implements Serializable {
       if (limit > 0 && parts.size() >= limit - 1) {
         break;
       }
+      // JDK 8+: a zero-width match at the beginning of the input never produces
+      // a leading empty substring.
+      if (last == 0 && m.start() == 0 && m.end() == 0) {
+        continue;
+      }
       parts.add(text.substring(last, m.start()));
       last = m.end();
     }
+    // If no match advanced the position, return the entire input as a single element.
+    // This matches JDK behavior: an input that was never actually split is returned as-is,
+    // bypassing trailing-empty-string removal.
+    if (last == 0) {
+      return new String[] {text};
+    }
+
     parts.add(text.substring(last));
 
     // limit == 0: remove trailing empty strings.

--- a/safere/src/test/java/dev/eaftan/safere/CrossEngineTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/CrossEngineTest.java
@@ -67,8 +67,8 @@ class CrossEngineTest {
         new TestCase("abc", "abc"),
         new TestCase("abc", "xabcy"),
         new TestCase("abc", "def"),
-        new TestCase("", "abc", Divergence.MATCH_DIFFERS),
-        new TestCase("", "", Divergence.MATCH_DIFFERS),
+        new TestCase("", "abc"),
+        new TestCase("", ""),
         new TestCase("hello world", "hello world"),
         new TestCase("hello world", "say hello world now"),
         new TestCase("aaa", "aaaa"),
@@ -103,14 +103,14 @@ class CrossEngineTest {
         new TestCase("\\w+", "hello world"),
 
         // ===== Quantifiers =====
-        new TestCase("a*", "", Divergence.MATCH_DIFFERS),
+        new TestCase("a*", ""),
         new TestCase("a*", "aaa"),
-        new TestCase("a*", "bbb", Divergence.MATCH_DIFFERS),
+        new TestCase("a*", "bbb"),
         new TestCase("a+", "aaa"),
-        new TestCase("a+", "", Divergence.MATCH_DIFFERS),
+        new TestCase("a+", ""),
         new TestCase("a?", "a"),
-        new TestCase("a?", "", Divergence.MATCH_DIFFERS),
-        new TestCase("a?", "b", Divergence.MATCH_DIFFERS),
+        new TestCase("a?", ""),
+        new TestCase("a?", "b"),
         new TestCase("a{3}", "aaa"),
         new TestCase("a{3}", "aa"),
         new TestCase("a{3}", "aaaa"),
@@ -123,10 +123,10 @@ class CrossEngineTest {
         new TestCase("a{1,}", "aaa"),
 
         // ===== Non-greedy quantifiers =====
-        new TestCase("a*?", "aaa", Divergence.MATCH_DIFFERS),
-        new TestCase("a+?", "aaa", Divergence.MATCH_DIFFERS),
-        new TestCase("a??", "a", Divergence.MATCH_DIFFERS),
-        new TestCase("a{2,4}?", "aaaa", Divergence.MATCH_DIFFERS),
+        new TestCase("a*?", "aaa"),
+        new TestCase("a+?", "aaa"),
+        new TestCase("a??", "a"),
+        new TestCase("a{2,4}?", "aaaa"),
 
         // ===== Dot =====
         new TestCase(".", "a"),
@@ -147,11 +147,11 @@ class CrossEngineTest {
         new TestCase("^abc$", "abc"),
         new TestCase("^abc$", "abcx"),
         new TestCase("^abc$", "xabc"),
-        new TestCase("^$", "", Divergence.MATCH_DIFFERS),
+        new TestCase("^$", ""),
         new TestCase("^$", "a"),
-        new TestCase("^", "", Divergence.MATCH_DIFFERS),
-        new TestCase("^", "abc", Divergence.MATCH_DIFFERS),
-        new TestCase("$", "", Divergence.MATCH_DIFFERS),
+        new TestCase("^", ""),
+        new TestCase("^", "abc"),
+        new TestCase("$", ""),
         new TestCase("$", "abc"),
 
         // ===== Alternation =====
@@ -163,7 +163,7 @@ class CrossEngineTest {
         new TestCase("a|b|c", "b"),
         new TestCase("a|b|c", "d"),
         new TestCase("abc|def|ghi", "def"),
-        new TestCase("a|ab", "ab", Divergence.MATCH_DIFFERS),
+        new TestCase("a|ab", "ab"),
 
         // ===== Groups and captures =====
         new TestCase("(a)(b)(c)", "abc"),
@@ -254,10 +254,10 @@ class CrossEngineTest {
         new TestCase("(?>a+)", "aaa", Divergence.SAFERE_REJECTS),
 
         // ===== Edge cases =====
-        new TestCase("(a*)", "", Divergence.MATCH_DIFFERS),
+        new TestCase("(a*)", ""),
         new TestCase("a*b", "b"),
         new TestCase("a*b", "aaab"),
-        new TestCase(".{0}", "abc", Divergence.MATCH_DIFFERS),
+        new TestCase(".{0}", "abc"),
         new TestCase("a{100}", "a".repeat(100)),
         new TestCase("a{100}", "a".repeat(99)),
         new TestCase("a?a?a?aaa", "aaa"),
@@ -282,7 +282,7 @@ class CrossEngineTest {
         new TestCase("\\s+", "one two  three"),
 
         // ===== Nested quantifiers =====
-        new TestCase("(a+)+", "aaa", Divergence.MATCH_DIFFERS),
+        new TestCase("(a+)+", "aaa"),
         new TestCase("((a|b)+)", "abab"),
 
         // ===== Character class edge cases =====
@@ -298,10 +298,10 @@ class CrossEngineTest {
         new TestCase("(?i)abc", "AbC"),
         new TestCase("(?i)abc", "def"),
         new TestCase("(?i)[a-z]+", "HeLLo"),
-        new TestCase("a{0}", "a", Divergence.MATCH_DIFFERS),
-        new TestCase("a{0}", "", Divergence.MATCH_DIFFERS),
+        new TestCase("a{0}", "a"),
+        new TestCase("a{0}", ""),
         new TestCase("(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)", "abcdefghij"),
-        new TestCase("x*", "y", Divergence.MATCH_DIFFERS));
+        new TestCase("x*", "y"));
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes all 22 `Divergence.MATCH_DIFFERS` annotations in `CrossEngineTest`, restoring full equality assertions (matches, find, replaceAll, split) for these test cases.

## Changes

### CrossEngineTest.java
- Changed 22 test cases from `Divergence.MATCH_DIFFERS` to `Divergence.NONE` (via the two-arg `TestCase` constructor).

### Pattern.java — fix `split()` for zero-width matches
Two bugs in `Pattern.split()` prevented these test cases from passing:

1. **Leading empty substring from zero-width match at position 0**: JDK 8+ skips zero-width matches at the beginning of the input. SafeRE was not doing this, producing an extra leading empty string (e.g., `"a*".split("bbb")` returned `["", "b", "b", "b"]` instead of `["b", "b", "b"]`).

2. **Empty input early return**: When no match advances the position, the JDK returns `[input]` directly, bypassing trailing-empty-string removal. SafeRE was adding the input as a remainder and then trimming it, causing `"a*".split("")` to return `[]` instead of `[""]`.

Fixes #56