### PR TITLE
Add \\uhhhh unicode escape support to parser

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1084,6 +1084,26 @@ final class Parser {
         }
         return Utils.unhex(c2) * 16 + Utils.unhex(c3);
       }
+      // Unicode escape: \\uhhhh (exactly 4 hex digits).
+      // If the value is a high surrogate and the next escape is a low surrogate,
+      // they are combined into a single supplementary code point.
+      case 'u' -> {
+        int code = parseExactHex(4);
+        if (Character.isHighSurrogate((char) code)
+            && pos + 5 < pattern.length()
+            && pattern.charAt(pos) == '\\'
+            && pattern.charAt(pos + 1) == 'u') {
+          int savedPos = pos;
+          pos += 2; // skip \\u
+          int low = parseExactHex(4);
+          if (Character.isLowSurrogate((char) low)) {
+            code = Character.toCodePoint((char) code, (char) low);
+          } else {
+            pos = savedPos; // not a surrogate pair, backtrack
+          }
+        }
+        return code;
+      }
       // C escapes.
       case 'n' -> { return '\n'; }
       case 'r' -> { return '\r'; }
@@ -1112,6 +1132,26 @@ final class Parser {
         throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);
       }
     }
+  }
+
+  /**
+   * Parses exactly {@code n} hex digits at the current position and returns their value.
+   * Advances {@code pos} past the digits.
+   */
+  private int parseExactHex(int n) {
+    if (pos + n > pattern.length()) {
+      throw new PatternSyntaxException("invalid unicode escape", pattern, pos - 2);
+    }
+    int code = 0;
+    for (int i = 0; i < n; i++) {
+      int hc = pattern.charAt(pos);
+      if (!Utils.isHexDigit(hc)) {
+        throw new PatternSyntaxException("invalid unicode escape", pattern, pos);
+      }
+      code = code * 16 + Utils.unhex(hc);
+      pos++;
+    }
+    return code;
   }
 
   // ---- Perl character class escapes (\d, \s, \w, \D, \S, \W) ----

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -174,28 +174,24 @@ class JdkSyntaxCompatibilityTest {
     // -- Unicode escape (backslash-u) --
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape \\\\uhhhh (BMP)")
     void unicodeEscapeBmp() {
       assertMatchesSame("\\u0041", "A");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape \\\\uhhhh (Thai character)")
     void unicodeEscapeThai() {
       assertMatchesSame("\\u0E01", "\u0E01");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape range in character class")
     void unicodeEscapeRange() {
       assertMatchesSame("[\\u0E00-\\u0E7F]", "\u0E01");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape \\\\uhhhh (supplementary via surrogate pair)")
     void unicodeEscapeSurrogatePair() {
       // JDK treats surrogate pair escapes as U+1F600
@@ -1320,7 +1316,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("Thai character range with \\\\u escapes")
     void thaiCharacterRange() {
       assertMatchesSame("([\\u0E00-\\u0E7F])([0-9a-zA-Z])", "\u0E01a");


### PR DESCRIPTION
Parse `\uhhhh` (exactly 4 hex digits) in regex patterns, matching JDK behavior. When a high surrogate is followed by a `\uhhhh` low surrogate, they are combined into a single supplementary code point.

Enables 5 previously disabled tests in `JdkSyntaxCompatibilityTest`.

Fixes #133