### PR TITLE
Update benchmark results documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ Drop-in replacements for `java.util.regex`:
   machines, such as relative ratios between related inputs or scaling behavior.
 - **Do not include test counts in documentation** (DESIGN.md, TESTING.md,
   etc.) — counts change frequently as tests are added and will go stale.
+- When updating BENCHMARKS.md, include the full Git SHA that the benchmarks
+  were run against and that commit's date/time in UTC using `Z` notation
+  (for example, `2026-04-27T02:42:22Z`). Do not include a separate benchmark
+  results timestamp unless explicitly requested.
 
 ## External Validation
 
@@ -291,13 +295,17 @@ per invocation and collect results incrementally:
 
 When reporting benchmark results in BENCHMARKS.md, always compute and report
 **geometric mean of the speed ratios** (SafeRE time / competitor time) as the
-single summary statistic. Report two geomeans, against both JDK and RE2/J:
+single summary statistic. Report three geomeans, against JDK, RE2/J, and
+RE2-FFM:
 
 1. **Core workloads geomean** — includes: literalMatch, emailFind, findInText,
-   alternationFind, charClassMatch, captureGroups, pigLatinReplace, httpFull
-   (and any future "everyday usage" benchmarks). This answers: "Is SafeRE
-   competitive for normal use?"
-2. **Pathological/scaling geomean** — includes: pathological, searchHardFail,
+   alternationFind, charClassMatch, captureGroups, pigLatinReplace, and
+   httpFull. These are focused microbenchmarks that isolate engine behavior.
+2. **Application workloads geomean** — includes the data-driven validation,
+   parsing, extraction, scanning, and redaction cases from
+   `ApplicationBenchmark`. This answers: "Is SafeRE competitive on ordinary
+   application regex use?"
+3. **Pathological/scaling geomean** — includes: pathological, searchHardFail,
    and other benchmarks that demonstrate linear-time guarantees or scaling
    behavior. This answers: "Does the linear-time guarantee matter?"
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -7,12 +7,14 @@ Go [`regexp`](https://pkg.go.dev/regexp) (Go 1.26.1) on common regex
 workloads and pathological patterns that demonstrate backtracking blowup.
 
 **Environment:**
+- Benchmarked commit: `0ebd8aed7edcfe43c5a9cee92efee84167a76aa0`
+- Commit date/time: 2026-04-27T02:42:22Z
 - CPU: Intel Core i7-11700K (8 cores / 16 threads, 3.6 GHz base)
 - RAM: 32 GB
 - OS: Ubuntu 24.04.4 LTS on WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2),
   Windows 11 host
 - JDK: OpenJDK 25.0.2+10-69 (targeting Java 21)
-- JMH: 1.37, fork mode (1 fork, 3 warmup × 1s, 5 measurement × 1s)
+- JMH: 1.37, fork mode (3 forks, 3 warmup × 5s, 5 measurement × 5s)
 - RE2-FFM: C++ RE2 (2024-07-02) accessed via Java FFM API (JEP 454)
 - C++ compiler: g++ 13.3.0, `-O3 -DNDEBUG` (CMake Release)
 - Go: 1.26.1 linux/amd64
@@ -37,13 +39,9 @@ All benchmarks use a warmup-then-measure approach, but the settings differ
 between Java and native harnesses to account for their different runtime
 characteristics.
 
-**Java (JMH):** 1 fork × (3 warmup × 1s + 5 measurement × 1s). These results
-were collected before [#152](https://github.com/eaftan/safere/issues/152)
-discovered that JMH annotation settings in the benchmark classes were
-overriding the intended publication-quality defaults. The actual settings used
-were less rigorous than intended. A full re-run with publication-quality
-settings (3 forks, 3 warmup × 5s, 5 measurement × 5s) is tracked in
-[#155](https://github.com/eaftan/safere/issues/155).
+**Java (JMH):** 3 forks × (3 warmup × 5s + 5 measurement × 5s), except
+pathological benchmark classes use `-f 0` so the JDK engine can be timed only
+for feasible input sizes without spawning JVMs that may hang.
 
 **C++ and Go:** 2 warmup + 10 measurement iterations × 2s each, single process.
 Native code has no JIT, so the same binary always runs the same machine code —
@@ -63,41 +61,53 @@ operation type and expected result in that file, so Java, C++, and Go validate
 the same semantics before timing.
 
 **Workload coverage:** The suite separates focused microbenchmarks,
-data-driven application workloads, and pathological/scaling workloads. The
-published numerical tables below were collected before `ApplicationBenchmark`
-was added; rerun the collection script before adding application-workload
-ratios to the summary tables.
+data-driven application workloads, and pathological/scaling workloads.
 
 | Setting | Java (JMH) | C++ | Go |
 |---|---|---|---|
-| Warmup | 5 × 10s per fork | 2 × 2s | 2 × 2s |
-| Measurement | 5 × 10s per fork | 10 × 2s | 10 × 2s |
-| Forks | 5 (fresh JVM each) | 1 (single process) | 1 (single process) |
-| Total samples | 25 | 10 | 10 |
+| Warmup | 3 × 5s per fork | 2 × 2s | 2 × 2s |
+| Measurement | 5 × 5s per fork | 10 × 2s | 10 × 2s |
+| Forks | 3 (fresh JVM each) | 1 (single process) | 1 (single process) |
+| Total samples | 15 | 10 | 10 |
 | Optimization | JIT (steady-state) | `-O3 -DNDEBUG` | Go default |
 
 ## Matching Performance (ns/op, lower is better)
 
 | Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Literal match (`"hello"`) | 9 | 13 | 126 | 55 | 40 | 78 | **1.4× faster** | **14× faster** | **6.1× faster** |
-| Char class match (`[a-zA-Z]+`) | 18 | 24 | 1,225 | 113 | 85 | 395 | **1.3× faster** | **68× faster** | **6.3× faster** |
-| Alternation find (`foo\|bar\|…` ×8) | 812 | 526 | 4,266 | 604 | 19 | 1,784 | 1.5× slower | **5.3× faster** | 1.3× slower |
-| Capture groups (`(\d{4})-(\d{2})-(\d{2})`) | 74 | 84 | 575 | 320 | 77 | 241 | **1.1× faster** | **7.8× faster** | **4.3× faster** |
-| Find -ing words in prose (~350 chars) | 3,114 | 2,931 | 19,402 | 4,237 | 19 | 12,975 | ~same | **6.2× faster** | **1.4× faster** |
-| Email pattern find | 259 | 395 | 1,910 | 223 | 89 | 544 | **1.5× faster** | **7.4× faster** | 1.2× slower |
+| Literal match (`"hello"`) | 11 | 13 | 128 | 57 | 40 | 76 | **1.2× faster** | **12× faster** | **5.3× faster** |
+| Char class match (`[a-zA-Z]+`) | 21 | 24 | 1,236 | 110 | 82 | 364 | **1.2× faster** | **60× faster** | **5.4× faster** |
+| Alternation find (`foo\|bar\|…` ×8) | 2,207 | 534 | 4,344 | 615 | 17 | 1,693 | 4.1× slower | **2.0× faster** | 3.6× slower |
+| Capture groups (`(\d{4})-(\d{2})-(\d{2})`) | 77 | 96 | 559 | 325 | 75 | 233 | **1.2× faster** | **7.3× faster** | **4.2× faster** |
+| Find -ing words in prose (~350 chars) | 3,429 | 2,985 | 20,026 | 4,249 | 17 | 12,426 | 1.1× slower | **5.8× faster** | **1.2× faster** |
+| Email pattern find | 285 | 394 | 1,918 | 230 | 82 | 546 | **1.4× faster** | **6.7× faster** | 1.2× slower |
 
-SafeRE **matches or beats JDK** on 5 of 6 core matching benchmarks, with the
-remaining one within 1.5×. Capture groups is now a SafeRE win (74 vs 84 ns/op,
-1.1× faster) thanks to the OnePass optimization. The character-class match fast
-path (precomputed ASCII bitmap loop) delivers 18 ns — 1.3× faster than JDK and
-68× faster than RE2/J. Email find beats JDK by 1.5× thanks to DFA caching and
-the DFA sandwich optimization. SafeRE also beats RE2-FFM on 4 of 6
-benchmarks — by 6.1× on literal match, 6.3× on character class, 4.3× on
-capture groups, and 1.4× on find-in-text — losing only on alternation (1.3×)
-and email find (1.2×) where RE2-FFM's native code has an edge. C++ RE2 remains
-the fastest on alternation and find-in-text workloads due to native code and
-UTF-8 encoding.
+SafeRE beats JDK on literal matching, character-class matching, capture groups,
+and email find. It is slower on alternation find, where C++ RE2 and RE2-FFM
+benefit from native-code prefix handling, and modestly slower on find-in-text.
+SafeRE remains faster than RE2/J on every matching benchmark, with especially
+large gains on literal and character-class matches.
+
+## Application Workloads (ns/op, lower is better)
+
+Data-driven validation, parsing, extraction, scanning, and redaction cases from
+`ApplicationBenchmark`.
+
+| Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
+|---|--:|--:|--:|--:|--:|--:|---|---|---|
+| UUID validation | 425 | 1,299 | 2,549 | 602 | 344 | 956 | **3.1× faster** | **6.0× faster** | **1.4× faster** |
+| Log line parse | 3,861 | 1,118 | 15,867 | 2,873 | 1,998 | 2,249 | 3.5× slower | **4.1× faster** | 1.3× slower |
+| API route match | 611 | 646 | 6,650 | 1,007 | 306 | 997 | **1.1× faster** | **11× faster** | **1.6× faster** |
+| Stack trace extract | 5,895 | 2,450 | 28,185 | 4,754 | 4,106 | 4,367 | 2.4× slower | **4.8× faster** | 1.2× slower |
+| Case-insensitive keywords | 4,059 | 1,213 | 6,740 | 1,284 | 477 | 4,417 | 3.3× slower | **1.7× faster** | 3.2× slower |
+| URL extraction | 869 | 1,270 | 7,572 | 1,424 | 608 | 1,572 | **1.5× faster** | **8.7× faster** | **1.6× faster** |
+| CSV field scan | 3,285 | 742 | 10,245 | 6,268 | 1,222 | 3,455 | 4.4× slower | **3.1× faster** | **1.9× faster** |
+| Secret redaction | 2,147 | 783 | 7,166 | 978 | 618 | 2,524 | 2.7× slower | **3.3× faster** | 2.2× slower |
+
+SafeRE wins 3 of 8 application workloads against JDK and is faster than RE2/J
+on all 8. Against RE2-FFM, SafeRE wins UUID validation, API route matching,
+URL extraction, and CSV field scanning, while RE2-FFM has an edge on workloads
+where C++ RE2's native execution offsets FFM overhead.
 
 ## Search Scaling (µs/op, lower is better)
 
@@ -116,40 +126,40 @@ the same constant-time behavior for Hard and Medium patterns.
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.09 | 0.16 | 0.10 | 0.16 | 0.09 | **1.8× faster** | ~same | **1.8× faster** |
-| 10 KB | 0.81 | 1.41 | 0.82 | 1.05 | 0.24 | **1.7× faster** | ~same | **1.3× faster** |
-| 100 KB | 8.0 | 14.0 | 8.0 | 10.7 | 2.3 | **1.8× faster** | ~same | **1.3× faster** |
-| 1 MB | 82 | 143 | 82 | 151 | 24 | **1.7× faster** | ~same | **1.8× faster** |
+| 1 KB | 0.09 | 0.16 | 0.10 | 0.17 | 0.08 | **1.8× faster** | ~same | **1.9× faster** |
+| 10 KB | 0.83 | 1.44 | 0.84 | 1.07 | 0.23 | **1.7× faster** | ~same | **1.3× faster** |
+| 100 KB | 8.2 | 14.2 | 8.2 | 11.1 | 2.3 | **1.7× faster** | ~same | **1.4× faster** |
+| 1 MB | 84 | 146 | 84 | 152 | 24 | **1.7× faster** | ~same | **1.8× faster** |
 
 ### Medium: `[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (starts with char class)
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.39 | 0.26 | 21.9 | 0.16 | 14 | 1.5× slower | **56× faster** | 2.4× slower |
-| 10 KB | 3.8 | 2.5 | 230 | 1.1 | 178 | 1.5× slower | **61× faster** | 3.5× slower |
-| 100 KB | 37 | 24 | 2,397 | 11 | 1,779 | 1.5× slower | **65× faster** | 3.4× slower |
-| 1 MB | 385 | 249 | 24,426 | 152 | 18,641 | 1.5× slower | **63× faster** | 2.5× slower |
+| 1 KB | 0.38 | 0.26 | 21.7 | 0.16 | 14 | 1.5× slower | **56× faster** | 2.4× slower |
+| 10 KB | 3.7 | 2.4 | 233 | 1.0 | 171 | 1.5× slower | **63× faster** | 3.6× slower |
+| 100 KB | 37 | 24 | 2,397 | 11 | 1,714 | 1.5× slower | **65× faster** | 3.5× slower |
+| 1 MB | 381 | 370 | 24,548 | 149 | 18,101 | ~same | **64× faster** | 2.5× slower |
 
 Character-class prefix acceleration allows SafeRE to scan directly for
 `[XYZ]` before invoking the DFA, reducing the gap with JDK to just 1.5×.
 SafeRE is **56–65× faster than RE2/J** on this pattern. RE2-FFM benefits
 from C++ RE2's reverse DFA, achieving near-constant time and beating SafeRE
-by 2.4–3.5×.
+by 2.4–3.6×.
 
 ### Hard: `[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (catastrophic in backtracking engines)
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.018 | 76 | 37 | 0.17 | 19 | **4,200× faster** | **2,100× faster** | **9.4× faster** |
-| 10 KB | 0.018 | 434 | 373 | 1.1 | 250 | **24,000× faster** | **21,000× faster** | **61× faster** |
-| 100 KB | 0.018 | 4,615 | 3,718 | 11 | 2,480 | **256,000× faster** | **207,000× faster** | **611× faster** |
-| 1 MB | 0.019 | 43,773 | 37,857 | 152 | 25,445 | **2.3M× faster** | **2.0M× faster** | **8,000× faster** |
+| 1 KB | 0.021 | 59 | 36 | 0.17 | 18 | **2,800× faster** | **1,700× faster** | **8.2× faster** |
+| 10 KB | 0.021 | 448 | 380 | 1.1 | 244 | **21,000× faster** | **18,000× faster** | **51× faster** |
+| 100 KB | 0.020 | 4,472 | 3,748 | 11 | 2,437 | **224,000× faster** | **187,000× faster** | **560× faster** |
+| 1 MB | 0.020 | 45,835 | 38,671 | 153 | 24,995 | **2.3M× faster** | **1.9M× faster** | **7,700× faster** |
 
-SafeRE achieves **constant-time rejection** (0.018–0.019 µs regardless of text
+SafeRE achieves **constant-time rejection** (~0.020 µs regardless of text
 size) on this pattern, similar to C++ RE2's reverse DFA optimization. SafeRE
 detects at compile time that the required literal suffix `ABCDEFGHIJKLMNOPQRSTUVWXYZ`
 cannot occur in random ASCII text and short-circuits before scanning. This is
-even faster than C++ RE2 (0.048 µs) and RE2-FFM, which must still invoke the
+even faster than C++ RE2 (0.044 µs) and RE2-FFM, which must still invoke the
 reverse DFA. JDK's backtracking engine exhibits O(n²) behavior due to the
 leading `[ -~]*`, making SafeRE millions of times faster at 1 MB. RE2/J and
 Go `regexp` handle it in linear time but are still orders of magnitude slower
@@ -159,32 +169,32 @@ than SafeRE's constant-time path.
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.32 | 0.19 | 0.79 | 0.24 | 0.22 | 1.7× slower | **2.5× faster** | 1.3× slower |
-| 10 KB | 1.1 | 1.5 | 1.5 | 1.1 | 0.74 | **1.4× faster** | **1.4× faster** | ~same |
-| 100 KB | 8.4 | 14.9 | 8.9 | 10.8 | 2.8 | **1.8× faster** | ~same | **1.3× faster** |
-| 1 MB | 83 | 150 | 83 | 153 | 25 | **1.8× faster** | ~same | **1.8× faster** |
+| 1 KB | 0.35 | 0.18 | 0.81 | 0.24 | 0.21 | 1.9× slower | **2.4× faster** | 1.4× slower |
+| 10 KB | 1.1 | 1.6 | 1.6 | 1.1 | 0.72 | **1.4× faster** | **1.4× faster** | ~same |
+| 100 KB | 8.5 | 15.2 | 8.9 | 11.1 | 2.7 | **1.8× faster** | ~same | **1.3× faster** |
+| 1 MB | 84 | 154 | 84 | 155 | 24 | **1.8× faster** | ~same | **1.8× faster** |
 
 SafeRE has higher per-match startup cost but scales well; it overtakes JDK
-at 10 KB. DFA caching keeps the 1 KB case at 0.32 µs. RE2-FFM follows a
-similar pattern — 1.3× faster than SafeRE at 1 KB but 1.8× slower at 1 MB,
+at 10 KB. DFA caching keeps the 1 KB case at 0.35 µs. RE2-FFM follows a
+similar pattern — 1.4× faster than SafeRE at 1 KB but 1.8× slower at 1 MB,
 as FFM per-call overhead grows with input size.
 
 ## Capture Group Scaling (ns/op, lower is better)
 
 | Groups | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|--:|---|---|---|
-| 0 | 56 | 31 | 392 | 73 | 61 | 160 | 1.8× slower | **7.0× faster** | **1.3× faster** |
-| 1 | 72 | 41 | 879 | 284 | 68 | 242 | 1.8× slower | **12× faster** | **3.9× faster** |
-| 3 | 94 | 75 | 958 | 329 | 84 | 311 | 1.3× slower | **10× faster** | **3.5× faster** |
-| 10 | 200 | 235 | 1,398 | 737 | 367 | 600 | **1.2× faster** | **7.0× faster** | **3.7× faster** |
+| 0 | 60 | 30 | 399 | 74 | 59 | 160 | 2.0× slower | **6.7× faster** | **1.2× faster** |
+| 1 | 75 | 40 | 887 | 273 | 65 | 232 | 1.9× slower | **12× faster** | **3.6× faster** |
+| 3 | 97 | 78 | 963 | 328 | 79 | 293 | 1.2× slower | **10× faster** | **3.4× faster** |
+| 10 | 197 | 236 | 1,405 | 755 | 372 | 533 | **1.2× faster** | **7.1× faster** | **3.8× faster** |
 
-SafeRE closes the gap with JDK as capture count grows — from 1.8× slower at
+SafeRE closes the gap with JDK as capture count grows — from 2.0× slower at
 0 groups to **1.2× faster at 10 groups**. SafeRE is consistently **7–12×
-faster than RE2/J** and **3.5–3.9× faster than RE2-FFM** on capture extraction
+faster than RE2/J** and **3.4–3.8× faster than RE2-FFM** on capture extraction
 (at 1+ groups). The RE2-FFM gap reflects FFM call overhead on top of C++ RE2's
-capture engine. At 0 groups (no captures), SafeRE is 1.3× faster than RE2-FFM.
-C++ RE2 matches SafeRE at 10 groups — both use OnePass engines that scale
-similarly with group count. Go `regexp` is 1.5–2.1× slower than SafeRE,
+capture engine. At 0 groups (no captures), SafeRE is 1.2× faster than RE2-FFM.
+C++ RE2 is slower than SafeRE at 10 groups — both use OnePass-style engines
+that scale similarly with group count. Go `regexp` is 1.6–2.7× slower than SafeRE,
 consistent with its NFA-only approach.
 
 ## HTTP Request Parsing (ns/op, lower is better)
@@ -193,33 +203,33 @@ Pattern: `^(?:GET|POST) +([^ ]+) HTTP`
 
 | Input | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Full request (97 chars) | 276 | 90 | 8,218 | 389 | 324 | 982 | 3.1× slower | **30× faster** | **1.4× faster** |
-| Small request (18 chars) | 66 | 49 | 929 | 139 | 72 | 247 | 1.3× slower | **14× faster** | **2.1× faster** |
-| Extract URL (97 chars) | 279 | 94 | 8,177 | 386 | 321 | 974 | 3.0× slower | **29× faster** | **1.4× faster** |
+| Full request (97 chars) | 269 | 91 | 8,108 | 384 | 308 | 902 | 3.0× slower | **30× faster** | **1.4× faster** |
+| Small request (18 chars) | 70 | 49 | 950 | 138 | 69 | 223 | 1.4× slower | **14× faster** | **2.0× faster** |
+| Extract URL (97 chars) | 276 | 92 | 8,100 | 384 | 311 | 900 | 3.0× slower | **29× faster** | **1.4× faster** |
 
-SafeRE's HTTP parsing improved significantly from 1,292 to 276 ns/op thanks to
-the HTTP/OnePass fast path optimization. SafeRE is now within 3.1× of JDK on
-full HTTP requests (previously 14×) and is faster than C++ RE2 (276 vs
-324 ns). SafeRE remains **14–30× faster than RE2/J** on all HTTP workloads.
+SafeRE's HTTP parsing improved significantly from 1,292 to 269 ns/op thanks to
+the HTTP/OnePass fast path optimization. SafeRE is now within 3.0× of JDK on
+full HTTP requests (previously 14×) and is faster than C++ RE2 (269 vs
+308 ns). SafeRE remains **14–30× faster than RE2/J** on all HTTP workloads.
 RE2-FFM is slightly slower than SafeRE on this benchmark, with SafeRE 1.4×
-faster on full and extract, and 2.1× faster on small request patterns.
+faster on full and extract, and 2.0× faster on small request patterns.
 
 ## Replace Performance (ns/op, lower is better)
 
 | Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Literal replaceFirst (`"b"→"bb"`) | 30 | 40 | 147 | 215 | 98 | 605 | **1.3× faster** | **4.9× faster** | **7.2× faster** |
-| Literal replaceAll | 105 | 105 | 706 | 688 | 406 | 495 | ~same | **6.7× faster** | **6.6× faster** |
-| Pig Latin replaceAll (backrefs) | 1,415 | 838 | 8,347 | 2,342 | 1,875 | 2,990 | 1.7× slower | **5.9× faster** | **1.7× faster** |
-| Digit replaceAll (`\d+`→`"NUM"`) | 194 | 292 | 3,100 | 974 | 644 | 1,612 | **1.5× faster** | **16× faster** | **5.0× faster** |
-| Empty-match replaceAll (`a*`) | 243 | 76 | 398 | 648 | 368 | 353 | 3.2× slower | **1.6× faster** | **2.7× faster** |
+| Literal replaceFirst (`"b"→"bb"`) | 30 | 40 | 146 | 213 | 97 | 566 | **1.3× faster** | **4.9× faster** | **7.1× faster** |
+| Literal replaceAll | 105 | 106 | 704 | 681 | 414 | 462 | ~same | **6.7× faster** | **6.5× faster** |
+| Pig Latin replaceAll (backrefs) | 1,519 | 902 | 7,857 | 2,318 | 1,837 | 2,700 | 1.7× slower | **5.2× faster** | **1.5× faster** |
+| Digit replaceAll (`\d+`→`"NUM"`) | 195 | 283 | 3,091 | 964 | 648 | 1,495 | **1.5× faster** | **16× faster** | **4.9× faster** |
+| Empty-match replaceAll (`a*`) | 270 | 75 | 398 | 638 | 378 | 333 | 3.6× slower | **1.5× faster** | **2.4× faster** |
 
 SafeRE wins on literal replacements — **faster than all other engines**
 (including C++ RE2!) on replaceFirst (30 ns), thanks to the `String.indexOf()`
 fast path. Digit replaceAll is **1.5× faster than JDK** thanks to the
-character-class replaceAll fast path. Pig Latin replaceAll runs at 1,415 ns
+character-class replaceAll fast path. Pig Latin replaceAll runs at 1,519 ns
 via compiled replacement templates and direct BitState find+capture. SafeRE
-beats RE2-FFM on every replace benchmark by **1.7–7.2×**, as repeated FFM
+beats RE2-FFM on every replace benchmark by **1.5–7.1×**, as repeated FFM
 round-trips per match add significant overhead. For empty-match replacement,
 JDK remains fastest. Go `regexp` is consistently faster than RE2/J on
 replacements.
@@ -231,9 +241,9 @@ feature — neither JDK nor RE2/J has a built-in multi-pattern API).
 
 | Patterns | Unanchored (match) | Unanchored (no match) | Anchored (match) | Anchored (no match) |
 |--:|--:|--:|--:|--:|
-| 4 | 2,989 | 2,285 | 1,858 | 1,638 |
-| 16 | 30,033 | 17,532 | 5,384 | 5,102 |
-| 64 | 111,646 | 85,093 | 18,274 | 17,827 |
+| 4 | 3,243 | 2,630 | 2,219 | 1,885 |
+| 16 | 30,717 | 17,271 | 5,779 | 5,484 |
+| 64 | 78,935 | 58,597 | 18,324 | 17,614 |
 
 Anchored matching is 2–5× faster than unanchored. Scaling is roughly linear
 in pattern count.
@@ -244,15 +254,15 @@ in pattern count.
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
 |--:|--:|--:|--:|--:|--:|--:|
-| 1 KB | 0.55 | 0.85 | 108 | 3.0 | 0.046 | 1.4 |
-| 10 KB | 0.55 | 0.84 | 106 | 31 | 0.046 | 3.7 |
-| 100 KB | 0.57 | 0.84 | 109 | 451 | 0.046 | 3.7 |
+| 1 KB | 0.55 | 0.83 | 105 | 3.0 | 0.047 | 1.4 |
+| 10 KB | 0.55 | 0.83 | 104 | 32 | 0.047 | 3.6 |
+| 100 KB | 0.57 | 0.84 | 106 | 447 | 0.047 | 3.5 |
 
 SafeRE handles this pattern in ~0.56 µs regardless of text size. JDK's
 backtracking engine quickly fails and returns false in ~0.84 µs. SafeRE is
-**1.5× faster than JDK** and **193–198× faster than RE2/J** on this pattern.
-C++ RE2 handles it trivially (~46 ns) thanks to its mature DFA. RE2-FFM
-degrades sharply with text size (3 µs → 451 µs) due to increasing UTF-16 →
+**1.5× faster than JDK** and **184–190× faster than RE2/J** on this pattern.
+C++ RE2 handles it trivially (~47 ns) thanks to its mature DFA. RE2-FFM
+degrades sharply with text size (3 µs → 447 µs) due to increasing UTF-16 →
 UTF-8 conversion cost on the FFM boundary. Go `regexp` handles it well
 (~4 µs), much faster than RE2/J.
 
@@ -260,35 +270,35 @@ UTF-8 conversion cost on the FFM boundary. Go `regexp` handles it well
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 3.0 | 15 | 377 | 1.5 | 1.1 | 186 | **5.0× faster** | **126× faster** | 2.0× slower |
-| 10 KB | 27 | 151 | 3,760 | 14 | 11 | 2,225 | **5.6× faster** | **139× faster** | 1.9× slower |
-| 100 KB | 277 | 1,402 | 37,633 | 141 | 108 | 21,858 | **5.1× faster** | **136× faster** | 2.0× slower |
+| 1 KB | 3.0 | 15 | 374 | 1.4 | 1.1 | 184 | **5.0× faster** | **125× faster** | 2.1× slower |
+| 10 KB | 27 | 139 | 3,806 | 14 | 11 | 2,139 | **5.2× faster** | **142× faster** | 1.9× slower |
+| 100 KB | 277 | 1,465 | 37,525 | 140 | 106 | 22,167 | **5.3× faster** | **135× faster** | 2.0× slower |
 
 SafeRE is significantly faster than both JDK and RE2/J here. RE2/J's NFA-only
 approach is much slower than SafeRE's DFA on this high-fanout quantifier
 pattern. SafeRE is within 2.6× of C++ RE2, showing both use the same
 algorithmic approach. RE2-FFM is ~2× faster than SafeRE, tracking close to
 native C++ RE2 with modest FFM overhead. Go `regexp` is similar to RE2/J
-(NFA-only), both ~62–79× slower than SafeRE.
+(NFA-only), both ~62–80× slower than SafeRE.
 
 ## Compilation Performance (µs/op, lower is better)
 
 | Pattern | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Simple (`hello`) | 0.44 | 0.09 | 0.27 | 3.39 | 1.56 | 0.89 | 4.9× slower | 1.6× slower | **7.7× faster** |
-| Medium (datetime with 6 captures) | 4.65 | 0.31 | 2.12 | 10.44 | 6.94 | 6.36 | 15× slower | 2.2× slower | **2.2× faster** |
-| Complex (email regex) | 2.47 | 0.22 | 1.12 | 6.93 | 4.69 | 2.49 | 11× slower | 2.2× slower | **2.8× faster** |
-| Alternation (12 alternatives) | 3.55 | 0.41 | 3.01 | 12.33 | 8.22 | 6.12 | 8.7× slower | 1.2× slower | **3.5× faster** |
+| Simple (`hello`) | 0.46 | 0.09 | 0.27 | 3.90 | 1.48 | 0.87 | 5.1× slower | 1.7× slower | **8.5× faster** |
+| Medium (datetime with 6 captures) | 4.76 | 0.31 | 2.12 | 23.52 | 6.47 | 5.88 | 15× slower | 2.2× slower | **4.9× faster** |
+| Complex (email regex) | 2.64 | 0.23 | 1.14 | 11.59 | 4.52 | 2.41 | 12× slower | 2.3× slower | **4.4× faster** |
+| Alternation (12 alternatives) | 3.60 | 0.41 | 2.96 | 21.16 | 7.67 | 5.69 | 8.8× slower | 1.2× slower | **5.9× faster** |
 
 Lazy initialization defers OnePass analysis and DFA equivalence-class setup
 to first match, reducing compile-time work to just parsing and program
-compilation. SafeRE is now within 1.6× of RE2/J on simple patterns. JDK
+compilation. SafeRE is now within 1.7× of RE2/J on simple patterns. JDK
 defers most work to match time and remains the fastest compiler. SafeRE
-compiles **2.2–7.7× faster than RE2-FFM**, which is the slowest due to FFM
-call overhead plus C++ RE2's eager DFA setup. C++ RE2 compilation is 1.5–2×
-*slower* than SafeRE — C++ RE2 performs more eager work at compile time (DFA
-setup, prefilter analysis). Go `regexp` compiles faster than SafeRE (no DFA
-construction up front).
+compiles **4.4–8.5× faster than RE2-FFM**, which is the slowest due to FFM
+call overhead plus C++ RE2's eager DFA setup. C++ RE2 compilation is
+1.4–3.2× slower than SafeRE — C++ RE2 performs more eager work at compile
+time (DFA setup, prefilter analysis). Go `regexp` compilation is comparable
+overall and is faster than SafeRE only on the complex email pattern.
 
 ## Pathological Pattern: `a?{n}a{n}` matched against `a{n}`
 
@@ -301,28 +311,29 @@ RE2/J's NFA.
 
 | n | SafeRE | RE2/J | RE2-FFM | C++ RE2 | Go | SafeRE/RE2/J | SafeRE/C++ |
 |--:|--:|--:|--:|--:|--:|---|---|
-| 10 | 0.042 | 1.72 | 0.068 | 0.055 | 0.886 | **41× faster** | ~same |
-| 15 | 0.055 | 3.73 | 0.082 | 0.069 | 1.82 | **68× faster** | ~same |
-| 20 | 0.072 | 6.64 | 0.092 | 0.071 | 3.07 | **92× faster** | ~same |
-| 25 | 0.090 | 10.15 | 0.099 | 0.078 | 4.79 | **113× faster** | 1.2× slower |
-| 30 | 0.108 | 14.76 | 0.104 | 0.084 | 6.63 | **137× faster** | 1.3× slower |
-| 50 | 0.371 | 38.49 | 0.125 | 0.108 | 17.0 | **104× faster** | 3.4× slower |
-| 100 | 0.705 | 148.3 | 0.191 | 0.172 | 64.9 | **210× faster** | 4.1× slower |
+| 10 | 0.043 | 1.68 | 0.068 | 0.054 | 0.880 | **39× faster** | ~same |
+| 15 | 0.058 | 3.73 | 0.081 | 0.067 | 1.76 | **64× faster** | ~same |
+| 20 | 0.070 | 6.61 | 0.089 | 0.073 | 2.95 | **94× faster** | ~same |
+| 25 | 0.082 | 10.14 | 0.095 | 0.079 | 4.44 | **124× faster** | ~same |
+| 30 | 0.094 | 14.53 | 0.100 | 0.085 | 6.62 | **155× faster** | 1.1× slower |
+| 50 | 0.456 | 37.73 | 0.127 | 0.110 | 16.5 | **83× faster** | 4.1× slower |
+| 100 | 0.933 | 145.9 | 0.191 | 0.172 | 66.3 | **156× faster** | 5.4× slower |
 
 All four linear-time engines scale linearly. SafeRE and C++ RE2 (both
 DFA-based) have the lowest growth rates at small n, though SafeRE shows higher
-growth at large n (3.4× slower than C++ RE2 at n=50, 4.1× at n=100). RE2-FFM
+growth at large n (4.1× slower than C++ RE2 at n=50, 5.4× at n=100). RE2-FFM
 tracks close to C++ RE2 with small FFM overhead. Go `regexp` and RE2/J (both
-NFA-only) are 19–210× slower than SafeRE. Go `regexp` is ~2.5× faster than
-RE2/J, reflecting Go's native-code advantage over Java for NFA execution.
+NFA-only) are slower than SafeRE: RE2/J by 39–156× and Go by 20–71×. Go
+`regexp` is usually faster than RE2/J, reflecting Go's native-code advantage
+over Java for NFA execution.
 
 ### Three-way comparison (µs/op, small n where JDK is feasible)
 
 | n | SafeRE | RE2/J | JDK | RE2-FFM | SafeRE vs JDK |
 |--:|--:|--:|--:|--:|--:|
-| 10 | 0.042 | 1.72 | 9.5 | 0.072 | **226×** |
-| 15 | 0.058 | 3.74 | 388 | 0.082 | **6,690×** |
-| 20 | 0.073 | 6.77 | 15,389 | 0.094 | **210,808×** |
+| 10 | 0.042 | 1.72 | 9.3 | 0.074 | **222×** |
+| 15 | 0.055 | 3.90 | 396 | 0.082 | **7,200×** |
+| 20 | 0.070 | 6.64 | 15,316 | 0.090 | **218,803×** |
 | 25 | — | — | *(hangs)* | — | ∞ |
 
 ## Find-in-Text Scaling (µs/op, lower is better)
@@ -331,14 +342,14 @@ RE2/J, reflecting Go's native-code advantage over Java for NFA execution.
 
 | Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
 |--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 7.3 | 7.3 | 48 | 12 | 32 | ~same | **6.6× faster** | **1.6× faster** |
-| 10 KB | 77 | 68 | 468 | 132 | 316 | 1.1× slower | **6.1× faster** | **1.7× faster** |
-| 100 KB | 778 | 659 | 4,552 | 8,015 | 4,242 | 1.2× slower | **5.9× faster** | **10× faster** |
-| 1 MB | 7,881 | 6,840 | 46,626 | 1,419,234 | 46,741 | 1.2× slower | **5.9× faster** | **180× faster** |
+| 1 KB | 8.7 | 7.4 | 49 | 12 | 31 | 1.2× slower | **5.7× faster** | **1.4× faster** |
+| 10 KB | 84 | 73 | 475 | 139 | 308 | 1.2× slower | **5.6× faster** | **1.6× faster** |
+| 100 KB | 821 | 719 | 4,599 | 8,201 | 4,145 | 1.1× slower | **5.6× faster** | **10× faster** |
+| 1 MB | 8,444 | 7,045 | 46,825 | 1,495,616 | 43,831 | 1.2× slower | **5.5× faster** | **177× faster** |
 
 SafeRE is **close to JDK** on find-all-matches scaling, within 1.2× at all
-sizes. SafeRE is **5.9–6.6× faster than RE2/J** at all scales. SafeRE is
-also **1.6–180× faster than RE2-FFM**, with the advantage growing dramatically
+sizes. SafeRE is **5.5–5.7× faster than RE2/J** at all scales. SafeRE is
+also **1.4–177× faster than RE2-FFM**, with the advantage growing dramatically
 at larger sizes due to RE2-FFM's per-call FFM overhead. DFA caching,
 word-boundary support, and the DFA sandwich optimization keep SafeRE
 competitive with JDK.
@@ -364,7 +375,7 @@ to 1.0. This is the standard approach used in systems benchmarking (SPEC,
 DaCapo, Renaissance).
 
 **Caveats:** The geomean is only as meaningful as the benchmark suite is
-representative. We report two geomeans to avoid conflating qualitatively
+representative. We report three geomeans to avoid conflating qualitatively
 different workloads:
 
 1. **Core micro workloads** — focused regex operations: literal match, character
@@ -387,77 +398,87 @@ ratios and confidence intervals are available in the detailed tables above.
 
 | Category | Geomean | Interpretation |
 |---|--:|---|
-| Core workloads (8 benchmarks) | 1.13 | **SafeRE is 1.1× slower overall** |
-| Pathological/scaling (3 benchmarks) | 0.000074 | **SafeRE is ~13,500× faster** |
+| Core workloads (8 benchmarks) | 1.33 | **SafeRE is 1.3× slower overall** |
+| Application workloads (8 benchmarks) | 1.71 | **SafeRE is 1.7× slower overall** |
+| Pathological/scaling (3 benchmarks) | 0.000072 | **SafeRE is ~13,800× faster** |
 
-On core workloads, SafeRE is 1.1× slower than JDK overall — a modest gap
-driven by HTTP parsing (3.1×) and pig Latin replace (1.7×). SafeRE wins on
-4 of 8 core benchmarks (literal match, char class match, capture groups,
-email find) and is within 1.1× on find-in-text. The pathological
-geomean reflects the fundamental algorithmic difference: SafeRE guarantees
-linear time while JDK's backtracking engine exhibits exponential blowup on
-adversarial patterns. The dramatic improvement from 241× to 13,500× is driven
-by SafeRE's constant-time rejection on the Hard search pattern.
+On core workloads, SafeRE is 1.3× slower than JDK overall, driven mostly by
+alternation find (4.1×), HTTP parsing (3.0×), and pig Latin replace (1.7×).
+SafeRE wins on 4 of 8 core benchmarks: literal match, character-class match,
+capture groups, and email find.
+
+On application workloads, SafeRE is 1.7× slower than JDK overall. SafeRE wins
+UUID validation, API route matching, and URL extraction, while JDK is faster on
+log parsing, stack-trace extraction, case-insensitive keyword search, CSV
+field scanning, and secret redaction. The pathological geomean reflects the
+fundamental algorithmic difference: SafeRE guarantees linear time while JDK's
+backtracking engine exhibits exponential blowup on adversarial patterns.
 
 ### vs RE2/J
 
 | Category | Geomean | Interpretation |
 |---|--:|---|
-| Core workloads (8 benchmarks) | 0.087 | **SafeRE is 11.5× faster overall** |
-| Pathological/scaling (3 benchmarks) | 0.00034 | **SafeRE is ~2,930× faster** |
+| Core workloads (8 benchmarks) | 0.106 | **SafeRE is 9.4× faster overall** |
+| Application workloads (8 benchmarks) | 0.218 | **SafeRE is 4.6× faster overall** |
+| Pathological/scaling (3 benchmarks) | 0.00034 | **SafeRE is ~2,910× faster** |
 
-SafeRE beats RE2/J on every single benchmark in the suite. Both libraries
-provide linear-time guarantees, but SafeRE's DFA, OnePass, and BitState
-engines provide a large constant-factor advantage over RE2/J's NFA-only
-approach. The pathological geomean improved from 52× to 2,930× due to
-SafeRE's constant-time Hard search rejection.
+SafeRE beats RE2/J on every benchmark in the summary categories. Both
+libraries provide linear-time guarantees, but SafeRE's DFA, OnePass, and
+BitState engines provide a large constant-factor advantage over RE2/J's
+NFA-only approach. The advantage is 9.4× on core workloads and 4.6× on
+application workloads, where SafeRE wins every listed application case.
 
 ### vs RE2-FFM (C++ RE2 via FFM)
 
 | Category | Geomean | Interpretation |
 |---|--:|---|
-| Core workloads (8 benchmarks) | 0.49 | **SafeRE is 2.1× faster overall** |
-| Pathological/scaling (3 benchmarks) | 0.058 | **SafeRE is ~17.3× faster** |
+| Core workloads (8 benchmarks) | 0.585 | **SafeRE is 1.7× faster overall** |
+| Application workloads (8 benchmarks) | 1.06 | **SafeRE is roughly even overall** |
+| Pathological/scaling (3 benchmarks) | 0.059 | **SafeRE is ~17.0× faster** |
 
-On core workloads, SafeRE is 2.1× faster than RE2-FFM overall. SafeRE wins
-decisively on literal match (6.1×), character class match (6.3×), capture
-groups (4.3×), and pig Latin replace (1.7×). SafeRE is now 1.4× faster than
-RE2-FFM on HTTP parsing. Find-in-text is roughly comparable at small sizes
-and increasingly SafeRE-favorable at larger sizes.
+On core workloads, SafeRE is 1.7× faster than RE2-FFM overall. SafeRE wins
+decisively on literal match, character-class match, capture groups, HTTP
+parsing, and several replacement workloads. RE2-FFM wins on alternation and
+email find, where C++ RE2's native execution has an edge.
 
-On pathological/scaling workloads, SafeRE is now 17.3× faster overall —
-a dramatic reversal from the previous 3.1× slower. SafeRE's constant-time
-Hard search rejection (0.019 µs vs RE2-FFM's 152 µs at 1 MB) is the main
+On application workloads, SafeRE and RE2-FFM are roughly even by geomean.
+SafeRE wins UUID validation, API route matching, URL extraction, and CSV field
+scanning; RE2-FFM wins log parsing, stack-trace extraction,
+case-insensitive keyword search, and secret redaction.
+
+On pathological/scaling workloads, SafeRE is now 17.0× faster overall —
+a dramatic reversal from the previous 3.1× slower result. SafeRE's constant-time
+Hard search rejection (0.020 µs vs RE2-FFM's 153 µs at 1 MB) is the main
 driver. On the other two pathological benchmarks — `a?{20}a{20}` and nested
 quantifiers — SafeRE and RE2-FFM are within 2× of each other, both scaling
 linearly. RE2-FFM also pays FFM per-call overhead that grows with input size,
 making it much slower than SafeRE on find-all-matches workloads at scale
-(e.g., find-in-text at 1 MB: 1.42 seconds vs 7.9 ms).
+(e.g., find-in-text at 1 MB: 1.50 seconds vs 8.4 ms).
 
 ## Analysis
 
 **Where SafeRE wins (vs Java engines):**
-- **Literal matching** — 1.4× faster than JDK, 14× faster than RE2/J
-- **Character class matching** — 1.3× faster than JDK, 68× faster than RE2/J
+- **Literal matching** — 1.2× faster than JDK, 12× faster than RE2/J
+- **Character class matching** — 1.2× faster than JDK, 60× faster than RE2/J
 - **Literal replacement** — Fastest of all engines (including C++ RE2!) on replaceFirst
-- **Email find** — 1.5× faster than JDK, 7.4× faster than RE2/J
+- **Email find** — 1.4× faster than JDK, 6.7× faster than RE2/J
 - **Digit replaceAll** — 1.5× faster than JDK, 16× faster than RE2/J
-- **Find-in-text** — within 1.2× of JDK, 5.9–6.6× faster than RE2/J
+- **Find-in-text** — within 1.2× of JDK, 5.5–5.7× faster than RE2/J
 - **Capture groups** — 7–12× faster than RE2/J, 1.2× faster than JDK at 10 groups
-- **Hard search** — constant-time rejection (0.018–0.019 µs at all sizes), 4,200–2.3M× faster than JDK, 2,100–2.0M× faster than RE2/J
-- **Nested quantifiers** — 5.0–5.6× faster than JDK, 126–139× faster than RE2/J
+- **Hard search** — constant-time rejection (~0.020 µs at all sizes), 2,800–2.3M× faster than JDK, 1,700–1.9M× faster than RE2/J
+- **Nested quantifiers** — 5.0–5.3× faster than JDK, 125–142× faster than RE2/J
 - **Easy search on large text** — 1.7–1.8× faster than JDK, comparable to RE2/J
 - **Medium search** — 56–65× faster than RE2/J
 - **HTTP parsing** — 14–30× faster than RE2/J
-- **Pathological `a?{n}a{n}`** — 226–211,000× faster than JDK, 41–210× faster than RE2/J
+- **Pathological `a?{n}a{n}`** — 222–219,000× faster than JDK, 39–156× faster than RE2/J
 
 **Where JDK wins:**
-- **HTTP parsing** — 3.1× faster (SafeRE's OnePass engine has higher per-character
-  overhead on anchored patterns, though the gap narrowed from 14× to 3.1× with
+- **HTTP parsing** — 3.0× faster (SafeRE's OnePass engine has higher per-character
+  overhead on anchored patterns, though the gap narrowed from 14× to 3.0× with
   the HTTP/OnePass fast path optimization)
 - **Pig Latin replace** — 1.7× faster (per-match capture extraction cost in multi-match replaceAll)
-- **Empty-match replace** — 3.2× faster
-- **Compilation** — 4.9–15× faster (defers work to match time)
+- **Empty-match replace** — JDK is 3.6× faster
+- **Compilation** — 5.1–15× faster (defers work to match time)
 
 **Where RE2/J fits:**
 - RE2/J is **slower than both SafeRE and JDK** on every matching benchmark
@@ -470,19 +491,19 @@ making it much slower than SafeRE on find-all-matches workloads at scale
 - RE2-FFM provides C++ RE2's algorithmic strength (DFA, reverse DFA) from Java
   via the Foreign Function & Memory API
 - On short inputs (< 1 KB), RE2-FFM is competitive with SafeRE and sometimes
-  faster (e.g., alternation find at 604 ns vs 812 ns)
+  faster (e.g., alternation find at 615 ns vs 2,207 ns)
 - On large inputs, FFM per-call overhead becomes significant — especially for
   find-all-matches workloads where each `find()` call crosses the JNI/FFM
   boundary with UTF-16 → UTF-8 conversion
-- Compilation is 2–3× slower than SafeRE due to FFM call overhead plus C++
+- Compilation is 4–6× slower than SafeRE due to FFM call overhead plus C++
   RE2's eager DFA setup
-- SafeRE now beats RE2-FFM on the Hard search pattern (0.019 µs vs 152 µs
-  at 1 MB) and is 17.3× faster overall on pathological/scaling workloads
+- SafeRE now beats RE2-FFM on the Hard search pattern (0.020 µs vs 153 µs
+  at 1 MB) and is 17.0× faster overall on pathological/scaling workloads
 
 **SafeRE vs C++ RE2:**
 - C++ RE2 is typically **2–20× faster** on matching due to native code, UTF-8
   encoding (shorter strings), and no GC/JIT overhead
-- **Hard search** — SafeRE is now faster than C++ RE2 (0.018 vs 0.048 µs),
+- **Hard search** — SafeRE is now faster than C++ RE2 (0.020 vs 0.044 µs),
   achieving constant-time rejection by detecting the required literal suffix
   cannot occur
 - **Compilation** — SafeRE compiles **faster** than C++ RE2 thanks to lazy
@@ -491,30 +512,31 @@ making it much slower than SafeRE on find-all-matches workloads at scale
   the DFA implementation is correct and efficient
 - **Literal replacement** — SafeRE is **faster** than C++ RE2 (30 vs 98 ns for
   replaceFirst), demonstrating Java's `String.indexOf()` optimization
-- **Nested quantifiers** — SafeRE is within 2.6× of C++ RE2 (277 vs 108 µs at
+- **Nested quantifiers** — SafeRE is within 2.6× of C++ RE2 (277 vs 106 µs at
   100 KB), both scaling linearly
 
 **SafeRE vs Go `regexp`:**
 - Go `regexp` is an NFA-only implementation (no DFA), like RE2/J
 - SafeRE **beats Go on DFA-dominated workloads**: pathological (7–152× faster),
-  nested quantifiers (62–79× faster), hard search (1,000–1.4M× faster)
+  nested quantifiers (61–80× faster), hard search (880–1.2M× faster)
 - Go beats SafeRE on short-string matching and compilation (no DFA overhead)
 - Go `regexp` is consistently ~2–3× faster than RE2/J across the board,
   reflecting Go's native-code advantage over Java for NFA execution
 
 **Key takeaway:** SafeRE is the fastest RE2-family engine on the JVM —
-**2.1× faster than RE2-FFM** and **11.5× faster than RE2/J** on core
+**1.7× faster than RE2-FFM** and **9.4× faster than RE2/J** on core
 workloads by geomean. SafeRE is within a small constant factor of the
 C++ original and significantly faster than both Go `regexp` and RE2/J on
-DFA-dominated workloads. On core workloads, SafeRE is **1.1× slower than
-JDK by geomean** (driven by HTTP parsing at 3.1× and pig Latin replace at
-1.7×), while providing **guaranteed linear time** that JDK cannot offer.
-On pathological/scaling workloads, SafeRE is **13,500× faster than JDK** and
-**17.3× faster than RE2-FFM** — the latter a reversal from the previous 3.1×
+DFA-dominated workloads. On core workloads, SafeRE is **1.3× slower than
+JDK by geomean** (driven by alternation find at 4.1×, HTTP parsing at 3.0×,
+and pig Latin replace at 1.7×), while providing **guaranteed linear time**
+that JDK cannot offer.
+On pathological/scaling workloads, SafeRE is **13,800× faster than JDK** and
+**17.0× faster than RE2-FFM** — the latter a reversal from the previous 3.1×
 disadvantage, driven by the new constant-time Hard search rejection.
 
 **The tradeoff:** SafeRE trades higher per-match overhead on HTTP-style
-anchored patterns (3.1× slower than JDK) for **guaranteed linear time** and
+anchored patterns (3.0× slower than JDK) for **guaranteed linear time** and
 **better scaling** on large inputs and pathological patterns. For
 safety-critical applications (user-supplied regexes, large documents, content
 filtering), SafeRE eliminates the risk of catastrophic backtracking while being
@@ -522,13 +544,10 @@ substantially faster than all other RE2-family implementations except
 the C++ original.
 
 **Impact of fork mode:** These results were collected with JMH fork mode
-(1 fork per benchmark), which starts a fresh JVM to avoid JIT profile
-pollution between benchmarks. Prior results collected in no-fork mode (`-f 0`)
-showed distorted JDK numbers (artificially slow on some benchmarks due to JIT
-profile contamination from RE2/J and SafeRE code paths). Fork-mode results
-are more representative of real-world performance where JDK regex runs in its
-own application. A re-run with 3 forks (to better sample JIT variance) is
-planned.
+(3 forks per benchmark), which starts fresh JVMs to avoid JIT profile
+pollution between benchmarks and samples fork-to-fork variance. Pathological
+benchmark classes intentionally run without forking because some JDK cases can
+hang at larger input sizes.
 
 ## Optimizations Applied
 
@@ -599,11 +618,11 @@ planned.
     for non-matching inputs.
 29. **HTTP/OnePass fast path** — Improved anchored pattern handling in the OnePass
     engine, reducing per-character overhead for patterns like
-    `^(?:GET|POST) +([^ ]+) HTTP` from 1,292 to 276 ns/op.
+    `^(?:GET|POST) +([^ ]+) HTTP` from 1,292 to 269 ns/op.
 
 ## Remaining Opportunities
 
-- **HTTP parsing overhead** — HTTP patterns are now 3.1× slower than JDK
+- **HTTP parsing overhead** — HTTP patterns are now 3.0× slower than JDK
   (improved from 14× with the HTTP/OnePass fast path). The remaining gap is
   OnePass per-character overhead on the 97-char request; JDK's backtracking
   engine has lower per-match setup cost on short anchored patterns.
@@ -611,9 +630,9 @@ planned.
   fundamental: SafeRE uses BitState (multi-state exploration) per match while
   JDK does a single backtracking pass. Compiled replacement templates and
   direct BitState already reduced this from 2.2× to 1.7×.
-- **Empty-match replace** — 3.2× faster than JDK. Empty-match handling requires
+- **Empty-match replace** — 3.6× slower than JDK. Empty-match handling requires
   careful position advancement and is a known gap.
-- **Compilation** — Pattern compilation is 4.9–15× slower than JDK. Opportunities
+- **Compilation** — Pattern compilation is 5.1–15× slower than JDK. Opportunities
   include caching parsed Regexp trees.
 - **DFA state budget tuning** — The default 10,000-state budget may be
   suboptimal for some pattern/text combinations.
@@ -653,15 +672,15 @@ provide order-of-magnitude context.
 | Benchmark | SafeRE (B/op) | JDK (B/op) | RE2/J (B/op) | RE2-FFM (B/op) |
 |---|--:|--:|--:|--:|
 | literalMatch | 96 | 56 | 72 | 48 |
-| charClassMatch | 96 | 56 | 88 | 80 |
-| alternationFind | 544 | 136 | 208 | 512 |
-| captureGroups | 408 | 368 | 432 | 408 |
-| findInText | 2,080 | 136 | 976 | 2,448 |
-| emailFind | 168 | 136 | 88 | 224 |
+| charClassMatch | 104 | 56 | 88 | 80 |
+| alternationFind | 336 | 136 | 208 | 512 |
+| captureGroups | 368 | 368 | 432 | 408 |
+| findInText | 2,088 | 136 | 976 | 2,448 |
+| emailFind | 176 | 136 | 88 | 224 |
 
 SafeRE allocates more per match than JDK on most workloads due to Matcher
 state objects and DFA workspace arrays. The highest allocation rate is
-findInText (2,080 B/op) where repeated `find()` calls accumulate Matcher and
+findInText (2,088 B/op) where repeated `find()` calls accumulate Matcher and
 capture state. RE2-FFM allocates similarly to SafeRE on complex patterns due
 to FFM memory segment management, but uses less on simple literal matches.
 
@@ -687,33 +706,31 @@ How per-match allocation scales with text size (Easy and Medium patterns).
 
 | Text size | SafeRE (B/op) | JDK (B/op) | RE2/J (B/op) |
 |---|--:|--:|--:|
-| 1 KB | 72 | 56 | 48 |
-| 10 KB | 72 | 56 | 48 |
-| 100 KB | 72 | 56 | 48 |
-| 1 MB | 73 | 57 | 83 |
+| 1 KB | 80 | 56 | 48 |
+| 10 KB | 80 | 56 | 48 |
+| 100 KB | 80 | 56 | 48 |
+| 1 MB | 80 | 58 | 48 |
 
 **Medium pattern:** `[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$`
 
 | Text size | SafeRE (B/op) | JDK (B/op) | RE2/J (B/op) |
 |---|--:|--:|--:|
-| 1 KB | 72 | 56 | 48 |
-| 10 KB | 72 | 56 | 50 |
-| 100 KB | 72 | 56 | 136 |
-| 1 MB | 75 | 58 | 288 |
+| 1 KB | 80 | 56 | 48 |
+| 10 KB | 80 | 56 | 81 |
+| 100 KB | 80 | 56 | 51 |
+| 1 MB | 81 | 98 | 153 |
 
-All three engines show near-constant allocation up to 100 KB, indicating
-streaming behavior. RE2/J's Medium pattern allocation grows at 1 MB (288 B/op),
-likely due to internal buffer resizing in its NFA engine. SafeRE and JDK
-remain essentially flat.
+All three engines show near-constant allocation across input sizes, indicating
+streaming behavior. SafeRE stays near 80 B/op for these search workloads.
 
 ### DFA Cache Growth (SafeRE only)
 
 | Pattern | Cache growth (bytes) |
 |---|--:|
-| simple | 72 |
-| medium | 72 |
-| complex | 12,240 |
-| alternation | 3,168 |
+| simple | 80 |
+| medium | 80 |
+| complex | 16,344 |
+| alternation | 3,176 |
 
 SafeRE lazily builds DFA states during matching. The cache is bounded by
 `maxStates` (default 10,000 states). Simple patterns that use the literal


### PR DESCRIPTION
## Summary
- update BENCHMARKS.md with the 2026-04-27 benchmark results and benchmarked commit metadata
- add application workload geomeans and refresh stale benchmark analysis text
- document benchmark result metadata and geomean reporting guidance in AGENTS.md

## Tests
- Not run; documentation-only update.

Fixes #154