### PR TITLE
Make run-java-benchmarks.sh the single source of truth for JMH settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,14 +74,10 @@ jobs:
           cache: maven
 
       - name: Smoke test Java benchmarks
-        run: ./run-java-benchmarks.sh RegexBenchmark
-        env:
-          JMH_OPTS: "-f 0 -wi 1 -i 1 -w 1 -r 1"
+        run: ./run-java-benchmarks.sh --smoke RegexBenchmark
 
       - name: Smoke test Java memory benchmarks (GC profiler)
-        run: ./run-java-memory-benchmarks.sh RegexBenchmark
-        env:
-          JMH_OPTS: "-f 0 -wi 1 -i 1 -w 1 -r 1"
+        run: ./run-java-memory-benchmarks.sh --smoke RegexBenchmark
 
       - name: Smoke test Java memory benchmarks (pattern sizes)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,12 +228,16 @@ runs `mvn install` to build a shaded (fat) JAR, then runs it with
 self-contained classpath. Do NOT use `mvn exec:java`, which breaks fork
 mode because the forked child cannot find JMH classes.
 
+The script is the **single source of truth** for benchmark settings.
+Benchmark classes have no `@Fork`, `@Warmup`, or `@Measurement` annotations
+— all statistical rigor settings are controlled by the script.
+
 ```bash
-# BENCHMARKS.md updates — NO JMH_OPTS, full JMH defaults
+# BENCHMARKS.md updates — publication-quality (default, no flags needed)
 ./run-java-benchmarks.sh RegexBenchmark
 
 # Quick development iteration ONLY — fast but NOT for BENCHMARKS.md
-JMH_OPTS="-f 0 -wi 1 -i 3 -w 1 -r 1" ./run-java-benchmarks.sh RegexBenchmark
+./run-java-benchmarks.sh --quick RegexBenchmark
 ```
 
 **Run benchmarks in batches, not all at once.** Run 2–3 benchmark classes
@@ -255,17 +259,20 @@ per invocation and collect results incrementally:
 
 ### Key Rules
 
-- **NEVER set `JMH_OPTS` when generating data for BENCHMARKS.md.** Use full
-  JMH defaults (5 forks, 5 warmup × 10s, 5 measurement × 10s). `JMH_OPTS`
-  is ONLY for quick development iteration.
+- **The default run is always publication-quality.** Running the script
+  without `--quick` produces 5 forks, 5 warmup × 10s, 5 measurement × 10s.
+  No environment variables or extra flags needed.
+- **Use `--quick` for development iteration only.** Quick mode uses 1 fork,
+  3 warmup × 1s, 5 measurement × 1s. Never use `--quick` results in
+  BENCHMARKS.md.
+- **Pathological benchmarks always use `-f 0`.** The script handles this
+  automatically — PathologicalBenchmark and PathologicalComparisonBenchmark
+  run without forking because the JDK engine can hang on large inputs.
 - **NEVER run benchmarks in parallel.** All benchmark runs (Java, C++, Go)
   must run sequentially, one at a time. Parallel runs compete for CPU,
   cache, and memory bandwidth, producing inaccurate results.
 - **Do not commit optimizations that do not improve benchmark results.**
   Every optimization must be validated with before/after benchmarks.
-- **Use fork mode for publishable data.** Each fork starts a fresh JVM,
-  eliminating JIT profile pollution. Use `-f 0` only for quick spot-checks
-  during development.
 - **All harnesses share `benchmark-data.json`.** This ensures identical
   patterns, inputs, and parameters across Java, C++, and Go. Edit the
   JSON file to change workloads; never hardcode values in the harness.

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -7,6 +7,7 @@
 # Usage:
 #   ./run-java-benchmarks.sh RegexBenchmark         # publication-quality (default)
 #   ./run-java-benchmarks.sh --quick RegexBenchmark  # fast dev iteration
+#   ./run-java-benchmarks.sh --smoke RegexBenchmark  # CI smoke test (minimal)
 #   ./run-java-benchmarks.sh                         # run all benchmarks
 #
 # The script builds a shaded (fat) JAR containing all dependencies and runs
@@ -23,6 +24,9 @@
 #                        5 measurement × 10s. Use for BENCHMARKS.md.
 #   --quick:             Dev iteration — 1 fork, 3 warmup × 1s,
 #                        5 measurement × 1s. NOT for BENCHMARKS.md.
+#   --smoke:             CI smoke test — 0 forks, 1 warmup × 1s,
+#                        1 measurement × 1s. Just verifies benchmarks compile
+#                        and run without errors.
 #
 # Pathological benchmarks (PathologicalBenchmark, PathologicalComparisonBenchmark)
 # always run with -f 0 (no forking) because the JDK engine can hang on large
@@ -37,19 +41,28 @@ RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 # Publication-quality settings (JMH built-in defaults, made explicit).
 PUBLISH_OPTS="-f 5 -wi 5 -w 10 -i 5 -r 10"
 QUICK_OPTS="-f 1 -wi 3 -w 1 -i 5 -r 1"
+SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 
 # Pathological benchmarks must run without forking (JDK can hang).
 PATHOLOGICAL_PUBLISH_OPTS="-f 0 -wi 5 -w 10 -i 5 -r 10"
 PATHOLOGICAL_QUICK_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
+PATHOLOGICAL_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 
-# Parse --quick flag.
+# Parse mode flag.
 MODE="publish"
 if [ "${1:-}" = "--quick" ]; then
   MODE="quick"
   shift
+elif [ "${1:-}" = "--smoke" ]; then
+  MODE="smoke"
+  shift
 fi
 
-if [ "$MODE" = "quick" ]; then
+if [ "$MODE" = "smoke" ]; then
+  JMH_OPTS="$SMOKE_OPTS"
+  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_SMOKE_OPTS"
+  echo "=== Smoke-test mode (CI only) ==="
+elif [ "$MODE" = "quick" ]; then
   JMH_OPTS="$QUICK_OPTS"
   PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_QUICK_OPTS"
   echo "=== Quick mode (NOT for BENCHMARKS.md) ==="

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -5,14 +5,28 @@
 # Run SafeRE JMH benchmarks.
 #
 # Usage:
-#   ./run-java-benchmarks.sh                    # run all benchmarks
-#   ./run-java-benchmarks.sh RegexBenchmark     # run a specific benchmark class
-#   ./run-java-benchmarks.sh Capture Regex      # run multiple benchmark classes
+#   ./run-java-benchmarks.sh RegexBenchmark         # publication-quality (default)
+#   ./run-java-benchmarks.sh --quick RegexBenchmark  # fast dev iteration
+#   ./run-java-benchmarks.sh                         # run all benchmarks
 #
 # The script builds a shaded (fat) JAR containing all dependencies and runs
 # it with `java -jar`. This is required for JMH fork mode to work — forked
 # JVMs need a self-contained classpath. Running via `mvn exec:java` breaks
 # fork mode because the forked child cannot find JMH classes.
+#
+# The benchmark classes have no @Fork/@Warmup/@Measurement annotations, so
+# ALL statistical rigor settings come from this script. This avoids confusion
+# between annotation values and command-line overrides.
+#
+# Modes:
+#   Default (no flags):  Publication-quality — 5 forks, 5 warmup × 10s,
+#                        5 measurement × 10s. Use for BENCHMARKS.md.
+#   --quick:             Dev iteration — 1 fork, 3 warmup × 1s,
+#                        5 measurement × 1s. NOT for BENCHMARKS.md.
+#
+# Pathological benchmarks (PathologicalBenchmark, PathologicalComparisonBenchmark)
+# always run with -f 0 (no forking) because the JDK engine can hang on large
+# inputs, making forked JVM processes unrecoverable.
 
 set -euo pipefail
 
@@ -20,10 +34,30 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 
-# JMH options (can be overridden via JMH_OPTS env var)
-# Default: no flags, letting JMH use its built-in defaults
-# (5 forks, 5 warmup iters x 10s, 5 measurement iters x 10s).
-JMH_OPTS="${JMH_OPTS:-}"
+# Publication-quality settings (JMH built-in defaults, made explicit).
+PUBLISH_OPTS="-f 5 -wi 5 -w 10 -i 5 -r 10"
+QUICK_OPTS="-f 1 -wi 3 -w 1 -i 5 -r 1"
+
+# Pathological benchmarks must run without forking (JDK can hang).
+PATHOLOGICAL_PUBLISH_OPTS="-f 0 -wi 5 -w 10 -i 5 -r 10"
+PATHOLOGICAL_QUICK_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
+
+# Parse --quick flag.
+MODE="publish"
+if [ "${1:-}" = "--quick" ]; then
+  MODE="quick"
+  shift
+fi
+
+if [ "$MODE" = "quick" ]; then
+  JMH_OPTS="$QUICK_OPTS"
+  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_QUICK_OPTS"
+  echo "=== Quick mode (NOT for BENCHMARKS.md) ==="
+else
+  JMH_OPTS="$PUBLISH_OPTS"
+  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_PUBLISH_OPTS"
+  echo "=== Publication mode (for BENCHMARKS.md) ==="
+fi
 
 # JVM args for FFM native access and native library path.
 JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR"
@@ -31,12 +65,29 @@ JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DI
 echo "=== Building safere + benchmark JAR ==="
 mvn install -DskipTests -q -f "$SCRIPT_DIR/pom.xml"
 
+# Returns true if the benchmark name matches a pathological benchmark.
+is_pathological() {
+  case "$1" in
+    *Pathological*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_benchmark() {
+  local bench="$1"
+  local opts="$JMH_OPTS"
+  if is_pathological "$bench"; then
+    opts="$PATHOLOGICAL_JMH_OPTS"
+  fi
+  echo "=== Running $bench ($opts) ==="
+  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "$bench"
+}
+
 if [ $# -eq 0 ]; then
   echo "=== Running all benchmarks ==="
   java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $JMH_OPTS
 else
   for bench in "$@"; do
-    echo "=== Running $bench ==="
-    java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $JMH_OPTS "$bench"
+    run_benchmark "$bench"
   done
 fi

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -5,14 +5,17 @@
 # Run SafeRE JMH benchmarks with GC profiling to measure allocation rates.
 #
 # Usage:
-#   ./run-java-memory-benchmarks.sh                    # run all benchmarks
-#   ./run-java-memory-benchmarks.sh RegexBenchmark     # run a specific benchmark class
-#   ./run-java-memory-benchmarks.sh Capture Regex      # run multiple benchmark classes
+#   ./run-java-memory-benchmarks.sh RegexBenchmark         # publication-quality (default)
+#   ./run-java-memory-benchmarks.sh --quick RegexBenchmark  # fast dev iteration
+#   ./run-java-memory-benchmarks.sh --smoke RegexBenchmark  # CI smoke test
+#   ./run-java-memory-benchmarks.sh                         # run all benchmarks
 #
 # This runs the same benchmarks as run-java-benchmarks.sh but adds JMH's
 # GC profiler (-prof gc), which reports gc.alloc.rate.norm (bytes allocated
 # per operation). This metric is deterministic — it counts bytes, not time —
 # and is not affected by other processes on the machine.
+#
+# See run-java-benchmarks.sh for details on modes and settings.
 
 set -euo pipefail
 
@@ -20,11 +23,31 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 
-# JMH options (can be overridden via JMH_OPTS env var)
-# Default: no flags, letting JMH use its built-in defaults
-# (5 forks, 5 warmup iters x 10s, 5 measurement iters x 10s).
-# The GC profiler is always added.
-JMH_OPTS="${JMH_OPTS:-}"
+# Publication-quality settings (JMH built-in defaults, made explicit).
+PUBLISH_OPTS="-f 5 -wi 5 -w 10 -i 5 -r 10"
+QUICK_OPTS="-f 1 -wi 3 -w 1 -i 5 -r 1"
+SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
+
+# Parse mode flag.
+MODE="publish"
+if [ "${1:-}" = "--quick" ]; then
+  MODE="quick"
+  shift
+elif [ "${1:-}" = "--smoke" ]; then
+  MODE="smoke"
+  shift
+fi
+
+if [ "$MODE" = "smoke" ]; then
+  JMH_OPTS="$SMOKE_OPTS"
+  echo "=== Smoke-test mode (CI only) ==="
+elif [ "$MODE" = "quick" ]; then
+  JMH_OPTS="$QUICK_OPTS"
+  echo "=== Quick mode (NOT for BENCHMARKS.md) ==="
+else
+  JMH_OPTS="$PUBLISH_OPTS"
+  echo "=== Publication mode (for BENCHMARKS.md) ==="
+fi
 
 # JVM args for FFM native access and native library path.
 JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR"

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CaptureScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CaptureScalingBenchmark.java
@@ -8,14 +8,11 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Benchmarks for capture group overhead scaling, ported from RE2 C++ {@code regexp_benchmark.cc}.
@@ -26,9 +23,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class CaptureScalingBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CompileBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CompileBenchmark.java
@@ -8,23 +8,17 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Benchmarks for pattern compilation time: SafeRE vs {@code java.util.regex}.
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class CompileBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/FanoutBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/FanoutBenchmark.java
@@ -9,15 +9,12 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Pathological fanout benchmark, ported from RE2 C++ {@code regexp_benchmark.cc}.
@@ -31,9 +28,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class FanoutBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/HttpBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/HttpBenchmark.java
@@ -8,14 +8,11 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * HTTP request parsing benchmark, ported from RE2 C++ {@code regexp_benchmark.cc}.
@@ -25,9 +22,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class HttpBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryScalingBenchmark.java
@@ -11,15 +11,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * JMH benchmarks measuring how per-match allocation rate scales with input size. Run with {@code
@@ -36,9 +33,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class MemoryScalingBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalBenchmark.java
@@ -8,15 +8,12 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Benchmark demonstrating the pathological case that causes backtracking engines to exhibit
@@ -37,9 +34,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(0)
 @State(Scope.Thread)
 public class PathologicalBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalComparisonBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalComparisonBenchmark.java
@@ -8,15 +8,12 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Comparison of SafeRE vs JDK on the pathological pattern {@code a?{n}a{n}} for small n values
@@ -24,9 +21,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(0)
 @State(Scope.Thread)
 public class PathologicalComparisonBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternSetBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternSetBenchmark.java
@@ -10,15 +10,12 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Benchmarks for {@link PatternSet} multi-pattern matching.
@@ -28,9 +25,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class PatternSetBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexBenchmark.java
@@ -8,14 +8,11 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * JMH benchmarks comparing SafeRE against {@code java.util.regex}. Run with:
@@ -35,9 +32,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class RegexBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ReplaceBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ReplaceBenchmark.java
@@ -8,14 +8,11 @@ package org.safere.benchmark;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Benchmarks for replace operations: SafeRE vs {@code java.util.regex}.
@@ -25,9 +22,6 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class ReplaceBenchmark {
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SearchScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SearchScalingBenchmark.java
@@ -9,15 +9,12 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
@@ -38,9 +35,6 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
 @State(Scope.Thread)
 public class SearchScalingBenchmark {
 


### PR DESCRIPTION
## Summary

Remove `@Fork`, `@Warmup`, `@Measurement` annotations from all 11 benchmark classes. The shell script now controls all statistical rigor settings, eliminating the annotation-vs-CLI-vs-docs confusion from #152.

## Changes

**Benchmark classes** (11 files): Removed `@Fork`, `@Warmup`, `@Measurement` annotations and their imports. Kept `@BenchmarkMode`, `@OutputTimeUnit`, `@State` (these are semantic, not rigor settings).

**`run-java-benchmarks.sh`**: 
- Default mode (no flags) = publication-quality: `-f 5 -wi 5 -w 10 -i 5 -r 10`
- `--quick` flag = dev iteration: `-f 1 -wi 3 -w 1 -i 5 -r 1`
- Pathological benchmarks automatically get `-f 0` (JDK engine can hang)
- Removed `JMH_OPTS` env var — no more hidden overrides

**`AGENTS.md`**: Updated benchmarking section to reflect the new approach.

## Why

The old setup had three conflicting layers (JMH defaults, annotations, CLI flags). The annotations silently produced 1-fork/1-second data when AGENTS.md said you'd get publication-quality results. Now the default is always correct.

Fixes #152