### PR TITLE
Treat \r\n as atomic line terminator to match JDK behavior

### DIFF
--- a/safere/src/main/java/dev/eaftan/safere/Dfa.java
+++ b/safere/src/main/java/dev/eaftan/safere/Dfa.java
@@ -625,7 +625,18 @@ final class Dfa {
     boolean wasWord = (s.flags & FLAG_LAST_WORD) != 0;
     int wordBeforeFlags = (isWord != wasWord) ? EmptyOp.WORD_BOUNDARY
         : EmptyOp.NON_WORD_BOUNDARY;
-    boolean endLineHere = prog.unixLines() ? (cp == '\n') : Nfa.isLineTerminator(cp);
+    boolean endLineHere;
+    if (prog.unixLines()) {
+      endLineHere = (cp == '\n');
+    } else {
+      endLineHere = Nfa.isLineTerminator(cp);
+      // Don't fire END_LINE at the \n of an atomic \r\n pair. END_LINE fires before the \r
+      // (the start of the pair), not between \r and \n.
+      if (endLineHere && cp == '\n'
+          && nextPos >= 2 && text.charAt(nextPos - 2) == '\r') {
+        endLineHere = false;
+      }
+    }
 
     // Collect successors of unsatisfied EMPTY_WIDTH instructions whose deferred flags
     // are now satisfiable and that have no other unsatisfied flags.
@@ -943,7 +954,7 @@ final class Dfa {
         if ((s.flags & FLAG_MATCH_BEFORE) != 0) {
           int endPos = pos;
           if (!needEndMatch || endPos == textLen
-              || (trailingTermStart < textLen && endPos >= trailingTermStart)) {
+              || (trailingTermStart < textLen && endPos == trailingTermStart)) {
             matched = true;
             matchEnd = endPos;
             if (!longest && (!needEndMatch || endPos == textLen)) {
@@ -958,7 +969,7 @@ final class Dfa {
             || (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0) {
           int endPos = Math.min(nextPos, textLen);
           if (!needEndMatch || endPos == textLen
-              || (trailingTermStart < textLen && endPos >= trailingTermStart)) {
+              || (trailingTermStart < textLen && endPos == trailingTermStart)) {
             matched = true;
             matchEnd = endPos;
             if (!longest && (!needEndMatch || endPos == textLen)) {
@@ -1224,7 +1235,7 @@ final class Dfa {
           int endPos = (s.flags & FLAG_MATCH_BEFORE) != 0
               ? pos : Math.min(nextPos, textLen);
           if (!needEndMatch || endPos == textLen
-              || (trailingTermStart < textLen && endPos >= trailingTermStart)) {
+              || (trailingTermStart < textLen && endPos == trailingTermStart)) {
             // Collect match IDs from the state's instructions.
             for (int id : collectMatchIds(s.insts)) {
               seen.set(id);

--- a/safere/src/main/java/dev/eaftan/safere/Matcher.java
+++ b/safere/src/main/java/dev/eaftan/safere/Matcher.java
@@ -837,17 +837,22 @@ public final class Matcher implements MatchResult {
           boolean ul = prog.unixLines();
           if (textLen > 0 && (ul ? text.charAt(textLen - 1) == '\n'
               : Nfa.isLineTerminator(text.charAt(textLen - 1)))) {
-            Dfa.SearchResult altRev =
-                revDfa.doSearchReverse(text, textLen - 1, effectiveStart, true, true);
-            if (altRev == null) {
-              budgetExceeded = true;
-            } else if (altRev.matched()
-                && (matchStart < 0 || altRev.pos() < matchStart)) {
-              matchStart = altRev.pos();
+            // For \r\n, the trailing terminator starts at textLen-2 (before \r), not
+            // textLen-1 (between \r and \n). Skip the textLen-1 check for \r\n.
+            boolean isAtomicCrLf = !ul && textLen >= 2
+                && text.charAt(textLen - 2) == '\r' && text.charAt(textLen - 1) == '\n';
+            if (!isAtomicCrLf) {
+              Dfa.SearchResult altRev =
+                  revDfa.doSearchReverse(text, textLen - 1, effectiveStart, true, true);
+              if (altRev == null) {
+                budgetExceeded = true;
+              } else if (altRev.matched()
+                  && (matchStart < 0 || altRev.pos() < matchStart)) {
+                matchStart = altRev.pos();
+              }
             }
-            // For \r\n, also try position before \r.
-            if (!budgetExceeded && !ul && textLen >= 2 && text.charAt(textLen - 1) == '\n'
-                && text.charAt(textLen - 2) == '\r') {
+            // For \r\n, try position before \r.
+            if (!budgetExceeded && isAtomicCrLf) {
               Dfa.SearchResult altRev2 =
                   revDfa.doSearchReverse(text, textLen - 2, effectiveStart, true, true);
               if (altRev2 == null) {
@@ -963,19 +968,24 @@ public final class Matcher implements MatchResult {
             if (prog.dollarAnchorEnd() && earlyEnd == text.length()) {
               int len = text.length();
               boolean ul = prog.unixLines();
-              // Try position before trailing \n (or standalone line terminator)
+              // Try position before trailing line terminator.
               if (len > 0 && (ul ? text.charAt(len - 1) == '\n'
                   : Nfa.isLineTerminator(text.charAt(len - 1)))) {
-                Dfa.SearchResult altRevResult =
-                    revDfa.doSearchReverse(
-                        text, earlyEnd - 1, effectiveStart, true, true);
-                if (altRevResult != null && altRevResult.matched()
-                    && altRevResult.pos() < matchStart) {
-                  matchStart = altRevResult.pos();
+                // For \r\n, the trailing terminator starts at len-2 (before \r), not
+                // len-1 (between \r and \n). Skip the earlyEnd-1 check for \r\n.
+                boolean isAtomicCrLf = !ul && len >= 2
+                    && text.charAt(len - 2) == '\r' && text.charAt(len - 1) == '\n';
+                if (!isAtomicCrLf) {
+                  Dfa.SearchResult altRevResult =
+                      revDfa.doSearchReverse(
+                          text, earlyEnd - 1, effectiveStart, true, true);
+                  if (altRevResult != null && altRevResult.matched()
+                      && altRevResult.pos() < matchStart) {
+                    matchStart = altRevResult.pos();
+                  }
                 }
-                // For \r\n, also try position before \r
-                if (!ul && len >= 2 && text.charAt(len - 1) == '\n'
-                    && text.charAt(len - 2) == '\r') {
+                // For \r\n, try position before \r.
+                if (isAtomicCrLf && earlyEnd - 2 >= effectiveStart) {
                   Dfa.SearchResult altRevResult2 =
                       revDfa.doSearchReverse(
                           text, earlyEnd - 2, effectiveStart, true, true);

--- a/safere/src/main/java/dev/eaftan/safere/Nfa.java
+++ b/safere/src/main/java/dev/eaftan/safere/Nfa.java
@@ -503,7 +503,9 @@ final class Nfa {
       return ch == '\n' && pos + 1 == len;
     }
     if (ch == '\n' && pos + 1 == len) {
-      return true;
+      // Don't treat the \n of an atomic \r\n as a standalone trailing line terminator.
+      // The trailing terminator is the \r\n pair starting at pos-1.
+      return pos == 0 || text.charAt(pos - 1) != '\r';
     }
     if (ch == '\r') {
       return pos + 1 == len || (pos + 2 == len && text.charAt(pos + 1) == '\n');
@@ -570,9 +572,15 @@ final class Nfa {
           }
         }
       } else if (isLineTerminator(ch)) {
-        flags |= EmptyOp.END_LINE;
-        if (isAtTrailingLineTerminator(text, pos, false)) {
-          flags |= EmptyOp.DOLLAR_END;
+        // Don't set END_LINE at the \n of an atomic \r\n pair — JDK treats \r\n as a single
+        // line terminator. END_LINE fires before the \r (the start of the pair), not between
+        // \r and \n.
+        boolean isAtomicLF = (ch == '\n' && pos > 0 && text.charAt(pos - 1) == '\r');
+        if (!isAtomicLF) {
+          flags |= EmptyOp.END_LINE;
+          if (isAtTrailingLineTerminator(text, pos, false)) {
+            flags |= EmptyOp.DOLLAR_END;
+          }
         }
       }
     }

--- a/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/dev/eaftan/safere/ExhaustiveUtils.java
@@ -119,9 +119,9 @@ final class ExhaustiveUtils {
    * Test a single (regexp, text, flags) triple. Compares SafeRE vs JDK for matches() and find().
    * Returns the number of test cases executed.
    *
-   * <p>Skips tests where text contains standalone {@code \r} (not part of {@code \r\n}), since JDK
-   * treats {@code \r} as a line terminator but SafeRE (like RE2) does not. This is a known design
-   * difference, not a bug.
+   * <p>Skips tests where text contains standalone {@code \r} (not part of {@code \r\n}). Texts
+   * with {@code \r\n} pairs are now tested correctly — SafeRE treats {@code \r\n} as an atomic
+   * line terminator matching JDK behavior (see issue #78).
    */
   static int testPair(String regexp, String text, int flags, List<TestResult> failures) {
     int tests = 0;
@@ -433,13 +433,19 @@ final class ExhaustiveUtils {
   }
 
   /**
-   * Returns true if the text contains any {@code \r} character. JDK treats {@code \r} (both
-   * standalone and in {@code \r\n}) specially — dot doesn't match it, {@code $} matches before it,
-   * etc. SafeRE (like RE2) only gives special treatment to {@code \n}. This is a known design
-   * difference, not a bug.
+   * Returns true if the text contains a standalone {@code \r} that is not part of a {@code \r\n}
+   * pair. Texts containing only {@code \r\n} pairs are now tested correctly — SafeRE treats
+   * {@code \r\n} as an atomic line terminator matching JDK behavior (see issue #78).
    */
   private static boolean hasStandaloneCarriageReturn(String text) {
-    return text.indexOf('\r') >= 0;
+    int idx = 0;
+    while ((idx = text.indexOf('\r', idx)) >= 0) {
+      if (idx + 1 >= text.length() || text.charAt(idx + 1) != '\n') {
+        return true; // standalone \r (not followed by \n)
+      }
+      idx += 2; // skip past \r\n
+    }
+    return false;
   }
 
   /**

--- a/safere/src/test/java/dev/eaftan/safere/MatcherTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/MatcherTest.java
@@ -1652,4 +1652,121 @@ class MatcherTest {
       assertThat(m.group(2)).isEqualTo("data");
     }
   }
+
+  @Nested
+  @DisplayName("Atomic \\r\\n line terminator (#77, #78)")
+  class AtomicCrLfTests {
+
+    @Test
+    @DisplayName("find() with $ on \\r\\n does not infinite-loop (#77)")
+    void dollarFindOnCrLfTerminates() {
+      // Before the fix, this never terminated because $ matched between \r and \n,
+      // causing find() to loop without advancing.
+      Pattern p = Pattern.compile("$");
+      Matcher m = p.matcher("\r\n");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("(?m)$ on \\r\\n matches at 0 and 2 only (#78)")
+    void multilineDollarOnCrLf() {
+      Pattern p = Pattern.compile("(?m)$");
+      Matcher m = p.matcher("\r\n");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("(?m)$ on a\\r\\nb matches at 1 and 4 only (#78)")
+    void multilineDollarOnTextWithCrLf() {
+      Pattern p = Pattern.compile("(?m)$");
+      Matcher m = p.matcher("a\r\nb");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(4);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("$ (non-multiline) on \\r\\n matches at end")
+    void dollarNonMultilineOnCrLf() {
+      Pattern p = Pattern.compile("$");
+      Matcher m = p.matcher("\r\n");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("(?m)$ on standalone \\r still matches")
+    void multilineDollarOnStandaloneCr() {
+      Pattern p = Pattern.compile("(?m)$");
+      Matcher m = p.matcher("a\rb");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(3);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("(?m)$ on standalone \\n still matches")
+    void multilineDollarOnStandaloneLf() {
+      Pattern p = Pattern.compile("(?m)$");
+      Matcher m = p.matcher("a\nb");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(3);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("UNIX_LINES: (?m)$ on \\r\\n treats \\n only")
+    void unixLinesMultilineDollarOnCrLf() {
+      Pattern p = Pattern.compile("(?m)$", Pattern.UNIX_LINES);
+      Matcher m = p.matcher("a\r\nb");
+      assertThat(m.find()).isTrue();
+      // In UNIX_LINES, only \n is a line terminator; \r is ordinary.
+      // $ matches before \n (pos 2) and at end (pos 4).
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(4);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("(?:$|\\n)+ on \\r\\n matches correctly (#78)")
+    void dollarOrNewlineOnCrLf() {
+      Pattern p = Pattern.compile("(?m)(?:$|\\n)+");
+      Matcher m = p.matcher("\r\n");
+      assertThat(m.find()).isTrue();
+    }
+
+    @Test
+    @DisplayName("(?:$|\\r)+ on \\r\\n matches correctly (#78)")
+    void dollarOrCrOnCrLf() {
+      Pattern p = Pattern.compile("(?m)(?:$|\\r)+");
+      Matcher m = p.matcher("\r\n");
+      assertThat(m.find()).isTrue();
+    }
+
+    @Test
+    @DisplayName("(?:$|[\\r\\n])+ on \\r\\n matches correctly (#78)")
+    void dollarOrCrLfClassOnCrLf() {
+      Pattern p = Pattern.compile("(?m)(?:$|[\\r\\n])+");
+      Matcher m = p.matcher("\r\n");
+      assertThat(m.find()).isTrue();
+    }
+  }
 }

--- a/safere/src/test/java/dev/eaftan/safere/NfaTest.java
+++ b/safere/src/test/java/dev/eaftan/safere/NfaTest.java
@@ -542,6 +542,26 @@ class NfaTest {
     }
 
     @Test
+    @DisplayName("END_LINE NOT between \\r and \\n in \\r\\n (#78)")
+    void noEndLineBetweenCrLf() {
+      // Position 1 is at the \r in "a\r\nb"; END_LINE SHOULD fire here (before the \r\n pair).
+      int flags = Nfa.emptyFlags("a\r\nb", 1, false);
+      assertThat(flags & EmptyOp.END_LINE).isNotZero();
+
+      // Position 2 is at the \n in "a\r\nb" (between \r and \n in the atomic pair);
+      // END_LINE must NOT fire here.
+      int flags2 = Nfa.emptyFlags("a\r\nb", 2, false);
+      assertThat(flags2 & EmptyOp.END_LINE).isZero();
+    }
+
+    @Test
+    @DisplayName("END_LINE at standalone \\r not followed by \\n still fires")
+    void endLineAtStandaloneCr() {
+      int flags = Nfa.emptyFlags("\r", 0, false);
+      assertThat(flags & EmptyOp.END_LINE).isNotZero();
+    }
+
+    @Test
     @DisplayName("UNIX_LINES: \\r is not a line terminator")
     void unixLinesCrNotLineTerm() {
       // After \r: no BEGIN_LINE in UNIX_LINES mode


### PR DESCRIPTION
Fixes #78. Also fixes #77 (infinite loop with `$` on `\r\n`).

## Problem

JDK treats `\r\n` as a single atomic line terminator. SafeRE was treating `\r` and `\n` independently, causing:
- `$` to match between `\r` and `\n` (incorrect position)
- `find()` to infinite-loop on `\r\n` text (#77)

## Fix

The fix touches 5 layers — the `$` anchor is stripped by the compiler and enforcement is spread across all engines:

1. **`Nfa.emptyFlags()`**: Suppress `END_LINE` and `DOLLAR_END` at the `\n` of an atomic `\r\n` pair. Fixes NFA, BitState, and OnePass (they all delegate to `emptyFlags()`).

2. **`Nfa.isAtTrailingLineTerminator()`**: Don't treat the `\n` of `\r\n` as a standalone trailing terminator. Fixes the `anchorEnd` acceptance checks in OnePass, BitState, and NFA.

3. **`Dfa.computeNextInsts()`**: Suppress `endLineHere` when `\n` is preceded by `\r`.

4. **`Dfa.doSearch()` match acceptance**: Change `>= trailingTermStart` to `== trailingTermStart` so positions between `\r` and `\n` are not valid `$` match positions.

5. **`Matcher` dollarAnchorEnd sandwich**: Skip the `earlyEnd-1` reverse DFA check when trailing `\r\n` is present.

## Tests

- Added `AtomicCrLfTests` nested class in `MatcherTest` with 11 tests covering multiline/non-multiline `$`, standalone `\r`/`\n`, `UNIX_LINES` mode, and combined patterns
- Added `NfaTest` unit tests for END_LINE suppression between `\r` and `\n`
- Narrowed `ExhaustiveUtils.hasStandaloneCarriageReturn()` to only skip truly standalone `\r` (not `\r\n` pairs), enabling more cross-engine exhaustive tests