### PR TITLE
Implement remaining java.util.regex API methods

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -6,6 +6,7 @@
 package org.safere;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Function;
@@ -63,6 +64,7 @@ public final class Matcher implements MatchResult {
   private int regionStart;
   private int regionEnd;
   private boolean lastHitEnd;
+  private boolean lastRequireEnd;
 
   /**
    * Cached BitState instance borrowed from the parent Pattern's thread-local cache, reused across
@@ -422,12 +424,12 @@ public final class Matcher implements MatchResult {
         }
       }
       lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
+      lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
     }
   }
 
   /** Core matches logic, operates on the (possibly substituted) {@code text} field. */
   private boolean matchesCore() {
-
     // Literal fast path: for fully literal patterns with no user capture groups.
     String literal = parentPattern.literalMatch();
     if (literal != null && parentPattern.numGroups() == 0) {
@@ -524,6 +526,7 @@ public final class Matcher implements MatchResult {
         }
       }
       lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
+      lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
     }
   }
 
@@ -680,6 +683,7 @@ public final class Matcher implements MatchResult {
       }
       // Track hitEnd: true if no match found (engine scanned to end) or match reaches regionEnd.
       lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
+      lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
     }
   }
 
@@ -1575,6 +1579,7 @@ public final class Matcher implements MatchResult {
     groups = null;
     capturesResolved = true;
     lastHitEnd = false;
+    lastRequireEnd = false;
     return this;
   }
 
@@ -1654,6 +1659,34 @@ public final class Matcher implements MatchResult {
    */
   public boolean hitEnd() {
     return lastHitEnd;
+  }
+
+  /**
+   * Returns true if more input could change a positive match into a negative one. If this method
+   * returns true, and a match was found, then more input could cause the match to be lost. If this
+   * method returns false and a match was found, then more input might change the match but the
+   * match won't be lost. If a match was not found, then requireEnd has no meaning.
+   *
+   * <p>This is a conservative approximation: it returns {@code true} when the pattern contains
+   * {@code $} or word-boundary assertions ({@code \b}, {@code \B}) and the last match reached the
+   * end of the input region. Like the JDK, {@code \z} does not trigger {@code requireEnd}.
+   *
+   * @return true if more input could change a positive match into a negative one
+   */
+  public boolean requireEnd() {
+    return lastRequireEnd;
+  }
+
+  /**
+   * Returns an unmodifiable map of named capturing groups to their 1-based group indices. This
+   * method overrides the default {@link java.util.regex.MatchResult#namedGroups()} method which
+   * throws {@link UnsupportedOperationException}.
+   *
+   * @return an unmodifiable map from group names to group numbers
+   */
+  @Override
+  public Map<String, Integer> namedGroups() {
+    return parentPattern.namedGroups();
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -103,6 +103,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasNullableAlternation;
   private final transient boolean hasBoundedRepeat;
   private final transient boolean hasAnchorInQuant;
+  private final transient boolean hasEndConstraint;
   private final transient boolean[] charClassPrefixAscii;
 
   /**
@@ -172,7 +173,8 @@ public final class Pattern implements Serializable {
       Map<String, Integer> namedGroups, String prefix, boolean prefixFoldCase,
       String literalMatch, boolean hasLazy, boolean hasAlternation,
       boolean hasNullableAlternation,
-      boolean hasBoundedRepeat, boolean hasAnchorInQuant, boolean[] charClassPrefixAscii,
+      boolean hasBoundedRepeat, boolean hasAnchorInQuant, boolean hasEndConstraint,
+      boolean[] charClassPrefixAscii,
       int[] charClassMatchRanges, long charClassMatchBitmap0, long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty) {
     this.pattern = pattern;
@@ -188,6 +190,7 @@ public final class Pattern implements Serializable {
     this.hasNullableAlternation = hasNullableAlternation;
     this.hasBoundedRepeat = hasBoundedRepeat;
     this.hasAnchorInQuant = hasAnchorInQuant;
+    this.hasEndConstraint = hasEndConstraint;
     this.charClassPrefixAscii = charClassPrefixAscii;
     this.charClassMatchRanges = charClassMatchRanges;
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
@@ -234,6 +237,7 @@ public final class Pattern implements Serializable {
     boolean hasNullableAlt = hasAlt && hasNullableAlternation(re);
     boolean hasBounded = hasBoundedRepeat(re);
     boolean hasAnchorQuant = hasAnchorInQuantifier(re);
+    boolean hasEndConst = hasEndConstraint(re);
     // Extract character-class prefix for acceleration when no literal prefix exists.
     boolean[] ccPrefixAscii = (prefix == null)
         ? extractCharClassPrefixAscii(re) : null;
@@ -242,7 +246,7 @@ public final class Pattern implements Serializable {
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(regex, flags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
-        ccPrefixAscii,
+        hasEndConst, ccPrefixAscii,
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
@@ -364,6 +368,81 @@ public final class Pattern implements Serializable {
     // If no match advanced the position, return the entire input as a single element.
     // This matches JDK behavior: an input that was never actually split is returned as-is,
     // bypassing trailing-empty-string removal.
+    if (last == 0) {
+      return new String[] {text};
+    }
+
+    parts.add(text.substring(last));
+
+    // limit == 0: remove trailing empty strings.
+    if (limit == 0) {
+      int end = parts.size();
+      while (end > 0 && parts.get(end - 1).isEmpty()) {
+        end--;
+      }
+      parts = parts.subList(0, end);
+    }
+
+    return parts.toArray(new String[0]);
+  }
+
+  /**
+   * Splits the given input around matches of this pattern, returning both the substrings between
+   * matches and the matching delimiters, interleaved. The resulting array alternates between
+   * substrings and delimiters: {@code [substring, delimiter, substring, delimiter, ...,
+   * substring]}.
+   *
+   * <p>This is equivalent to {@code splitWithDelimiters(input, 0)}.
+   *
+   * @param input the character sequence to be split
+   * @return the array of strings computed by splitting the input around matches of this pattern,
+   *     with the matching delimiters interleaved
+   * @since 21
+   */
+  public String[] splitWithDelimiters(CharSequence input) {
+    return splitWithDelimiters(input, 0);
+  }
+
+  /**
+   * Splits the given input around matches of this pattern, returning both the substrings between
+   * matches and the matching delimiters, interleaved.
+   *
+   * <p>The {@code limit} parameter controls the number of times the pattern is applied:
+   * <ul>
+   *   <li>If {@code limit > 0}, the pattern is applied at most {@code limit - 1} times, and the
+   *       resulting array will have at most {@code 2 * limit - 1} entries.
+   *   <li>If {@code limit == 0}, the pattern is applied as many times as possible, and trailing
+   *       empty strings are discarded.
+   *   <li>If {@code limit < 0}, the pattern is applied as many times as possible, and trailing
+   *       empty strings are retained.
+   * </ul>
+   *
+   * @param input the character sequence to be split
+   * @param limit the result threshold
+   * @return the array of strings computed by splitting the input around matches of this pattern,
+   *     with the matching delimiters interleaved
+   * @since 21
+   */
+  public String[] splitWithDelimiters(CharSequence input, int limit) {
+    String text = input.toString();
+    Matcher m = matcher(text);
+    List<String> parts = new ArrayList<>();
+    int last = 0;
+
+    while (m.find()) {
+      if (limit > 0 && parts.size() >= 2 * limit - 2) {
+        break;
+      }
+      // JDK 8+: a zero-width match at the beginning of the input never produces
+      // a leading empty substring or empty delimiter.
+      if (last == 0 && m.start() == 0 && m.end() == 0) {
+        continue;
+      }
+      parts.add(text.substring(last, m.start()));
+      parts.add(text.substring(m.start(), m.end()));
+      last = m.end();
+    }
+    // If no match advanced the position, return the entire input as a single element.
     if (last == 0) {
       return new String[] {text};
     }
@@ -728,8 +807,15 @@ public final class Pattern implements Serializable {
     return ast;
   }
 
-  /** Returns an unmodifiable map of named capture groups to their 1-based indices. */
-  Map<String, Integer> namedGroups() {
+  /**
+   * Returns an unmodifiable map of named capturing groups to their 1-based group indices.
+   *
+   * <p>If the pattern has no named capturing groups, an empty map is returned.
+   *
+   * @return an unmodifiable map from group names to group numbers
+   * @since 20
+   */
+  public Map<String, Integer> namedGroups() {
     return namedGroups;
   }
 
@@ -739,6 +825,15 @@ public final class Pattern implements Serializable {
    */
   int numGroups() {
     return prog.numCaptures() - 1;
+  }
+
+  /**
+   * Returns {@code true} if the pattern contains end-of-input or end-of-line assertions
+   * ({@code $}, {@code \z}, {@code \b}, {@code \B}). Used by {@link Matcher#requireEnd()} to
+   * conservatively determine whether more input could invalidate a positive match.
+   */
+  boolean hasEndConstraint() {
+    return hasEndConstraint;
   }
 
   // ---------------------------------------------------------------------------
@@ -958,6 +1053,40 @@ public final class Pattern implements Serializable {
       if ((node.op == RegexpOp.REPEAT || node.op == RegexpOp.QUEST)
           && node.min < node.max && node.max > 0) {
         return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns {@code true} if the AST contains positional assertions that the JDK's
+   * {@code Matcher.requireEnd()} tracks: {@code $} ({@link RegexpOp#END_LINE} in multiline, or
+   * {@link RegexpOp#END_TEXT} with {@link ParseFlags#WAS_DOLLAR} in non-multiline), {@code \b}
+   * ({@link RegexpOp#WORD_BOUNDARY}), or {@code \B} ({@link RegexpOp#NO_WORD_BOUNDARY}).
+   *
+   * <p>Note: {@code \z} ({@link RegexpOp#END_TEXT} without WAS_DOLLAR) is intentionally excluded
+   * because the JDK does not set {@code requireEnd} for it.
+   */
+  private static boolean hasEndConstraint(Regexp re) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      switch (node.op) {
+        case END_LINE, WORD_BOUNDARY, NO_WORD_BOUNDARY:
+          return true;
+        case END_TEXT:
+          if ((node.flags & ParseFlags.WAS_DOLLAR) != 0) {
+            return true;
+          }
+          break;
+        default:
+          break;
       }
       if (node.subs != null) {
         for (Regexp sub : node.subs) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1771,4 +1771,138 @@ class MatcherTest {
       assertThat(m.find()).isTrue();
     }
   }
+
+  @Nested
+  @DisplayName("requireEnd()")
+  class RequireEndTests {
+
+    @Test
+    @DisplayName("requireEnd() is false for simple literal find")
+    void requireEndFalseForLiteralFind() {
+      Pattern p = Pattern.compile("abc");
+      Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      assertThat(m.requireEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is true for dollar-anchored find at end")
+    void requireEndTrueForDollarAnchor() {
+      Pattern p = Pattern.compile("abc$");
+      Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is false for \\z anchor (JDK does not track \\z)")
+    void requireEndFalseForEndTextAnchor() {
+      Pattern p = Pattern.compile("abc\\z");
+      Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      // JDK does not set requireEnd for \z, only for $.
+      assertThat(m.requireEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is true for word boundary at end")
+    void requireEndTrueForWordBoundary() {
+      Pattern p = Pattern.compile("\\babc\\b");
+      Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is false after reset")
+    void requireEndFalseAfterReset() {
+      Pattern p = Pattern.compile("abc$");
+      Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+      m.reset();
+      assertThat(m.requireEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is false when match does not hit end")
+    void requireEndFalseWhenNotAtEnd() {
+      Pattern p = Pattern.compile("abc");
+      Matcher m = p.matcher("abcdef");
+      assertThat(m.find()).isTrue();
+      assertThat(m.hitEnd()).isFalse();
+      assertThat(m.requireEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("requireEnd() with matches()")
+    void requireEndWithMatches() {
+      Pattern p = Pattern.compile("abc$");
+      Matcher m = p.matcher("abc");
+      assertThat(m.matches()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+    }
+
+    @Test
+    @DisplayName("requireEnd() with lookingAt()")
+    void requireEndWithLookingAt() {
+      Pattern p = Pattern.compile("abc$");
+      Matcher m = p.matcher("abc");
+      assertThat(m.lookingAt()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is false for literal matches()")
+    void requireEndFalseForLiteralMatches() {
+      Pattern p = Pattern.compile("abc");
+      Matcher m = p.matcher("abc");
+      assertThat(m.matches()).isTrue();
+      // No end assertions in pattern — match doesn't depend on end position.
+      assertThat(m.requireEnd()).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("namedGroups()")
+  class NamedGroupsTests {
+
+    @Test
+    @DisplayName("namedGroups() returns named groups from pattern")
+    void namedGroupsReturnsMap() {
+      Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+      Matcher m = p.matcher("user@host");
+      assertThat(m.namedGroups()).containsEntry("user", 1);
+      assertThat(m.namedGroups()).containsEntry("host", 2);
+    }
+
+    @Test
+    @DisplayName("namedGroups() returns empty map for no named groups")
+    void namedGroupsEmpty() {
+      Pattern p = Pattern.compile("(\\w+)@(\\w+)");
+      Matcher m = p.matcher("user@host");
+      assertThat(m.namedGroups()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("namedGroups() is unmodifiable")
+    void namedGroupsUnmodifiable() {
+      Pattern p = Pattern.compile("(?P<name>\\w+)");
+      Matcher m = p.matcher("hello");
+      assertThatThrownBy(() -> m.namedGroups().put("foo", 99))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("namedGroups() returns from MatchResult interface")
+    void namedGroupsFromMatchResult() {
+      Pattern p = Pattern.compile("(?P<word>\\w+)");
+      Matcher m = p.matcher("hello");
+      assertThat(m.find()).isTrue();
+      MatchResult result = m.toMatchResult();
+      // MatchResult.namedGroups() should work via the override on SnapshotMatchResult
+      // or the default method. SafeRE's Matcher overrides it.
+      assertThat(m.namedGroups()).containsEntry("word", 1);
+    }
+  }
 }

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -297,6 +297,82 @@ class PatternTest {
   }
 
   @Nested
+  @DisplayName("splitWithDelimiters()")
+  class SplitWithDelimiters {
+    @Test
+    void splitWithDelimitersSimple() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters("a,b,c");
+      assertThat(parts).containsExactly("a", ",", "b", ",", "c");
+    }
+
+    @Test
+    void splitWithDelimitersRegex() {
+      Pattern p = Pattern.compile(":+");
+      String[] parts = p.splitWithDelimiters("boo:::and::foo");
+      assertThat(parts).containsExactly("boo", ":::", "and", "::", "foo");
+    }
+
+    @Test
+    void splitWithDelimitersLimit2() {
+      Pattern p = Pattern.compile(":+");
+      String[] parts = p.splitWithDelimiters("boo:::and::foo", 2);
+      assertThat(parts).containsExactly("boo", ":::", "and::foo");
+    }
+
+    @Test
+    void splitWithDelimitersLimit5() {
+      Pattern p = Pattern.compile(":+");
+      String[] parts = p.splitWithDelimiters("boo:::and::foo", 5);
+      assertThat(parts).containsExactly("boo", ":::", "and", "::", "foo");
+    }
+
+    @Test
+    void splitWithDelimitersNegativeLimit() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters("a,b,,", -1);
+      assertThat(parts).containsExactly("a", ",", "b", ",", "", ",", "");
+    }
+
+    @Test
+    void splitWithDelimitersTrailingEmpty() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters("a,b,,");
+      // limit=0: only the trailing empty substring is removed; delimiters are kept.
+      assertThat(parts).containsExactly("a", ",", "b", ",", "", ",");
+    }
+
+    @Test
+    void splitWithDelimitersNoMatch() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters("abc");
+      assertThat(parts).containsExactly("abc");
+    }
+
+    @Test
+    void splitWithDelimitersLimit1() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters("a,b,c", 1);
+      assertThat(parts).containsExactly("a,b,c");
+    }
+
+    @Test
+    void splitWithDelimitersWhitespace() {
+      Pattern p = Pattern.compile("\\s+");
+      String[] parts = p.splitWithDelimiters("hello   world  foo");
+      assertThat(parts).containsExactly("hello", "   ", "world", "  ", "foo");
+    }
+
+    @Test
+    void splitWithDelimitersMatchAtStart() {
+      // Positive-width match at position 0 produces a leading empty substring.
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters(",a,b", -1);
+      assertThat(parts).containsExactly("", ",", "a", ",", "b");
+    }
+  }
+
+  @Nested
   @DisplayName("asPredicate() / asMatchPredicate()")
   class Predicates {
     @Test
@@ -369,6 +445,13 @@ class PatternTest {
     void numGroupsNoCaptures() {
       Pattern p = Pattern.compile("abc");
       assertThat(p.numGroups()).isZero();
+    }
+    @Test
+    @DisplayName("namedGroups() returns unmodifiable map")
+    void namedGroupsUnmodifiable() {
+      Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+      assertThatThrownBy(() -> p.namedGroups().put("foo", 99))
+          .isInstanceOf(UnsupportedOperationException.class);
     }
   }
 


### PR DESCRIPTION
Implements the three missing `java.util.regex` API methods (#82):

- **`Pattern.splitWithDelimiters(CharSequence, int)`** — Like `split()` but interleaves the matched delimiters in the result array. JDK 21+.
- **`Pattern.namedGroups()`** / **`Matcher.namedGroups()`** — Returns an unmodifiable map of named capturing groups to 1-based group indices. Made public (was package-private on Pattern); overrides the `MatchResult` default on Matcher. JDK 20+.
- **`Matcher.requireEnd()`** — Returns whether more input could change a positive match into a negative one. Conservative approximation based on pattern analysis (`$`, `\b`, `\B` assertions + hitEnd). Matches JDK behavior including the `\z` vs `$` distinction. JDK 1.5+.

Cross-validated against the JDK for all three methods with zero mismatches.

Fixes #82