### PR TITLE
Add RE2/J attribution to LICENSE, headers, and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,23 @@ The RE2/J (Java) reference is in `re2j-reference/`.
 
 ## License
 
-BSD 3-Clause License (same as RE2). All source files must include this header:
+BSD 3-Clause License (same as RE2 and RE2/J). All source files must
+include a license header. Most files use this header:
 
 ```java
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+```
+
+Files that incorporate code from RE2/J use this header instead:
+
+```java
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -327,7 +327,10 @@ needed.
 ## Relationship to RE2
 
 SafeRE is a port of RE2's architecture to Java, using the C++ RE2 source
-as a reference.  Key differences from the C++ version:
+as a reference.  SafeRE also incorporates code from
+[RE2/J](https://github.com/google/re2j), particularly in the parser,
+Java API layer (Pattern/Matcher), and portions of the test suite.
+Key differences from the C++ version:
 
 | Aspect | RE2 (C++) | SafeRE (Java) |
 |--------|-----------|---------------|

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,16 @@
+SafeRE is a Java port of RE2 (https://github.com/google/re2).
+It also incorporates code from RE2/J (https://github.com/google/re2j),
+a Java port of Go's regexp package.
+
+Modifications and Java port: Copyright (c) 2026 Eddie Aftandilian.
+
+Both RE2 and RE2/J are licensed under the BSD 3-Clause License.
+Their respective copyright notices and license terms follow.
+
+===========================================================================
+RE2 — Copyright (c) 2009 The RE2 Authors
+===========================================================================
+
 Copyright (c) 2009 The RE2 Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13,6 +26,43 @@ distribution.
    * Neither the name of Google Inc. nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+RE2/J — Copyright (c) 2009 The Go Authors
+===========================================================================
+
+RE2/J is a work derived from Go's regexp package, whose license
+(http://golang.org/LICENSE) is as follows:
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the names of its contributors
+     may be used to endorse or promote products derived from this
+     software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/README.md
+++ b/README.md
@@ -334,11 +334,15 @@ See [BENCHMARKS.md](BENCHMARKS.md) for full results. Highlights:
 ## License
 
 This project is a Java port of [RE2](https://github.com/google/re2).
+It also incorporates code from [RE2/J](https://github.com/google/re2j),
+a Java port of Go's `regexp` package.
 
 RE2 is Copyright (c) 2009 The RE2 Authors. All rights reserved.
 
-This project contains code derived from RE2 and is licensed under
-the BSD 3-Clause License, consistent with the original project.
+RE2/J is Copyright (c) 2009 The Go Authors. All rights reserved.
+
+This project contains code derived from both RE2 and RE2/J and is licensed
+under the BSD 3-Clause License, consistent with both original projects.
 
 Modifications and Java port: Copyright (c) 2026 Eddie Aftandilian.
 
@@ -347,14 +351,14 @@ See [LICENSE](LICENSE) for details.
 ## Acknowledgments
 
 This work builds directly on the design and implementation of RE2 by
-the RE2 authors.
+the RE2 authors, and on RE2/J by the Go authors.
 
 - [RE2](https://github.com/google/re2) — the C++ library whose design and
   algorithms SafeRE is based on
 - [Go `regexp`](https://pkg.go.dev/regexp) — the Go standard library
   implementation of RE2
 - [RE2/J](https://github.com/google/re2j) — an earlier port of RE2 to Java.
-  SafeRE's test suite includes tests ported from RE2/J
-  (see [TESTING.md](TESTING.md))
+  SafeRE's parser, Java API layer, and portions of the test suite are
+  derived from RE2/J (see [TESTING.md](TESTING.md))
 - Russ Cox's [article series on regular expression matching](https://swtch.com/~rsc/regexp/regexp1.html)
   — explains the theory behind RE2's approach

--- a/safere/src/main/java/org/safere/CharClass.java
+++ b/safere/src/main/java/org/safere/CharClass.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/Prog.java
+++ b/safere/src/main/java/org/safere/Prog.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/RegexpOp.java
+++ b/safere/src/main/java/org/safere/RegexpOp.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/UnicodeTables.java
+++ b/safere/src/main/java/org/safere/UnicodeTables.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/main/java/org/safere/Utils.java
+++ b/safere/src/main/java/org/safere/Utils.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/LicenseHeaderTest.java
+++ b/safere/src/test/java/org/safere/LicenseHeaderTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 /** Verifies that all Java source files include the required license header. */
 class LicenseHeaderTest {
 
+  // Standard header (4 lines) — files derived from C++ RE2 only.
   private static final String LINE_1 =
       "// This file is part of a Java port of RE2 (https://github.com/google/re2).";
   private static final String LINE_2 =
@@ -25,6 +26,16 @@ class LicenseHeaderTest {
   private static final String LINE_3 =
       "// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.";
   private static final String LINE_4 =
+      "// Licensed under the BSD 3-Clause License (see LICENSE file).";
+
+  // Extended header (6 lines) — files that also incorporate code from RE2/J.
+  private static final String RE2J_LINE_3 =
+      "// Portions derived from RE2/J (https://github.com/google/re2j),";
+  private static final String RE2J_LINE_4 =
+      "// Copyright (c) 2009 The Go Authors.";
+  private static final String RE2J_LINE_5 =
+      "// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.";
+  private static final String RE2J_LINE_6 =
       "// Licensed under the BSD 3-Clause License (see LICENSE file).";
 
   @Test
@@ -54,13 +65,29 @@ class LicenseHeaderTest {
   private static boolean hasLicenseHeader(Path path) {
     try {
       List<String> lines = Files.readAllLines(path);
-      return lines.size() >= 4
-          && lines.get(0).equals(LINE_1)
-          && lines.get(1).equals(LINE_2)
-          && lines.get(2).equals(LINE_3)
-          && lines.get(3).equals(LINE_4);
+      return hasStandardHeader(lines) || hasRe2jHeader(lines);
     } catch (IOException e) {
       return false;
     }
+  }
+
+  /** Standard 4-line header for files derived from C++ RE2 only. */
+  private static boolean hasStandardHeader(List<String> lines) {
+    return lines.size() >= 4
+        && lines.get(0).equals(LINE_1)
+        && lines.get(1).equals(LINE_2)
+        && lines.get(2).equals(LINE_3)
+        && lines.get(3).equals(LINE_4);
+  }
+
+  /** Extended 6-line header for files that also incorporate code from RE2/J. */
+  private static boolean hasRe2jHeader(List<String> lines) {
+    return lines.size() >= 6
+        && lines.get(0).equals(LINE_1)
+        && lines.get(1).equals(LINE_2)
+        && lines.get(2).equals(RE2J_LINE_3)
+        && lines.get(3).equals(RE2J_LINE_4)
+        && lines.get(4).equals(RE2J_LINE_5)
+        && lines.get(5).equals(RE2J_LINE_6);
   }
 }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/ProgTest.java
+++ b/safere/src/test/java/org/safere/ProgTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/RE2FindTest.java
+++ b/safere/src/test/java/org/safere/RE2FindTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/RE2PosixTest.java
+++ b/safere/src/test/java/org/safere/RE2PosixTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/RE2ReplaceTest.java
+++ b/safere/src/test/java/org/safere/RE2ReplaceTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -1,5 +1,7 @@
 // This file is part of a Java port of RE2 (https://github.com/google/re2).
 // Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
 // Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
 // Licensed under the BSD 3-Clause License (see LICENSE file).
 


### PR DESCRIPTION
SafeRE draws from both C++ RE2 and RE2/J (a Java port of Go's regexp package). The existing LICENSE and file headers credited only C++ RE2 ("The RE2 Authors"). RE2/J has a different copyright holder ("The Go Authors") and needs separate attribution.

**Changes:**
- **LICENSE**: Add RE2/J copyright section alongside C++ RE2
- **File headers**: Add RE2/J attribution line to 17 files that incorporate code from RE2/J (9 source, 8 test)
- **LicenseHeaderTest**: Accept both 4-line (RE2-only) and 6-line (RE2/J) header variants
- **AGENTS.md**: Document both header formats
- **README.md**: Add RE2/J to License section and Acknowledgments
- **DESIGN.md**: Mention RE2/J as a reference alongside C++ RE2

**Provenance summary:**
| Category | Files |
|---|---|
| Source (RE2/J primary) | Parser, Utils, RegexpOp |
| Source (Both RE2 + RE2/J) | CharClass, Compiler, Pattern, Prog, Regexp, UnicodeTables |
| Test (RE2/J primary) | MatcherTest, ParserTest, PatternTest, ProgTest, RE2FindTest, RE2PosixTest, RE2ReplaceTest |
| Test (Both) | SimplifierTest |

Refs #26