### PR TITLE
Add inline flags (?d) and (?u); fix (?U) semantics

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1584,6 +1584,11 @@ final class Parser {
       int c = pattern.codePointAt(pos);
       pos += Character.charCount(c);
       switch (c) {
+        case 'd' -> {
+          sawflags = true;
+          if (negated) nflags &= ~ParseFlags.UNIX_LINES;
+          else nflags |= ParseFlags.UNIX_LINES;
+        }
         case 'i' -> {
           sawflags = true;
           if (negated) nflags &= ~ParseFlags.FOLD_CASE;
@@ -1599,10 +1604,18 @@ final class Parser {
           if (negated) nflags &= ~ParseFlags.DOT_NL;
           else nflags |= ParseFlags.DOT_NL;
         }
+        case 'u' -> {
+          sawflags = true;
+          if (negated) nflags &= ~ParseFlags.UNICODE_GROUPS;
+          else nflags |= ParseFlags.UNICODE_GROUPS;
+        }
         case 'U' -> {
           sawflags = true;
-          if (negated) nflags &= ~ParseFlags.NON_GREEDY;
-          else nflags |= ParseFlags.NON_GREEDY;
+          if (negated) {
+            nflags &= ~(ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS);
+          } else {
+            nflags |= ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS;
+          }
         }
         case 'x' -> {
           sawflags = true;

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1066,7 +1066,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?d) UNIX_LINES")
     void flagD() {
       assertCompiles("(?d).");
@@ -1087,7 +1086,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?u) unicode case")
     void flagU() {
       assertCompiles("(?u)(?i)abc");
@@ -1106,7 +1104,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("combined flags (?dm)")
     void combinedFlags() {
       assertCompiles("(?dm)^test$");
@@ -1125,21 +1122,18 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?d) combined with (?m) from issue #127")
     void flagDWithM() {
       assertCompiles("(?m)(?d)^(####? .+|---)$");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("all JDK flags combined (?idmsuxU)")
     void allFlags() {
       assertCompiles("(?idmsuxU)test");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("all JDK flags negated (?-idmsuxU)")
     void allFlagsNegated() {
       assertCompiles("(?idmsuxU)(?-idmsuxU)test");
@@ -1309,7 +1303,6 @@ class JdkSyntaxCompatibilityTest {
   class Issue127EdgeCases {
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?m)(?d)^(####? .+|---)$")
     void inlineFlagDWithMultiline() {
       assertMatchesSame("(?m)(?d)^(####? .+|---)$", "## Hello");

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1192,10 +1192,12 @@ class ParserTest {
     }
 
     @Test
-    void nonGreedy_UFlag() {
+    void unicodeCharClass_UFlag() {
+      // (?U) is JDK's UNICODE_CHARACTER_CLASS, not RE2's non-greedy.
       Regexp re = parse("(?U)a*");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
-      assertThat(re.nonGreedy()).isTrue();
+      assertThat(re.nonGreedy()).isFalse();
+      assertThat((re.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Add `(?d)` for UNIX_LINES and `(?u)` for UNICODE_CASE inline flags. Remap `(?U)` from RE2's NON_GREEDY to JDK's UNICODE_CHARACTER_CLASS.

Enables 7 previously disabled tests in `JdkSyntaxCompatibilityTest`.

Fixes #134