### PR TITLE
Skip CI for doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,34 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          fi
+          # Check if any non-doc files changed
+          CODE_FILES=$(echo "$FILES" | grep -vE '(\.md$|\.txt$|^LICENSE$)' | grep -v '^$' || true)
+          if [ -n "$CODE_FILES" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +51,8 @@ jobs:
         run: mvn verify -pl safere -Dtest.parallelism=4 --batch-mode --no-transfer-progress
 
   benchmark-smoke-test-java:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -52,6 +81,8 @@ jobs:
             dev.eaftan.safere.benchmark.MemoryBenchmark
 
   benchmark-smoke-test-cpp:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -75,6 +106,8 @@ jobs:
             --data safere-benchmarks/benchmark-data.json MemoryBenchmark
 
   benchmark-smoke-test-go:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Add a `changes` detection job that checks whether any non-documentation files (`*.md`, `*.txt`, `LICENSE`) were modified. All CI jobs now depend on this check and skip when only docs change.

Skipped jobs report a "skipped" status that satisfies required checks, so auto-merge still works for doc-only PRs.