### PR TITLE
Make Unicode property name lookup loose per UTS#18

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1304,13 +1304,13 @@ final class Parser {
   }
 
   private static int[][] lookupKeywordProperty(String key, String value) {
-    // Keywords are case-insensitive per JDK behavior.
+    // Keywords are case-insensitive per JDK behavior; remove underscores/hyphens/spaces.
     String normalizedKey =
-        key.toUpperCase(java.util.Locale.ROOT).replace('-', '_').replace(' ', '_');
+        key.toUpperCase(java.util.Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
     return switch (normalizedKey) {
       case "SCRIPT", "SC" -> UnicodeProperties.lookupScriptOrCategory(value);
       case "BLOCK", "BLK" -> UnicodeProperties.lookupBlock(value);
-      case "GENERAL_CATEGORY", "GC" -> UnicodeProperties.lookupScriptOrCategory(value);
+      case "GENERALCATEGORY", "GC" -> UnicodeProperties.lookupScriptOrCategory(value);
       default -> null;
     };
   }

--- a/safere/src/main/java/org/safere/UnicodeProperties.java
+++ b/safere/src/main/java/org/safere/UnicodeProperties.java
@@ -142,15 +142,38 @@ final class UnicodeProperties {
     }
   }
 
+  private static final class BinaryNormalizedHolder {
+    // Maps normalized key → original BINARY_PROPERTIES key.
+    static final Map<String, String> NORMALIZED_KEYS = buildNormalizedKeys();
+
+    private static Map<String, String> buildNormalizedKeys() {
+      Map<String, String> map = new HashMap<>();
+      for (String key : BinaryHolder.BINARY_PROPERTIES.keySet()) {
+        map.put(normalize(key), key);
+      }
+      return map;
+    }
+  }
+
   // ---- Public lookup methods ----
 
   /**
-   * Looks up a binary Unicode property by name (e.g., "Alphabetic", "Lowercase").
+   * Looks up a binary Unicode property by name (e.g., "Alphabetic", "Lowercase"). The lookup is
+   * loose per UTS#18: case, underscores, and hyphens are ignored.
    *
    * @return the range table, or {@code null} if not a recognized binary property
    */
   static int[][] lookupBinaryProperty(String name) {
-    return BinaryHolder.BINARY_PROPERTIES.get(name);
+    int[][] table = BinaryHolder.BINARY_PROPERTIES.get(name);
+    if (table != null) {
+      return table;
+    }
+    // Fall back to normalized (case/underscore/hyphen insensitive) lookup.
+    String canonicalKey = BinaryNormalizedHolder.NORMALIZED_KEYS.get(normalize(name));
+    if (canonicalKey != null) {
+      return BinaryHolder.BINARY_PROPERTIES.get(canonicalKey);
+    }
+    return null;
   }
 
   /**
@@ -190,11 +213,11 @@ final class UnicodeProperties {
   }
 
   /**
-   * Normalizes a property name for case-insensitive comparison: uppercases and replaces spaces and
-   * hyphens with underscores.
+   * Normalizes a property name for loose matching per UTS#18: uppercases and removes underscores,
+   * hyphens, and spaces.
    */
   private static String normalize(String name) {
-    return name.toUpperCase(Locale.ROOT).replace(' ', '_').replace('-', '_');
+    return name.toUpperCase(Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
   }
 
   /**

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -699,7 +699,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/136")
     @DisplayName("\\\\p{IsWhiteSpace} (no underscore, from issue #127)")
     void isWhiteSpaceNoUnderscore() {
       // JDK is flexible about underscores in property names
@@ -1320,7 +1319,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/136")
     @DisplayName("\\\\p{IsWhiteSpace} (no underscore)")
     void isWhiteSpaceNoUnderscore() {
       assertMatchesSame("\\p{IsWhiteSpace}", " ");


### PR DESCRIPTION
Property name lookups now ignore case, underscores, hyphens, and spaces, matching JDK behavior and UTS#18 requirements. Both binary properties and script/category names use the same normalization.

Enables 2 previously disabled tests in `JdkSyntaxCompatibilityTest`.

Fixes #136