### PR TITLE
Skip redundant DFA precheck for direct fallback

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -60,6 +60,14 @@ public final class Matcher implements MatchResult {
    */
   private static final int MAX_LAZY_FALLBACK_SUBMATCHES = 3;
 
+  /**
+   * Maximum input length where skipping the forward DFA precheck can pay off for unreliable-start
+   * patterns. On short inputs, BitState's complete search is cheap enough that running the DFA
+   * first often duplicates work; on longer inputs, the DFA remains valuable as a fast no-match
+   * filter.
+   */
+  private static final int DIRECT_FALLBACK_TEXT_LIMIT = 512;
+
   private Pattern parentPattern;
   private CharSequence inputSequence;
   private String text;
@@ -952,10 +960,22 @@ public final class Matcher implements MatchResult {
       }
     }
 
+    boolean directFallback =
+        !regionActive
+            && !parentPattern.dfaStartReliable()
+            && (prefix != null || ccPrefixAscii != null)
+            && text.length() <= DIRECT_FALLBACK_TEXT_LIMIT
+            && BitState.maxTextSize(prog) >= text.length();
+
     // Fast path: use cached DFA to check if a match exists in the remaining text.
     // Use longest=false for a quick existence check — this returns the earliest match end.
+    // For short unreliable-start patterns that fit BitState, skip this precheck: a successful
+    // precheck cannot produce reusable bounds and would fall through to the complete fallback
+    // search anyway.
     Dfa.SearchResult fwdResult;
-    {
+    if (directFallback) {
+      fwdResult = null;
+    } else {
       fwdResult = dfa().doSearch(text, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
         hasMatch = false;

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -411,6 +411,56 @@ class MatcherTest {
       assertThat(m.group(1)).isEqualTo("ERROR");
       assertThat(m.find()).isFalse();
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "(bcd|abcde)",
+      "(.+?X|bc)",
+      "(?:a{1,3})?a{3}",
+      "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
+      "(?i)\\b(error|warning|timeout|failed)\\b"
+    })
+    @DisplayName("find() fallback paths match JDK for unreliable DFA-start patterns")
+    void findFallbackMatchesJdkForUnreliableDfaStartPatterns(String regex) {
+      String text =
+          "java.lang.IllegalStateException: failed\n"
+              + "\tat org.example.Main.main(Main.java:25)\n"
+              + "xxabcde yy aaa failed bcX";
+      Matcher m = Pattern.compile(regex).matcher(text);
+      java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(text);
+
+      boolean safereFound = m.find();
+      boolean jdkFound = jdk.find();
+      assertThat(safereFound).isEqualTo(jdkFound);
+      if (!jdkFound) {
+        return;
+      }
+      assertThat(m.group()).isEqualTo(jdk.group());
+      assertThat(m.start()).isEqualTo(jdk.start());
+      assertThat(m.end()).isEqualTo(jdk.end());
+      for (int group = 1; group <= jdk.groupCount(); group++) {
+        assertThat(m.group(group)).isEqualTo(jdk.group(group));
+        assertThat(m.start(group)).isEqualTo(jdk.start(group));
+        assertThat(m.end(group)).isEqualTo(jdk.end(group));
+      }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "(bcd|abcde)",
+      "(.+?X|bc)",
+      "(?:a{1,3})?a{3}",
+      "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
+      "(?i)\\b(error|warning|timeout|failed)\\b"
+    })
+    @DisplayName("find() returns false for no-match unreliable DFA-start patterns")
+    void findFallbackNoMatchForUnreliableDfaStartPatterns(String regex) {
+      Matcher m = Pattern.compile(regex).matcher("plain text without the target shape");
+      java.util.regex.Matcher jdk =
+          java.util.regex.Pattern.compile(regex).matcher("plain text without the target shape");
+
+      assertThat(m.find()).isEqualTo(jdk.find());
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

- skip the forward DFA existence precheck for short unreliable-start patterns when prefix acceleration already found a plausible start and BitState can handle the text
- preserve the DFA precheck for broader scans and long inputs where it remains useful as a no-match filter
- add JDK-comparison coverage for alternation, lazy quantifiers, bounded repeats, anchored/multiline patterns, keyword scans, and no-match cases

Fixes #190

## Validation

- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere test -q`
- A/B quick benchmark run against parent commit `f06ff2b` and PR head `cc146f6` using:
  - `./run-java-benchmarks.sh --quick 'ApplicationBenchmark.(caseInsensitiveKeywords|csvFieldScan|stackTraceExtract|urlExtraction)_safere'`

## Quick Benchmark Impact

Quick mode is for development signal only, not publication-quality results. Lower is better.

| Benchmark | Before #190 (`f06ff2b`) | After #190 (`cc146f6`) | Change |
| --- | ---: | ---: | ---: |
| `caseInsensitiveKeywords_safere` | 3973.575 ns/op | 3782.711 ns/op | 4.8% faster |
| `csvFieldScan_safere` | 3193.070 ns/op | 3242.055 ns/op | 1.5% slower |
| `stackTraceExtract_safere` | 6077.801 ns/op | 5939.007 ns/op | 2.3% faster |
| `urlExtraction_safere` | 876.320 ns/op | 869.727 ns/op | 0.8% faster |

The direct-fallback guard is intentionally narrow because an earlier broader condition improved CSV more but regressed keyword scans. This version keeps the DFA precheck for broader scans and only skips it after prefix/char-class prefix acceleration has already found a plausible start.