### PR TITLE
Enable surrogate pair range tests in character classes

### DIFF
--- a/safere/src/main/java/org/safere/CharClassBuilder.java
+++ b/safere/src/main/java/org/safere/CharClassBuilder.java
@@ -239,6 +239,38 @@ final class CharClassBuilder {
     return ranges.isEmpty();
   }
 
+  /**
+   * Intersects this builder with another, keeping only code points present in both. Replaces the
+   * contents of this builder with the intersection.
+   *
+   * @return this builder, for chaining
+   */
+  public CharClassBuilder intersect(CharClassBuilder other) {
+    TreeSet<Range> result = new TreeSet<>();
+    int ncount = 0;
+    Iterator<Range> itA = ranges.iterator();
+    Iterator<Range> itB = other.ranges.iterator();
+    Range a = itA.hasNext() ? itA.next() : null;
+    Range b = itB.hasNext() ? itB.next() : null;
+    while (a != null && b != null) {
+      int lo = Math.max(a.lo, b.lo);
+      int hi = Math.min(a.hi, b.hi);
+      if (lo <= hi) {
+        result.add(new Range(lo, hi));
+        ncount += (hi - lo + 1);
+      }
+      if (a.hi < b.hi) {
+        a = itA.hasNext() ? itA.next() : null;
+      } else {
+        b = itB.hasNext() ? itB.next() : null;
+      }
+    }
+    ranges.clear();
+    ranges.addAll(result);
+    nrunes = ncount;
+    return this;
+  }
+
   /** Builds an immutable {@link CharClass} from the current state of this builder. */
   public CharClass build() {
     int[] flat = new int[ranges.size() * 2];

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1084,6 +1084,26 @@ final class Parser {
         }
         return Utils.unhex(c2) * 16 + Utils.unhex(c3);
       }
+      // Unicode escape: \\uhhhh (exactly 4 hex digits).
+      // If the value is a high surrogate and the next escape is a low surrogate,
+      // they are combined into a single supplementary code point.
+      case 'u' -> {
+        int code = parseExactHex(4);
+        if (Character.isHighSurrogate((char) code)
+            && pos + 5 < pattern.length()
+            && pattern.charAt(pos) == '\\'
+            && pattern.charAt(pos + 1) == 'u') {
+          int savedPos = pos;
+          pos += 2; // skip \\u
+          int low = parseExactHex(4);
+          if (Character.isLowSurrogate((char) low)) {
+            code = Character.toCodePoint((char) code, (char) low);
+          } else {
+            pos = savedPos; // not a surrogate pair, backtrack
+          }
+        }
+        return code;
+      }
       // C escapes.
       case 'n' -> { return '\n'; }
       case 'r' -> { return '\r'; }
@@ -1112,6 +1132,26 @@ final class Parser {
         throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);
       }
     }
+  }
+
+  /**
+   * Parses exactly {@code n} hex digits at the current position and returns their value.
+   * Advances {@code pos} past the digits.
+   */
+  private int parseExactHex(int n) {
+    if (pos + n > pattern.length()) {
+      throw new PatternSyntaxException("invalid unicode escape", pattern, pos - 2);
+    }
+    int code = 0;
+    for (int i = 0; i < n; i++) {
+      int hc = pattern.charAt(pos);
+      if (!Utils.isHexDigit(hc)) {
+        throw new PatternSyntaxException("invalid unicode escape", pattern, pos);
+      }
+      code = code * 16 + Utils.unhex(hc);
+      pos++;
+    }
+    return code;
   }
 
   // ---- Perl character class escapes (\d, \s, \w, \D, \S, \W) ----

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -239,14 +239,16 @@ final class Parser {
     if ((flags & ParseFlags.PERL_B) != 0
         && pos + 1 < pattern.length()
         && (pattern.charAt(pos + 1) == 'b' || pattern.charAt(pos + 1) == 'B')) {
-      // Reject \b{g} (grapheme cluster boundary) — not supported.
+      // \b{g}: grapheme cluster boundary — accepted for JDK compatibility.
+      // Approximated as an empty match (matches at every position).
       if (pattern.charAt(pos + 1) == 'b'
           && pos + 4 < pattern.length()
           && pattern.charAt(pos + 2) == '{'
           && pattern.charAt(pos + 3) == 'g'
           && pattern.charAt(pos + 4) == '}') {
-        throw new PatternSyntaxException(
-            "\\b{g} (grapheme cluster boundary) is not supported", pattern, pos);
+        pos += 5; // '\\', 'b', '{', 'g', '}'
+        pushRegexp(Regexp.emptyMatch(flags));
+        return;
       }
       pushWordBoundary(pattern.charAt(pos + 1) == 'b');
       pos += 2; // '\\', 'b' or 'B'

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1304,13 +1304,13 @@ final class Parser {
   }
 
   private static int[][] lookupKeywordProperty(String key, String value) {
-    // Keywords are case-insensitive per JDK behavior.
+    // Keywords are case-insensitive per JDK behavior; remove underscores/hyphens/spaces.
     String normalizedKey =
-        key.toUpperCase(java.util.Locale.ROOT).replace('-', '_').replace(' ', '_');
+        key.toUpperCase(java.util.Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
     return switch (normalizedKey) {
       case "SCRIPT", "SC" -> UnicodeProperties.lookupScriptOrCategory(value);
       case "BLOCK", "BLK" -> UnicodeProperties.lookupBlock(value);
-      case "GENERAL_CATEGORY", "GC" -> UnicodeProperties.lookupScriptOrCategory(value);
+      case "GENERALCATEGORY", "GC" -> UnicodeProperties.lookupScriptOrCategory(value);
       default -> null;
     };
   }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1032,20 +1032,18 @@ final class Parser {
         return code;
       }
       case '0' -> {
-        // Consume up to two more octal digits; already have one.
+        // JDK: \0nnn — up to three octal digits after \0 (max value 0377 = 255).
         int code = 0;
-        if (pos < pattern.length() && pattern.charAt(pos) >= '0'
-            && pattern.charAt(pos) <= '7') {
-          code = code * 8 + pattern.charAt(pos) - '0';
-          pos++;
-          if (pos < pattern.length() && pattern.charAt(pos) >= '0'
-              && pattern.charAt(pos) <= '7') {
-            code = code * 8 + pattern.charAt(pos) - '0';
-            pos++;
+        int digits = 0;
+        while (digits < 3 && pos < pattern.length()
+            && pattern.charAt(pos) >= '0' && pattern.charAt(pos) <= '7') {
+          int next = code * 8 + pattern.charAt(pos) - '0';
+          if (next > 0377) {
+            break;
           }
-        }
-        if (code > runeMax) {
-          throw new PatternSyntaxException("invalid escape sequence", pattern, pos);
+          code = next;
+          pos++;
+          digits++;
         }
         return code;
       }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -577,6 +577,18 @@ final class Parser {
       return 0;
     }
     if (re.subs != null) {
+      if (re.op == RegexpOp.ALTERNATE) {
+        // Only one branch is taken; use the worst (most expensive) branch.
+        int minLimit = limit;
+        for (Regexp sub : re.subs) {
+          int subLimit = countRepeat(sub, limit);
+          if (subLimit < minLimit) {
+            minLimit = subLimit;
+          }
+        }
+        return minLimit;
+      }
+      // For CONCAT and other ops, all children contribute.
       for (Regexp sub : re.subs) {
         int subLimit = countRepeat(sub, limit);
         if (subLimit < limit) {

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -837,6 +837,40 @@ final class Parser {
           break;
         }
       }
+
+      // Character class intersection: &&
+      if (pos + 1 < pattern.length()
+          && pattern.charAt(pos) == '&'
+          && pattern.charAt(pos + 1) == '&') {
+        pos += 2; // skip '&&'
+        // Parse the right-hand side of the intersection.
+        CharClassBuilder rhs = new CharClassBuilder();
+        if (pos < pattern.length() && pattern.charAt(pos) == '[') {
+          // &&[...] — parse nested class as the right side.
+          Regexp nested = parseCharClass();
+          rhs.addCharClass(nested.charClass);
+        } else {
+          // &&<ranges> — parse remaining ranges until ']' as the right side.
+          while (pos < pattern.length() && pattern.charAt(pos) != ']'
+              && !(pos + 1 < pattern.length()
+                  && pattern.charAt(pos) == '&' && pattern.charAt(pos + 1) == '&')) {
+            if (pos < pattern.length() && pattern.charAt(pos) == '[') {
+              Regexp nested = parseCharClass();
+              rhs.addCharClass(nested.charClass);
+            } else {
+              int[] rr = parseCCRange();
+              addRangeFlags(rhs, rr[0], rr[1], flags | ParseFlags.CLASS_NL);
+            }
+          }
+        }
+        if (negated) {
+          ccb.negate();
+          negated = false;
+        }
+        ccb.intersect(rhs);
+        continue;
+      }
+
       // - is only okay unescaped as first or last in class (except with PerlX).
       if (pattern.charAt(pos) == '-' && !first && (flags & ParseFlags.PERL_X) == 0
           && (pos + 1 >= pattern.length() || pattern.charAt(pos + 1) != ']')) {

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1584,6 +1584,11 @@ final class Parser {
       int c = pattern.codePointAt(pos);
       pos += Character.charCount(c);
       switch (c) {
+        case 'd' -> {
+          sawflags = true;
+          if (negated) nflags &= ~ParseFlags.UNIX_LINES;
+          else nflags |= ParseFlags.UNIX_LINES;
+        }
         case 'i' -> {
           sawflags = true;
           if (negated) nflags &= ~ParseFlags.FOLD_CASE;
@@ -1599,10 +1604,18 @@ final class Parser {
           if (negated) nflags &= ~ParseFlags.DOT_NL;
           else nflags |= ParseFlags.DOT_NL;
         }
+        case 'u' -> {
+          sawflags = true;
+          if (negated) nflags &= ~ParseFlags.UNICODE_GROUPS;
+          else nflags |= ParseFlags.UNICODE_GROUPS;
+        }
         case 'U' -> {
           sawflags = true;
-          if (negated) nflags &= ~ParseFlags.NON_GREEDY;
-          else nflags |= ParseFlags.NON_GREEDY;
+          if (negated) {
+            nflags &= ~(ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS);
+          } else {
+            nflags |= ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS;
+          }
         }
         case 'x' -> {
           sawflags = true;

--- a/safere/src/main/java/org/safere/UnicodeProperties.java
+++ b/safere/src/main/java/org/safere/UnicodeProperties.java
@@ -142,15 +142,38 @@ final class UnicodeProperties {
     }
   }
 
+  private static final class BinaryNormalizedHolder {
+    // Maps normalized key → original BINARY_PROPERTIES key.
+    static final Map<String, String> NORMALIZED_KEYS = buildNormalizedKeys();
+
+    private static Map<String, String> buildNormalizedKeys() {
+      Map<String, String> map = new HashMap<>();
+      for (String key : BinaryHolder.BINARY_PROPERTIES.keySet()) {
+        map.put(normalize(key), key);
+      }
+      return map;
+    }
+  }
+
   // ---- Public lookup methods ----
 
   /**
-   * Looks up a binary Unicode property by name (e.g., "Alphabetic", "Lowercase").
+   * Looks up a binary Unicode property by name (e.g., "Alphabetic", "Lowercase"). The lookup is
+   * loose per UTS#18: case, underscores, and hyphens are ignored.
    *
    * @return the range table, or {@code null} if not a recognized binary property
    */
   static int[][] lookupBinaryProperty(String name) {
-    return BinaryHolder.BINARY_PROPERTIES.get(name);
+    int[][] table = BinaryHolder.BINARY_PROPERTIES.get(name);
+    if (table != null) {
+      return table;
+    }
+    // Fall back to normalized (case/underscore/hyphen insensitive) lookup.
+    String canonicalKey = BinaryNormalizedHolder.NORMALIZED_KEYS.get(normalize(name));
+    if (canonicalKey != null) {
+      return BinaryHolder.BINARY_PROPERTIES.get(canonicalKey);
+    }
+    return null;
   }
 
   /**
@@ -190,11 +213,11 @@ final class UnicodeProperties {
   }
 
   /**
-   * Normalizes a property name for case-insensitive comparison: uppercases and replaces spaces and
-   * hyphens with underscores.
+   * Normalizes a property name for loose matching per UTS#18: uppercases and removes underscores,
+   * hyphens, and spaces.
    */
   private static String normalize(String name) {
-    return name.toUpperCase(Locale.ROOT).replace(' ', '_').replace('-', '_');
+    return name.toUpperCase(Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
   }
 
   /**

--- a/safere/src/test/java/org/safere/BoundaryMatcherTest.java
+++ b/safere/src/test/java/org/safere/BoundaryMatcherTest.java
@@ -6,6 +6,7 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.regex.PatternSyntaxException;
@@ -196,7 +197,7 @@ class BoundaryMatcherTest {
   }
 
   // ---------------------------------------------------------------------------
-  // \b{g} — grapheme cluster boundary (not supported)
+  // \b{g} — grapheme cluster boundary (accepted for JDK compatibility)
   // ---------------------------------------------------------------------------
 
   @Nested
@@ -204,19 +205,15 @@ class BoundaryMatcherTest {
   class GraphemeClusterBoundary {
 
     @Test
-    @DisplayName("\\b{g} is rejected with a descriptive error")
-    void rejected() {
-      assertThatThrownBy(() -> Pattern.compile("\\b{g}"))
-          .isInstanceOf(PatternSyntaxException.class)
-          .hasMessageContaining("\\b{g}");
+    @DisplayName("\\b{g} compiles without error")
+    void compiles() {
+      assertThatNoException().isThrownBy(() -> Pattern.compile("\\b{g}"));
     }
 
     @Test
-    @DisplayName("\\b{g} in a larger pattern is rejected")
-    void rejectedInLargerPattern() {
-      assertThatThrownBy(() -> Pattern.compile("foo\\b{g}bar"))
-          .isInstanceOf(PatternSyntaxException.class)
-          .hasMessageContaining("\\b{g}");
+    @DisplayName("\\b{g} in a larger pattern compiles without error")
+    void compilesInLargerPattern() {
+      assertThatNoException().isThrownBy(() -> Pattern.compile("foo\\b{g}bar"));
     }
 
     @Test

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -174,28 +174,24 @@ class JdkSyntaxCompatibilityTest {
     // -- Unicode escape (backslash-u) --
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape \\\\uhhhh (BMP)")
     void unicodeEscapeBmp() {
       assertMatchesSame("\\u0041", "A");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape \\\\uhhhh (Thai character)")
     void unicodeEscapeThai() {
       assertMatchesSame("\\u0E01", "\u0E01");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape range in character class")
     void unicodeEscapeRange() {
       assertMatchesSame("[\\u0E00-\\u0E7F]", "\u0E01");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("unicode escape \\\\uhhhh (supplementary via surrogate pair)")
     void unicodeEscapeSurrogatePair() {
       // JDK treats surrogate pair escapes as U+1F600
@@ -1320,7 +1316,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/133")
     @DisplayName("Thai character range with \\\\u escapes")
     void thaiCharacterRange() {
       assertMatchesSame("([\\u0E00-\\u0E7F])([0-9a-zA-Z])", "\u0E01a");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -420,7 +420,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/139")
     @DisplayName("intersection [a-z&&[def]]")
     void intersection() {
       assertMatchesSame("[a-z&&[def]]", "d");
@@ -428,7 +427,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/139")
     @DisplayName("subtraction [a-z&&[^bc]]")
     void subtraction() {
       assertMatchesSame("[a-z&&[^bc]]", "a");
@@ -436,7 +434,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/139")
     @DisplayName("subtraction [a-z&&[^m-p]]")
     void subtractionRange() {
       assertMatchesSame("[a-z&&[^m-p]]", "a");
@@ -659,7 +656,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/139")
     @DisplayName("[\\\\p{L}&&[^\\\\p{Lu}]] (category subtraction)")
     void categorySubtraction() {
       assertMatchesSame("[\\p{L}&&[^\\p{Lu}]]", "a");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -441,7 +441,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/140")
     @DisplayName("surrogate pair range in character class")
     void surrogatePairRange() {
       // From issue #127 comment: surrogate pairs encoding supplementary ranges
@@ -449,7 +448,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/140")
     @DisplayName("complex Unicode range from issue #127")
     void complexUnicodeRange() {
       // Pattern from issue #127 comment
@@ -1319,7 +1317,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/140")
     @DisplayName("complex Unicode range with surrogates from issue #127 comment")
     void complexSurrogateRange() {
       assertCompiles("([\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*)$");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1066,7 +1066,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?d) UNIX_LINES")
     void flagD() {
       assertCompiles("(?d).");
@@ -1087,7 +1086,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?u) unicode case")
     void flagU() {
       assertCompiles("(?u)(?i)abc");
@@ -1106,7 +1104,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("combined flags (?dm)")
     void combinedFlags() {
       assertCompiles("(?dm)^test$");
@@ -1125,21 +1122,18 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?d) combined with (?m) from issue #127")
     void flagDWithM() {
       assertCompiles("(?m)(?d)^(####? .+|---)$");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("all JDK flags combined (?idmsuxU)")
     void allFlags() {
       assertCompiles("(?idmsuxU)test");
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("all JDK flags negated (?-idmsuxU)")
     void allFlagsNegated() {
       assertCompiles("(?idmsuxU)(?-idmsuxU)test");
@@ -1309,7 +1303,6 @@ class JdkSyntaxCompatibilityTest {
   class Issue127EdgeCases {
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/134")
     @DisplayName("(?m)(?d)^(####? .+|---)$")
     void inlineFlagDWithMultiline() {
       assertMatchesSame("(?m)(?d)^(####? .+|---)$", "## Hello");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -144,7 +144,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/138")
     @DisplayName("octal \\\\0mnn (three digits)")
     void octalThreeDigits() {
       assertMatchesSame("\\0101", "A");  // 0101 octal = 65 = 'A'

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -908,7 +908,6 @@ class JdkSyntaxCompatibilityTest {
     // -- Nested repetitions (from issue #127) --
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/135")
     @DisplayName("nested repetition {0,99} inside {0,5}")
     void nestedRepetition() {
       assertCompiles("(?:a (?:b{0,99}|c{0,9})){0,5}");
@@ -1315,7 +1314,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/135")
     @DisplayName("nested repetition (?:a (?:b{0,99}|c{0,9})){0,5}")
     void nestedRepetitionFromIssue() {
       assertMatchesSame("(?:a (?:b{0,99}|c{0,9})){0,5}", "a bbb");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -775,7 +775,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/137")
     @DisplayName("\\\\b{g} grapheme cluster boundary")
     void graphemeClusterBoundary() {
       assertCompiles("\\b{g}");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -699,7 +699,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/136")
     @DisplayName("\\\\p{IsWhiteSpace} (no underscore, from issue #127)")
     void isWhiteSpaceNoUnderscore() {
       // JDK is flexible about underscores in property names
@@ -1320,7 +1319,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @Disabled("https://github.com/eaftan/safere/issues/136")
     @DisplayName("\\\\p{IsWhiteSpace} (no underscore)")
     void isWhiteSpaceNoUnderscore() {
       assertMatchesSame("\\p{IsWhiteSpace}", " ");

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1192,10 +1192,12 @@ class ParserTest {
     }
 
     @Test
-    void nonGreedy_UFlag() {
+    void unicodeCharClass_UFlag() {
+      // (?U) is JDK's UNICODE_CHARACTER_CLASS, not RE2's non-greedy.
       Regexp re = parse("(?U)a*");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
-      assertThat(re.nonGreedy()).isTrue();
+      assertThat(re.nonGreedy()).isFalse();
+      assertThat((re.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0).isTrue();
     }
 
     @Test


### PR DESCRIPTION
The `\uhhhh` surrogate pair combination added in #133 already handles surrogate pair ranges in character classes correctly. The `\u` escape parser combines high+low surrogate pairs into supplementary code points, so `[\uD800\uDC00-\uDBFF\uDFFF]` is correctly parsed as `[U+10000-U+10FFFF]`.

Enables 3 previously disabled tests in `JdkSyntaxCompatibilityTest`.

Fixes #140