### PR TITLE
Reuse BitState match result buffers

### DIFF
--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -118,6 +118,18 @@ final class BitState {
    */
   static int[] search(BitState cached, Prog prog, String text, int startPos, int searchLimit,
       boolean anchored, boolean longest, boolean endMatch, int nsubmatch) {
+    return search(
+        cached, prog, text, startPos, searchLimit, anchored, longest, endMatch, nsubmatch, null);
+  }
+
+  /**
+   * Searches using bit-state backtracking, writing successful captures into {@code resultBuffer}
+   * when it is large enough. This keeps the mutable backtracking capture registers separate from
+   * the returned result while allowing tight find loops to avoid one result-array allocation per
+   * match.
+   */
+  static int[] search(BitState cached, Prog prog, String text, int startPos, int searchLimit,
+      boolean anchored, boolean longest, boolean endMatch, int nsubmatch, int[] resultBuffer) {
     int textLen = text.length();
     int maxLen = maxTextSize(prog);
     if (maxLen < 0 || textLen > maxLen) {
@@ -140,7 +152,7 @@ final class BitState {
       bs = new BitState(prog, text, ncap, longest, endMatch);
     }
 
-    return bs.doSearch(startPos, searchLimit, anchored);
+    return bs.doSearch(startPos, searchLimit, anchored, resultBuffer);
   }
 
   /**
@@ -167,9 +179,19 @@ final class BitState {
    * @return submatch positions, or null if no match
    */
   int[] doSearch(int startPos, int searchLimit, boolean anchored) {
+    return doSearch(startPos, searchLimit, anchored, null);
+  }
+
+  /**
+   * Runs the bit-state search from the given start position, writing successful captures into
+   * {@code resultBuffer} when it is large enough.
+   */
+  int[] doSearch(int startPos, int searchLimit, boolean anchored, int[] resultBuffer) {
     budgetExceeded = false;
     stepCount = 0;
     stepBudget = Math.max(4096L, (long) MAX_WORK_PER_SLOT * prog.size() * (endPos + 1));
+    bestMatch = null;
+    matchResult = resultBuffer != null && resultBuffer.length >= ncap ? resultBuffer : new int[ncap];
     int limit = anchored ? startPos + 1 : Math.min(searchLimit + 1, textLen + 1);
     for (int searchStart = startPos; searchStart < limit; searchStart++) {
       if (trySearch(prog.start(), searchStart)) {
@@ -221,6 +243,9 @@ final class BitState {
 
   /** Best match found so far. */
   private int[] bestMatch;
+
+  /** Caller-owned or BitState-owned array that receives successful capture results. */
+  private int[] matchResult;
 
   /** Work-budget accounting for falling back when BitState backtracking is too expensive. */
   private long stepBudget;
@@ -487,7 +512,8 @@ final class BitState {
 
           if (!matched || (longest && pos > bestMatch[1])) {
             matched = true;
-            bestMatch = cap.clone();
+            System.arraycopy(cap, 0, matchResult, 0, ncap);
+            bestMatch = matchResult;
           }
 
           if (!longest) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -89,6 +89,7 @@ public final class Matcher implements MatchResult {
    */
   private BitState cachedBitState;
   private boolean bitStateBorrowed;
+  private int[] bitStateResult;
 
   /**
    * Whether all capture groups have been resolved. When the DFA sandwich determines match
@@ -1186,7 +1187,10 @@ public final class Matcher implements MatchResult {
       BitState bs =
           BitState.getOrCreate(cachedBitState, prog, text, endPos, ncap, longest,
               endMatchEffective);
-      int[] result = bs.doSearch(startPos, searchLimit, anchoredEffective);
+      if (bitStateResult == null || bitStateResult.length < ncap) {
+        bitStateResult = new int[ncap];
+      }
+      int[] result = bs.doSearch(startPos, searchLimit, anchoredEffective, bitStateResult);
       cachedBitState = bs;
       // Return to Pattern's cache for reuse by future Matchers.
       parentPattern.returnBitState(bs);

--- a/safere/src/test/java/org/safere/BitStateTest.java
+++ b/safere/src/test/java/org/safere/BitStateTest.java
@@ -75,6 +75,41 @@ class BitStateTest {
     }
   }
 
+  private static void assertReusableResultConsistent(ResultBufferCase tc) {
+    Regexp re = Parser.parse(tc.pattern(), FLAGS);
+    Prog prog = Compiler.compile(re);
+    int nsubmatch = prog.numCaptures();
+    int ncap = 2 * Math.max(nsubmatch, 1);
+    int[] resultBuffer = new int[ncap + 2];
+    for (int i = 0; i < resultBuffer.length; i++) {
+      resultBuffer[i] = -1000 - i;
+    }
+
+    int[] bsResult = BitState.search(
+        null,
+        prog,
+        tc.input(),
+        0,
+        tc.input().length(),
+        tc.anchored(),
+        tc.longest(),
+        tc.endMatch(),
+        nsubmatch,
+        resultBuffer);
+    Nfa.Anchor anchor = tc.anchored() ? Nfa.Anchor.ANCHORED : Nfa.Anchor.UNANCHORED;
+    Nfa.MatchKind kind = tc.endMatch() ? Nfa.MatchKind.FULL_MATCH
+        : (tc.longest() ? Nfa.MatchKind.LONGEST_MATCH : Nfa.MatchKind.FIRST_MATCH);
+    int[] nfaResult = Nfa.search(prog, tc.input(), anchor, kind, nsubmatch);
+
+    assertThat(bsResult)
+        .as("BitState should return the reusable result buffer for %s", tc)
+        .isSameAs(resultBuffer);
+    assertCapturesEqual(tc.pattern(), tc.input(), bsResult, nfaResult);
+    assertThat(resultBuffer[ncap])
+        .as("BitState should not write past ncap for %s", tc)
+        .isEqualTo(-1000 - ncap);
+  }
+
   // ---------------------------------------------------------------------------
   // Basic tests
   // ---------------------------------------------------------------------------
@@ -282,6 +317,14 @@ class BitStateTest {
     }
   }
 
+  record ResultBufferCase(
+      String pattern, String input, boolean anchored, boolean longest, boolean endMatch) {
+    @Override
+    public String toString() {
+      return "/" + pattern + "/ on \"" + input + "\"";
+    }
+  }
+
   static Stream<TestCase> consistencyCases() {
     List<TestCase> cases = new ArrayList<>();
     cases.add(new TestCase("abc", "abc"));
@@ -305,6 +348,16 @@ class BitStateTest {
     return cases.stream();
   }
 
+  static Stream<ResultBufferCase> resultBufferCases() {
+    return Stream.of(
+        new ResultBufferCase("(a(b(c)))", "abc", true, false, true),
+        new ResultBufferCase("(cat|dog)-(\\d+)?", "dog-", true, false, true),
+        new ResultBufferCase("(a|ab)+", "ab", true, false, true),
+        new ResultBufferCase("(a(b)?)+", "aba", true, false, false),
+        new ResultBufferCase("(a*)", "aaa", true, true, false),
+        new ResultBufferCase("(\\w+)-(\\d+)", "xx abc-123 yy", false, false, false));
+  }
+
   @ParameterizedTest(name = "unanchored: {0}")
   @MethodSource("consistencyCases")
   void unanchoredConsistency(TestCase tc) {
@@ -315,5 +368,11 @@ class BitStateTest {
   @MethodSource("consistencyCases")
   void anchoredFullMatchConsistency(TestCase tc) {
     assertConsistentAnchored(tc.pattern(), tc.input(), false, true);
+  }
+
+  @ParameterizedTest(name = "reusable result: {0}")
+  @MethodSource("resultBufferCases")
+  void reusableResultBufferPreservesCaptureSemantics(ResultBufferCase tc) {
+    assertReusableResultConsistent(tc);
   }
 }


### PR DESCRIPTION
## Summary

- let BitState copy successful captures into a reusable result buffer instead of cloning the working capture array for every successful match
- reuse a Matcher-owned BitState result buffer across BitState-backed find loops
- add BitState coverage for reusable result buffers with nested captures, alternation, optional groups, repeated groups, longest matching, and unanchored matching

Fixes #189

## Validation

- `mvn -pl safere -Dtest=BitStateTest,MatcherTest test -q`
- `mvn -pl safere test -q`
- `git diff --check`

## Quick Benchmark Impact

Quick mode is for development signal only, not publication-quality results. Lower is better.

Command:

- `./run-java-benchmarks.sh --quick 'ApplicationBenchmark.csvFieldScan_safere'`

| Benchmark | Before #189 (`7e02590`) | After #189 (`f5e1d8c`) | Change |
| --- | ---: | ---: | ---: |
| `csvFieldScan_safere` | 3206.566 ns/op | 3165.010 ns/op | 1.3% faster |

Allocation profile command:

- `java ... -jar safere-benchmarks/target/benchmarks.jar ... -prof gc 'ApplicationBenchmark.csvFieldScan_safere'`

| Metric | Before #189 (`7e02590`) | After #189 (`f5e1d8c`) | Change |
| --- | ---: | ---: | ---: |
| `gc.alloc.rate.norm` | 1864.024 B/op | 1528.023 B/op | 18.0% less allocation |

The primary effect of this change is allocation reduction in BitState-backed find loops. The quick timing result is a small improvement and within quick-mode noise; the normalized allocation reduction is the more direct signal for #189.