### PR TITLE
Restrict named capture group names to ASCII letters/digits

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1671,12 +1671,15 @@ final class Parser {
 
   private static boolean isValidCaptureName(String name) {
     if (name.isEmpty()) return false;
-    for (int i = 0; i < name.length(); ) {
-      int r = name.codePointAt(i);
-      i += Character.charCount(r);
-      if (Utils.isAlnum(r) || r == '_') continue;
-      // Also allow Unicode letters and digits.
-      if (Character.isLetterOrDigit(r) || Character.getType(r) == Character.CONNECTOR_PUNCTUATION) {
+    // Match java.util.regex.Pattern rules: first character must be an ASCII letter,
+    // subsequent characters must be ASCII letters or digits.
+    char first = name.charAt(0);
+    if (!((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z'))) {
+      return false;
+    }
+    for (int i = 1; i < name.length(); i++) {
+      char c = name.charAt(i);
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
         continue;
       }
       return false;

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -690,10 +690,10 @@ class ParserTest {
     }
 
     @Test
-    void namedCapture_unicodeName() {
-      Regexp re = parse("(?P<\u4e2d\u6587>a)");
-      assertThat(re.op).isEqualTo(RegexpOp.CAPTURE);
-      assertThat(re.name).isEqualTo("\u4e2d\u6587");
+    void namedCapture_unicodeName_rejected() {
+      // JDK only allows ASCII letters/digits in group names.
+      assertThatThrownBy(() -> parse("(?P<\u4e2d\u6587>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test
@@ -1325,6 +1325,43 @@ class ParserTest {
     @Test
     void invalidNamedCapture_spaceInName_angle() {
       assertThatThrownBy(() -> parse("(?<x y>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    // Regression: (?<test_group>.*) rejected — underscore not allowed (issue #129)
+    void invalidNamedCapture_underscore() {
+      assertThatThrownBy(() -> parse("(?<test_group>.*)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void invalidNamedCapture_startsWithDigit() {
+      assertThatThrownBy(() -> parse("(?<1abc>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void invalidNamedCapture_startsWithDigit_P() {
+      assertThatThrownBy(() -> parse("(?P<1abc>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void invalidNamedCapture_unicodeLetter() {
+      assertThatThrownBy(() -> parse("(?<caf\u00e9>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void invalidNamedCapture_connectorPunctuation() {
+      assertThatThrownBy(() -> parse("(?<foo\u203fbar>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void invalidNamedCapture_allDigits() {
+      assertThatThrownBy(() -> parse("(?<123>a)"))
           .isInstanceOf(PatternSyntaxException.class);
     }
 


### PR DESCRIPTION
Match `java.util.regex.Pattern` rules for group names: first character must be an ASCII letter (`A-Z`, `a-z`), subsequent characters must be ASCII letters or digits (`A-Z`, `a-z`, `0-9`).

Previously SafeRE was too lenient, accepting:
- Underscores (e.g. `(?<test_group>.*)`) — the reported bug
- Names starting with digits (e.g. `(?<1abc>a)`)
- Unicode letters (e.g. `(?<café>a)`)
- Connector punctuation (e.g. `(?<foo‿bar>a)`)

Added regression tests for all four dimensions plus the exact example from the issue.

Fixes #129