### PR TITLE
Add application regex benchmarks

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -61,6 +61,11 @@ Student's t-distribution (t ≈ 4.781 for 9 df at 99.9%).
 a single `benchmark-data.json` file, ensuring identical workloads across
 languages.
 
+**Workload coverage:** The suite separates focused microbenchmarks from
+corpus-style application workloads. The published numerical tables below were
+collected before `ApplicationBenchmark` was added; rerun the collection script
+before adding application-workload ratios to the summary tables.
+
 | Setting | Java (JMH) | C++ | Go |
 |---|---|---|---|
 | Warmup | 5 × 10s per fork | 2 × 2s | 2 × 2s |
@@ -360,11 +365,14 @@ DaCapo, Renaissance).
 representative. We report two geomeans to avoid conflating qualitatively
 different workloads:
 
-1. **Core workloads** — everyday regex operations: literal match, character
+1. **Core micro workloads** — focused regex operations: literal match, character
    class match, alternation find, capture groups, find-in-text, email find,
-   pig Latin replace, HTTP full request. These represent typical application
-   usage patterns.
-2. **Pathological/scaling** — workloads that stress linear-time guarantees:
+   pig Latin replace, HTTP full request. These are useful for isolating engine
+   behavior, but they are not a complete model of application regex use.
+2. **Application workloads** — corpus-style validation, parsing, extraction,
+   scanning, and redaction cases from `ApplicationBenchmark`. These are intended
+   to represent ordinary application usage more directly than the microbenchmarks.
+3. **Pathological/scaling** — workloads that stress linear-time guarantees:
    `a?{n}a{n}` at n=20, `[ -~]*…$` hard search at 1 MB, nested quantifier
    `(?:a?){20}a{20}` at 100 KB. These are less common in everyday code but
    represent the safety guarantee that motivates the library.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ SafeRE includes a [JMH](https://github.com/openjdk/jmh) benchmark suite in the
 `safere-benchmarks` module, comparing SafeRE against `java.util.regex` (JDK),
 [RE2/J](https://github.com/google/re2j), RE2-FFM (C++ RE2 via Java
 [FFM API](https://openjdk.org/jeps/454)), C++ RE2, and Go `regexp`.
+The suite includes focused microbenchmarks, corpus-style application workloads,
+scaling/pathological cases, replacement, memory, and `PatternSet` benchmarks.
 
 ### Publication-Quality Benchmark Collection
 
@@ -363,6 +365,7 @@ development iteration or focused investigation; use
 # Java benchmarks (throughput)
 ./run-java-benchmarks.sh                        # all benchmarks
 ./run-java-benchmarks.sh RegexBenchmark         # specific class
+./run-java-benchmarks.sh ApplicationBenchmark   # application workloads
 
 # Java memory profiling (allocation rates via JMH GC profiler)
 ./run-java-memory-benchmarks.sh                 # all benchmarks
@@ -381,11 +384,11 @@ cross-language comparison. Prerequisites: CMake ≥ 3.14 + C++17 compiler
 ```bash
 # C++ RE2 benchmarks
 ./run-cpp-benchmarks.sh                    # all C++ benchmarks
-./run-cpp-benchmarks.sh Regex Compile      # specific benchmark groups
+./run-cpp-benchmarks.sh Regex Application  # specific benchmark groups
 
 # Go regexp benchmarks
 ./run-go-benchmarks.sh                     # all Go benchmarks
-./run-go-benchmarks.sh Regex Compile       # specific benchmark groups
+./run-go-benchmarks.sh Regex Application   # specific benchmark groups
 ```
 
 ### Comparing Results Manually

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -108,7 +108,7 @@ if [ "$MODE" = "smoke" ]; then
     ./run-java-memory-benchmarks.sh --smoke RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
-    ./run-java-benchmarks.sh RegexBenchmark CompileBenchmark
+    ./run-java-benchmarks.sh RegexBenchmark ApplicationBenchmark CompileBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
     ./run-java-benchmarks.sh SearchScalingBenchmark CaptureScalingBenchmark
@@ -145,7 +145,7 @@ if [ "$MODE" = "smoke" ]; then
     ./run-cpp-benchmarks.sh RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-    ./run-cpp-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+    ./run-cpp-benchmarks.sh Regex Application Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
 fi
 
 log "Extracting C++ JSONL"
@@ -156,7 +156,7 @@ if [ "$MODE" = "smoke" ]; then
     ./run-go-benchmarks.sh RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-    ./run-go-benchmarks.sh Regex Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+    ./run-go-benchmarks.sh Regex Application Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
 fi
 
 log "Extracting Go JSONL"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -118,6 +118,62 @@
     }
   },
 
+  "application": {
+    "uuidValidation": {
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+      "texts": [
+        "550e8400-e29b-41d4-a716-446655440000",
+        "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        "not-a-uuid",
+        "550e8400e29b41d4a716446655440000",
+        "ffffffff-ffff-5fff-bfff-ffffffffffff",
+        "12345678-1234-7234-9234-123456789abc"
+      ]
+    },
+    "logLineParse": {
+      "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\s+(INFO|WARN|ERROR)\\s+([A-Za-z0-9_.-]+)\\s+-\\s+(.+)$",
+      "texts": [
+        "2026-03-31T14:22:08Z INFO api.gateway - request completed status=200 latency=38ms",
+        "2026-03-31T14:22:09Z WARN db.pool - connection wait exceeded threshold=100ms",
+        "2026-03-31T14:22:10Z ERROR worker-7 - job failed id=abc123 retry=2",
+        "debug line without structured prefix",
+        "2026-03-31 14:22:11 INFO api.gateway - malformed timestamp"
+      ]
+    },
+    "apiRouteMatch": {
+      "pattern": "^/api/v[0-9]+/(users|orders|inventory)/([A-Za-z0-9_-]+)(?:\\?.*)?$",
+      "texts": [
+        "/api/v1/users/12345",
+        "/api/v2/orders/ord_9f3a?include=items",
+        "/api/v3/inventory/sku-7788",
+        "/assets/app.js",
+        "/api/v1/users/",
+        "/api/latest/users/12345"
+      ]
+    },
+    "stackTraceExtract": {
+      "pattern": "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
+      "text": "java.lang.IllegalStateException: failed to process request\n\tat org.example.api.Handler.handle(Handler.java:87)\n\tat org.example.api.Router.dispatch(Router.java:142)\n\tat org.example.Main.main(Main.java:25)\nCaused by: java.io.IOException: timeout\n\tat org.example.net.Client.read(Client.java:203)"
+    },
+    "caseInsensitiveKeywords": {
+      "pattern": "(?i)\\b(error|warning|timeout|failed)\\b",
+      "text": "INFO startup complete\nWarning cache miss ratio high\nrequest failed after TIMEOUT waiting for backend\nERROR circuit breaker opened\nhealth check passed"
+    },
+    "urlExtraction": {
+      "pattern": "(https?://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]*)?)",
+      "text": "Docs: https://example.com/docs/v1/index.html?lang=en and callback http://localhost:8080/api/callback?id=42; mirror at https://cdn.example.org/assets/app.js"
+    },
+    "csvFieldScan": {
+      "pattern": "(?m)(?:^|,)(?:\"([^\"]*)\"|([^,\\r\\n]+))",
+      "text": "id,name,email,status,created_at\n42,\"Ada Lovelace\",ada@example.com,active,2026-03-31T14:22:08Z\n43,\"Grace Hopper\",grace@example.com,pending,2026-04-01T09:15:00Z"
+    },
+    "secretRedaction": {
+      "pattern": "(?i)\\b(password|token|secret)=([^\\s&]+)",
+      "text": "user=service password=hunter2 token=abc123XYZ path=/api secret=prod-key-9 debug=true",
+      "replacement": "$1=REDACTED"
+    }
+  },
+
   "pathological": {
     "nValues": [10, 15, 20, 25, 30, 50, 100],
     "nValuesComparison": [10, 15, 20],

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -269,6 +269,107 @@ void run_regex_benchmarks(const json& data,
   });
 }
 
+void run_application_benchmarks(const json& data,
+                                const std::vector<std::string>& filters) {
+  const auto& sec = data["application"];
+
+  RE2 uuid(sec["uuidValidation"]["pattern"].get<std::string>());
+  RE2 log_line(sec["logLineParse"]["pattern"].get<std::string>());
+  RE2 api_route(sec["apiRouteMatch"]["pattern"].get<std::string>());
+  RE2 stack_trace(sec["stackTraceExtract"]["pattern"].get<std::string>());
+  RE2 keywords(sec["caseInsensitiveKeywords"]["pattern"].get<std::string>());
+  RE2 url(sec["urlExtraction"]["pattern"].get<std::string>());
+  RE2 csv(sec["csvFieldScan"]["pattern"].get<std::string>());
+  RE2 secret(sec["secretRedaction"]["pattern"].get<std::string>());
+
+  std::vector<std::string> uuid_texts =
+      sec["uuidValidation"]["texts"].get<std::vector<std::string>>();
+  std::vector<std::string> log_line_texts =
+      sec["logLineParse"]["texts"].get<std::vector<std::string>>();
+  std::vector<std::string> api_route_texts =
+      sec["apiRouteMatch"]["texts"].get<std::vector<std::string>>();
+  std::string stack_trace_text = sec["stackTraceExtract"]["text"];
+  std::string keyword_text = sec["caseInsensitiveKeywords"]["text"];
+  std::string url_text = sec["urlExtraction"]["text"];
+  std::string csv_text = sec["csvFieldScan"]["text"];
+  std::string secret_text = sec["secretRedaction"]["text"];
+  std::string secret_replacement =
+      convert_replacement(sec["secretRedaction"]["replacement"].get<std::string>());
+
+  auto run = [&](const std::string& name, const std::function<void()>& fn) {
+    if (matches_filter(name, filters)) {
+      print_json(measure(name, fn));
+    }
+  };
+
+  run("ApplicationBenchmark.uuidValidation", [&]() {
+    int count = 0;
+    for (const auto& text : uuid_texts) {
+      if (RE2::FullMatch(text, uuid)) ++count;
+    }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.logLineParse", [&]() {
+    int count = 0;
+    for (const auto& text : log_line_texts) {
+      std::string ts, level, component, message;
+      if (RE2::FullMatch(text, log_line, &ts, &level, &component, &message)) {
+        count += level.size() + component.size();
+      }
+    }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.apiRouteMatch", [&]() {
+    int count = 0;
+    for (const auto& text : api_route_texts) {
+      std::string resource, id;
+      if (RE2::FullMatch(text, api_route, &resource, &id)) {
+        count += resource.size() + id.size();
+      }
+    }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.stackTraceExtract", [&]() {
+    re2::StringPiece input(stack_trace_text);
+    int count = 0;
+    std::string klass, method, file, line;
+    while (RE2::FindAndConsume(&input, stack_trace, &klass, &method, &file, &line)) {
+      count += klass.size() + line.size();
+    }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.caseInsensitiveKeywords", [&]() {
+    re2::StringPiece input(keyword_text);
+    int count = 0;
+    std::string match;
+    while (RE2::FindAndConsume(&input, keywords, &match)) { ++count; }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.urlExtraction", [&]() {
+    re2::StringPiece input(url_text);
+    int count = 0;
+    std::string match;
+    while (RE2::FindAndConsume(&input, url, &match)) {
+      count += match.size();
+    }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.csvFieldScan", [&]() {
+    re2::StringPiece input(csv_text);
+    int count = 0;
+    std::string quoted, unquoted;
+    while (RE2::FindAndConsume(&input, csv, &quoted, &unquoted)) {
+      count += quoted.size() + unquoted.size();
+    }
+    do_not_optimize(count);
+  });
+  run("ApplicationBenchmark.secretRedaction", [&]() {
+    std::string s = secret_text;
+    RE2::GlobalReplace(&s, secret, secret_replacement);
+    do_not_optimize(s);
+  });
+}
+
 void run_compile_benchmarks(const json& data,
                             const std::vector<std::string>& filters) {
   const auto& sec = data["compile"];
@@ -613,6 +714,7 @@ int main(int argc, char* argv[]) {
   json data = load_benchmark_data(data_path);
 
   run_regex_benchmarks(data, filters);
+  run_application_benchmarks(data, filters);
   run_compile_benchmarks(data, filters);
   run_search_scaling_benchmarks(data, filters);
   run_capture_scaling_benchmarks(data, filters);

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -186,6 +186,21 @@ func getIntSlice(data any, path string) []int {
 	return result
 }
 
+func getStringSlice(data any, path string) []string {
+	v := get(data, path)
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, len(arr))
+	for i, item := range arr {
+		if s, ok := item.(string); ok {
+			result[i] = s
+		}
+	}
+	return result
+}
+
 // ---------------------------------------------------------------------------
 // Text generators
 // ---------------------------------------------------------------------------
@@ -268,6 +283,92 @@ func runRegexBenchmarks(data map[string]any, filters []string) {
 	})
 	run("RegexBenchmark.emailFind", func() {
 		sink = email.FindString(emailText)
+	})
+}
+
+func runApplicationBenchmarks(data map[string]any, filters []string) {
+	sec := data["application"]
+
+	uuid := regexp.MustCompile(getString(sec, "uuidValidation.pattern"))
+	logLine := regexp.MustCompile(getString(sec, "logLineParse.pattern"))
+	apiRoute := regexp.MustCompile(getString(sec, "apiRouteMatch.pattern"))
+	stackTrace := regexp.MustCompile(getString(sec, "stackTraceExtract.pattern"))
+	keywords := regexp.MustCompile(getString(sec, "caseInsensitiveKeywords.pattern"))
+	url := regexp.MustCompile(getString(sec, "urlExtraction.pattern"))
+	csv := regexp.MustCompile(getString(sec, "csvFieldScan.pattern"))
+	secret := regexp.MustCompile(getString(sec, "secretRedaction.pattern"))
+
+	uuidTexts := getStringSlice(sec, "uuidValidation.texts")
+	logLineTexts := getStringSlice(sec, "logLineParse.texts")
+	apiRouteTexts := getStringSlice(sec, "apiRouteMatch.texts")
+	stackTraceText := getString(sec, "stackTraceExtract.text")
+	keywordText := getString(sec, "caseInsensitiveKeywords.text")
+	urlText := getString(sec, "urlExtraction.text")
+	csvText := getString(sec, "csvFieldScan.text")
+	secretText := getString(sec, "secretRedaction.text")
+	secretReplacement := convertReplacement(getString(sec, "secretRedaction.replacement"))
+
+	run := func(name string, fn func()) {
+		if matchesFilter(name, filters) {
+			printJSON(measureNs(name, fn))
+		}
+	}
+
+	run("ApplicationBenchmark.uuidValidation", func() {
+		count := 0
+		for _, text := range uuidTexts {
+			if uuid.MatchString(text) {
+				count++
+			}
+		}
+		sink = count
+	})
+	run("ApplicationBenchmark.logLineParse", func() {
+		count := 0
+		for _, text := range logLineTexts {
+			groups := logLine.FindStringSubmatch(text)
+			if groups != nil {
+				count += len(groups[2]) + len(groups[3])
+			}
+		}
+		sink = count
+	})
+	run("ApplicationBenchmark.apiRouteMatch", func() {
+		count := 0
+		for _, text := range apiRouteTexts {
+			groups := apiRoute.FindStringSubmatch(text)
+			if groups != nil {
+				count += len(groups[1]) + len(groups[2])
+			}
+		}
+		sink = count
+	})
+	run("ApplicationBenchmark.stackTraceExtract", func() {
+		count := 0
+		for _, groups := range stackTrace.FindAllStringSubmatch(stackTraceText, -1) {
+			count += len(groups[1]) + len(groups[4])
+		}
+		sink = count
+	})
+	run("ApplicationBenchmark.caseInsensitiveKeywords", func() {
+		sink = len(keywords.FindAllString(keywordText, -1))
+	})
+	run("ApplicationBenchmark.urlExtraction", func() {
+		count := 0
+		for _, match := range url.FindAllString(urlText, -1) {
+			count += len(match)
+		}
+		sink = count
+	})
+	run("ApplicationBenchmark.csvFieldScan", func() {
+		count := 0
+		for _, match := range csv.FindAllString(csvText, -1) {
+			count += len(match)
+		}
+		sink = count
+	})
+	run("ApplicationBenchmark.secretRedaction", func() {
+		sink = secret.ReplaceAllString(secretText, secretReplacement)
 	})
 }
 
@@ -612,6 +713,7 @@ func main() {
 	data := loadBenchmarkData(dataPath)
 
 	runRegexBenchmarks(data, filters)
+	runApplicationBenchmarks(data, filters)
 	runCompileBenchmarks(data, filters)
 	runSearchScalingBenchmarks(data, filters)
 	runCaptureScalingBenchmarks(data, filters)

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationBenchmark.java
@@ -1,0 +1,454 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Benchmarks for ordinary application regex workloads over small corpora. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class ApplicationBenchmark {
+
+  private org.safere.Pattern safeUuid;
+  private java.util.regex.Pattern jdkUuid;
+  private com.google.re2j.Pattern re2jUuid;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmUuid;
+  private List<String> uuidTexts;
+
+  private org.safere.Pattern safeLogLine;
+  private java.util.regex.Pattern jdkLogLine;
+  private com.google.re2j.Pattern re2jLogLine;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmLogLine;
+  private List<String> logLineTexts;
+
+  private org.safere.Pattern safeApiRoute;
+  private java.util.regex.Pattern jdkApiRoute;
+  private com.google.re2j.Pattern re2jApiRoute;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmApiRoute;
+  private List<String> apiRouteTexts;
+
+  private org.safere.Pattern safeStackTrace;
+  private java.util.regex.Pattern jdkStackTrace;
+  private com.google.re2j.Pattern re2jStackTrace;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmStackTrace;
+  private String stackTraceText;
+
+  private org.safere.Pattern safeKeywords;
+  private java.util.regex.Pattern jdkKeywords;
+  private com.google.re2j.Pattern re2jKeywords;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmKeywords;
+  private String keywordText;
+
+  private org.safere.Pattern safeUrl;
+  private java.util.regex.Pattern jdkUrl;
+  private com.google.re2j.Pattern re2jUrl;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmUrl;
+  private String urlText;
+
+  private org.safere.Pattern safeCsv;
+  private java.util.regex.Pattern jdkCsv;
+  private com.google.re2j.Pattern re2jCsv;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmCsv;
+  private String csvText;
+
+  private org.safere.Pattern safeSecret;
+  private java.util.regex.Pattern jdkSecret;
+  private com.google.re2j.Pattern re2jSecret;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmSecret;
+  private String secretText;
+  private String secretReplacement;
+
+  @Setup
+  public void setup() {
+    BenchmarkData data = BenchmarkData.get();
+
+    String uuidPattern = data.getString("application.uuidValidation.pattern");
+    uuidTexts = data.getStringList("application.uuidValidation.texts");
+    safeUuid = org.safere.Pattern.compile(uuidPattern);
+    jdkUuid = java.util.regex.Pattern.compile(uuidPattern);
+    re2jUuid = com.google.re2j.Pattern.compile(uuidPattern);
+    re2ffmUuid = org.safere.re2ffm.RE2FfmPattern.compile(uuidPattern);
+
+    String logLinePattern = data.getString("application.logLineParse.pattern");
+    logLineTexts = data.getStringList("application.logLineParse.texts");
+    safeLogLine = org.safere.Pattern.compile(logLinePattern);
+    jdkLogLine = java.util.regex.Pattern.compile(logLinePattern);
+    re2jLogLine = com.google.re2j.Pattern.compile(logLinePattern);
+    re2ffmLogLine = org.safere.re2ffm.RE2FfmPattern.compile(logLinePattern);
+
+    String apiRoutePattern = data.getString("application.apiRouteMatch.pattern");
+    apiRouteTexts = data.getStringList("application.apiRouteMatch.texts");
+    safeApiRoute = org.safere.Pattern.compile(apiRoutePattern);
+    jdkApiRoute = java.util.regex.Pattern.compile(apiRoutePattern);
+    re2jApiRoute = com.google.re2j.Pattern.compile(apiRoutePattern);
+    re2ffmApiRoute = org.safere.re2ffm.RE2FfmPattern.compile(apiRoutePattern);
+
+    String stackTracePattern = data.getString("application.stackTraceExtract.pattern");
+    stackTraceText = data.getString("application.stackTraceExtract.text");
+    safeStackTrace = org.safere.Pattern.compile(stackTracePattern);
+    jdkStackTrace = java.util.regex.Pattern.compile(stackTracePattern);
+    re2jStackTrace = com.google.re2j.Pattern.compile(stackTracePattern);
+    re2ffmStackTrace = org.safere.re2ffm.RE2FfmPattern.compile(stackTracePattern);
+
+    String keywordPattern = data.getString("application.caseInsensitiveKeywords.pattern");
+    keywordText = data.getString("application.caseInsensitiveKeywords.text");
+    safeKeywords = org.safere.Pattern.compile(keywordPattern);
+    jdkKeywords = java.util.regex.Pattern.compile(keywordPattern);
+    re2jKeywords = com.google.re2j.Pattern.compile(keywordPattern);
+    re2ffmKeywords = org.safere.re2ffm.RE2FfmPattern.compile(keywordPattern);
+
+    String urlPattern = data.getString("application.urlExtraction.pattern");
+    urlText = data.getString("application.urlExtraction.text");
+    safeUrl = org.safere.Pattern.compile(urlPattern);
+    jdkUrl = java.util.regex.Pattern.compile(urlPattern);
+    re2jUrl = com.google.re2j.Pattern.compile(urlPattern);
+    re2ffmUrl = org.safere.re2ffm.RE2FfmPattern.compile(urlPattern);
+
+    String csvPattern = data.getString("application.csvFieldScan.pattern");
+    csvText = data.getString("application.csvFieldScan.text");
+    safeCsv = org.safere.Pattern.compile(csvPattern);
+    jdkCsv = java.util.regex.Pattern.compile(csvPattern);
+    re2jCsv = com.google.re2j.Pattern.compile(csvPattern);
+    re2ffmCsv = org.safere.re2ffm.RE2FfmPattern.compile(csvPattern);
+
+    String secretPattern = data.getString("application.secretRedaction.pattern");
+    secretText = data.getString("application.secretRedaction.text");
+    secretReplacement = data.getString("application.secretRedaction.replacement");
+    safeSecret = org.safere.Pattern.compile(secretPattern);
+    jdkSecret = java.util.regex.Pattern.compile(secretPattern);
+    re2jSecret = com.google.re2j.Pattern.compile(secretPattern);
+    re2ffmSecret = org.safere.re2ffm.RE2FfmPattern.compile(secretPattern);
+  }
+
+  @Benchmark
+  public int uuidValidation_safere() {
+    int count = 0;
+    for (String text : uuidTexts) {
+      if (safeUuid.matcher(text).matches()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int uuidValidation_jdk() {
+    int count = 0;
+    for (String text : uuidTexts) {
+      if (jdkUuid.matcher(text).matches()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int uuidValidation_re2j() {
+    int count = 0;
+    for (String text : uuidTexts) {
+      if (re2jUuid.matcher(text).matches()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int uuidValidation_re2ffm() {
+    int count = 0;
+    for (String text : uuidTexts) {
+      if (re2ffmUuid.matcher(text).matches()) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int logLineParse_safere() {
+    int count = 0;
+    for (String text : logLineTexts) {
+      org.safere.Matcher matcher = safeLogLine.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(2).length() + matcher.group(3).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int logLineParse_jdk() {
+    int count = 0;
+    for (String text : logLineTexts) {
+      java.util.regex.Matcher matcher = jdkLogLine.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(2).length() + matcher.group(3).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int logLineParse_re2j() {
+    int count = 0;
+    for (String text : logLineTexts) {
+      com.google.re2j.Matcher matcher = re2jLogLine.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(2).length() + matcher.group(3).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int logLineParse_re2ffm() {
+    int count = 0;
+    for (String text : logLineTexts) {
+      org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmLogLine.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(2).length() + matcher.group(3).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int apiRouteMatch_safere() {
+    int count = 0;
+    for (String text : apiRouteTexts) {
+      org.safere.Matcher matcher = safeApiRoute.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(1).length() + matcher.group(2).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int apiRouteMatch_jdk() {
+    int count = 0;
+    for (String text : apiRouteTexts) {
+      java.util.regex.Matcher matcher = jdkApiRoute.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(1).length() + matcher.group(2).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int apiRouteMatch_re2j() {
+    int count = 0;
+    for (String text : apiRouteTexts) {
+      com.google.re2j.Matcher matcher = re2jApiRoute.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(1).length() + matcher.group(2).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int apiRouteMatch_re2ffm() {
+    int count = 0;
+    for (String text : apiRouteTexts) {
+      org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmApiRoute.matcher(text);
+      if (matcher.matches()) {
+        count += matcher.group(1).length() + matcher.group(2).length();
+      }
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int stackTraceExtract_safere() {
+    org.safere.Matcher matcher = safeStackTrace.matcher(stackTraceText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group(1).length() + matcher.group(4).length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int stackTraceExtract_jdk() {
+    java.util.regex.Matcher matcher = jdkStackTrace.matcher(stackTraceText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group(1).length() + matcher.group(4).length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int stackTraceExtract_re2j() {
+    com.google.re2j.Matcher matcher = re2jStackTrace.matcher(stackTraceText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group(1).length() + matcher.group(4).length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int stackTraceExtract_re2ffm() {
+    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmStackTrace.matcher(stackTraceText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group(1).length() + matcher.group(4).length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int caseInsensitiveKeywords_safere() {
+    org.safere.Matcher matcher = safeKeywords.matcher(keywordText);
+    int count = 0;
+    while (matcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int caseInsensitiveKeywords_jdk() {
+    java.util.regex.Matcher matcher = jdkKeywords.matcher(keywordText);
+    int count = 0;
+    while (matcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int caseInsensitiveKeywords_re2j() {
+    com.google.re2j.Matcher matcher = re2jKeywords.matcher(keywordText);
+    int count = 0;
+    while (matcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int caseInsensitiveKeywords_re2ffm() {
+    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmKeywords.matcher(keywordText);
+    int count = 0;
+    while (matcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int urlExtraction_safere() {
+    org.safere.Matcher matcher = safeUrl.matcher(urlText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int urlExtraction_jdk() {
+    java.util.regex.Matcher matcher = jdkUrl.matcher(urlText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int urlExtraction_re2j() {
+    com.google.re2j.Matcher matcher = re2jUrl.matcher(urlText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int urlExtraction_re2ffm() {
+    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmUrl.matcher(urlText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int csvFieldScan_safere() {
+    org.safere.Matcher matcher = safeCsv.matcher(csvText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int csvFieldScan_jdk() {
+    java.util.regex.Matcher matcher = jdkCsv.matcher(csvText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int csvFieldScan_re2j() {
+    com.google.re2j.Matcher matcher = re2jCsv.matcher(csvText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int csvFieldScan_re2ffm() {
+    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmCsv.matcher(csvText);
+    int count = 0;
+    while (matcher.find()) {
+      count += matcher.group().length();
+    }
+    return count;
+  }
+
+  @Benchmark
+  public String secretRedaction_safere() {
+    return safeSecret.matcher(secretText).replaceAll(secretReplacement);
+  }
+
+  @Benchmark
+  public String secretRedaction_jdk() {
+    return jdkSecret.matcher(secretText).replaceAll(secretReplacement);
+  }
+
+  @Benchmark
+  public String secretRedaction_re2j() {
+    return re2jSecret.matcher(secretText).replaceAll(secretReplacement);
+  }
+
+  @Benchmark
+  public String secretRedaction_re2ffm() {
+    return re2ffmSecret.matcher(secretText).replaceAll(secretReplacement);
+  }
+}


### PR DESCRIPTION
## Summary
- add ApplicationBenchmark with corpus-style validation, parsing, extraction, scanning, and redaction workloads
- share the new application workload data across Java, C++ RE2, and Go regexp harnesses
- include the application benchmark group in benchmark collection and clarify benchmark workload buckets in docs

Fixes #24

## Testing
- mvn -pl safere test
- mvn -pl safere-benchmarks test -q
- ./run-java-benchmarks.sh --smoke ApplicationBenchmark
- ./run-java-benchmarks.sh --smoke ApplicationBenchmark.urlExtraction ApplicationBenchmark.csvFieldScan
- env GOCACHE=/tmp/safere-go-build-cache ./run-go-benchmarks.sh ApplicationBenchmark
- env GOCACHE=/tmp/safere-go-build-cache ./run-go-benchmarks.sh ApplicationBenchmark.urlExtraction ApplicationBenchmark.csvFieldScan
- ./run-cpp-benchmarks.sh ApplicationBenchmark.urlExtraction ApplicationBenchmark.csvFieldScan ApplicationBenchmark.secretRedaction