### PR TITLE
Fix nested repetition limit for alternation branches

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -577,6 +577,18 @@ final class Parser {
       return 0;
     }
     if (re.subs != null) {
+      if (re.op == RegexpOp.ALTERNATE) {
+        // Only one branch is taken; use the worst (most expensive) branch.
+        int minLimit = limit;
+        for (Regexp sub : re.subs) {
+          int subLimit = countRepeat(sub, limit);
+          if (subLimit < minLimit) {
+            minLimit = subLimit;
+          }
+        }
+        return minLimit;
+      }
+      // For CONCAT and other ops, all children contribute.
       for (Regexp sub : re.subs) {
         int subLimit = countRepeat(sub, limit);
         if (subLimit < limit) {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -908,7 +908,6 @@ class JdkSyntaxCompatibilityTest {
     // -- Nested repetitions (from issue #127) --
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/135")
     @DisplayName("nested repetition {0,99} inside {0,5}")
     void nestedRepetition() {
       assertCompiles("(?:a (?:b{0,99}|c{0,9})){0,5}");
@@ -1315,7 +1314,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/135")
     @DisplayName("nested repetition (?:a (?:b{0,99}|c{0,9})){0,5}")
     void nestedRepetitionFromIssue() {
       assertMatchesSame("(?:a (?:b{0,99}|c{0,9})){0,5}", "a bbb");


### PR DESCRIPTION
countRepeat was compounding repeat counts across alternation branches sequentially, treating them as if all branches were visited. For ALTERNATE nodes, only one branch is taken at match time, so only the worst-case branch should be considered.

Enables 2 previously disabled tests in `JdkSyntaxCompatibilityTest`.

Fixes #135