### PR TITLE
Add Maven Central publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Releasing version: $VERSION"
+          mvn versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false --batch-mode --no-transfer-progress
+
+      - name: Build and test
+        run: mvn -pl safere verify -Dtest.parallelism=4 --batch-mode --no-transfer-progress
+
+      - name: Publish to Maven Central
+        run: mvn -pl safere deploy -Prelease -DskipTests --batch-mode --no-transfer-progress
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ Patterns that require exponential time in `java.util.regex` — such as
 `a?{25}a{25}` matched against `a` repeated 25 times — complete in microseconds
 with SafeRE.
 
+## Installation
+
+SafeRE is available on [Maven Central](https://central.sonatype.com/artifact/org.safere/safere).
+
+**Maven:**
+
+```xml
+<dependency>
+  <groupId>org.safere</groupId>
+  <artifactId>safere</artifactId>
+  <version>0.1.0</version>
+</dependency>
+```
+
+**Gradle (Kotlin DSL):**
+
+```kotlin
+implementation("org.safere:safere:0.1.0")
+```
+
+**Gradle (Groovy DSL):**
+
+```groovy
+implementation 'org.safere:safere:0.1.0'
+```
+
 ## Quick Start
 
 ```java

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,80 @@
+# Releasing SafeRE
+
+This document describes how to publish a new release of SafeRE to Maven Central.
+
+## Prerequisites
+
+The following GitHub secrets must be configured in the repository:
+
+| Secret | Description |
+|---|---|
+| `GPG_PRIVATE_KEY` | Armored GPG private key for signing artifacts |
+| `GPG_PASSPHRASE` | Passphrase for the GPG key |
+| `MAVEN_CENTRAL_USERNAME` | Maven Central Portal token username |
+| `MAVEN_CENTRAL_PASSWORD` | Maven Central Portal token password |
+
+## Release Process
+
+### 1. Update the version
+
+Remove the `-SNAPSHOT` suffix from the version in all POM files:
+
+```bash
+mvn versions:set -DnewVersion=X.Y.Z -DgenerateBackupPoms=false
+```
+
+### 2. Commit the version change
+
+```bash
+git add -A
+git commit -m "Release vX.Y.Z"
+```
+
+### 3. Tag the release
+
+```bash
+git tag vX.Y.Z
+```
+
+### 4. Push the commit and tag
+
+```bash
+git push origin main
+git push origin vX.Y.Z
+```
+
+Pushing the tag triggers the
+[release workflow](.github/workflows/release.yml), which:
+
+1. Sets the POM version from the tag
+2. Builds and runs all tests
+3. Signs all artifacts with GPG
+4. Publishes to Maven Central via the Central Portal
+
+### 5. Verify the release
+
+- Check the [GitHub Actions run](https://github.com/eaftan/safere/actions/workflows/release.yml)
+  for success.
+- After a few minutes, verify the artifact appears on
+  [Maven Central](https://central.sonatype.com/artifact/org.safere/safere).
+
+### 6. Bump to next SNAPSHOT
+
+```bash
+mvn versions:set -DnewVersion=X.Y+1.0-SNAPSHOT -DgenerateBackupPoms=false
+git add -A
+git commit -m "Bump version to X.Y+1.0-SNAPSHOT"
+git push origin main
+```
+
+## Troubleshooting
+
+- **GPG signing fails**: Ensure the GPG private key secret is the full armored
+  output of `gpg --armor --export-secret-keys`, including the `BEGIN` and `END`
+  lines.
+- **Central Portal rejects the upload**: Verify that the `org.safere` namespace
+  is verified at [central.sonatype.com](https://central.sonatype.com) and that
+  all POM metadata (`<url>`, `<licenses>`, `<scm>`, `<developers>`) is present.
+- **Token expired**: Generate a new token at
+  [central.sonatype.com/usertoken](https://central.sonatype.com/usertoken) and
+  update the GitHub secrets.

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,29 @@
 
   <name>SafeRE Parent</name>
   <description>Linear-time regular expression matching library for Java</description>
+  <url>https://safere.org</url>
+
+  <licenses>
+    <license>
+      <name>BSD-3-Clause</name>
+      <url>https://github.com/eaftan/safere/blob/main/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>eaftan</id>
+      <name>Eddie Aftandilian</name>
+      <url>https://github.com/eaftan</url>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eaftan/safere.git</connection>
+    <developerConnection>scm:git:git@github.com:eaftan/safere.git</developerConnection>
+    <url>https://github.com/eaftan/safere</url>
+  </scm>
 
   <modules>
     <module>safere</module>
@@ -26,4 +49,69 @@
     <jacoco.version>0.8.12</jacoco.version>
     <jmh.version>1.37</jmh.version>
   </properties>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.11.2</version>
+            <configuration>
+              <source>21</source>
+              <doclint>all,-missing</doclint>
+              <quiet>true</quiet>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.7</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.10.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -17,6 +17,10 @@
   <name>SafeRE Benchmarks</name>
   <description>JMH benchmarks for SafeRE</description>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.safere</groupId>

--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -17,6 +17,10 @@
   <name>SafeRE FFM RE2 Wrapper</name>
   <description>Java FFM wrapper around C++ RE2 for benchmarking</description>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <build>
     <plugins>
       <!-- Build native shim library via cmake -->


### PR DESCRIPTION
Add the infrastructure needed to publish SafeRE to Maven Central.

**Changes:**
- **Parent POM**: Add required Maven Central metadata (`<url>`, `<licenses>`, `<developers>`, `<scm>`)
- **Release profile**: `maven-source-plugin`, `maven-javadoc-plugin`, `maven-gpg-plugin`, `central-publishing-maven-plugin` (v0.10.0)
- **Deploy skip**: `safere-benchmarks` and `safere-ffm-re2` skip deploy
- **Release workflow**: `.github/workflows/release.yml` triggered on `v*` tags — builds, tests, signs, publishes
- **README.md**: Add Installation section with Maven/Gradle dependency snippets
- **RELEASING.md**: Document the step-by-step release process for maintainers

**Required GitHub secrets** (already configured):
| Secret | Description |
|---|---|
| `GPG_PRIVATE_KEY` | Armored GPG private key |
| `GPG_PASSPHRASE` | GPG key passphrase |
| `MAVEN_CENTRAL_USERNAME` | Central Portal token username |
| `MAVEN_CENTRAL_PASSWORD` | Central Portal token password |

Refs #92