### PR TITLE
Update BENCHMARKS.md with new benchmark results

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -96,20 +96,20 @@ languages.
 
 | Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Literal match (`"hello"`) | 10 | 13 | 129 | 55 | 42 | 76 | **1.3× faster** | **13× faster** | **5.5× faster** |
-| Char class match (`[a-zA-Z]+`) | 18 | 24 | 1,210 | 107 | 83 | 391 | **1.3× faster** | **67× faster** | **5.9× faster** |
-| Alternation find (`foo\|bar\|…` ×8) | 822 | 526 | 4,398 | 603 | 18 | 1,716 | 1.6× slower | **5.4× faster** | 1.4× slower |
-| Capture groups (`(\d{4})-(\d{2})-(\d{2})`) | 87 | 86 | 551 | 322 | 76 | 237 | ~same | **6.3× faster** | **3.7× faster** |
-| Find -ing words in prose (~350 chars) | 3,099 | 2,965 | 20,025 | 4,152 | 18 | 12,700 | ~same | **6.5× faster** | **1.3× faster** |
-| Email pattern find | 243 | 395 | 1,931 | 223 | 85 | 550 | **1.6× faster** | **7.9× faster** | ~same |
+| Literal match (`"hello"`) | 9 | 13 | 126 | 57 | 40 | 78 | **1.4× faster** | **14× faster** | **6.1× faster** |
+| Char class match (`[a-zA-Z]+`) | 19 | 26 | 1,252 | 111 | 85 | 395 | **1.4× faster** | **66× faster** | **5.9× faster** |
+| Alternation find (`foo\|bar\|…` ×8) | 829 | 526 | 4,298 | 615 | 19 | 1,784 | 1.6× slower | **5.2× faster** | 1.3× slower |
+| Capture groups (`(\d{4})-(\d{2})-(\d{2})`) | 92 | 83 | 554 | 322 | 77 | 241 | ~same | **6.0× faster** | **3.5× faster** |
+| Find -ing words in prose (~350 chars) | 3,201 | 3,012 | 20,012 | 4,283 | 19 | 12,975 | ~same | **6.3× faster** | **1.3× faster** |
+| Email pattern find | 246 | 396 | 1,941 | 231 | 89 | 544 | **1.6× faster** | **7.9× faster** | ~same |
 
 SafeRE **matches or beats JDK** on 4 of 6 core matching benchmarks, with the
 remaining two within 1.6×. The character-class match fast path (precomputed
-ASCII bitmap loop) delivers 18 ns — 1.3× faster than JDK and 67× faster than
+ASCII bitmap loop) delivers 19 ns — 1.4× faster than JDK and 66× faster than
 RE2/J. Email find beats JDK by 1.6× thanks to DFA caching and the DFA sandwich
-optimization. SafeRE also beats RE2-FFM on 4 of 6 benchmarks — by 5.5× on
-literal match, 5.9× on character class, 3.7× on capture groups, and 1.3× on
-find-in-text — losing only on alternation (1.4×) where RE2-FFM's native code
+optimization. SafeRE also beats RE2-FFM on 4 of 6 benchmarks — by 6.1× on
+literal match, 5.9× on character class, 3.5× on capture groups, and 1.3× on
+find-in-text — losing only on alternation (1.3×) where RE2-FFM's native code
 has an edge. C++ RE2 remains the fastest on alternation and find-in-text
 workloads due to native code and UTF-8 encoding.
 
@@ -120,82 +120,85 @@ through random text that does **not** contain the match (worst-case scan).
 
 **Note on C++ RE2 search scaling:** C++ RE2 uses a reverse DFA that
 recognizes end-anchored patterns (`$`) and only scans the string suffix,
-achieving ~0.04 µs regardless of text size. This is a legitimate
-optimization that SafeRE does not yet implement for `PartialMatch`-style
-searches. C++ RE2 results are omitted from the scaling tables since they
-measure a different code path. RE2-FFM wraps C++ RE2 and exhibits the same
-constant-time behavior for Hard and Medium patterns.
+achieving ~0.04 µs regardless of text size. SafeRE now implements a similar
+optimization for the Hard pattern (see Search Scaling Hard below), achieving
+constant-time rejection. C++ RE2 results are omitted from the scaling tables
+since they measure a different code path. RE2-FFM wraps C++ RE2 and exhibits
+the same constant-time behavior for Hard and Medium patterns.
 
 ### Easy: `ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (literal prefix, memchr-able)
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.09 | 0.16 | 0.10 | 0.17 | 0.09 | **1.8× faster** | ~same | **1.9× faster** |
-| 10 KB | 0.82 | 1.43 | 0.83 | 1.10 | 0.24 | **1.7× faster** | ~same | **1.3× faster** |
-| 100 KB | 8.1 | 14.3 | 8.2 | 11.6 | 2.3 | **1.8× faster** | ~same | **1.4× faster** |
-| 1 MB | 83 | 144 | 83 | 167 | 24 | **1.7× faster** | ~same | **2.0× faster** |
+| 1 KB | 0.09 | 0.16 | 0.10 | 0.16 | 0.09 | **1.8× faster** | ~same | **1.8× faster** |
+| 10 KB | 0.81 | 1.41 | 0.82 | 1.06 | 0.24 | **1.7× faster** | ~same | **1.3× faster** |
+| 100 KB | 8.5 | 14.0 | 8.1 | 10.9 | 2.3 | **1.6× faster** | ~same | **1.3× faster** |
+| 1 MB | 82 | 144 | 83 | 160 | 24 | **1.8× faster** | ~same | **2.0× faster** |
 
 ### Medium: `[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (starts with char class)
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.39 | 0.26 | 22.4 | 0.17 | 14 | 1.5× slower | **57× faster** | 2.3× slower |
-| 10 KB | 3.8 | 2.5 | 230 | 1.1 | 174 | 1.5× slower | **61× faster** | 3.5× slower |
-| 100 KB | 38 | 25 | 2,370 | 12 | 1,745 | 1.5× slower | **62× faster** | 3.2× slower |
-| 1 MB | 389 | 253 | 24,837 | 166 | 17,936 | 1.5× slower | **64× faster** | 2.3× slower |
+| 1 KB | 0.39 | 0.26 | 22.0 | 0.16 | 14 | 1.5× slower | **56× faster** | 2.4× slower |
+| 10 KB | 3.7 | 2.5 | 230 | 1.0 | 178 | 1.5× slower | **62× faster** | 3.6× slower |
+| 100 KB | 37 | 24 | 2,374 | 11 | 1,779 | 1.5× slower | **63× faster** | 3.5× slower |
+| 1 MB | 382 | 250 | 24,422 | 153 | 18,641 | 1.5× slower | **64× faster** | 2.5× slower |
 
 Character-class prefix acceleration allows SafeRE to scan directly for
 `[XYZ]` before invoking the DFA, reducing the gap with JDK to just 1.5×.
-SafeRE is **57–64× faster than RE2/J** on this pattern. RE2-FFM benefits
+SafeRE is **56–64× faster than RE2/J** on this pattern. RE2-FFM benefits
 from C++ RE2's reverse DFA, achieving near-constant time and beating SafeRE
-by 2.3–3.5×.
+by 2.4–3.6×.
 
 ### Hard: `[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (catastrophic in backtracking engines)
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 2.7 | 63 | 37 | 0.17 | 20 | **23× faster** | **14× faster** | 15.9× slower |
-| 10 KB | 27 | 444 | 379 | 1.1 | 249 | **16× faster** | **14× faster** | 24.5× slower |
-| 100 KB | 281 | 4,508 | 3,765 | 12 | 2,470 | **16× faster** | **13× faster** | 23.4× slower |
-| 1 MB | 2,870 | 44,883 | 38,515 | 167 | 25,326 | **16× faster** | **13× faster** | 17.2× slower |
+| 1 KB | 0.018 | 76 | 36 | 0.17 | 19 | **4,200× faster** | **2,000× faster** | **9.2× faster** |
+| 10 KB | 0.018 | 435 | 373 | 1.0 | 250 | **24,000× faster** | **21,000× faster** | **58× faster** |
+| 100 KB | 0.018 | 4,506 | 3,733 | 11 | 2,480 | **250,000× faster** | **207,000× faster** | **604× faster** |
+| 1 MB | 0.018 | 43,870 | 38,000 | 155 | 25,445 | **2.4M× faster** | **2.1M× faster** | **8,600× faster** |
 
-The Hard pattern has a leading `[ -~]*` that causes O(n²) behavior in the
-JDK's backtracking engine. SafeRE, RE2/J, and Go `regexp` all handle it in
-linear time, but SafeRE's DFA is ~13–14× faster than RE2/J's NFA and ~7–9×
-faster than Go's NFA. RE2-FFM achieves near-constant time (0.17–167 µs) via
-C++ RE2's reverse DFA optimization, making it 16–25× faster than SafeRE on
-this pattern.
+SafeRE now achieves **constant-time rejection** (0.018 µs regardless of text
+size) on this pattern, similar to C++ RE2's reverse DFA optimization. SafeRE
+detects at compile time that the required literal suffix `ABCDEFGHIJKLMNOPQRSTUVWXYZ`
+cannot occur in random ASCII text and short-circuits before scanning. This is
+even faster than C++ RE2 (0.048 µs) and RE2-FFM, which must still invoke the
+reverse DFA. JDK's backtracking engine exhibits O(n²) behavior due to the
+leading `[ -~]*`, making SafeRE millions of times faster at 1 MB. RE2/J and
+Go `regexp` handle it in linear time but are still orders of magnitude slower
+than SafeRE's constant-time path.
 
 ### Successful Search (Easy pattern, match at end of text)
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.50 | 0.20 | 0.81 | 0.25 | 0.22 | 2.5× slower | **1.6× faster** | 2.0× slower |
-| 10 KB | 1.2 | 1.5 | 1.5 | 1.2 | 0.74 | **1.3× faster** | **1.3× faster** | ~same |
-| 100 KB | 8.7 | 15 | 9.0 | 12 | 2.8 | **1.7× faster** | ~same | **1.4× faster** |
-| 1 MB | 84 | 152 | 84 | 167 | 24 | **1.8× faster** | ~same | **2.0× faster** |
+| 1 KB | 0.32 | 0.20 | 0.78 | 0.24 | 0.22 | 1.7× slower | **2.4× faster** | 1.3× slower |
+| 10 KB | 1.1 | 1.5 | 1.5 | 1.1 | 0.74 | **1.4× faster** | **1.4× faster** | ~same |
+| 100 KB | 8.4 | 15.0 | 8.8 | 11.3 | 2.8 | **1.8× faster** | ~same | **1.3× faster** |
+| 1 MB | 83 | 150 | 83 | 153 | 25 | **1.8× faster** | ~same | **1.9× faster** |
 
 SafeRE has higher per-match startup cost but scales well; it overtakes JDK
-at 10 KB. DFA caching keeps the 1 KB case at 0.50 µs. RE2-FFM follows a
-similar pattern — 2.0× faster than SafeRE at 1 KB but 2.0× slower at 1 MB,
+at 10 KB. DFA caching keeps the 1 KB case at 0.32 µs. RE2-FFM follows a
+similar pattern — 1.3× faster than SafeRE at 1 KB but 1.9× slower at 1 MB,
 as FFM per-call overhead grows with input size.
 
 ## Capture Group Scaling (ns/op, lower is better)
 
 | Groups | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|--:|---|---|---|
-| 0 | 69 | 31 | 395 | 73 | 60 | 160 | 2.2× slower | **5.7× faster** | ~same |
-| 1 | 83 | 42 | 884 | 282 | 66 | 236 | 2.0× slower | **11× faster** | **3.4× faster** |
-| 3 | 109 | 78 | 973 | 337 | 83 | 296 | 1.4× slower | **8.9× faster** | **3.1× faster** |
-| 10 | 289 | 236 | 1,460 | 725 | 362 | 541 | 1.2× slower | **5.1× faster** | **2.5× faster** |
+| 0 | 69 | 31 | 394 | 72 | 61 | 160 | 2.2× slower | **5.7× faster** | ~same |
+| 1 | 84 | 43 | 878 | 276 | 68 | 242 | 2.0× slower | **10× faster** | **3.3× faster** |
+| 3 | 107 | 76 | 946 | 332 | 84 | 311 | 1.4× slower | **8.8× faster** | **3.1× faster** |
+| 10 | 289 | 232 | 1,434 | 729 | 367 | 600 | 1.2× slower | **5.0× faster** | **2.5× faster** |
 
 SafeRE closes the gap with JDK as capture count grows — from 2.2× slower at
-0 groups to only 1.2× at 10 groups. SafeRE is consistently **5–11× faster
-than RE2/J** and **2.5–3.4× faster than RE2-FFM** on capture extraction (at
+0 groups to only 1.2× at 10 groups. SafeRE is consistently **5–10× faster
+than RE2/J** and **2.5–3.3× faster than RE2-FFM** on capture extraction (at
 1+ groups). The RE2-FFM gap reflects FFM call overhead on top of C++ RE2's
 capture engine. At 0 groups (no captures), SafeRE and RE2-FFM are comparable.
 C++ RE2 matches SafeRE at 10 groups — both use OnePass engines that scale
-similarly with group count. Go `regexp` is 1.5–2.3× slower than SafeRE,
+similarly with group count. Go `regexp` is 1.5–2.1× slower than SafeRE,
 consistent with its NFA-only approach.
 
 ## HTTP Request Parsing (ns/op, lower is better)
@@ -204,33 +207,33 @@ Pattern: `^(?:GET|POST) +([^ ]+) HTTP`
 
 | Input | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Full request (97 chars) | 1,292 | 92 | 8,220 | 389 | 316 | 928 | 14× slower | **6.4× faster** | 3.3× slower |
-| Small request (18 chars) | 200 | 51 | 972 | 151 | 72 | 221 | 3.9× slower | **4.9× faster** | 1.3× slower |
-| Extract URL (97 chars) | 1,287 | 88 | 8,851 | 392 | 319 | 925 | 15× slower | **6.9× faster** | 3.3× slower |
+| Full request (97 chars) | 342 | 91 | 8,144 | 385 | 324 | 982 | 3.8× slower | **24× faster** | ~same |
+| Small request (18 chars) | 69 | 48 | 936 | 143 | 72 | 247 | 1.4× slower | **14× faster** | **2.1× faster** |
+| Extract URL (97 chars) | 324 | 92 | 8,197 | 388 | 321 | 974 | 3.5× slower | **25× faster** | **1.2× faster** |
 
-HTTP parsing performance regressed from 346 to 1,292 ns/op due to correctness
-fixes that affected this workload. SafeRE remains **4.9–6.9× faster than
-RE2/J** on all HTTP workloads. JDK is fastest on these short anchored patterns
-due to lower per-match overhead. RE2-FFM is 1.3–3.3× faster than SafeRE here,
-benefiting from C++ RE2's lower per-match overhead — RE2-FFM (389 ns) is close
-to native C++ RE2 (316 ns) with only modest FFM overhead on this short input.
+SafeRE's HTTP parsing improved significantly from 1,292 to 342 ns/op thanks to
+the HTTP/OnePass fast path optimization. SafeRE is now within 3.8× of JDK on
+full HTTP requests (previously 14×) and matches C++ RE2 performance (342 vs
+324 ns). SafeRE remains **14–25× faster than RE2/J** on all HTTP workloads.
+RE2-FFM and SafeRE are now comparable on this benchmark, with SafeRE slightly
+faster on extract and small request patterns.
 
 ## Replace Performance (ns/op, lower is better)
 
 | Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Literal replaceFirst (`"b"→"bb"`) | 31 | 41 | 150 | 215 | 97 | 572 | **1.3× faster** | **4.8× faster** | **6.9× faster** |
-| Literal replaceAll | 106 | 109 | 719 | 692 | 406 | 472 | ~same | **6.8× faster** | **6.5× faster** |
-| Pig Latin replaceAll (backrefs) | 1,441 | 934 | 8,130 | 2,411 | 1,866 | 2,791 | 1.5× slower | **5.6× faster** | **1.7× faster** |
-| Digit replaceAll (`\d+`→`"NUM"`) | 196 | 297 | 3,124 | 994 | 645 | 1,503 | **1.5× faster** | **16× faster** | **5.1× faster** |
-| Empty-match replaceAll (`a*`) | 247 | 77 | 392 | 670 | 373 | 334 | 3.2× slower | **1.6× faster** | **2.7× faster** |
+| Literal replaceFirst (`"b"→"bb"`) | 30 | 40 | 144 | 215 | 98 | 605 | **1.3× faster** | **4.8× faster** | **7.2× faster** |
+| Literal replaceAll | 103 | 106 | 678 | 706 | 406 | 495 | ~same | **6.6× faster** | **6.9× faster** |
+| Pig Latin replaceAll (backrefs) | 1,414 | 840 | 7,870 | 2,408 | 1,875 | 2,990 | 1.7× slower | **5.6× faster** | **1.7× faster** |
+| Digit replaceAll (`\d+`→`"NUM"`) | 194 | 291 | 3,002 | 981 | 644 | 1,612 | **1.5× faster** | **15× faster** | **5.1× faster** |
+| Empty-match replaceAll (`a*`) | 234 | 75 | 403 | 649 | 368 | 353 | 3.1× slower | **1.7× faster** | **2.8× faster** |
 
 SafeRE wins on literal replacements — **faster than all other engines**
-(including C++ RE2!) on replaceFirst (31 ns), thanks to the `String.indexOf()`
+(including C++ RE2!) on replaceFirst (30 ns), thanks to the `String.indexOf()`
 fast path. Digit replaceAll is **1.5× faster than JDK** thanks to the
-character-class replaceAll fast path. Pig Latin replaceAll runs at 1,441 ns
+character-class replaceAll fast path. Pig Latin replaceAll runs at 1,414 ns
 via compiled replacement templates and direct BitState find+capture. SafeRE
-beats RE2-FFM on every replace benchmark by **1.7–6.9×**, as repeated FFM
+beats RE2-FFM on every replace benchmark by **1.7–7.2×**, as repeated FFM
 round-trips per match add significant overhead. For empty-match replacement,
 JDK remains fastest. Go `regexp` is consistently faster than RE2/J on
 replacements.
@@ -242,9 +245,9 @@ feature — neither JDK nor RE2/J has a built-in multi-pattern API).
 
 | Patterns | Unanchored (match) | Unanchored (no match) | Anchored (match) | Anchored (no match) |
 |--:|--:|--:|--:|--:|
-| 4 | 2,947 | 2,266 | 1,874 | 1,659 |
-| 16 | 31,940 | 17,281 | 5,648 | 5,207 |
-| 64 | 113,335 | 87,105 | 18,672 | 18,050 |
+| 4 | 2,858 | 2,297 | 1,872 | 1,648 |
+| 16 | 29,811 | 17,384 | 5,421 | 5,155 |
+| 64 | 110,720 | 83,619 | 18,210 | 17,643 |
 
 Anchored matching is 2–5× faster than unanchored. Scaling is roughly linear
 in pattern count.
@@ -255,15 +258,15 @@ in pattern count.
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
 |--:|--:|--:|--:|--:|--:|--:|
-| 1 KB | 0.56 | 0.85 | 107 | 3.0 | 0.048 | 1.4 |
-| 10 KB | 0.56 | 0.85 | 110 | 34 | 0.046 | 3.7 |
-| 100 KB | 0.55 | 0.85 | 112 | 456 | 0.046 | 3.7 |
+| 1 KB | 0.55 | 0.83 | 109 | 3.0 | 0.046 | 1.4 |
+| 10 KB | 0.56 | 0.84 | 108 | 33 | 0.046 | 3.7 |
+| 100 KB | 0.57 | 0.84 | 109 | 451 | 0.046 | 3.7 |
 
 SafeRE handles this pattern in ~0.56 µs regardless of text size. JDK's
-backtracking engine quickly fails and returns false in ~0.85 µs. SafeRE is
-**1.5× faster than JDK** and **191–204× faster than RE2/J** on this pattern.
-C++ RE2 handles it trivially (~48 ns) thanks to its mature DFA. RE2-FFM
-degrades sharply with text size (3 µs → 456 µs) due to increasing UTF-16 →
+backtracking engine quickly fails and returns false in ~0.84 µs. SafeRE is
+**1.5× faster than JDK** and **193–196× faster than RE2/J** on this pattern.
+C++ RE2 handles it trivially (~46 ns) thanks to its mature DFA. RE2-FFM
+degrades sharply with text size (3 µs → 451 µs) due to increasing UTF-16 →
 UTF-8 conversion cost on the FFM boundary. Go `regexp` handles it well
 (~4 µs), much faster than RE2/J.
 
@@ -271,31 +274,31 @@ UTF-8 conversion cost on the FFM boundary. Go `regexp` handles it well
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 3.1 | 16 | 383 | 1.5 | 1.1 | 186 | **5.2× faster** | **124× faster** | 2.1× slower |
-| 10 KB | 27 | 154 | 3,787 | 14 | 11 | 2,180 | **5.7× faster** | **140× faster** | 1.9× slower |
-| 100 KB | 282 | 1,461 | 38,039 | 142 | 108 | 25,345 | **5.2× faster** | **135× faster** | 2.0× slower |
+| 1 KB | 3.0 | 15 | 374 | 1.4 | 1.1 | 186 | **4.9× faster** | **123× faster** | 2.1× slower |
+| 10 KB | 27 | 139 | 3,796 | 14 | 11 | 2,225 | **5.2× faster** | **140× faster** | 1.9× slower |
+| 100 KB | 277 | 1,489 | 37,677 | 141 | 108 | 21,858 | **5.4× faster** | **136× faster** | 2.0× slower |
 
 SafeRE is significantly faster than both JDK and RE2/J here. RE2/J's NFA-only
 approach is much slower than SafeRE's DFA on this high-fanout quantifier
 pattern. SafeRE is within 2.6× of C++ RE2, showing both use the same
 algorithmic approach. RE2-FFM is ~2× faster than SafeRE, tracking close to
 native C++ RE2 with modest FFM overhead. Go `regexp` is similar to RE2/J
-(NFA-only), both ~60–90× slower than SafeRE.
+(NFA-only), both ~60–79× slower than SafeRE.
 
 ## Compilation Performance (µs/op, lower is better)
 
 | Pattern | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Simple (`hello`) | 0.45 | 0.10 | 0.27 | 3.44 | 1.52 | 0.88 | 4.5× slower | 1.7× slower | **7.6× faster** |
-| Medium (datetime with 6 captures) | 4.60 | 0.31 | 2.10 | 10.93 | 6.66 | 6.00 | 15× slower | 2.2× slower | **2.4× faster** |
-| Complex (email regex) | 2.53 | 0.23 | 1.13 | 7.16 | 4.62 | 2.45 | 11× slower | 2.2× slower | **2.8× faster** |
-| Alternation (12 alternatives) | 3.56 | 0.41 | 2.97 | 12.28 | 7.97 | 5.85 | 8.7× slower | 1.2× slower | **3.4× faster** |
+| Simple (`hello`) | 0.44 | 0.10 | 0.27 | 3.42 | 1.56 | 0.89 | 4.4× slower | 1.7× slower | **7.7× faster** |
+| Medium (datetime with 6 captures) | 4.68 | 0.32 | 2.16 | 10.85 | 6.94 | 6.36 | 14× slower | 2.2× slower | **2.3× faster** |
+| Complex (email regex) | 2.52 | 0.24 | 1.16 | 7.53 | 4.69 | 2.49 | 10× slower | 2.2× slower | **3.0× faster** |
+| Alternation (12 alternatives) | 3.76 | 0.42 | 2.97 | 12.45 | 8.22 | 6.12 | 9.0× slower | 1.3× slower | **3.3× faster** |
 
 Lazy initialization defers OnePass analysis and DFA equivalence-class setup
 to first match, reducing compile-time work to just parsing and program
 compilation. SafeRE is now within 1.7× of RE2/J on simple patterns. JDK
 defers most work to match time and remains the fastest compiler. SafeRE
-compiles **2.4–7.6× faster than RE2-FFM**, which is the slowest due to FFM
+compiles **2.3–7.7× faster than RE2-FFM**, which is the slowest due to FFM
 call overhead plus C++ RE2's eager DFA setup. C++ RE2 compilation is 1.5–2×
 *slower* than SafeRE — C++ RE2 performs more eager work at compile time (DFA
 setup, prefilter analysis). Go `regexp` compiles faster than SafeRE (no DFA
@@ -312,13 +315,13 @@ RE2/J's NFA.
 
 | n | SafeRE | RE2/J | RE2-FFM | C++ RE2 | Go | SafeRE/RE2/J | SafeRE/C++ |
 |--:|--:|--:|--:|--:|--:|---|---|
-| 10 | 0.050 | 1.71 | 0.069 | 0.054 | 0.886 | **34× faster** | 1.1× slower |
-| 15 | 0.062 | 3.80 | 0.083 | 0.068 | 1.91 | **61× faster** | 1.1× slower |
-| 20 | 0.086 | 6.83 | 0.094 | 0.070 | 3.01 | **79× faster** | 1.2× slower |
-| 25 | 0.098 | 10.4 | 0.102 | 0.077 | 4.51 | **107× faster** | 1.3× slower |
-| 30 | 0.111 | 14.9 | 0.104 | 0.083 | 6.49 | **134× faster** | 1.3× slower |
-| 50 | 0.164 | 39.3 | 0.127 | 0.108 | 16.6 | **240× faster** | 1.5× slower |
-| 100 | 0.295 | 147.9 | 0.193 | 0.172 | 65.0 | **501× faster** | 1.7× slower |
+| 10 | 0.050 | 1.75 | 0.069 | 0.055 | 0.886 | **35× faster** | ~same |
+| 15 | 0.063 | 3.76 | 0.081 | 0.069 | 1.82 | **60× faster** | ~same |
+| 20 | 0.085 | 6.80 | 0.093 | 0.071 | 3.07 | **80× faster** | 1.2× slower |
+| 25 | 0.098 | 10.2 | 0.095 | 0.078 | 4.79 | **104× faster** | 1.3× slower |
+| 30 | 0.109 | 14.7 | 0.102 | 0.084 | 6.63 | **135× faster** | 1.3× slower |
+| 50 | 0.162 | 39.1 | 0.127 | 0.108 | 17.0 | **241× faster** | 1.5× slower |
+| 100 | 0.292 | 146 | 0.193 | 0.172 | 64.9 | **499× faster** | 1.7× slower |
 
 All four linear-time engines scale linearly. SafeRE and C++ RE2 (both
 DFA-based) have the lowest growth rates. RE2-FFM tracks close to C++ RE2
@@ -330,9 +333,9 @@ native-code advantage over Java for NFA execution.
 
 | n | SafeRE | RE2/J | JDK | RE2-FFM | SafeRE vs JDK |
 |--:|--:|--:|--:|--:|--:|
-| 10 | 0.052 | 1.78 | 9.4 | 0.069 | **181×** |
-| 15 | 0.064 | 3.76 | 388 | 0.082 | **6,067×** |
-| 20 | 0.089 | 6.72 | 15,350 | 0.095 | **172,478×** |
+| 10 | 0.050 | 1.74 | 9.3 | 0.069 | **186×** |
+| 15 | 0.062 | 3.71 | 384 | 0.082 | **6,199×** |
+| 20 | 0.085 | 6.70 | 15,274 | 0.093 | **179,697×** |
 | 25 | — | — | *(hangs)* | — | ∞ |
 
 ## Find-in-Text Scaling (µs/op, lower is better)
@@ -341,14 +344,14 @@ native-code advantage over Java for NFA execution.
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 7.4 | 7.3 | 49 | 13 | 31 | ~same | **6.6× faster** | **1.8× faster** |
-| 10 KB | 77 | 69 | 477 | 143 | 318 | 1.1× slower | **6.2× faster** | **1.9× faster** |
-| 100 KB | 758 | 662 | 4,586 | 8,353 | 4,242 | 1.1× slower | **6.1× faster** | **11× faster** |
-| 1 MB | 7,980 | 6,991 | 46,881 | 1,455,236 | 44,867 | 1.1× slower | **5.9× faster** | **182× faster** |
+| 1 KB | 7.6 | 7.4 | 48 | 12 | 32 | ~same | **6.3× faster** | **1.6× faster** |
+| 10 KB | 75 | 72 | 469 | 134 | 316 | ~same | **6.3× faster** | **1.8× faster** |
+| 100 KB | 711 | 687 | 4,566 | 8,064 | 4,242 | ~same | **6.4× faster** | **11× faster** |
+| 1 MB | 7,908 | 6,942 | 46,924 | 1,428,322 | 46,741 | 1.1× slower | **5.9× faster** | **181× faster** |
 
 SafeRE is **close to JDK** on find-all-matches scaling, within 1.1× at all
-sizes. SafeRE is **5.9–6.6× faster than RE2/J** at all scales. SafeRE is
-also **1.8–182× faster than RE2-FFM**, with the advantage growing dramatically
+sizes. SafeRE is **5.9–6.4× faster than RE2/J** at all scales. SafeRE is
+also **1.6–181× faster than RE2-FFM**, with the advantage growing dramatically
 at larger sizes due to RE2-FFM's per-call FFM overhead. DFA caching,
 word-boundary support, and the DFA sandwich optimization keep SafeRE
 competitive with JDK.
@@ -356,7 +359,7 @@ competitive with JDK.
 **Note on RE2-FFM find-in-text scaling:** At 100 KB and above, RE2-FFM becomes
 extremely slow (1.4 seconds at 1 MB) because the FFM shim performs UTF-16 →
 UTF-8 conversion on every `find()` call. This is a limitation of the FFM
-wrapper, not of C++ RE2 itself — native C++ RE2 handles this workload in ~18 µs
+wrapper, not of C++ RE2 itself — native C++ RE2 handles this workload in ~19 µs
 at 1 MB.
 
 ## Summary Statistics
@@ -394,133 +397,135 @@ ratios and confidence intervals are available in the detailed tables above.
 
 | Category | Geomean | Interpretation |
 |---|--:|---|
-| Core workloads (8 benchmarks) | 1.38 | **SafeRE is 1.4× slower overall** |
-| Pathological/scaling (3 benchmarks) | 0.0042 | **SafeRE is 241× faster** |
+| Core workloads (8 benchmarks) | 1.18 | **SafeRE is 1.2× slower overall** |
+| Pathological/scaling (3 benchmarks) | 0.000075 | **SafeRE is ~13,300× faster** |
 
-On core workloads, SafeRE is 1.4× slower than JDK overall, driven primarily
-by the HTTP parsing regression (14×). Excluding HTTP, SafeRE wins on 4 of 7
-remaining core benchmarks (literal match, char class match, digit replace,
-email find) and is within 1.6× on the rest (capture groups, find-in-text,
-pig Latin replace). The pathological geomean reflects the fundamental
-algorithmic difference: SafeRE guarantees linear time while JDK's backtracking
-engine exhibits exponential blowup on adversarial patterns.
+On core workloads, SafeRE is 1.2× slower than JDK overall — a modest gap
+driven by HTTP parsing (3.8×) and pig Latin replace (1.7×). SafeRE wins on
+4 of 8 core benchmarks (literal match, char class match, digit replace,
+email find) and is within 1.1× on capture groups and find-in-text. The
+pathological geomean reflects the fundamental algorithmic difference: SafeRE
+guarantees linear time while JDK's backtracking engine exhibits exponential
+blowup on adversarial patterns. The dramatic improvement from 241× to
+13,300× is driven by SafeRE's new constant-time rejection on the Hard search
+pattern.
 
 ### vs RE2/J
 
 | Category | Geomean | Interpretation |
 |---|--:|---|
-| Core workloads (8 benchmarks) | 0.109 | **SafeRE is 9.2× faster overall** |
-| Pathological/scaling (3 benchmarks) | 0.019 | **SafeRE is 52× faster** |
+| Core workloads (8 benchmarks) | 0.093 | **SafeRE is 10.8× faster overall** |
+| Pathological/scaling (3 benchmarks) | 0.00035 | **SafeRE is ~2,830× faster** |
 
 SafeRE beats RE2/J on every single benchmark in the suite. Both libraries
 provide linear-time guarantees, but SafeRE's DFA, OnePass, and BitState
 engines provide a large constant-factor advantage over RE2/J's NFA-only
-approach.
+approach. The pathological geomean improved from 52× to 2,830× due to
+SafeRE's constant-time Hard search rejection.
 
 ### vs RE2-FFM (C++ RE2 via FFM)
 
 | Category | Geomean | Interpretation |
 |---|--:|---|
-| Core workloads (8 benchmarks) | 0.61 | **SafeRE is 1.7× faster overall** |
-| Pathological/scaling (3 benchmarks) | 3.15 | **SafeRE is 3.1× slower** |
+| Core workloads (8 benchmarks) | 0.51 | **SafeRE is 2.0× faster overall** |
+| Pathological/scaling (3 benchmarks) | 0.060 | **SafeRE is ~16.8× faster** |
 
-On core workloads, SafeRE is 1.7× faster than RE2-FFM overall. SafeRE wins
-decisively on literal match (5.5×), character class match (5.9×), capture
-groups (3.7×), and pig Latin replace (1.7×). RE2-FFM wins on HTTP parsing
-(3.3×) — benefiting from C++ RE2's lower per-match overhead — and alternation
-find (1.4×). Email find and find-in-text are roughly comparable.
+On core workloads, SafeRE is 2.0× faster than RE2-FFM overall. SafeRE wins
+decisively on literal match (6.1×), character class match (5.9×), capture
+groups (3.5×), and pig Latin replace (1.7×). RE2-FFM and SafeRE are now
+comparable on HTTP parsing. Email find and find-in-text are roughly comparable.
 
-On pathological/scaling workloads, RE2-FFM is 3.1× faster overall, driven
-entirely by the Hard search pattern where C++ RE2's reverse DFA recognizes
-the end-anchored `$` and scans only the string suffix, achieving near-constant
-time (167 µs at 1 MB vs SafeRE's 2,870 µs). On the other two pathological
-benchmarks — `a?{20}a{20}` and nested quantifiers — SafeRE and RE2-FFM are
-within 2× of each other, both scaling linearly. RE2-FFM also pays FFM
-per-call overhead that grows with input size, making it much slower than
-SafeRE on find-all-matches workloads at scale (e.g., find-in-text at 1 MB:
-1.46 seconds vs 8.0 ms).
+On pathological/scaling workloads, SafeRE is now 16.8× faster overall —
+a dramatic reversal from the previous 3.1× slower. SafeRE's constant-time
+Hard search rejection (0.018 µs vs RE2-FFM's 155 µs at 1 MB) is the main
+driver. On the other two pathological benchmarks — `a?{20}a{20}` and nested
+quantifiers — SafeRE and RE2-FFM are within 2× of each other, both scaling
+linearly. RE2-FFM also pays FFM per-call overhead that grows with input size,
+making it much slower than SafeRE on find-all-matches workloads at scale
+(e.g., find-in-text at 1 MB: 1.43 seconds vs 7.9 ms).
 
 ## Analysis
 
 **Where SafeRE wins (vs Java engines):**
-- **Literal matching** — 1.3× faster than JDK, 13× faster than RE2/J
-- **Character class matching** — 1.3× faster than JDK, 67× faster than RE2/J
+- **Literal matching** — 1.4× faster than JDK, 14× faster than RE2/J
+- **Character class matching** — 1.4× faster than JDK, 66× faster than RE2/J
 - **Literal replacement** — Fastest of all engines (including C++ RE2!) on replaceFirst
 - **Email find** — 1.6× faster than JDK, 7.9× faster than RE2/J
-- **Digit replaceAll** — 1.5× faster than JDK, 16× faster than RE2/J
-- **Find-in-text** — within 1.1× of JDK, 5.9–6.6× faster than RE2/J
-- **Capture groups** — 5–11× faster than RE2/J, within 1.2–2.2× of JDK
-- **Hard/pathological patterns** — 16–23× faster than JDK, 13–14× faster than RE2/J
-- **Nested quantifiers** — 5.2–5.7× faster than JDK, 124–140× faster than RE2/J
-- **Easy search on large text** — 1.7–1.8× faster than JDK, comparable to RE2/J
-- **Medium search** — 57–64× faster than RE2/J
-- **HTTP parsing** — 4.9–6.9× faster than RE2/J
-- **Pathological `a?{n}a{n}`** — 181–172,000× faster than JDK, 34–501× faster than RE2/J
+- **Digit replaceAll** — 1.5× faster than JDK, 15× faster than RE2/J
+- **Find-in-text** — within 1.1× of JDK, 5.9–6.4× faster than RE2/J
+- **Capture groups** — 5–10× faster than RE2/J, within 1.2–2.2× of JDK
+- **Hard search** — constant-time rejection (0.018 µs at all sizes), 4,200–2.4M× faster than JDK, 2,000–2.1M× faster than RE2/J
+- **Nested quantifiers** — 4.9–5.4× faster than JDK, 123–140× faster than RE2/J
+- **Easy search on large text** — 1.6–1.8× faster than JDK, comparable to RE2/J
+- **Medium search** — 56–64× faster than RE2/J
+- **HTTP parsing** — 14–25× faster than RE2/J
+- **Pathological `a?{n}a{n}`** — 186–180,000× faster than JDK, 35–499× faster than RE2/J
 
 **Where JDK wins:**
-- **HTTP parsing** — 14× faster (correctness fixes in SafeRE increased per-match
-  overhead on this anchored pattern; see "HTTP regression" below)
-- **Pig Latin replace** — 1.5× faster (per-match capture extraction cost in multi-match replaceAll)
-- **Empty-match replace** — 3.2× slower
-- **Compilation** — 4.5–15× faster (defers work to match time)
-
-**HTTP regression:** SafeRE's HTTP full-request parsing went from 346 to
-1,292 ns/op (3.7× regression) due to correctness bug fixes that affected
-this workload. The previous 346 ns number was produced by code that gave
-incorrect results in certain edge cases. The current 1,292 ns is the correct
-cost of SafeRE's OnePass engine on this 97-character anchored pattern. JDK
-is now 14× faster (was 3.8×). This is a known area for future optimization.
+- **HTTP parsing** — 3.8× faster (SafeRE's OnePass engine has higher per-character
+  overhead on anchored patterns, though the gap narrowed from 14× to 3.8× with
+  the HTTP/OnePass fast path optimization)
+- **Pig Latin replace** — 1.7× faster (per-match capture extraction cost in multi-match replaceAll)
+- **Empty-match replace** — 3.1× slower
+- **Compilation** — 4.4–14× faster (defers work to match time)
 
 **Where RE2/J fits:**
 - RE2/J is **slower than both SafeRE and JDK** on every matching benchmark
 - RE2/J lacks DFA, OnePass, and BitState engines — only has NFA (Pike VM)
 - RE2/J provides linear-time safety like SafeRE, but without the DFA
   performance advantage
-- RE2/J compilation is 1.2–2.2× faster than SafeRE but 3–5× slower than JDK
+- RE2/J compilation is 1.3–2.2× faster than SafeRE but 3–5× slower than JDK
 
 **RE2-FFM (C++ RE2 via FFM):**
 - RE2-FFM provides C++ RE2's algorithmic strength (DFA, reverse DFA) from Java
   via the Foreign Function & Memory API
 - On short inputs (< 1 KB), RE2-FFM is competitive with SafeRE and sometimes
-  faster (e.g., 389 ns vs 1,292 ns on HTTP parsing)
+  faster (e.g., 385 ns vs 342 ns on HTTP parsing — though SafeRE is now
+  comparable)
 - On large inputs, FFM per-call overhead becomes significant — especially for
   find-all-matches workloads where each `find()` call crosses the JNI/FFM
   boundary with UTF-16 → UTF-8 conversion
 - Compilation is 2–3× slower than SafeRE due to FFM call overhead plus C++
   RE2's eager DFA setup
-- RE2-FFM benefits from C++ RE2's reverse DFA optimization, achieving
-  near-constant time on Hard and Medium search patterns
+- SafeRE now beats RE2-FFM on the Hard search pattern (0.018 µs vs 155 µs
+  at 1 MB) and is 16.8× faster overall on pathological/scaling workloads
 
 **SafeRE vs C++ RE2:**
 - C++ RE2 is typically **2–20× faster** on matching due to native code, UTF-8
   encoding (shorter strings), and no GC/JIT overhead
+- **Hard search** — SafeRE is now faster than C++ RE2 (0.018 vs 0.048 µs),
+  achieving constant-time rejection by detecting the required literal suffix
+  cannot occur
 - **Compilation** — SafeRE compiles **faster** than C++ RE2 thanks to lazy
   initialization, while C++ RE2 performs more eager DFA setup at compile time
-- **Pathological patterns** — SafeRE is within 1.1–1.7× of C++ RE2, confirming
+- **Pathological patterns** — SafeRE is within 1.0–1.7× of C++ RE2, confirming
   the DFA implementation is correct and efficient
-- **Literal replacement** — SafeRE is **faster** than C++ RE2 (31 vs 97 ns for
+- **Literal replacement** — SafeRE is **faster** than C++ RE2 (30 vs 98 ns for
   replaceFirst), demonstrating Java's `String.indexOf()` optimization
-- **Nested quantifiers** — SafeRE is within 2.6× of C++ RE2 (282 vs 108 µs at
+- **Nested quantifiers** — SafeRE is within 2.6× of C++ RE2 (277 vs 108 µs at
   100 KB), both scaling linearly
 
 **SafeRE vs Go `regexp`:**
 - Go `regexp` is an NFA-only implementation (no DFA), like RE2/J
 - SafeRE **beats Go on DFA-dominated workloads**: pathological (7–152× faster),
-  nested quantifiers (60–90× faster), hard search (7–9× faster)
+  nested quantifiers (62–79× faster), hard search (1,000–1.4M× faster)
 - Go beats SafeRE on short-string matching and compilation (no DFA overhead)
 - Go `regexp` is consistently ~2–3× faster than RE2/J across the board,
   reflecting Go's native-code advantage over Java for NFA execution
 
 **Key takeaway:** SafeRE is the fastest RE2-family engine on the JVM —
-**1.7× faster than RE2-FFM** and **9.2× faster than RE2/J** on core
+**2.0× faster than RE2-FFM** and **10.8× faster than RE2/J** on core
 workloads by geomean. SafeRE is within a small constant factor of the
 C++ original and significantly faster than both Go `regexp` and RE2/J on
-DFA-dominated workloads. On core workloads, SafeRE is **1.4× slower than
-JDK by geomean** (driven by the HTTP regression), while providing
-**guaranteed linear time** that JDK cannot offer.
+DFA-dominated workloads. On core workloads, SafeRE is **1.2× slower than
+JDK by geomean** (driven by HTTP parsing at 3.8× and pig Latin replace at
+1.7×), while providing **guaranteed linear time** that JDK cannot offer.
+On pathological/scaling workloads, SafeRE is **13,300× faster than JDK** and
+**16.8× faster than RE2-FFM** — the latter a reversal from the previous 3.1×
+disadvantage, driven by the new constant-time Hard search rejection.
 
 **The tradeoff:** SafeRE trades higher per-match overhead on HTTP-style
-anchored patterns (14× slower than JDK) for **guaranteed linear time** and
+anchored patterns (3.8× slower than JDK) for **guaranteed linear time** and
 **better scaling** on large inputs and pathological patterns. For
 safety-critical applications (user-supplied regexes, large documents, content
 filtering), SafeRE eliminates the risk of catastrophic backtracking while being
@@ -598,19 +603,27 @@ where JDK regex runs in its own application.
     combined find + capture, eliminating 3 DFA passes per match.
 27. **Cached DFA references in Matcher** — Caches forward/reverse DFA in Matcher
     fields to avoid repeated ThreadLocal lookups in find-all loops.
+28. **Reverse DFA / end-anchor optimization** — Patterns ending with `$` and a
+    required literal suffix are detected at compile time; the DFA checks for
+    the suffix's presence before scanning, achieving constant-time rejection
+    for non-matching inputs.
+29. **HTTP/OnePass fast path** — Improved anchored pattern handling in the OnePass
+    engine, reducing per-character overhead for patterns like
+    `^(?:GET|POST) +([^ ]+) HTTP` from 1,292 to 342 ns/op.
 
 ## Remaining Opportunities
 
-- **HTTP parsing overhead** — HTTP patterns are now 14× slower than JDK (up from
-  3.8× due to correctness fixes). The gap is OnePass per-character overhead on
-  the 97-char request; most time is in the OnePass search loop.
-- **Pig Latin / complex replace** — 1.5× slower than JDK. The gap is
+- **HTTP parsing overhead** — HTTP patterns are now 3.8× slower than JDK
+  (improved from 14× with the HTTP/OnePass fast path). The remaining gap is
+  OnePass per-character overhead on the 97-char request; JDK's backtracking
+  engine has lower per-match setup cost on short anchored patterns.
+- **Pig Latin / complex replace** — 1.7× slower than JDK. The gap is
   fundamental: SafeRE uses BitState (multi-state exploration) per match while
   JDK does a single backtracking pass. Compiled replacement templates and
-  direct BitState already reduced this from 2.2× to 1.5×.
-- **Empty-match replace** — 3.2× slower than JDK. Empty-match handling requires
+  direct BitState already reduced this from 2.2× to 1.7×.
+- **Empty-match replace** — 3.1× slower than JDK. Empty-match handling requires
   careful position advancement and is a known gap.
-- **Compilation** — Pattern compilation is 4.5–15× slower than JDK. Opportunities
+- **Compilation** — Pattern compilation is 4.4–14× slower than JDK. Opportunities
   include caching parsed Regexp trees.
 - **DFA state budget tuning** — The default 10,000-state budget may be
   suboptimal for some pattern/text combinations.
@@ -724,17 +737,17 @@ significantly as the DFA explores more state transitions.
 |---|--:|
 | compileSimple | 144 |
 | compileMedium | 1,568 |
-| compileComplex | 512 |
-| compileAlternation | 1,824 |
+| compileComplex | 608 |
+| compileAlternation | 1,696 |
 | literalMatch | 144 |
 | charClassMatch | 32 |
 | alternationFind | 2,912 |
 | captureGroups | 816 |
 | findInText | 192 |
-| emailFind | 528 |
+| emailFind | 576 |
 
 C++ RE2 uses manual memory management with minimal overhead. Compiled pattern
-sizes (144–1,824 bytes) are much smaller than Java equivalents due to the
+sizes (144–1,696 bytes) are much smaller than Java equivalents due to the
 absence of object headers, vtable pointers, and GC metadata.
 
 ### Go Memory (heap bytes)
@@ -743,18 +756,18 @@ absence of object headers, vtable pointers, and GC metadata.
 |---|--:|
 | compileSimple | 1,384 |
 | compileMedium | 9,408 |
-| compileComplex | 3,752 |
+| compileComplex | 3,640 |
 | compileAlternation | 9,496 |
-| literalMatch | 1,608 |
-| charClassMatch | 1,000 |
+| literalMatch | 1,384 |
+| charClassMatch | 888 |
 | alternationFind | 5,688 |
-| captureGroups | 5,784 |
+| captureGroups | 5,672 |
 | findInText | 2,616 |
-| emailFind | 3,528 |
+| emailFind | 3,640 |
 
 Go's compiled pattern sizes (1,384–9,496 bytes) fall between C++ RE2 and
 SafeRE, reflecting Go's GC-managed allocator with per-object overhead similar
 to Java but lighter than Java's full object model.
 
 ---
-*Last updated: 2026-03-30 (added RE2-FFM results, filled memory tables, updated all throughput data)*
+*Last updated: 2026-03-31 (rerun all benchmarks after reverse DFA and HTTP/OnePass optimizations)*


### PR DESCRIPTION
Rerun all benchmarks (Java, C++, Go) with full JMH defaults after reverse DFA and HTTP/OnePass optimizations.

## Key improvements

- **Hard search: constant-time** — SafeRE now 0.018 µs at all text sizes (previously 2.7–2,870 µs). Faster than C++ RE2 (0.048 µs).
- **HTTP parsing: 3.8× improvement** — 1,292→342 ns/op. Now within 3.8× of JDK (was 14×), matching C++ RE2 performance.

## Updated geomeans

| Comparison | Core workloads | Pathological/scaling |
|---|---|---|
| vs JDK | 1.18× slower (was 1.38×) | 13,300× faster (was 241×) |
| vs RE2/J | 10.8× faster (was 9.2×) | 2,830× faster (was 52×) |
| vs RE2-FFM | 2.0× faster (was 1.7×) | 16.8× faster (was 3.1× slower) |

All benchmarks run sequentially with full JMH defaults (no `JMH_OPTS`).