### PR TITLE
Reduce publication benchmark settings for faster execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ per invocation and collect results incrementally:
 ### Key Rules
 
 - **The default run is always publication-quality.** Running the script
-  without `--quick` produces 5 forks, 5 warmup × 10s, 5 measurement × 10s.
+  without `--quick` produces 3 forks, 3 warmup × 5s, 5 measurement × 5s.
   No environment variables or extra flags needed.
 - **Use `--quick` for development iteration only.** Quick mode uses 1 fork,
   3 warmup × 1s, 5 measurement × 1s. Never use `--quick` results in

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -12,7 +12,7 @@ workloads and pathological patterns that demonstrate backtracking blowup.
 - OS: Ubuntu 24.04.4 LTS on WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2),
   Windows 11 host
 - JDK: OpenJDK 25.0.2+10-69 (targeting Java 21)
-- JMH: 1.37, fork mode (5 forks, full JMH defaults)
+- JMH: 1.37, fork mode (1 fork, 3 warmup × 1s, 5 measurement × 1s)
 - RE2-FFM: C++ RE2 (2024-07-02) accessed via Java FFM API (JEP 454)
 - C++ compiler: g++ 13.3.0, `-O3 -DNDEBUG` (CMake Release)
 - Go: 1.26.1 linux/amd64
@@ -58,15 +58,13 @@ All benchmarks use a warmup-then-measure approach, but the settings differ
 between Java and native harnesses to account for their different runtime
 characteristics.
 
-**Java (JMH):** All JMH defaults — 5 forks × (5 warmup × 10s + 5 measurement
-× 10s). Each fork starts a **fresh JVM process**, which is critical because
-the JIT compiler is non-deterministic — different runs may make different
-inlining and optimization decisions based on profiling data. Five forks sample
-this variance so results reflect typical JIT behavior rather than one lucky
-(or unlucky) compilation. The generous warmup (50s per fork) ensures the JIT
-completes tiered compilation (C1 → C2) and reaches steady state before
-measurement begins. Total: 25 samples from 5 independent JVMs, ~8 minutes per
-benchmark method.
+**Java (JMH):** 1 fork × (3 warmup × 1s + 5 measurement × 1s). These results
+were collected before [#152](https://github.com/eaftan/safere/issues/152)
+discovered that JMH annotation settings in the benchmark classes were
+overriding the intended publication-quality defaults. The actual settings used
+were less rigorous than intended. A full re-run with publication-quality
+settings (3 forks, 3 warmup × 5s, 5 measurement × 5s) is tracked in
+[#155](https://github.com/eaftan/safere/issues/155).
 
 **C++ and Go:** 2 warmup + 10 measurement iterations × 2s each, single process.
 Native code has no JIT, so the same binary always runs the same machine code —
@@ -535,12 +533,13 @@ substantially faster than all other RE2-family implementations except
 the C++ original.
 
 **Impact of fork mode:** These results were collected with JMH fork mode
-(5 forks per benchmark), which starts a fresh JVM for each fork to avoid
-JIT profile pollution between benchmarks. Prior results collected in no-fork
-mode (`-f 0`) showed distorted JDK numbers (artificially slow on some
-benchmarks due to JIT profile contamination from RE2/J and SafeRE code
-paths). Fork-mode results are more representative of real-world performance
-where JDK regex runs in its own application.
+(1 fork per benchmark), which starts a fresh JVM to avoid JIT profile
+pollution between benchmarks. Prior results collected in no-fork mode (`-f 0`)
+showed distorted JDK numbers (artificially slow on some benchmarks due to JIT
+profile contamination from RE2/J and SafeRE code paths). Fork-mode results
+are more representative of real-world performance where JDK regex runs in its
+own application. A re-run with 3 forks (to better sample JIT variance) is
+planned.
 
 ## Optimizations Applied
 

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -20,8 +20,8 @@
 # between annotation values and command-line overrides.
 #
 # Modes:
-#   Default (no flags):  Publication-quality — 5 forks, 5 warmup × 10s,
-#                        5 measurement × 10s. Use for BENCHMARKS.md.
+#   Default (no flags):  Publication-quality — 3 forks, 3 warmup × 5s,
+#                        5 measurement × 5s. Use for BENCHMARKS.md.
 #   --quick:             Dev iteration — 1 fork, 3 warmup × 1s,
 #                        5 measurement × 1s. NOT for BENCHMARKS.md.
 #   --smoke:             CI smoke test — 0 forks, 1 warmup × 1s,
@@ -38,13 +38,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 
-# Publication-quality settings (JMH built-in defaults, made explicit).
-PUBLISH_OPTS="-f 5 -wi 5 -w 10 -i 5 -r 10"
+# Publication-quality settings: 3 forks × (3 warmup × 5s + 5 measurement × 5s).
+# 15 samples per method — sufficient for meaningful confidence intervals.
+PUBLISH_OPTS="-f 3 -wi 3 -w 5 -i 5 -r 5"
 QUICK_OPTS="-f 1 -wi 3 -w 1 -i 5 -r 1"
 SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 
 # Pathological benchmarks must run without forking (JDK can hang).
-PATHOLOGICAL_PUBLISH_OPTS="-f 0 -wi 5 -w 10 -i 5 -r 10"
+PATHOLOGICAL_PUBLISH_OPTS="-f 0 -wi 3 -w 5 -i 5 -r 5"
 PATHOLOGICAL_QUICK_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
 PATHOLOGICAL_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -23,8 +23,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 
-# Publication-quality settings (JMH built-in defaults, made explicit).
-PUBLISH_OPTS="-f 5 -wi 5 -w 10 -i 5 -r 10"
+# Publication-quality settings: 3 forks × (3 warmup × 5s + 5 measurement × 5s).
+# 15 samples per method — sufficient for meaningful confidence intervals.
+PUBLISH_OPTS="-f 3 -wi 3 -w 5 -i 5 -r 5"
 QUICK_OPTS="-f 1 -wi 3 -w 1 -i 5 -r 1"
 SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 


### PR DESCRIPTION
Change default (publication-quality) JMH settings from `-f 5 -wi 5 -w 10 -i 5 -r 10` (~500s/method, ~35h total) to `-f 3 -wi 3 -w 5 -i 5 -r 5` (~120s/method, ~8.5h total).

3 forks with 15 samples per method is still rigorous enough for meaningful confidence intervals. The biggest savings come from reducing warmup (pure dead time) from 50s to 15s per fork.

No interface changes — `./run-java-benchmarks.sh` (no flags) is still publication quality, `--quick` and `--smoke` are unchanged.

Fixes #156