### PR TITLE
Reduce crosscheck append replacement overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ development iteration or focused investigation; use
 
 ```bash
 # Java benchmarks (throughput)
-./run-java-benchmarks.sh                        # all benchmarks
+./run-java-benchmarks.sh                        # standard benchmarks
 ./run-java-benchmarks.sh RegexBenchmark         # specific class
 
 # Java memory profiling (allocation rates via JMH GC profiler)
@@ -370,6 +370,14 @@ development iteration or focused investigation; use
 
 # Fast development iteration only — NOT for BENCHMARKS.md
 ./run-java-benchmarks.sh --quick RegexBenchmark
+```
+
+`CrosscheckOverheadBenchmark` is excluded from the no-argument Java benchmark
+run. It measures overhead in the `safere-crosscheck` facade and should be run
+explicitly only when optimizing crosscheck:
+
+```bash
+./run-java-benchmarks.sh --quick CrosscheckOverheadBenchmark
 ```
 
 ### C++ RE2 and Go Benchmarks

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -31,12 +31,16 @@
 # Pathological benchmarks (PathologicalBenchmark, PathologicalComparisonBenchmark)
 # always run with -f 0 (no forking) because the JDK engine can hang on large
 # inputs, making forked JVM processes unrecoverable.
+#
+# CrosscheckOverheadBenchmark is excluded from default no-argument runs. Run it
+# explicitly when working on safere-crosscheck performance.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
+DEFAULT_BENCHMARK_REGEX="^(?!org\\.safere\\.benchmark\\.CrosscheckOverheadBenchmark\\.).*$"
 
 # Publication-quality settings: 3 forks × (3 warmup × 5s + 5 measurement × 5s).
 # 15 samples per method — sufficient for meaningful confidence intervals.
@@ -98,8 +102,8 @@ run_benchmark() {
 }
 
 if [ $# -eq 0 ]; then
-  echo "=== Running all benchmarks ==="
-  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $JMH_OPTS
+  echo "=== Running standard benchmarks ($DEFAULT_BENCHMARK_REGEX) ==="
+  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $JMH_OPTS "$DEFAULT_BENCHMARK_REGEX"
 else
   for bench in "$@"; do
     run_benchmark "$bench"

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -33,6 +33,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.safere</groupId>
+      <artifactId>safere-crosscheck</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
       <version>1.8</version>

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrosscheckOverheadBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrosscheckOverheadBenchmark.java
@@ -1,0 +1,86 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Measures overhead added by the crosscheck facade for replacement loops that call
+ * {@code appendReplacement} once per match.
+ *
+ * <p>This is a diagnostic benchmark for crosscheck optimization work. The Java benchmark wrapper
+ * excludes it from default no-argument runs; run this class explicitly when needed.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class CrosscheckOverheadBenchmark {
+
+  @Param({"16", "128", "1024"})
+  public int matches;
+
+  private String text;
+  private String replacement;
+  private org.safere.Pattern saferePattern;
+  private java.util.regex.Pattern jdkPattern;
+  private org.safere.crosscheck.Pattern crosscheckPattern;
+
+  @Setup
+  public void setup() {
+    StringBuilder sb = new StringBuilder(matches * 12);
+    for (int i = 0; i < matches; i++) {
+      sb.append("item").append(i).append(';');
+    }
+    text = sb.toString();
+    replacement = "$2:$1";
+
+    String regex = "([a-z]+)(\\d+)";
+    saferePattern = org.safere.Pattern.compile(regex);
+    jdkPattern = java.util.regex.Pattern.compile(regex);
+    crosscheckPattern = org.safere.crosscheck.Pattern.compile(regex);
+  }
+
+  @Benchmark
+  public String appendReplacement_safere() {
+    org.safere.Matcher matcher = saferePattern.matcher(text);
+    StringBuilder sb = new StringBuilder(text.length());
+    while (matcher.find()) {
+      matcher.appendReplacement(sb, replacement);
+    }
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+
+  @Benchmark
+  public String appendReplacement_jdk() {
+    java.util.regex.Matcher matcher = jdkPattern.matcher(text);
+    StringBuilder sb = new StringBuilder(text.length());
+    while (matcher.find()) {
+      matcher.appendReplacement(sb, replacement);
+    }
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+
+  @Benchmark
+  public String appendReplacement_crosscheck() {
+    org.safere.crosscheck.Matcher matcher = crosscheckPattern.matcher(text);
+    StringBuilder sb = new StringBuilder(text.length());
+    while (matcher.find()) {
+      matcher.appendReplacement(sb, replacement);
+    }
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+}

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -137,3 +137,16 @@ The crosscheck facade covers:
 - **Unsupported features:** Patterns using backreferences, lookahead,
   lookbehind, or possessive quantifiers will throw
   `UnsupportedPatternException` at compile time.
+
+## Benchmarking
+
+Crosscheck overhead is measured by `CrosscheckOverheadBenchmark` in the
+`safere-benchmarks` module. It is excluded from the default no-argument Java
+benchmark run because it is a diagnostic benchmark for optimizing
+`safere-crosscheck`, not part of the normal SafeRE performance suite.
+
+Run it explicitly when working on crosscheck performance:
+
+```bash
+./run-java-benchmarks.sh --quick CrosscheckOverheadBenchmark
+```

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -187,56 +187,63 @@ public final class Matcher implements MatchResult {
   }
 
   /**
-   * Implements a non-terminal append-and-replace step, applying to both engines and comparing at
-   * {@link #appendTail}.
+   * Implements a non-terminal append-and-replace step, applying to both engines and comparing the
+   * appended fragment.
    *
-   * <p>Note: the caller's {@code StringBuilder} receives SafeRE's output. Use
-   * {@link #appendTail(StringBuilder)} to finalize and crosscheck.
+   * <p>Note: the caller's {@code StringBuilder} receives SafeRE's output.
    */
   public Matcher appendReplacement(StringBuilder sb, String replacement) {
-    String before = sb.toString();
-    safereMatcher.appendReplacement(sb, replacement);
-    StringBuilder jdkSb = new StringBuilder(before);
+    StringBuilder safeSb = new StringBuilder();
+    StringBuilder jdkSb = new StringBuilder();
+    safereMatcher.appendReplacement(safeSb, replacement);
     jdkMatcher.appendReplacement(jdkSb, replacement);
-    checkEqual("appendReplacement", quote(replacement), sb.toString(), jdkSb.toString());
+    String sr = safeSb.toString();
+    String jr = jdkSb.toString();
+    checkEqual("appendReplacement", quote(replacement), sr, jr);
+    sb.append(sr);
     return this;
   }
 
   /**
-   * Implements a terminal append step. Compares the full replacement result from both engines.
+   * Implements a terminal append step. Compares the tail fragment from both engines.
    *
-   * @throws CrosscheckException if the accumulated replacement results differ
+   * @throws CrosscheckException if the appended tail fragments differ
    */
   public StringBuilder appendTail(StringBuilder sb) {
-    String before = sb.toString();
-    safereMatcher.appendTail(sb);
-    StringBuilder jdkSb = new StringBuilder(before);
+    StringBuilder safeSb = new StringBuilder();
+    StringBuilder jdkSb = new StringBuilder();
+    safereMatcher.appendTail(safeSb);
     jdkMatcher.appendTail(jdkSb);
-    String sr = sb.toString();
+    String sr = safeSb.toString();
     String jr = jdkSb.toString();
     checkEqual("appendTail", "", sr, jr);
+    sb.append(sr);
     return sb;
   }
 
   /** Implements a non-terminal append-and-replace step using {@link StringBuffer}. */
   public Matcher appendReplacement(StringBuffer sb, String replacement) {
-    String before = sb.toString();
-    safereMatcher.appendReplacement(sb, replacement);
-    StringBuffer jdkSbuf = new StringBuffer(before);
+    StringBuffer safeSbuf = new StringBuffer();
+    StringBuffer jdkSbuf = new StringBuffer();
+    safereMatcher.appendReplacement(safeSbuf, replacement);
     jdkMatcher.appendReplacement(jdkSbuf, replacement);
-    checkEqual("appendReplacement", quote(replacement), sb.toString(), jdkSbuf.toString());
+    String sr = safeSbuf.toString();
+    String jr = jdkSbuf.toString();
+    checkEqual("appendReplacement", quote(replacement), sr, jr);
+    sb.append(sr);
     return this;
   }
 
   /** Implements a terminal append step using {@link StringBuffer}. */
   public StringBuffer appendTail(StringBuffer sb) {
-    String before = sb.toString();
-    safereMatcher.appendTail(sb);
-    StringBuffer jdkSbuf = new StringBuffer(before);
+    StringBuffer safeSbuf = new StringBuffer();
+    StringBuffer jdkSbuf = new StringBuffer();
+    safereMatcher.appendTail(safeSbuf);
     jdkMatcher.appendTail(jdkSbuf);
-    String sr = sb.toString();
+    String sr = safeSbuf.toString();
     String jr = jdkSbuf.toString();
     checkEqual("appendTail", "", sr, jr);
+    sb.append(sr);
     return sb;
   }
 

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -220,28 +220,28 @@ class CrosscheckTest {
     @DisplayName("appendReplacement/appendTail with direct StringBuilder mutation")
     void appendReplacementTailWithDirectStringBuilderMutation() {
       Matcher m = Pattern.compile("\\{\\{(.+?)\\}\\}").matcher("{{one}};{{two}};tail");
-      StringBuilder sb = new StringBuilder();
+      StringBuilder sb = new StringBuilder("prefix:");
       while (m.find()) {
         String group = m.group(1);
         m.appendReplacement(sb, "");
         sb.append(group);
       }
       m.appendTail(sb);
-      assertThat(sb.toString()).isEqualTo("one;two;tail");
+      assertThat(sb.toString()).isEqualTo("prefix:one;two;tail");
     }
 
     @Test
     @DisplayName("appendReplacement/appendTail with direct StringBuffer mutation")
     void appendReplacementTailWithDirectStringBufferMutation() {
       Matcher m = Pattern.compile("\\{\\{(.+?)\\}\\}").matcher("{{one}};{{two}};tail");
-      StringBuffer sb = new StringBuffer();
+      StringBuffer sb = new StringBuffer("prefix:");
       while (m.find()) {
         String group = m.group(1);
         m.appendReplacement(sb, "");
         sb.append(group);
       }
       m.appendTail(sb);
-      assertThat(sb.toString()).isEqualTo("one;two;tail");
+      assertThat(sb.toString()).isEqualTo("prefix:one;two;tail");
     }
   }
 


### PR DESCRIPTION
## Summary
- add a focused CrosscheckOverheadBenchmark for appendReplacement loops
- exclude that diagnostic benchmark from default Java benchmark runs and document how to run it explicitly
- compare only per-call append fragments in crosscheck appendReplacement/appendTail instead of repeatedly copying accumulated buffers

## Measurements
Quick JMH before/after for CrosscheckOverheadBenchmark.appendReplacement_crosscheck:
- 16 matches: 4606 ns/op -> 4191 ns/op
- 128 matches: 64906 ns/op -> 52191 ns/op
- 1024 matches: 1774478 ns/op -> 436860 ns/op

## Tests
- mvn -pl safere test -q
- mvn -pl safere-crosscheck test -q
- mvn -pl safere-benchmarks -am package -DskipTests -q
- ./run-java-benchmarks.sh --quick CrosscheckOverheadBenchmark
- ./run-java-benchmarks.sh --smoke CrosscheckOverheadBenchmark

Fixes #177