### PR TITLE
Make application benchmarks data-driven

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -58,13 +58,15 @@ interval half-width. Java uses JMH's built-in statistics. C++ and Go use
 Student's t-distribution (t ≈ 4.781 for 9 df at 99.9%).
 
 **Shared test data:** All harnesses read patterns, inputs, and parameters from
-a single `benchmark-data.json` file, ensuring identical workloads across
-languages.
+a single `benchmark-data.json` file. Application cases also define their
+operation type and expected result in that file, so Java, C++, and Go validate
+the same semantics before timing.
 
-**Workload coverage:** The suite separates focused microbenchmarks from
-corpus-style application workloads. The published numerical tables below were
-collected before `ApplicationBenchmark` was added; rerun the collection script
-before adding application-workload ratios to the summary tables.
+**Workload coverage:** The suite separates focused microbenchmarks,
+data-driven application workloads, and pathological/scaling workloads. The
+published numerical tables below were collected before `ApplicationBenchmark`
+was added; rerun the collection script before adding application-workload
+ratios to the summary tables.
 
 | Setting | Java (JMH) | C++ | Go |
 |---|---|---|---|
@@ -369,7 +371,7 @@ different workloads:
    class match, alternation find, capture groups, find-in-text, email find,
    pig Latin replace, HTTP full request. These are useful for isolating engine
    behavior, but they are not a complete model of application regex use.
-2. **Application workloads** — corpus-style validation, parsing, extraction,
+2. **Application workloads** — data-driven validation, parsing, extraction,
    scanning, and redaction cases from `ApplicationBenchmark`. These are intended
    to represent ordinary application usage more directly than the microbenchmarks.
 3. **Pathological/scaling** — workloads that stress linear-time guarantees:

--- a/README.md
+++ b/README.md
@@ -309,8 +309,11 @@ SafeRE includes a [JMH](https://github.com/openjdk/jmh) benchmark suite in the
 `safere-benchmarks` module, comparing SafeRE against `java.util.regex` (JDK),
 [RE2/J](https://github.com/google/re2j), RE2-FFM (C++ RE2 via Java
 [FFM API](https://openjdk.org/jeps/454)), C++ RE2, and Go `regexp`.
-The suite includes focused microbenchmarks, corpus-style application workloads,
+The suite includes focused microbenchmarks, data-driven application workloads,
 scaling/pathological cases, replacement, memory, and `PatternSet` benchmarks.
+Application workloads live in `safere-benchmarks/benchmark-data.json`, where
+each case defines its operation semantics and expected result for the Java,
+C++, and Go harnesses.
 
 ### Publication-Quality Benchmark Collection
 
@@ -398,6 +401,16 @@ A comparison script merges JMH, C++, and Go results into side-by-side markdown:
 ```bash
 python3 safere-benchmarks/scripts/compare-benchmarks.py \
   --jmh jmh-output.txt --json cpp-results.jsonl go-results.jsonl
+```
+
+To verify that all harnesses emitted the application benchmark names defined in
+`benchmark-data.json`, add:
+
+```bash
+python3 safere-benchmarks/scripts/compare-benchmarks.py \
+  --jmh jmh-output.txt --json cpp-results.jsonl go-results.jsonl \
+  --benchmark-data safere-benchmarks/benchmark-data.json \
+  --check-application-names
 ```
 
 ### Latest Results

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -163,10 +163,18 @@ log "Extracting Go JSONL"
 extract_jsonl "$OUTPUT_DIR/go-raw.txt" "$OUTPUT_DIR/go-results.jsonl"
 
 log "Generating merged markdown tables"
-python3 safere-benchmarks/scripts/compare-benchmarks.py \
-  --jmh "$OUTPUT_DIR/jmh-output.txt" \
-  --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl" \
-  --engines safere,jdk,re2j,re2_ffm,re2_cpp,go \
+COMPARE_ARGS=(
+  --jmh "$OUTPUT_DIR/jmh-output.txt"
+  --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl"
+  --engines safere,jdk,re2j,re2_ffm,re2_cpp,go
+)
+if [ "$MODE" != "smoke" ]; then
+  COMPARE_ARGS+=(
+    --benchmark-data safere-benchmarks/benchmark-data.json
+    --check-application-names
+  )
+fi
+python3 safere-benchmarks/scripts/compare-benchmarks.py "${COMPARE_ARGS[@]}" \
   > "$OUTPUT_DIR/merged-tables.md"
 
 if [ "$MODE" = "smoke" ]; then

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -118,8 +118,10 @@
     }
   },
 
-  "application": {
-    "uuidValidation": {
+  "application": [
+    {
+      "name": "uuidValidation",
+      "op": "matchesCorpus",
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
       "texts": [
         "550e8400-e29b-41d4-a716-446655440000",
@@ -128,9 +130,12 @@
         "550e8400e29b41d4a716446655440000",
         "ffffffff-ffff-5fff-bfff-ffffffffffff",
         "12345678-1234-7234-9234-123456789abc"
-      ]
+      ],
+      "expected": 3
     },
-    "logLineParse": {
+    {
+      "name": "logLineParse",
+      "op": "matchesGroupLengthSum",
       "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\s+(INFO|WARN|ERROR)\\s+([A-Za-z0-9_.-]+)\\s+-\\s+(.+)$",
       "texts": [
         "2026-03-31T14:22:08Z INFO api.gateway - request completed status=200 latency=38ms",
@@ -138,9 +143,13 @@
         "2026-03-31T14:22:10Z ERROR worker-7 - job failed id=abc123 retry=2",
         "debug line without structured prefix",
         "2026-03-31 14:22:11 INFO api.gateway - malformed timestamp"
-      ]
+      ],
+      "groups": [2, 3],
+      "expected": 39
     },
-    "apiRouteMatch": {
+    {
+      "name": "apiRouteMatch",
+      "op": "matchesGroupLengthSum",
       "pattern": "^/api/v[0-9]+/(users|orders|inventory)/([A-Za-z0-9_-]+)(?:\\?.*)?$",
       "texts": [
         "/api/v1/users/12345",
@@ -149,30 +158,48 @@
         "/assets/app.js",
         "/api/v1/users/",
         "/api/latest/users/12345"
-      ]
+      ],
+      "groups": [1, 2],
+      "expected": 41
     },
-    "stackTraceExtract": {
+    {
+      "name": "stackTraceExtract",
+      "op": "findAllGroupLengthSum",
       "pattern": "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
-      "text": "java.lang.IllegalStateException: failed to process request\n\tat org.example.api.Handler.handle(Handler.java:87)\n\tat org.example.api.Router.dispatch(Router.java:142)\n\tat org.example.Main.main(Main.java:25)\nCaused by: java.io.IOException: timeout\n\tat org.example.net.Client.read(Client.java:203)"
+      "text": "java.lang.IllegalStateException: failed to process request\n\tat org.example.api.Handler.handle(Handler.java:87)\n\tat org.example.api.Router.dispatch(Router.java:142)\n\tat org.example.Main.main(Main.java:25)\nCaused by: java.io.IOException: timeout\n\tat org.example.net.Client.read(Client.java:203)",
+      "groups": [1, 4],
+      "expected": 93
     },
-    "caseInsensitiveKeywords": {
+    {
+      "name": "caseInsensitiveKeywords",
+      "op": "findAllCount",
       "pattern": "(?i)\\b(error|warning|timeout|failed)\\b",
-      "text": "INFO startup complete\nWarning cache miss ratio high\nrequest failed after TIMEOUT waiting for backend\nERROR circuit breaker opened\nhealth check passed"
+      "text": "INFO startup complete\nWarning cache miss ratio high\nrequest failed after TIMEOUT waiting for backend\nERROR circuit breaker opened\nhealth check passed",
+      "expected": 4
     },
-    "urlExtraction": {
+    {
+      "name": "urlExtraction",
+      "op": "findAllLengthSum",
       "pattern": "(https?://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]*)?)",
-      "text": "Docs: https://example.com/docs/v1/index.html?lang=en and callback http://localhost:8080/api/callback?id=42; mirror at https://cdn.example.org/assets/app.js"
+      "text": "Docs: https://example.com/docs/v1/index.html?lang=en and callback http://localhost:8080/api/callback?id=42; mirror at https://cdn.example.org/assets/app.js",
+      "expected": 124
     },
-    "csvFieldScan": {
+    {
+      "name": "csvFieldScan",
+      "op": "findAllLengthSum",
       "pattern": "(?m)(?:^|,)(?:\"([^\"]*)\"|([^,\\r\\n]+))",
-      "text": "id,name,email,status,created_at\n42,\"Ada Lovelace\",ada@example.com,active,2026-03-31T14:22:08Z\n43,\"Grace Hopper\",grace@example.com,pending,2026-04-01T09:15:00Z"
+      "text": "id,name,email,status,created_at\n42,\"Ada Lovelace\",ada@example.com,active,2026-03-31T14:22:08Z\n43,\"Grace Hopper\",grace@example.com,pending,2026-04-01T09:15:00Z",
+      "expected": 156
     },
-    "secretRedaction": {
+    {
+      "name": "secretRedaction",
+      "op": "replaceAll",
       "pattern": "(?i)\\b(password|token|secret)=([^\\s&]+)",
       "text": "user=service password=hunter2 token=abc123XYZ path=/api secret=prod-key-9 debug=true",
-      "replacement": "$1=REDACTED"
+      "replacement": "$1=REDACTED",
+      "expected": "user=service password=REDACTED token=REDACTED path=/api secret=REDACTED debug=true"
     }
-  },
+  ],
 
   "pathological": {
     "nValues": [10, 15, 20, 25, 30, 50, 100],

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -15,6 +15,7 @@
 // Each filter is a substring match against benchmark names. If no filters
 // are given, all benchmarks are run.
 
+#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
@@ -22,6 +23,7 @@
 #include <fstream>
 #include <functional>
 #include <malloc.h>
+#include <memory>
 #include <random>
 #include <string>
 #include <vector>
@@ -271,103 +273,172 @@ void run_regex_benchmarks(const json& data,
 
 void run_application_benchmarks(const json& data,
                                 const std::vector<std::string>& filters) {
-  const auto& sec = data["application"];
-
-  RE2 uuid(sec["uuidValidation"]["pattern"].get<std::string>());
-  RE2 log_line(sec["logLineParse"]["pattern"].get<std::string>());
-  RE2 api_route(sec["apiRouteMatch"]["pattern"].get<std::string>());
-  RE2 stack_trace(sec["stackTraceExtract"]["pattern"].get<std::string>());
-  RE2 keywords(sec["caseInsensitiveKeywords"]["pattern"].get<std::string>());
-  RE2 url(sec["urlExtraction"]["pattern"].get<std::string>());
-  RE2 csv(sec["csvFieldScan"]["pattern"].get<std::string>());
-  RE2 secret(sec["secretRedaction"]["pattern"].get<std::string>());
-
-  std::vector<std::string> uuid_texts =
-      sec["uuidValidation"]["texts"].get<std::vector<std::string>>();
-  std::vector<std::string> log_line_texts =
-      sec["logLineParse"]["texts"].get<std::vector<std::string>>();
-  std::vector<std::string> api_route_texts =
-      sec["apiRouteMatch"]["texts"].get<std::vector<std::string>>();
-  std::string stack_trace_text = sec["stackTraceExtract"]["text"];
-  std::string keyword_text = sec["caseInsensitiveKeywords"]["text"];
-  std::string url_text = sec["urlExtraction"]["text"];
-  std::string csv_text = sec["csvFieldScan"]["text"];
-  std::string secret_text = sec["secretRedaction"]["text"];
-  std::string secret_replacement =
-      convert_replacement(sec["secretRedaction"]["replacement"].get<std::string>());
-
   auto run = [&](const std::string& name, const std::function<void()>& fn) {
     if (matches_filter(name, filters)) {
       print_json(measure(name, fn));
     }
   };
 
-  run("ApplicationBenchmark.uuidValidation", [&]() {
-    int count = 0;
-    for (const auto& text : uuid_texts) {
-      if (RE2::FullMatch(text, uuid)) ++count;
+  struct AppCase {
+    std::string name;
+    std::string op;
+    std::string pattern;
+    std::vector<std::string> texts;
+    std::string text;
+    std::vector<int> groups;
+    std::string replacement;
+    json expected;
+    RE2 re;
+
+    explicit AppCase(const json& item)
+        : name(item.at("name").get<std::string>()),
+          op(item.at("op").get<std::string>()),
+          pattern(item.at("pattern").get<std::string>()),
+          texts(item.contains("texts")
+                    ? item.at("texts").get<std::vector<std::string>>()
+                    : std::vector<std::string>()),
+          text(item.value("text", "")),
+          groups(item.contains("groups") ? item.at("groups").get<std::vector<int>>()
+                                         : std::vector<int>()),
+          replacement(item.contains("replacement")
+                          ? convert_replacement(item.at("replacement").get<std::string>())
+                          : ""),
+          expected(item.at("expected")),
+          re(pattern) {}
+  };
+
+  auto max_group = [](const std::vector<int>& groups) {
+    int max = 0;
+    for (int group : groups) {
+      if (group > max) max = group;
     }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.logLineParse", [&]() {
-    int count = 0;
-    for (const auto& text : log_line_texts) {
-      std::string ts, level, component, message;
-      if (RE2::FullMatch(text, log_line, &ts, &level, &component, &message)) {
-        count += level.size() + component.size();
+    return max;
+  };
+
+  auto group_length_sum = [](const std::vector<re2::StringPiece>& matches,
+                             const std::vector<int>& groups) {
+    int sum = 0;
+    for (int group : groups) {
+      if (group < static_cast<int>(matches.size()) && matches[group].data() != nullptr) {
+        sum += matches[group].size();
       }
     }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.apiRouteMatch", [&]() {
-    int count = 0;
-    for (const auto& text : api_route_texts) {
-      std::string resource, id;
-      if (RE2::FullMatch(text, api_route, &resource, &id)) {
-        count += resource.size() + id.size();
+    return sum;
+  };
+
+  auto matches_groups =
+      [&](const AppCase& app_case, const std::string& text,
+          std::vector<re2::StringPiece>* matches) {
+        int match_count = std::max(1, max_group(app_case.groups) + 1);
+        matches->assign(match_count, re2::StringPiece());
+        return app_case.re.Match(
+            text, 0, text.size(), RE2::ANCHOR_BOTH, matches->data(), match_count);
+      };
+
+  auto run_int = [&](const AppCase& app_case) {
+    if (app_case.op == "matchesCorpus") {
+      int count = 0;
+      for (const auto& text : app_case.texts) {
+        if (RE2::FullMatch(text, app_case.re)) ++count;
+      }
+      return count;
+    }
+    if (app_case.op == "matchesGroupLengthSum") {
+      int count = 0;
+      std::vector<re2::StringPiece> matches;
+      for (const auto& text : app_case.texts) {
+        if (matches_groups(app_case, text, &matches)) {
+          count += group_length_sum(matches, app_case.groups);
+        }
+      }
+      return count;
+    }
+    if (app_case.op == "findAllCount") {
+      int count = 0;
+      int start = 0;
+      std::vector<re2::StringPiece> matches(1);
+      while (start <= static_cast<int>(app_case.text.size()) &&
+             app_case.re.Match(app_case.text, start, app_case.text.size(),
+                               RE2::UNANCHORED, matches.data(), matches.size())) {
+        ++count;
+        int end = matches[0].data() - app_case.text.data() + matches[0].size();
+        start = matches[0].empty() ? end + 1 : end;
+      }
+      return count;
+    }
+    if (app_case.op == "findAllLengthSum" ||
+        app_case.op == "findAllGroupLengthSum") {
+      int count = 0;
+      int start = 0;
+      int match_count = std::max(1, max_group(app_case.groups) + 1);
+      std::vector<re2::StringPiece> matches(match_count);
+      while (start <= static_cast<int>(app_case.text.size()) &&
+             app_case.re.Match(app_case.text, start, app_case.text.size(),
+                               RE2::UNANCHORED, matches.data(), matches.size())) {
+        if (app_case.op == "findAllLengthSum") {
+          count += matches[0].size();
+        } else {
+          count += group_length_sum(matches, app_case.groups);
+        }
+        int end = matches[0].data() - app_case.text.data() + matches[0].size();
+        start = matches[0].empty() ? end + 1 : end;
+      }
+      return count;
+    }
+    fprintf(stderr, "ERROR: string op used as int op: %s\n", app_case.op.c_str());
+    exit(1);
+  };
+
+  auto run_string = [](const AppCase& app_case) {
+    std::string s = app_case.text;
+    RE2::GlobalReplace(&s, app_case.re, app_case.replacement);
+    return s;
+  };
+
+  std::vector<std::unique_ptr<AppCase>> cases;
+  for (const auto& item : data["application"]) {
+    cases.push_back(std::make_unique<AppCase>(item));
+  }
+
+  for (const auto& app_case_ptr : cases) {
+    const AppCase& app_case = *app_case_ptr;
+    if (!app_case.re.ok()) {
+      fprintf(stderr, "ERROR: invalid application pattern: %s\n",
+              app_case.name.c_str());
+      exit(1);
+    }
+    if (app_case.op.rfind("findAll", 0) == 0 &&
+        RE2::PartialMatch("", app_case.re)) {
+      fprintf(stderr, "ERROR: empty-width find-all application pattern: %s\n",
+              app_case.name.c_str());
+      exit(1);
+    }
+    if (app_case.op == "replaceAll") {
+      std::string actual = run_string(app_case);
+      if (actual != app_case.expected.get<std::string>()) {
+        fprintf(stderr, "ERROR: %s expected result mismatch\n", app_case.name.c_str());
+        exit(1);
+      }
+    } else {
+      int actual = run_int(app_case);
+      if (actual != app_case.expected.get<int>()) {
+        fprintf(stderr, "ERROR: %s expected %d but was %d\n",
+                app_case.name.c_str(), app_case.expected.get<int>(), actual);
+        exit(1);
       }
     }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.stackTraceExtract", [&]() {
-    re2::StringPiece input(stack_trace_text);
-    int count = 0;
-    std::string klass, method, file, line;
-    while (RE2::FindAndConsume(&input, stack_trace, &klass, &method, &file, &line)) {
-      count += klass.size() + line.size();
-    }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.caseInsensitiveKeywords", [&]() {
-    re2::StringPiece input(keyword_text);
-    int count = 0;
-    std::string match;
-    while (RE2::FindAndConsume(&input, keywords, &match)) { ++count; }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.urlExtraction", [&]() {
-    re2::StringPiece input(url_text);
-    int count = 0;
-    std::string match;
-    while (RE2::FindAndConsume(&input, url, &match)) {
-      count += match.size();
-    }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.csvFieldScan", [&]() {
-    re2::StringPiece input(csv_text);
-    int count = 0;
-    std::string quoted, unquoted;
-    while (RE2::FindAndConsume(&input, csv, &quoted, &unquoted)) {
-      count += quoted.size() + unquoted.size();
-    }
-    do_not_optimize(count);
-  });
-  run("ApplicationBenchmark.secretRedaction", [&]() {
-    std::string s = secret_text;
-    RE2::GlobalReplace(&s, secret, secret_replacement);
-    do_not_optimize(s);
-  });
+  }
+
+  for (const auto& app_case_ptr : cases) {
+    const AppCase& app_case = *app_case_ptr;
+    run("ApplicationBenchmark." + app_case.name, [&]() {
+      if (app_case.op == "replaceAll") {
+        do_not_optimize(run_string(app_case));
+      } else {
+        do_not_optimize(run_int(app_case));
+      }
+    });
+  }
 }
 
 void run_compile_benchmarks(const json& data,

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -287,89 +287,140 @@ func runRegexBenchmarks(data map[string]any, filters []string) {
 }
 
 func runApplicationBenchmarks(data map[string]any, filters []string) {
-	sec := data["application"]
-
-	uuid := regexp.MustCompile(getString(sec, "uuidValidation.pattern"))
-	logLine := regexp.MustCompile(getString(sec, "logLineParse.pattern"))
-	apiRoute := regexp.MustCompile(getString(sec, "apiRouteMatch.pattern"))
-	stackTrace := regexp.MustCompile(getString(sec, "stackTraceExtract.pattern"))
-	keywords := regexp.MustCompile(getString(sec, "caseInsensitiveKeywords.pattern"))
-	url := regexp.MustCompile(getString(sec, "urlExtraction.pattern"))
-	csv := regexp.MustCompile(getString(sec, "csvFieldScan.pattern"))
-	secret := regexp.MustCompile(getString(sec, "secretRedaction.pattern"))
-
-	uuidTexts := getStringSlice(sec, "uuidValidation.texts")
-	logLineTexts := getStringSlice(sec, "logLineParse.texts")
-	apiRouteTexts := getStringSlice(sec, "apiRouteMatch.texts")
-	stackTraceText := getString(sec, "stackTraceExtract.text")
-	keywordText := getString(sec, "caseInsensitiveKeywords.text")
-	urlText := getString(sec, "urlExtraction.text")
-	csvText := getString(sec, "csvFieldScan.text")
-	secretText := getString(sec, "secretRedaction.text")
-	secretReplacement := convertReplacement(getString(sec, "secretRedaction.replacement"))
-
 	run := func(name string, fn func()) {
 		if matchesFilter(name, filters) {
 			printJSON(measureNs(name, fn))
 		}
 	}
 
-	run("ApplicationBenchmark.uuidValidation", func() {
-		count := 0
-		for _, text := range uuidTexts {
-			if uuid.MatchString(text) {
-				count++
+	type appCase struct {
+		name        string
+		op          string
+		pattern     string
+		texts       []string
+		text        string
+		groups      []int
+		replacement string
+		expected    any
+		re          *regexp.Regexp
+		fullRe      *regexp.Regexp
+	}
+
+	rawCases, ok := data["application"].([]any)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "ERROR: application benchmark data must be a list")
+		os.Exit(1)
+	}
+	cases := make([]appCase, 0, len(rawCases))
+	for _, raw := range rawCases {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "ERROR: invalid application benchmark case")
+			os.Exit(1)
+		}
+		pattern := getString(item, "pattern")
+		c := appCase{
+			name:        getString(item, "name"),
+			op:          getString(item, "op"),
+			pattern:     pattern,
+			texts:       getStringSlice(item, "texts"),
+			text:        getString(item, "text"),
+			groups:      getIntSlice(item, "groups"),
+			replacement: convertReplacement(getString(item, "replacement")),
+			expected:    item["expected"],
+			re:          regexp.MustCompile(pattern),
+		}
+		if strings.HasPrefix(c.op, "matches") {
+			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
+		}
+		cases = append(cases, c)
+	}
+
+	groupLengthSum := func(indexes []int, groups []int) int {
+		sum := 0
+		for _, group := range groups {
+			start := indexes[2*group]
+			end := indexes[2*group+1]
+			if start >= 0 {
+				sum += end - start
 			}
 		}
-		sink = count
-	})
-	run("ApplicationBenchmark.logLineParse", func() {
-		count := 0
-		for _, text := range logLineTexts {
-			groups := logLine.FindStringSubmatch(text)
-			if groups != nil {
-				count += len(groups[2]) + len(groups[3])
+		return sum
+	}
+	runInt := func(c appCase) int {
+		switch c.op {
+		case "matchesCorpus":
+			count := 0
+			for _, text := range c.texts {
+				if c.fullRe.MatchString(text) {
+					count++
+				}
+			}
+			return count
+		case "matchesGroupLengthSum":
+			count := 0
+			for _, text := range c.texts {
+				indexes := c.fullRe.FindStringSubmatchIndex(text)
+				if indexes != nil {
+					count += groupLengthSum(indexes, c.groups)
+				}
+			}
+			return count
+		case "findAllCount":
+			return len(c.re.FindAllStringIndex(c.text, -1))
+		case "findAllLengthSum":
+			count := 0
+			for _, match := range c.re.FindAllStringIndex(c.text, -1) {
+				count += match[1] - match[0]
+			}
+			return count
+		case "findAllGroupLengthSum":
+			count := 0
+			for _, indexes := range c.re.FindAllStringSubmatchIndex(c.text, -1) {
+				count += groupLengthSum(indexes, c.groups)
+			}
+			return count
+		default:
+			fmt.Fprintf(os.Stderr, "ERROR: string op used as int op: %s\n", c.op)
+			os.Exit(1)
+		}
+		return 0
+	}
+	runString := func(c appCase) string {
+		return c.re.ReplaceAllString(c.text, c.replacement)
+	}
+
+	for _, c := range cases {
+		if strings.HasPrefix(c.op, "findAll") && c.re.FindStringIndex("") != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: empty-width find-all application pattern: %s\n", c.name)
+			os.Exit(1)
+		}
+		if c.op == "replaceAll" {
+			actual := runString(c)
+			if actual != c.expected.(string) {
+				fmt.Fprintf(os.Stderr, "ERROR: %s expected result mismatch\n", c.name)
+				os.Exit(1)
+			}
+		} else {
+			actual := runInt(c)
+			if actual != int(c.expected.(float64)) {
+				fmt.Fprintf(os.Stderr, "ERROR: %s expected %d but was %d\n",
+					c.name, int(c.expected.(float64)), actual)
+				os.Exit(1)
 			}
 		}
-		sink = count
-	})
-	run("ApplicationBenchmark.apiRouteMatch", func() {
-		count := 0
-		for _, text := range apiRouteTexts {
-			groups := apiRoute.FindStringSubmatch(text)
-			if groups != nil {
-				count += len(groups[1]) + len(groups[2])
+	}
+
+	for _, c := range cases {
+		c := c
+		run("ApplicationBenchmark."+c.name, func() {
+			if c.op == "replaceAll" {
+				sink = runString(c)
+			} else {
+				sink = runInt(c)
 			}
-		}
-		sink = count
-	})
-	run("ApplicationBenchmark.stackTraceExtract", func() {
-		count := 0
-		for _, groups := range stackTrace.FindAllStringSubmatch(stackTraceText, -1) {
-			count += len(groups[1]) + len(groups[4])
-		}
-		sink = count
-	})
-	run("ApplicationBenchmark.caseInsensitiveKeywords", func() {
-		sink = len(keywords.FindAllString(keywordText, -1))
-	})
-	run("ApplicationBenchmark.urlExtraction", func() {
-		count := 0
-		for _, match := range url.FindAllString(urlText, -1) {
-			count += len(match)
-		}
-		sink = count
-	})
-	run("ApplicationBenchmark.csvFieldScan", func() {
-		count := 0
-		for _, match := range csv.FindAllString(csvText, -1) {
-			count += len(match)
-		}
-		sink = count
-	})
-	run("ApplicationBenchmark.secretRedaction", func() {
-		sink = secret.ReplaceAllString(secretText, secretReplacement)
-	})
+		})
+	}
 }
 
 func runCompileBenchmarks(data map[string]any, filters []string) {

--- a/safere-benchmarks/scripts/compare-benchmarks.py
+++ b/safere-benchmarks/scripts/compare-benchmarks.py
@@ -21,6 +21,10 @@ Usage examples:
   python3 compare-benchmarks.py --jmh jmh.txt --json cpp.jsonl \
       --engines safere,jdk,re2j,re2_cpp
 
+  # Verify ApplicationBenchmark names match benchmark-data.json
+  python3 compare-benchmarks.py --jmh jmh.txt --json cpp.jsonl go.jsonl \
+      --benchmark-data benchmark-data.json --check-application-names
+
 JSON-lines format (one object per line):
   {"engine":"re2_cpp","benchmark":"RegexBenchmark.literalMatch",
    "score":40.674,"error":0.830,"unit":"ns/op"}
@@ -303,6 +307,39 @@ def generate_tables(results, engines):
     return "\n".join(lines)
 
 
+def _application_benchmarks_from_data(path):
+    with open(path) as fh:
+        data = json.load(fh)
+    return {
+        f"ApplicationBenchmark.{case['name']}"
+        for case in data.get("application", [])
+    }
+
+
+def verify_application_names(results, benchmark_data_path, engines):
+    """Verify every engine emitted the application case names from benchmark data."""
+    expected = _application_benchmarks_from_data(benchmark_data_path)
+    by_engine = collections.defaultdict(set)
+    seen_engines = collections.OrderedDict()
+    for result in results:
+        seen_engines[result.engine] = True
+        if result.benchmark.startswith("ApplicationBenchmark."):
+            by_engine[result.engine].add(result.benchmark)
+
+    expected_engines = engines or list(seen_engines)
+    errors = []
+    for engine in expected_engines:
+        names = by_engine[engine]
+        missing = sorted(expected - names)
+        extra = sorted(names - expected)
+        if missing:
+            errors.append(f"{engine}: missing {', '.join(missing)}")
+        if extra:
+            errors.append(f"{engine}: unexpected {', '.join(extra)}")
+    if errors:
+        raise SystemExit("Application benchmark name mismatch:\n" + "\n".join(errors))
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -329,6 +366,17 @@ def main(argv=None):
         help="Comma-separated engine names in desired column order "
              "(e.g. safere,jdk,re2j,re2_cpp).",
     )
+    parser.add_argument(
+        "--benchmark-data",
+        metavar="FILE",
+        default="benchmark-data.json",
+        help="Path to benchmark-data.json for application benchmark validation.",
+    )
+    parser.add_argument(
+        "--check-application-names",
+        action="store_true",
+        help="Verify emitted ApplicationBenchmark names match benchmark-data.json.",
+    )
     args = parser.parse_args(argv)
 
     if not args.jmh and not args.json:
@@ -346,6 +394,9 @@ def main(argv=None):
         sys.exit(1)
 
     engines = [e.strip() for e in args.engines.split(",")] if args.engines else []
+    if args.check_application_names:
+        verify_application_names(results, args.benchmark_data, engines)
+
     print(generate_tables(results, engines))
 
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationBenchmark.java
@@ -5,7 +5,8 @@
 
 package org.safere.benchmark;
 
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -21,434 +22,475 @@ import org.openjdk.jmh.annotations.State;
 @State(Scope.Thread)
 public class ApplicationBenchmark {
 
-  private org.safere.Pattern safeUuid;
-  private java.util.regex.Pattern jdkUuid;
-  private com.google.re2j.Pattern re2jUuid;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmUuid;
-  private List<String> uuidTexts;
-
-  private org.safere.Pattern safeLogLine;
-  private java.util.regex.Pattern jdkLogLine;
-  private com.google.re2j.Pattern re2jLogLine;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmLogLine;
-  private List<String> logLineTexts;
-
-  private org.safere.Pattern safeApiRoute;
-  private java.util.regex.Pattern jdkApiRoute;
-  private com.google.re2j.Pattern re2jApiRoute;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmApiRoute;
-  private List<String> apiRouteTexts;
-
-  private org.safere.Pattern safeStackTrace;
-  private java.util.regex.Pattern jdkStackTrace;
-  private com.google.re2j.Pattern re2jStackTrace;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmStackTrace;
-  private String stackTraceText;
-
-  private org.safere.Pattern safeKeywords;
-  private java.util.regex.Pattern jdkKeywords;
-  private com.google.re2j.Pattern re2jKeywords;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmKeywords;
-  private String keywordText;
-
-  private org.safere.Pattern safeUrl;
-  private java.util.regex.Pattern jdkUrl;
-  private com.google.re2j.Pattern re2jUrl;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmUrl;
-  private String urlText;
-
-  private org.safere.Pattern safeCsv;
-  private java.util.regex.Pattern jdkCsv;
-  private com.google.re2j.Pattern re2jCsv;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmCsv;
-  private String csvText;
-
-  private org.safere.Pattern safeSecret;
-  private java.util.regex.Pattern jdkSecret;
-  private com.google.re2j.Pattern re2jSecret;
-  private org.safere.re2ffm.RE2FfmPattern re2ffmSecret;
-  private String secretText;
-  private String secretReplacement;
+  private Map<String, ApplicationCase> cases;
+  private Map<String, org.safere.Pattern> saferePatterns;
+  private Map<String, java.util.regex.Pattern> jdkPatterns;
+  private Map<String, com.google.re2j.Pattern> re2jPatterns;
+  private Map<String, org.safere.re2ffm.RE2FfmPattern> re2ffmPatterns;
 
   @Setup
   public void setup() {
-    BenchmarkData data = BenchmarkData.get();
+    cases = BenchmarkData.get().getApplicationCases();
+    saferePatterns = new HashMap<>();
+    jdkPatterns = new HashMap<>();
+    re2jPatterns = new HashMap<>();
+    re2ffmPatterns = new HashMap<>();
 
-    String uuidPattern = data.getString("application.uuidValidation.pattern");
-    uuidTexts = data.getStringList("application.uuidValidation.texts");
-    safeUuid = org.safere.Pattern.compile(uuidPattern);
-    jdkUuid = java.util.regex.Pattern.compile(uuidPattern);
-    re2jUuid = com.google.re2j.Pattern.compile(uuidPattern);
-    re2ffmUuid = org.safere.re2ffm.RE2FfmPattern.compile(uuidPattern);
-
-    String logLinePattern = data.getString("application.logLineParse.pattern");
-    logLineTexts = data.getStringList("application.logLineParse.texts");
-    safeLogLine = org.safere.Pattern.compile(logLinePattern);
-    jdkLogLine = java.util.regex.Pattern.compile(logLinePattern);
-    re2jLogLine = com.google.re2j.Pattern.compile(logLinePattern);
-    re2ffmLogLine = org.safere.re2ffm.RE2FfmPattern.compile(logLinePattern);
-
-    String apiRoutePattern = data.getString("application.apiRouteMatch.pattern");
-    apiRouteTexts = data.getStringList("application.apiRouteMatch.texts");
-    safeApiRoute = org.safere.Pattern.compile(apiRoutePattern);
-    jdkApiRoute = java.util.regex.Pattern.compile(apiRoutePattern);
-    re2jApiRoute = com.google.re2j.Pattern.compile(apiRoutePattern);
-    re2ffmApiRoute = org.safere.re2ffm.RE2FfmPattern.compile(apiRoutePattern);
-
-    String stackTracePattern = data.getString("application.stackTraceExtract.pattern");
-    stackTraceText = data.getString("application.stackTraceExtract.text");
-    safeStackTrace = org.safere.Pattern.compile(stackTracePattern);
-    jdkStackTrace = java.util.regex.Pattern.compile(stackTracePattern);
-    re2jStackTrace = com.google.re2j.Pattern.compile(stackTracePattern);
-    re2ffmStackTrace = org.safere.re2ffm.RE2FfmPattern.compile(stackTracePattern);
-
-    String keywordPattern = data.getString("application.caseInsensitiveKeywords.pattern");
-    keywordText = data.getString("application.caseInsensitiveKeywords.text");
-    safeKeywords = org.safere.Pattern.compile(keywordPattern);
-    jdkKeywords = java.util.regex.Pattern.compile(keywordPattern);
-    re2jKeywords = com.google.re2j.Pattern.compile(keywordPattern);
-    re2ffmKeywords = org.safere.re2ffm.RE2FfmPattern.compile(keywordPattern);
-
-    String urlPattern = data.getString("application.urlExtraction.pattern");
-    urlText = data.getString("application.urlExtraction.text");
-    safeUrl = org.safere.Pattern.compile(urlPattern);
-    jdkUrl = java.util.regex.Pattern.compile(urlPattern);
-    re2jUrl = com.google.re2j.Pattern.compile(urlPattern);
-    re2ffmUrl = org.safere.re2ffm.RE2FfmPattern.compile(urlPattern);
-
-    String csvPattern = data.getString("application.csvFieldScan.pattern");
-    csvText = data.getString("application.csvFieldScan.text");
-    safeCsv = org.safere.Pattern.compile(csvPattern);
-    jdkCsv = java.util.regex.Pattern.compile(csvPattern);
-    re2jCsv = com.google.re2j.Pattern.compile(csvPattern);
-    re2ffmCsv = org.safere.re2ffm.RE2FfmPattern.compile(csvPattern);
-
-    String secretPattern = data.getString("application.secretRedaction.pattern");
-    secretText = data.getString("application.secretRedaction.text");
-    secretReplacement = data.getString("application.secretRedaction.replacement");
-    safeSecret = org.safere.Pattern.compile(secretPattern);
-    jdkSecret = java.util.regex.Pattern.compile(secretPattern);
-    re2jSecret = com.google.re2j.Pattern.compile(secretPattern);
-    re2ffmSecret = org.safere.re2ffm.RE2FfmPattern.compile(secretPattern);
+    for (ApplicationCase appCase : cases.values()) {
+      org.safere.Pattern saferePattern = org.safere.Pattern.compile(appCase.pattern);
+      saferePatterns.put(appCase.name, saferePattern);
+      jdkPatterns.put(appCase.name, java.util.regex.Pattern.compile(appCase.pattern));
+      re2jPatterns.put(appCase.name, com.google.re2j.Pattern.compile(appCase.pattern));
+      re2ffmPatterns.put(appCase.name, org.safere.re2ffm.RE2FfmPattern.compile(appCase.pattern));
+      validateExpected(appCase);
+    }
   }
 
   @Benchmark
   public int uuidValidation_safere() {
-    int count = 0;
-    for (String text : uuidTexts) {
-      if (safeUuid.matcher(text).matches()) {
-        count++;
-      }
-    }
-    return count;
+    return runSafereInt("uuidValidation");
   }
 
   @Benchmark
   public int uuidValidation_jdk() {
-    int count = 0;
-    for (String text : uuidTexts) {
-      if (jdkUuid.matcher(text).matches()) {
-        count++;
-      }
-    }
-    return count;
+    return runJdkInt("uuidValidation");
   }
 
   @Benchmark
   public int uuidValidation_re2j() {
-    int count = 0;
-    for (String text : uuidTexts) {
-      if (re2jUuid.matcher(text).matches()) {
-        count++;
-      }
-    }
-    return count;
+    return runRe2jInt("uuidValidation");
   }
 
   @Benchmark
   public int uuidValidation_re2ffm() {
-    int count = 0;
-    for (String text : uuidTexts) {
-      if (re2ffmUuid.matcher(text).matches()) {
-        count++;
-      }
-    }
-    return count;
+    return runRe2ffmInt("uuidValidation");
   }
 
   @Benchmark
   public int logLineParse_safere() {
-    int count = 0;
-    for (String text : logLineTexts) {
-      org.safere.Matcher matcher = safeLogLine.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(2).length() + matcher.group(3).length();
-      }
-    }
-    return count;
+    return runSafereInt("logLineParse");
   }
 
   @Benchmark
   public int logLineParse_jdk() {
-    int count = 0;
-    for (String text : logLineTexts) {
-      java.util.regex.Matcher matcher = jdkLogLine.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(2).length() + matcher.group(3).length();
-      }
-    }
-    return count;
+    return runJdkInt("logLineParse");
   }
 
   @Benchmark
   public int logLineParse_re2j() {
-    int count = 0;
-    for (String text : logLineTexts) {
-      com.google.re2j.Matcher matcher = re2jLogLine.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(2).length() + matcher.group(3).length();
-      }
-    }
-    return count;
+    return runRe2jInt("logLineParse");
   }
 
   @Benchmark
   public int logLineParse_re2ffm() {
-    int count = 0;
-    for (String text : logLineTexts) {
-      org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmLogLine.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(2).length() + matcher.group(3).length();
-      }
-    }
-    return count;
+    return runRe2ffmInt("logLineParse");
   }
 
   @Benchmark
   public int apiRouteMatch_safere() {
-    int count = 0;
-    for (String text : apiRouteTexts) {
-      org.safere.Matcher matcher = safeApiRoute.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(1).length() + matcher.group(2).length();
-      }
-    }
-    return count;
+    return runSafereInt("apiRouteMatch");
   }
 
   @Benchmark
   public int apiRouteMatch_jdk() {
-    int count = 0;
-    for (String text : apiRouteTexts) {
-      java.util.regex.Matcher matcher = jdkApiRoute.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(1).length() + matcher.group(2).length();
-      }
-    }
-    return count;
+    return runJdkInt("apiRouteMatch");
   }
 
   @Benchmark
   public int apiRouteMatch_re2j() {
-    int count = 0;
-    for (String text : apiRouteTexts) {
-      com.google.re2j.Matcher matcher = re2jApiRoute.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(1).length() + matcher.group(2).length();
-      }
-    }
-    return count;
+    return runRe2jInt("apiRouteMatch");
   }
 
   @Benchmark
   public int apiRouteMatch_re2ffm() {
-    int count = 0;
-    for (String text : apiRouteTexts) {
-      org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmApiRoute.matcher(text);
-      if (matcher.matches()) {
-        count += matcher.group(1).length() + matcher.group(2).length();
-      }
-    }
-    return count;
+    return runRe2ffmInt("apiRouteMatch");
   }
 
   @Benchmark
   public int stackTraceExtract_safere() {
-    org.safere.Matcher matcher = safeStackTrace.matcher(stackTraceText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group(1).length() + matcher.group(4).length();
-    }
-    return count;
+    return runSafereInt("stackTraceExtract");
   }
 
   @Benchmark
   public int stackTraceExtract_jdk() {
-    java.util.regex.Matcher matcher = jdkStackTrace.matcher(stackTraceText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group(1).length() + matcher.group(4).length();
-    }
-    return count;
+    return runJdkInt("stackTraceExtract");
   }
 
   @Benchmark
   public int stackTraceExtract_re2j() {
-    com.google.re2j.Matcher matcher = re2jStackTrace.matcher(stackTraceText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group(1).length() + matcher.group(4).length();
-    }
-    return count;
+    return runRe2jInt("stackTraceExtract");
   }
 
   @Benchmark
   public int stackTraceExtract_re2ffm() {
-    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmStackTrace.matcher(stackTraceText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group(1).length() + matcher.group(4).length();
-    }
-    return count;
+    return runRe2ffmInt("stackTraceExtract");
   }
 
   @Benchmark
   public int caseInsensitiveKeywords_safere() {
-    org.safere.Matcher matcher = safeKeywords.matcher(keywordText);
-    int count = 0;
-    while (matcher.find()) {
-      count++;
-    }
-    return count;
+    return runSafereInt("caseInsensitiveKeywords");
   }
 
   @Benchmark
   public int caseInsensitiveKeywords_jdk() {
-    java.util.regex.Matcher matcher = jdkKeywords.matcher(keywordText);
-    int count = 0;
-    while (matcher.find()) {
-      count++;
-    }
-    return count;
+    return runJdkInt("caseInsensitiveKeywords");
   }
 
   @Benchmark
   public int caseInsensitiveKeywords_re2j() {
-    com.google.re2j.Matcher matcher = re2jKeywords.matcher(keywordText);
-    int count = 0;
-    while (matcher.find()) {
-      count++;
-    }
-    return count;
+    return runRe2jInt("caseInsensitiveKeywords");
   }
 
   @Benchmark
   public int caseInsensitiveKeywords_re2ffm() {
-    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmKeywords.matcher(keywordText);
-    int count = 0;
-    while (matcher.find()) {
-      count++;
-    }
-    return count;
+    return runRe2ffmInt("caseInsensitiveKeywords");
   }
 
   @Benchmark
   public int urlExtraction_safere() {
-    org.safere.Matcher matcher = safeUrl.matcher(urlText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runSafereInt("urlExtraction");
   }
 
   @Benchmark
   public int urlExtraction_jdk() {
-    java.util.regex.Matcher matcher = jdkUrl.matcher(urlText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runJdkInt("urlExtraction");
   }
 
   @Benchmark
   public int urlExtraction_re2j() {
-    com.google.re2j.Matcher matcher = re2jUrl.matcher(urlText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runRe2jInt("urlExtraction");
   }
 
   @Benchmark
   public int urlExtraction_re2ffm() {
-    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmUrl.matcher(urlText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runRe2ffmInt("urlExtraction");
   }
 
   @Benchmark
   public int csvFieldScan_safere() {
-    org.safere.Matcher matcher = safeCsv.matcher(csvText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runSafereInt("csvFieldScan");
   }
 
   @Benchmark
   public int csvFieldScan_jdk() {
-    java.util.regex.Matcher matcher = jdkCsv.matcher(csvText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runJdkInt("csvFieldScan");
   }
 
   @Benchmark
   public int csvFieldScan_re2j() {
-    com.google.re2j.Matcher matcher = re2jCsv.matcher(csvText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runRe2jInt("csvFieldScan");
   }
 
   @Benchmark
   public int csvFieldScan_re2ffm() {
-    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmCsv.matcher(csvText);
-    int count = 0;
-    while (matcher.find()) {
-      count += matcher.group().length();
-    }
-    return count;
+    return runRe2ffmInt("csvFieldScan");
   }
 
   @Benchmark
   public String secretRedaction_safere() {
-    return safeSecret.matcher(secretText).replaceAll(secretReplacement);
+    return runSafereString("secretRedaction");
   }
 
   @Benchmark
   public String secretRedaction_jdk() {
-    return jdkSecret.matcher(secretText).replaceAll(secretReplacement);
+    return runJdkString("secretRedaction");
   }
 
   @Benchmark
   public String secretRedaction_re2j() {
-    return re2jSecret.matcher(secretText).replaceAll(secretReplacement);
+    return runRe2jString("secretRedaction");
   }
 
   @Benchmark
   public String secretRedaction_re2ffm() {
-    return re2ffmSecret.matcher(secretText).replaceAll(secretReplacement);
+    return runRe2ffmString("secretRedaction");
+  }
+
+  private int runSafereInt(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return runSafereInt(appCase, saferePatterns.get(name));
+  }
+
+  private int runJdkInt(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return runJdkInt(appCase, jdkPatterns.get(name));
+  }
+
+  private int runRe2jInt(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return runRe2jInt(appCase, re2jPatterns.get(name));
+  }
+
+  private int runRe2ffmInt(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return runRe2ffmInt(appCase, re2ffmPatterns.get(name));
+  }
+
+  private String runSafereString(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return saferePatterns.get(name).matcher(appCase.text).replaceAll(appCase.replacement);
+  }
+
+  private String runJdkString(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return jdkPatterns.get(name).matcher(appCase.text).replaceAll(appCase.replacement);
+  }
+
+  private String runRe2jString(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return re2jPatterns.get(name).matcher(appCase.text).replaceAll(appCase.replacement);
+  }
+
+  private String runRe2ffmString(String name) {
+    ApplicationCase appCase = cases.get(name);
+    return re2ffmPatterns.get(name).matcher(appCase.text).replaceAll(appCase.replacement);
+  }
+
+  private static int runSafereInt(ApplicationCase appCase, org.safere.Pattern pattern) {
+    return switch (appCase.op) {
+      case "matchesCorpus" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          if (pattern.matcher(text).matches()) {
+            count++;
+          }
+        }
+        yield count;
+      }
+      case "matchesGroupLengthSum" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          org.safere.Matcher matcher = pattern.matcher(text);
+          if (matcher.matches()) {
+            count += groupLengthSum(matcher::group, appCase.groups);
+          }
+        }
+        yield count;
+      }
+      case "findAllCount" -> {
+        org.safere.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count++;
+        }
+        yield count;
+      }
+      case "findAllLengthSum" -> {
+        org.safere.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += matcher.group().length();
+        }
+        yield count;
+      }
+      case "findAllGroupLengthSum" -> {
+        org.safere.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += groupLengthSum(matcher::group, appCase.groups);
+        }
+        yield count;
+      }
+      default -> throw new IllegalArgumentException("String op used as int op: " + appCase.op);
+    };
+  }
+
+  private static int runJdkInt(ApplicationCase appCase, java.util.regex.Pattern pattern) {
+    return switch (appCase.op) {
+      case "matchesCorpus" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          if (pattern.matcher(text).matches()) {
+            count++;
+          }
+        }
+        yield count;
+      }
+      case "matchesGroupLengthSum" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          java.util.regex.Matcher matcher = pattern.matcher(text);
+          if (matcher.matches()) {
+            count += groupLengthSum(matcher::group, appCase.groups);
+          }
+        }
+        yield count;
+      }
+      case "findAllCount" -> {
+        java.util.regex.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count++;
+        }
+        yield count;
+      }
+      case "findAllLengthSum" -> {
+        java.util.regex.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += matcher.group().length();
+        }
+        yield count;
+      }
+      case "findAllGroupLengthSum" -> {
+        java.util.regex.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += groupLengthSum(matcher::group, appCase.groups);
+        }
+        yield count;
+      }
+      default -> throw new IllegalArgumentException("String op used as int op: " + appCase.op);
+    };
+  }
+
+  private static int runRe2jInt(ApplicationCase appCase, com.google.re2j.Pattern pattern) {
+    return switch (appCase.op) {
+      case "matchesCorpus" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          if (pattern.matcher(text).matches()) {
+            count++;
+          }
+        }
+        yield count;
+      }
+      case "matchesGroupLengthSum" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          com.google.re2j.Matcher matcher = pattern.matcher(text);
+          if (matcher.matches()) {
+            count += groupLengthSum(matcher::group, appCase.groups);
+          }
+        }
+        yield count;
+      }
+      case "findAllCount" -> {
+        com.google.re2j.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count++;
+        }
+        yield count;
+      }
+      case "findAllLengthSum" -> {
+        com.google.re2j.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += matcher.group().length();
+        }
+        yield count;
+      }
+      case "findAllGroupLengthSum" -> {
+        com.google.re2j.Matcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += groupLengthSum(matcher::group, appCase.groups);
+        }
+        yield count;
+      }
+      default -> throw new IllegalArgumentException("String op used as int op: " + appCase.op);
+    };
+  }
+
+  private static int runRe2ffmInt(
+      ApplicationCase appCase, org.safere.re2ffm.RE2FfmPattern pattern) {
+    return switch (appCase.op) {
+      case "matchesCorpus" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          if (pattern.matcher(text).matches()) {
+            count++;
+          }
+        }
+        yield count;
+      }
+      case "matchesGroupLengthSum" -> {
+        int count = 0;
+        for (String text : appCase.texts) {
+          org.safere.re2ffm.RE2FfmMatcher matcher = pattern.matcher(text);
+          if (matcher.matches()) {
+            count += groupLengthSum(matcher::group, appCase.groups);
+          }
+        }
+        yield count;
+      }
+      case "findAllCount" -> {
+        org.safere.re2ffm.RE2FfmMatcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count++;
+        }
+        yield count;
+      }
+      case "findAllLengthSum" -> {
+        org.safere.re2ffm.RE2FfmMatcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += matcher.group().length();
+        }
+        yield count;
+      }
+      case "findAllGroupLengthSum" -> {
+        org.safere.re2ffm.RE2FfmMatcher matcher = pattern.matcher(appCase.text);
+        int count = 0;
+        while (matcher.find()) {
+          count += groupLengthSum(matcher::group, appCase.groups);
+        }
+        yield count;
+      }
+      default -> throw new IllegalArgumentException("String op used as int op: " + appCase.op);
+    };
+  }
+
+  private static int groupLengthSum(GroupReader groupReader, int[] groups) {
+    int sum = 0;
+    for (int group : groups) {
+      String value = groupReader.group(group);
+      if (value != null) {
+        sum += value.length();
+      }
+    }
+    return sum;
+  }
+
+  private void validateExpected(ApplicationCase appCase) {
+    org.safere.Pattern saferePattern = saferePatterns.get(appCase.name);
+    if (appCase.op.startsWith("findAll") && saferePattern.matcher("").find()) {
+      throw new IllegalArgumentException(
+          appCase.name + " uses an empty-width pattern with find-all op " + appCase.op);
+    }
+    if (appCase.expectsString()) {
+      validateString(
+          appCase.name, "safere", runSafereString(appCase.name), appCase.expectedString());
+      validateString(appCase.name, "jdk", runJdkString(appCase.name), appCase.expectedString());
+      validateString(appCase.name, "re2j", runRe2jString(appCase.name), appCase.expectedString());
+      validateString(
+          appCase.name, "re2ffm", runRe2ffmString(appCase.name), appCase.expectedString());
+      return;
+    }
+    validateInt(appCase.name, "safere", runSafereInt(appCase.name), appCase.expectedInt());
+    validateInt(appCase.name, "jdk", runJdkInt(appCase.name), appCase.expectedInt());
+    validateInt(appCase.name, "re2j", runRe2jInt(appCase.name), appCase.expectedInt());
+    validateInt(appCase.name, "re2ffm", runRe2ffmInt(appCase.name), appCase.expectedInt());
+  }
+
+  private static void validateInt(String caseName, String engine, int actual, int expected) {
+    if (actual != expected) {
+      throw new IllegalArgumentException(
+          caseName + " " + engine + " expected " + expected + " but was " + actual);
+    }
+  }
+
+  private static void validateString(
+      String caseName, String engine, String actual, String expected) {
+    if (!actual.equals(expected)) {
+      throw new IllegalArgumentException(
+          caseName + " " + engine + " expected " + expected + " but was " + actual);
+    }
+  }
+
+  private interface GroupReader {
+    String group(int group);
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationBenchmarkValidator.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationBenchmarkValidator.java
@@ -1,0 +1,29 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.Map;
+
+/** Smoke utility for validating data-driven application benchmark cases. */
+public final class ApplicationBenchmarkValidator {
+
+  private ApplicationBenchmarkValidator() {}
+
+  /** Loads and validates all application benchmark cases. */
+  public static void main(String[] args) {
+    Map<String, ApplicationCase> cases = BenchmarkData.get().getApplicationCases();
+    if (cases.isEmpty()) {
+      throw new IllegalArgumentException("No application benchmark cases configured");
+    }
+    for (ApplicationCase appCase : cases.values()) {
+      org.safere.Pattern pattern = org.safere.Pattern.compile(appCase.pattern);
+      if (appCase.op.startsWith("findAll") && pattern.matcher("").find()) {
+        throw new IllegalArgumentException(
+            appCase.name + " uses an empty-width pattern with find-all op " + appCase.op);
+      }
+    }
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ApplicationCase.java
@@ -1,0 +1,144 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
+
+/** One data-driven application benchmark case from {@code benchmark-data.json}. */
+final class ApplicationCase {
+
+  final String name;
+  final String op;
+  final String pattern;
+  final List<String> texts;
+  final String text;
+  final int[] groups;
+  final String replacement;
+  final JsonElement expected;
+
+  private ApplicationCase(
+      String name,
+      String op,
+      String pattern,
+      List<String> texts,
+      String text,
+      int[] groups,
+      String replacement,
+      JsonElement expected) {
+    this.name = name;
+    this.op = op;
+    this.pattern = pattern;
+    this.texts = texts;
+    this.text = text;
+    this.groups = groups;
+    this.replacement = replacement;
+    this.expected = expected;
+  }
+
+  static ApplicationCase fromJson(JsonObject obj) {
+    String name = requireString(obj, "name");
+    String op = requireString(obj, "op");
+    String pattern = requireString(obj, "pattern");
+    List<String> texts = stringList(obj, "texts");
+    String text = optionalString(obj, "text");
+    int[] groups = intArray(obj, "groups");
+    String replacement = optionalString(obj, "replacement");
+    JsonElement expected = require(obj, "expected");
+
+    switch (op) {
+      case "matchesCorpus" -> requireTexts(name, texts);
+      case "matchesGroupLengthSum" -> {
+        requireTexts(name, texts);
+        requireGroups(name, groups);
+      }
+      case "findAllCount", "findAllLengthSum" -> requireText(name, text);
+      case "findAllGroupLengthSum" -> {
+        requireText(name, text);
+        requireGroups(name, groups);
+      }
+      case "replaceAll" -> {
+        requireText(name, text);
+        if (replacement == null) {
+          throw new IllegalArgumentException(name + " requires replacement");
+        }
+      }
+      default -> throw new IllegalArgumentException("Unknown application benchmark op: " + op);
+    }
+    return new ApplicationCase(name, op, pattern, texts, text, groups, replacement, expected);
+  }
+
+  boolean expectsString() {
+    return "replaceAll".equals(op);
+  }
+
+  int expectedInt() {
+    return expected.getAsInt();
+  }
+
+  String expectedString() {
+    return expected.getAsString();
+  }
+
+  private static JsonElement require(JsonObject obj, String key) {
+    JsonElement value = obj.get(key);
+    if (value == null) {
+      throw new IllegalArgumentException("Missing application case field: " + key);
+    }
+    return value;
+  }
+
+  private static String requireString(JsonObject obj, String key) {
+    return require(obj, key).getAsString();
+  }
+
+  private static String optionalString(JsonObject obj, String key) {
+    JsonElement value = obj.get(key);
+    return value == null ? null : value.getAsString();
+  }
+
+  private static List<String> stringList(JsonObject obj, String key) {
+    JsonElement value = obj.get(key);
+    if (value == null) {
+      return List.of();
+    }
+    List<String> result = new ArrayList<>(value.getAsJsonArray().size());
+    value.getAsJsonArray().forEach(item -> result.add(item.getAsString()));
+    return List.copyOf(result);
+  }
+
+  private static int[] intArray(JsonObject obj, String key) {
+    JsonElement value = obj.get(key);
+    if (value == null) {
+      return new int[0];
+    }
+    int[] result = new int[value.getAsJsonArray().size()];
+    for (int i = 0; i < result.length; i++) {
+      result[i] = value.getAsJsonArray().get(i).getAsInt();
+    }
+    return result;
+  }
+
+  private static void requireTexts(String name, List<String> texts) {
+    if (texts.isEmpty()) {
+      throw new IllegalArgumentException(name + " requires texts");
+    }
+  }
+
+  private static void requireText(String name, String text) {
+    if (text == null) {
+      throw new IllegalArgumentException(name + " requires text");
+    }
+  }
+
+  private static void requireGroups(String name, int[] groups) {
+    if (groups.length == 0) {
+      throw new IllegalArgumentException(name + " requires groups");
+    }
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -13,7 +13,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Loads benchmark data (patterns, texts, parameters) from the shared {@code benchmark-data.json}
@@ -100,5 +103,18 @@ public final class BenchmarkData {
       result.add(item.getAsString());
     }
     return result;
+  }
+
+  /** Returns application benchmark cases in JSON order, keyed by case name. */
+  public Map<String, ApplicationCase> getApplicationCases() {
+    JsonArray arr = root.getAsJsonArray("application");
+    Map<String, ApplicationCase> cases = new LinkedHashMap<>();
+    for (JsonElement item : arr) {
+      ApplicationCase appCase = ApplicationCase.fromJson(item.getAsJsonObject());
+      if (cases.put(appCase.name, appCase) != null) {
+        throw new IllegalArgumentException("Duplicate application benchmark case: " + appCase.name);
+      }
+    }
+    return Collections.unmodifiableMap(cases);
   }
 }


### PR DESCRIPTION
## Summary

- Re-express application benchmark workloads as data-driven cases in benchmark-data.json with explicit operation types and expected results.
- Refactor Java, C++, and Go application benchmark harnesses to dispatch through the shared operation model while keeping Java JMH wrapper names stable.
- Add application expected-result validation and benchmark-name alignment checks, including detection of engines with no application rows.
- Document the data-driven application workload model and wire strict name validation into publication benchmark collection.

Fixes #179

## Validation

- mvn -pl safere-benchmarks -DskipTests package -q
- java -cp target/benchmarks.jar org.safere.benchmark.ApplicationBenchmarkValidator
- cmake --build build
- GOCACHE=/tmp/safere-go-cache go test ./...
- ./build/re2_benchmark --data ../benchmark-data.json uuidValidation
- GOCACHE=/tmp/safere-go-cache go run . --data ../benchmark-data.json uuidValidation
- ./run-java-benchmarks.sh --smoke ApplicationBenchmark.uuidValidation
- python3 -m json.tool safere-benchmarks/benchmark-data.json
- bash -n collect-benchmark-results.sh
- synthetic compare-benchmarks.py checks for complete and missing application rows
- git diff --check
- mvn -pl safere test -q

Note: the first full safere test run hit a timing-threshold flake in MatcherTest; a targeted rerun and a subsequent full rerun passed. Tracked separately in #181.