### PR TITLE
Fix capture extraction performance cliff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,9 @@ Drop-in replacements for `java.util.regex`:
 - Use `@Test`, `@ParameterizedTest`, `@DisplayName` as appropriate
 - Aim for high coverage; JaCoCo is configured in the build
 - Port test cases from RE2's C++ test suite where applicable
+- For performance regressions, do not hardcode specific elapsed durations in
+  tests. Test the performance behavior directly in a way that is stable across
+  machines, such as relative ratios between related inputs or scaling behavior.
 - **Do not include test counts in documentation** (DESIGN.md, TESTING.md,
   etc.) — counts change frequently as tests are added and will go stale.
 

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -30,6 +30,9 @@ final class BitState {
   /** Maximum bitmap size in bits. Limits the product of prog size × text length. */
   private static final int MAX_BITMAP_BITS = 256 * 1024;
 
+  /** Maximum BitState jobs to run per instruction/position slot before falling back to NFA. */
+  private static final int MAX_WORK_PER_SLOT = 8;
+
   /**
    * Returns the maximum text length (in chars) for which BitState can be used with the given
    * program, or -1 if the program is too large for BitState.
@@ -164,10 +167,16 @@ final class BitState {
    * @return submatch positions, or null if no match
    */
   int[] doSearch(int startPos, int searchLimit, boolean anchored) {
+    budgetExceeded = false;
+    stepCount = 0;
+    stepBudget = Math.max(4096L, (long) MAX_WORK_PER_SLOT * prog.size() * (endPos + 1));
     int limit = anchored ? startPos + 1 : Math.min(searchLimit + 1, textLen + 1);
     for (int searchStart = startPos; searchStart < limit; searchStart++) {
       if (trySearch(prog.start(), searchStart)) {
         return bestMatch;
+      }
+      if (budgetExceeded) {
+        return null;
       }
       if (searchStart < textLen) {
         int cp = text.codePointAt(searchStart);
@@ -213,6 +222,11 @@ final class BitState {
   /** Best match found so far. */
   private int[] bestMatch;
 
+  /** Work-budget accounting for falling back when BitState backtracking is too expensive. */
+  private long stepBudget;
+  private long stepCount;
+  private boolean budgetExceeded;
+
   /** Explicit job stack for backtracking. */
   private int[] jobInstId;
   private int[] jobPos;
@@ -246,6 +260,9 @@ final class BitState {
     this.jobInstId = new int[maxJobs];
     this.jobPos = new int[maxJobs];
     this.jobCount = 0;
+    this.stepBudget = Math.max(4096L, (long) MAX_WORK_PER_SLOT * prog.size() * (textLen + 1));
+    this.stepCount = 0;
+    this.budgetExceeded = false;
   }
 
   /**
@@ -327,6 +344,10 @@ final class BitState {
     }
 
     while (jobCount > 0) {
+      if (++stepCount > stepBudget) {
+        budgetExceeded = true;
+        return false;
+      }
       jobCount--;
       int id = jobInstId[jobCount];
       int pos = jobPos[jobCount];
@@ -479,6 +500,11 @@ final class BitState {
     }
 
     return matched;
+  }
+
+  /** Returns whether the previous search stopped because BitState exceeded its work budget. */
+  boolean budgetExceeded() {
+    return budgetExceeded;
   }
 
   /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1121,7 +1121,9 @@ public final class Matcher implements MatchResult {
   private int[] searchWithBitStateOrNfa(Prog prog, String text, int startPos,
       int searchLimit, int endPos, boolean anchored, boolean longest, boolean endMatch,
       int nsubmatch) {
-    // Try BitState if the full text is small enough for the visited bitmap.
+    // Try BitState if the full text is small enough for the visited bitmap. BitState is an
+    // optimization; if capture-priority backtracking exceeds its work budget, fall back to the
+    // Pike NFA below.
     int maxBitStateLen = BitState.maxTextSize(prog);
     if (maxBitStateLen >= 0 && text.length() <= maxBitStateLen) {
       boolean anchoredEffective = anchored || prog.anchorStart();
@@ -1139,8 +1141,10 @@ public final class Matcher implements MatchResult {
       cachedBitState = bs;
       // Return to Pattern's cache for reuse by future Matchers.
       parentPattern.returnBitState(bs);
-      // BitState is a complete engine — if it searched and found no match, NFA won't either.
-      return result;
+      if (!bs.budgetExceeded()) {
+        // BitState is a complete engine — if it searched and found no match, NFA won't either.
+        return result;
+      }
     }
 
     // Fall back to general NFA (only for texts too large for BitState).

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -9,10 +9,9 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
-import java.time.Duration;
 import java.util.regex.MatchResult;
+import java.util.function.IntConsumer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -135,20 +134,34 @@ class MatcherTest {
     @Test
     @DisplayName("matches() stays linear for repeated dot-star with bounded captures")
     void matchesWithRepeatedDotStarAndBoundedCaptures() {
-      String input = issue161SqlUnionInput(10);
       Pattern p =
           Pattern.compile(
               ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
               Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-      Matcher m = p.matcher(input);
 
-      assertTimeoutPreemptively(
-          Duration.ofSeconds(1),
-          () -> {
+      assertNoIssue166PerformanceCliff(
+          "matches()",
+          blocks -> {
+            String input = issue161SqlUnionInput(blocks);
+            Matcher m = p.matcher(input);
             assertThat(m.matches()).isTrue();
             assertThat(m.group()).isEqualTo(input);
             assertThat(m.start()).isEqualTo(0);
             assertThat(m.end()).isEqualTo(input.length());
+          });
+    }
+
+    @Test
+    @DisplayName("lookingAt() stays linear for repeated dot-star with bounded captures")
+    void lookingAtWithRepeatedDotStarAndBoundedCaptures() {
+      Pattern p = issue161SqlUnionPattern();
+
+      assertNoIssue166PerformanceCliff(
+          "lookingAt()",
+          blocks -> {
+            Matcher m = p.matcher(issue161SqlUnionInput(blocks));
+            assertThat(m.lookingAt()).isTrue();
+            assertThat(m.group(1)).contains("INFORMATION_SCHEMA");
           });
     }
 
@@ -157,6 +170,20 @@ class MatcherTest {
   @Nested
   @DisplayName("find()")
   class FindTests {
+
+    @Test
+    @DisplayName("group access after find() stays linear for repeated dot-star captures")
+    void findGroupWithRepeatedDotStarAndBoundedCaptures() {
+      Pattern p = issue161SqlUnionPattern();
+
+      assertNoIssue166PerformanceCliff(
+          "find()+group(1)",
+          blocks -> {
+            Matcher m = p.matcher(issue161SqlUnionInput(blocks));
+            assertThat(m.find()).isTrue();
+            assertThat(m.group(1)).contains("INFORMATION_SCHEMA");
+          });
+    }
 
     @Test
     @DisplayName("find() locates a single match in the input")
@@ -1206,6 +1233,22 @@ class MatcherTest {
   class RegionTests {
 
     @Test
+    @DisplayName("region find stays linear for repeated dot-star captures")
+    void regionFindWithRepeatedDotStarAndBoundedCaptures() {
+      Pattern p = issue161SqlUnionPattern();
+
+      assertNoIssue166PerformanceCliff(
+          "region().find()",
+          blocks -> {
+            String input = "prefix\n" + issue161SqlUnionInput(blocks) + "suffix\n";
+            Matcher m = p.matcher(input);
+            m.region("prefix\n".length(), input.length() - "suffix\n".length());
+            assertThat(m.find()).isTrue();
+            assertThat(m.group(1)).contains("INFORMATION_SCHEMA");
+          });
+    }
+
+    @Test
     @DisplayName("find() respects region boundaries")
     void findRespectsRegion() {
       Pattern p = Pattern.compile("\\d+");
@@ -1986,5 +2029,28 @@ class MatcherTest {
           .append("UNION ALL\n");
     }
     return input.toString();
+  }
+
+  private static Pattern issue161SqlUnionPattern() {
+    return Pattern.compile(
+        ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  }
+
+  private static void assertNoIssue166PerformanceCliff(String api, IntConsumer scenario) {
+    long largerPositiveNanos = runtimeNanos(() -> scenario.accept(16));
+    long nearMinimumNanos = runtimeNanos(() -> scenario.accept(5));
+
+    assertThat(nearMinimumNanos)
+        .as("%s near-minimum input should not be dramatically slower than a larger "
+            + "positive input; near=%d ns, larger=%d ns",
+            api, nearMinimumNanos, largerPositiveNanos)
+        .isLessThan(largerPositiveNanos * 50);
+  }
+
+  private static long runtimeNanos(Runnable task) {
+    long start = System.nanoTime();
+    task.run();
+    return System.nanoTime() - start;
   }
 }


### PR DESCRIPTION
## Summary
- add a BitState work budget and fall back to Pike NFA when capture-priority backtracking stops being cheap
- cover the #166 lookingAt, find()+group(1), and region().find() performance cliff with relative performance tests
- document that performance tests should avoid hardcoded elapsed durations

Fixes #166

## Tests
- mvn -pl safere -Dtest=MatcherTest test -q
- mvn -pl safere test -q