### PR TITLE
Update old dev.eaftan package paths to org.safere in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,8 @@ Follow the [Google Java Style Guide](https://google.github.io/styleguide/javagui
 ## Project Structure
 
 ```
-safere/src/main/java/dev/eaftan/safere/   # Library source
-safere/src/test/java/dev/eaftan/safere/   # Tests
+safere/src/main/java/org/safere/   # Library source
+safere/src/test/java/org/safere/   # Tests
 safere-benchmarks/                         # JMH benchmark suite
 re2-reference/                             # C++ RE2 reference (read-only)
 re2j-reference/                            # RE2/J (Java) reference (read-only)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -279,7 +279,7 @@ differences from the C++ version:
 ## Source Layout
 
 ```
-safere/src/main/java/dev/eaftan/safere/
+safere/src/main/java/org/safere/
 ├── Pattern.java          # Public API: compiled regex
 ├── Matcher.java          # Public API: match state, engine orchestration
 ├── PatternSet.java       # Public API: multi-pattern matching

--- a/PLAN.md
+++ b/PLAN.md
@@ -70,7 +70,7 @@ Set up Maven project structure, establish the package, create core enums and
 Unicode data tables.
 
 - Maven `pom.xml` with JUnit 6 (6.0.3), Java 21
-- Package structure: `src/main/java/dev/eaftan/safere/`
+- Package structure: `src/main/java/org/safere/`
 - `RegexpOp` enum (21 operators from `regexp.h`)
 - `Inst.Op` enum (8 opcodes from `prog.h`)
 - `EmptyOp` flags


### PR DESCRIPTION
Updates remaining references to the old `dev/eaftan/safere` package path in documentation files (AGENTS.md, DESIGN.md, PLAN.md) to reflect the current `org/safere` package structure.