### PR TITLE
Add benchmark result collection script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dependency-reduced-pom.xml
 safere-ffm-re2/build/
 org.safere.benchmark.*
 .flattened-pom.xml
+
+# Local benchmark result captures
+benchmark-results/

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -28,29 +28,8 @@ the same algorithmic ballpark as other RE2-family engines, not to declare a
 winner across language boundaries. Within the Java ecosystem, the SafeRE vs JDK
 vs RE2/J vs RE2-FFM comparison is apples-to-apples.
 
-**Running benchmarks:**
-
-```bash
-# Java benchmarks — always use the wrapper script (runs `mvn install` first)
-./run-java-benchmarks.sh                        # all benchmarks
-./run-java-benchmarks.sh CaptureScalingBenchmark  # specific class
-
-# Java memory profiling — allocation rates (bytes/op) via JMH GC profiler
-./run-java-memory-benchmarks.sh                        # all benchmarks with -prof gc
-./run-java-memory-benchmarks.sh RegexBenchmark         # specific class
-
-# Java compiled pattern sizes — standalone measurement
-java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
-  org.safere.benchmark.MemoryBenchmark
-
-# C++ RE2 benchmarks
-./run-cpp-benchmarks.sh                    # all C++ benchmarks
-./run-cpp-benchmarks.sh Regex Compile      # specific benchmark groups
-
-# Go regexp benchmarks
-./run-go-benchmarks.sh                     # all Go benchmarks
-./run-go-benchmarks.sh Regex Compile       # specific benchmark groups
-```
+For instructions on collecting publication-quality benchmark data, see
+[Benchmarks](README.md#benchmarks) in the README.
 
 ## Methodology
 

--- a/README.md
+++ b/README.md
@@ -310,10 +310,52 @@ SafeRE includes a [JMH](https://github.com/openjdk/jmh) benchmark suite in the
 [RE2/J](https://github.com/google/re2j), RE2-FFM (C++ RE2 via Java
 [FFM API](https://openjdk.org/jeps/454)), C++ RE2, and Go `regexp`.
 
-### Running Benchmarks
+### Publication-Quality Benchmark Collection
+
+To collect a full set of benchmark data for updating
+[BENCHMARKS.md](BENCHMARKS.md), run the collection script from the repository
+root:
+
+```bash
+./collect-benchmark-results.sh
+```
+
+The script runs the Java, C++ RE2, and Go benchmark batches sequentially,
+captures raw output, extracts native JSON-lines results, and generates merged
+markdown tables. It does not run the test suite.
+
+By default, results are written to a timestamped directory under
+`benchmark-results/`, and `benchmark-results/latest` is updated to point to
+the newest run. To choose a specific output directory:
+
+```bash
+./collect-benchmark-results.sh --output-dir benchmark-results/my-run
+```
+
+When the run finishes, hand off the result directory to the agent that will
+update `BENCHMARKS.md`:
+
+```text
+benchmark-results/latest
+```
+
+The important files in that directory are:
+
+```text
+jmh-output.txt
+cpp-results.jsonl
+go-results.jsonl
+merged-tables.md
+java-memory.txt
+java-pattern-memory.txt
+```
+
+### Targeted Benchmark Runs
 
 Always use the wrapper scripts — they run `mvn install` first to ensure
-the benchmark module picks up the latest SafeRE code:
+the benchmark module picks up the latest SafeRE code. These are useful for
+development iteration or focused investigation; use
+`./collect-benchmark-results.sh` for full publication-quality collection.
 
 ```bash
 # Java benchmarks (throughput)
@@ -324,8 +366,8 @@ the benchmark module picks up the latest SafeRE code:
 ./run-java-memory-benchmarks.sh                 # all benchmarks
 ./run-java-memory-benchmarks.sh RegexBenchmark  # specific class
 
-# Override JMH options (development only — NOT for BENCHMARKS.md)
-JMH_OPTS="-f 0 -wi 1 -i 3 -w 1 -r 1" ./run-java-benchmarks.sh RegexBenchmark
+# Fast development iteration only — NOT for BENCHMARKS.md
+./run-java-benchmarks.sh --quick RegexBenchmark
 ```
 
 ### C++ RE2 and Go Benchmarks
@@ -344,7 +386,7 @@ cross-language comparison. Prerequisites: CMake ≥ 3.14 + C++17 compiler
 ./run-go-benchmarks.sh Regex Compile       # specific benchmark groups
 ```
 
-### Comparing Results
+### Comparing Results Manually
 
 A comparison script merges JMH, C++, and Go results into side-by-side markdown:
 

--- a/README.md
+++ b/README.md
@@ -322,15 +322,11 @@ root:
 
 The script runs the Java, C++ RE2, and Go benchmark batches sequentially,
 captures raw output, extracts native JSON-lines results, and generates merged
-markdown tables. It does not run the test suite.
+markdown tables.
 
 By default, results are written to a timestamped directory under
 `benchmark-results/`, and `benchmark-results/latest` is updated to point to
-the newest run. To choose a specific output directory:
-
-```bash
-./collect-benchmark-results.sh --output-dir benchmark-results/my-run
-```
+the newest run. 
 
 When the run finishes, hand off the result directory to the agent that will
 update `BENCHMARKS.md`:

--- a/README.md
+++ b/README.md
@@ -320,6 +320,12 @@ root:
 ./collect-benchmark-results.sh
 ```
 
+To verify the collection pipeline without doing a full run:
+
+```bash
+./collect-benchmark-results.sh --smoke
+```
+
 The script runs the Java, C++ RE2, and Go benchmark batches sequentially,
 captures raw output, extracts native JSON-lines results, and generates merged
 markdown tables.

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
+# See LICENSE file in the project root for details.
+#
+# Collect publication-quality benchmark outputs for updating BENCHMARKS.md.
+#
+# Usage:
+#   ./collect-benchmark-results.sh
+#   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
+#
+# The script intentionally does not run the test suite. It runs benchmark
+# batches sequentially, captures raw output, extracts native JSONL results, and
+# generates merged markdown tables.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTPUT_DIR="$SCRIPT_DIR/benchmark-results/$DEFAULT_RUN_ID"
+
+usage() {
+  cat <<EOF
+Usage:
+  ./collect-benchmark-results.sh
+  ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
+
+Collects publication-quality benchmark outputs for updating BENCHMARKS.md.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output-dir)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --output-dir requires a path" >&2
+        exit 2
+      fi
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$OUTPUT_DIR" != /* ]]; then
+  OUTPUT_DIR="$SCRIPT_DIR/$OUTPUT_DIR"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+log() {
+  printf '\n=== %s ===\n' "$*"
+}
+
+run_and_capture() {
+  local output_file="$1"
+  shift
+  log "Running: $*"
+  "$@" 2>&1 | tee "$output_file"
+}
+
+extract_jsonl() {
+  local input_file="$1"
+  local output_file="$2"
+  grep '^{' "$input_file" > "$output_file"
+}
+
+cd "$SCRIPT_DIR"
+
+log "Writing benchmark outputs to $OUTPUT_DIR"
+
+run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
+  ./run-java-benchmarks.sh RegexBenchmark CompileBenchmark
+
+run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
+  ./run-java-benchmarks.sh SearchScalingBenchmark CaptureScalingBenchmark
+
+run_and_capture "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
+  ./run-java-benchmarks.sh HttpBenchmark ReplaceBenchmark FanoutBenchmark
+
+run_and_capture "$OUTPUT_DIR/java-04-pathological.txt" \
+  ./run-java-benchmarks.sh PathologicalBenchmark PathologicalComparisonBenchmark
+
+run_and_capture "$OUTPUT_DIR/java-05-patternset.txt" \
+  ./run-java-benchmarks.sh PatternSetBenchmark
+
+log "Combining Java JMH output"
+cat \
+  "$OUTPUT_DIR/java-01-core.txt" \
+  "$OUTPUT_DIR/java-02-scaling.txt" \
+  "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
+  "$OUTPUT_DIR/java-04-pathological.txt" \
+  "$OUTPUT_DIR/java-05-patternset.txt" \
+  > "$OUTPUT_DIR/jmh-output.txt"
+
+run_and_capture "$OUTPUT_DIR/java-memory.txt" \
+  ./run-java-memory-benchmarks.sh RegexBenchmark SearchScalingBenchmark MemoryScalingBenchmark
+
+run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \
+  java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
+    org.safere.benchmark.MemoryBenchmark
+
+run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
+  ./run-cpp-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+
+log "Extracting C++ JSONL"
+extract_jsonl "$OUTPUT_DIR/cpp-raw.txt" "$OUTPUT_DIR/cpp-results.jsonl"
+
+run_and_capture "$OUTPUT_DIR/go-raw.txt" \
+  ./run-go-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+
+log "Extracting Go JSONL"
+extract_jsonl "$OUTPUT_DIR/go-raw.txt" "$OUTPUT_DIR/go-results.jsonl"
+
+log "Generating merged markdown tables"
+python3 safere-benchmarks/scripts/compare-benchmarks.py \
+  --jmh "$OUTPUT_DIR/jmh-output.txt" \
+  --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl" \
+  --engines safere,jdk,re2j,re2_ffm,re2_cpp,go \
+  > "$OUTPUT_DIR/merged-tables.md"
+
+log "Updating latest symlink"
+ln -sfn "$OUTPUT_DIR" "$SCRIPT_DIR/benchmark-results/latest"
+
+log "Done"
+cat <<EOF
+Benchmark result files are in:
+  $OUTPUT_DIR
+
+Point the agent at:
+  benchmark-results/latest
+
+Key files:
+  jmh-output.txt
+  cpp-results.jsonl
+  go-results.jsonl
+  merged-tables.md
+  java-memory.txt
+  java-pattern-memory.txt
+EOF

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -6,6 +6,7 @@
 #
 # Usage:
 #   ./collect-benchmark-results.sh
+#   ./collect-benchmark-results.sh --smoke
 #   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 #
 # The script intentionally does not run the test suite. It runs benchmark
@@ -17,19 +18,28 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEFAULT_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 OUTPUT_DIR="$SCRIPT_DIR/benchmark-results/$DEFAULT_RUN_ID"
+MODE="publish"
 
 usage() {
   cat <<EOF
 Usage:
   ./collect-benchmark-results.sh
+  ./collect-benchmark-results.sh --smoke
   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 
 Collects publication-quality benchmark outputs for updating BENCHMARKS.md.
+
+Options:
+  --smoke       Run one small benchmark through the collection pipeline.
 EOF
 }
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    --smoke)
+      MODE="smoke"
+      shift
+      ;;
     --output-dir)
       if [ $# -lt 2 ]; then
         echo "ERROR: --output-dir requires a path" >&2
@@ -49,6 +59,10 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$MODE" = "smoke" ] && [ "$OUTPUT_DIR" = "$SCRIPT_DIR/benchmark-results/$DEFAULT_RUN_ID" ]; then
+  OUTPUT_DIR="$SCRIPT_DIR/benchmark-results/smoke-$DEFAULT_RUN_ID"
+fi
+
 if [[ "$OUTPUT_DIR" != /* ]]; then
   OUTPUT_DIR="$SCRIPT_DIR/$OUTPUT_DIR"
 fi
@@ -66,6 +80,11 @@ run_and_capture() {
   "$@" 2>&1 | tee "$output_file"
 }
 
+clean_benchmark_module() {
+  log "Cleaning benchmark module before rebuild"
+  mvn -pl safere-benchmarks clean -q -f "$SCRIPT_DIR/pom.xml"
+}
+
 extract_jsonl() {
   local input_file="$1"
   local output_file="$2"
@@ -75,46 +94,70 @@ extract_jsonl() {
 cd "$SCRIPT_DIR"
 
 log "Writing benchmark outputs to $OUTPUT_DIR"
+log "Mode: $MODE"
 
-run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
-  ./run-java-benchmarks.sh RegexBenchmark CompileBenchmark
+if [ "$MODE" = "smoke" ]; then
+  run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
+    ./run-java-benchmarks.sh --smoke RegexBenchmark.literalMatch
 
-run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
-  ./run-java-benchmarks.sh SearchScalingBenchmark CaptureScalingBenchmark
+  log "Combining Java JMH output"
+  cp "$OUTPUT_DIR/java-01-core.txt" "$OUTPUT_DIR/jmh-output.txt"
 
-run_and_capture "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
-  ./run-java-benchmarks.sh HttpBenchmark ReplaceBenchmark FanoutBenchmark
+  clean_benchmark_module
+  run_and_capture "$OUTPUT_DIR/java-memory.txt" \
+    ./run-java-memory-benchmarks.sh --smoke RegexBenchmark.literalMatch
+else
+  run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
+    ./run-java-benchmarks.sh RegexBenchmark CompileBenchmark
 
-run_and_capture "$OUTPUT_DIR/java-04-pathological.txt" \
-  ./run-java-benchmarks.sh PathologicalBenchmark PathologicalComparisonBenchmark
+  run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
+    ./run-java-benchmarks.sh SearchScalingBenchmark CaptureScalingBenchmark
 
-run_and_capture "$OUTPUT_DIR/java-05-patternset.txt" \
-  ./run-java-benchmarks.sh PatternSetBenchmark
+  run_and_capture "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
+    ./run-java-benchmarks.sh HttpBenchmark ReplaceBenchmark FanoutBenchmark
 
-log "Combining Java JMH output"
-cat \
-  "$OUTPUT_DIR/java-01-core.txt" \
-  "$OUTPUT_DIR/java-02-scaling.txt" \
-  "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
-  "$OUTPUT_DIR/java-04-pathological.txt" \
-  "$OUTPUT_DIR/java-05-patternset.txt" \
-  > "$OUTPUT_DIR/jmh-output.txt"
+  run_and_capture "$OUTPUT_DIR/java-04-pathological.txt" \
+    ./run-java-benchmarks.sh PathologicalBenchmark PathologicalComparisonBenchmark
 
-run_and_capture "$OUTPUT_DIR/java-memory.txt" \
-  ./run-java-memory-benchmarks.sh RegexBenchmark SearchScalingBenchmark MemoryScalingBenchmark
+  run_and_capture "$OUTPUT_DIR/java-05-patternset.txt" \
+    ./run-java-benchmarks.sh PatternSetBenchmark
+
+  log "Combining Java JMH output"
+  cat \
+    "$OUTPUT_DIR/java-01-core.txt" \
+    "$OUTPUT_DIR/java-02-scaling.txt" \
+    "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
+    "$OUTPUT_DIR/java-04-pathological.txt" \
+    "$OUTPUT_DIR/java-05-patternset.txt" \
+    > "$OUTPUT_DIR/jmh-output.txt"
+
+  clean_benchmark_module
+  run_and_capture "$OUTPUT_DIR/java-memory.txt" \
+    ./run-java-memory-benchmarks.sh RegexBenchmark SearchScalingBenchmark MemoryScalingBenchmark
+fi
 
 run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \
   java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
     org.safere.benchmark.MemoryBenchmark
 
-run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-  ./run-cpp-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+if [ "$MODE" = "smoke" ]; then
+  run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
+    ./run-cpp-benchmarks.sh RegexBenchmark.literalMatch
+else
+  run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
+    ./run-cpp-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+fi
 
 log "Extracting C++ JSONL"
 extract_jsonl "$OUTPUT_DIR/cpp-raw.txt" "$OUTPUT_DIR/cpp-results.jsonl"
 
-run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-  ./run-go-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+if [ "$MODE" = "smoke" ]; then
+  run_and_capture "$OUTPUT_DIR/go-raw.txt" \
+    ./run-go-benchmarks.sh RegexBenchmark.literalMatch
+else
+  run_and_capture "$OUTPUT_DIR/go-raw.txt" \
+    ./run-go-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+fi
 
 log "Extracting Go JSONL"
 extract_jsonl "$OUTPUT_DIR/go-raw.txt" "$OUTPUT_DIR/go-results.jsonl"
@@ -126,7 +169,17 @@ python3 safere-benchmarks/scripts/compare-benchmarks.py \
   --engines safere,jdk,re2j,re2_ffm,re2_cpp,go \
   > "$OUTPUT_DIR/merged-tables.md"
 
+if [ "$MODE" = "smoke" ]; then
+  log "Verifying smoke output"
+  missing_cell="$(printf '\342\200\224')"
+  if grep -q "$missing_cell" "$OUTPUT_DIR/merged-tables.md"; then
+    echo "ERROR: smoke merged table contains missing result cells" >&2
+    exit 1
+  fi
+fi
+
 log "Updating latest symlink"
+mkdir -p "$SCRIPT_DIR/benchmark-results"
 ln -sfn "$OUTPUT_DIR" "$SCRIPT_DIR/benchmark-results/latest"
 
 log "Done"

--- a/safere-benchmarks/scripts/compare-benchmarks.py
+++ b/safere-benchmarks/scripts/compare-benchmarks.py
@@ -47,9 +47,13 @@ Result = collections.namedtuple("Result", ["engine", "benchmark", "score", "erro
 _ENGINE_SUFFIXES = collections.OrderedDict([
     ("_safere", "safere"),
     ("_jdk", "jdk"),
+    ("_re2ffm", "re2_ffm"),
     ("_re2j", "re2j"),
 ])
 _DEFAULT_ENGINE = "safere"
+_ENGINE_ALIASES = {
+    "go_regexp": "go",
+}
 
 
 def _engine_from_method(method):
@@ -73,14 +77,14 @@ def _engine_from_method(method):
 # ---------------------------------------------------------------------------
 
 # Regex for the data rows of JMH text output.  Handles optional Cnt column and
-# the ``±`` separator between score and error.
+# the optional ``±`` separator between score and error.
 _JMH_LINE_RE = re.compile(
     r"^(?P<bench>\S+)"       # Fully-qualified benchmark name
     r"\s+\S+"                # Mode (avgt, thrpt, …)
-    r"\s+\d+"                # Cnt
+    r"(?:\s+\d+)?"           # Optional Cnt
     r"\s+(?P<score>[\d.]+)"  # Score
-    r"\s+[±]"               # ± separator
-    r"\s+(?P<error>[\d.]+)"  # Error
+    r"(?:\s+[±]"             # Optional ± separator
+    r"\s+(?P<error>[\d.]+))?"  # Optional error
     r"\s+(?P<unit>\S+)"      # Units
     r"\s*$"
 )
@@ -96,17 +100,15 @@ def parse_jmh(path):
                 continue
             full_name = m.group("bench")
             score = float(m.group("score"))
-            error = float(m.group("error"))
+            error = float(m.group("error") or 0)
             unit = m.group("unit")
 
             # Split "ClassName.method" – keep ClassName prefix for grouping.
             dot = full_name.rfind(".")
             if dot == -1:
-                class_name = ""
-                method = full_name
-            else:
-                class_name = full_name[: dot]
-                method = full_name[dot + 1 :]
+                continue
+            class_name = full_name[: dot]
+            method = full_name[dot + 1 :]
 
             engine, base_method = _engine_from_method(method)
             benchmark = f"{class_name}.{base_method}" if class_name else base_method
@@ -129,8 +131,9 @@ def parse_jsonl(path):
                 print(f"WARNING: {path}:{lineno}: skipping invalid JSON: {exc}",
                       file=sys.stderr)
                 continue
+            engine = _ENGINE_ALIASES.get(obj["engine"], obj["engine"])
             results.append(Result(
-                engine=obj["engine"],
+                engine=engine,
                 benchmark=obj["benchmark"],
                 score=float(obj["score"]),
                 error=float(obj.get("error", 0)),


### PR DESCRIPTION
## Summary
- Add a publication-quality benchmark collection script that captures Java, C++, Go, memory, and merged table outputs
- Document the script and agent handoff path in README
- Ignore local benchmark result captures

## Testing
- bash -n collect-benchmark-results.sh
- ./collect-benchmark-results.sh --help

Note: Benchmarks were not run.