### PR TITLE
Add flatten-maven-plugin for Maven Central compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Thumbs.db
 dependency-reduced-pom.xml
 safere-ffm-re2/build/
 org.safere.benchmark.*
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,30 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.6.0</version>
+            <configuration>
+              <flattenMode>ossrh</flattenMode>
+            </configuration>
+            <executions>
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>flatten-clean</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <version>3.3.1</version>


### PR DESCRIPTION
The first release attempt failed because Maven Central couldn't resolve the child POM's parent reference (`safere-parent` isn't published). The `flatten-maven-plugin` with `ossrh` mode produces a standalone POM that inlines all inherited metadata.

This was already applied to the successful v0.1.0 release tag but needs to be merged back to `main` for future releases.

**Changes:**
- Add `flatten-maven-plugin` (v1.6.0, `ossrh` mode) to the `release` profile
- Add `.flattened-pom.xml` to `.gitignore`

Refs #92