### PR TITLE
Accelerate constrained find start positions

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -852,7 +852,12 @@ public final class Matcher implements MatchResult {
 
     Pattern.StartAcceleration startAcceleration = parentPattern.startAcceleration();
     if (startAcceleration != null) {
-      return findWithStartAcceleration(prog, startAcceleration, effectiveStart, regionActive);
+      int idx = nextAcceleratedStart(text, startAcceleration, effectiveStart, prog.unixLines());
+      if (idx < 0) {
+        hasMatch = false;
+        return false;
+      }
+      effectiveStart = idx;
     }
 
     // OnePass primary path for small texts: for OnePass-eligible unanchored patterns on short
@@ -1128,40 +1133,6 @@ public final class Matcher implements MatchResult {
     }
     hasMatch = true;
     return true;
-  }
-
-  private boolean findWithStartAcceleration(
-      Prog prog,
-      Pattern.StartAcceleration acceleration,
-      int startPos,
-      boolean regionActive) {
-    boolean lazyFallbackCaptures =
-        !regionActive
-            && !eagerFallbackCaptures
-            && prog.numCaptures() <= MAX_LAZY_FALLBACK_SUBMATCHES;
-    int nsubmatch = lazyFallbackCaptures ? 1 : prog.numCaptures();
-    int candidate = nextAcceleratedStart(text, acceleration, startPos, prog.unixLines());
-    while (candidate >= 0) {
-      int[] result = searchWithBitStateOrNfa(
-          prog, text, candidate, candidate, text.length(), true, false, false, nsubmatch);
-      if (result != null) {
-        if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
-          groups = result;
-        } else {
-          setDeferredGroups(result[0], result[1], prog.numCaptures(), true, false);
-        }
-        hasMatch = true;
-        return true;
-      }
-      int next = candidate + 1;
-      if (candidate < text.length()) {
-        int cp = text.codePointAt(candidate);
-        next = candidate + Character.charCount(cp);
-      }
-      candidate = nextAcceleratedStart(text, acceleration, next, prog.unixLines());
-    }
-    hasMatch = false;
-    return false;
   }
 
   /** Case-insensitive indexOf using Unicode case folding. */

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -850,6 +850,11 @@ public final class Matcher implements MatchResult {
       effectiveStart = idx;
     }
 
+    Pattern.StartAcceleration startAcceleration = parentPattern.startAcceleration();
+    if (startAcceleration != null) {
+      return findWithStartAcceleration(prog, startAcceleration, effectiveStart, regionActive);
+    }
+
     // OnePass primary path for small texts: for OnePass-eligible unanchored patterns on short
     // input, scan with OnePass directly. OnePass is faster than BitState — no visited bitmap
     // or job stack allocation, deterministic single-pass traversal per start position.
@@ -1125,6 +1130,40 @@ public final class Matcher implements MatchResult {
     return true;
   }
 
+  private boolean findWithStartAcceleration(
+      Prog prog,
+      Pattern.StartAcceleration acceleration,
+      int startPos,
+      boolean regionActive) {
+    boolean lazyFallbackCaptures =
+        !regionActive
+            && !eagerFallbackCaptures
+            && prog.numCaptures() <= MAX_LAZY_FALLBACK_SUBMATCHES;
+    int nsubmatch = lazyFallbackCaptures ? 1 : prog.numCaptures();
+    int candidate = nextAcceleratedStart(text, acceleration, startPos, prog.unixLines());
+    while (candidate >= 0) {
+      int[] result = searchWithBitStateOrNfa(
+          prog, text, candidate, candidate, text.length(), true, false, false, nsubmatch);
+      if (result != null) {
+        if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
+          groups = result;
+        } else {
+          setDeferredGroups(result[0], result[1], prog.numCaptures(), true, false);
+        }
+        hasMatch = true;
+        return true;
+      }
+      int next = candidate + 1;
+      if (candidate < text.length()) {
+        int cp = text.codePointAt(candidate);
+        next = candidate + Character.charCount(cp);
+      }
+      candidate = nextAcceleratedStart(text, acceleration, next, prog.unixLines());
+    }
+    hasMatch = false;
+    return false;
+  }
+
   /** Case-insensitive indexOf using Unicode case folding. */
   private static int indexOfIgnoreCase(String text, String prefix, int fromIndex) {
     int prefixLen = prefix.length();
@@ -1150,6 +1189,55 @@ public final class Matcher implements MatchResult {
       }
     }
     return -1;
+  }
+
+  private static int nextAcceleratedStart(
+      String text, Pattern.StartAcceleration acceleration, int fromIndex, boolean unixLines) {
+    int start = Math.max(0, fromIndex);
+    for (int i = start; i < text.length(); i++) {
+      if (matchesStartAcceleration(text, i, acceleration, unixLines)) {
+        return i;
+      }
+      int cp = text.codePointAt(i);
+      i += Character.charCount(cp) - 1;
+    }
+    return -1;
+  }
+
+  private static boolean matchesStartAcceleration(
+      String text, int pos, Pattern.StartAcceleration acceleration, boolean unixLines) {
+    boolean lineStart = isBeginLine(text, pos, unixLines);
+    boolean asciiStart = matchesAsciiStart(text, pos, acceleration.asciiStart);
+    if (acceleration.requireLineStart) {
+      return lineStart && (acceleration.asciiStart == null || asciiStart);
+    }
+    return (acceleration.allowLineStart && lineStart) || asciiStart;
+  }
+
+  private static boolean matchesAsciiStart(String text, int pos, boolean[] asciiStart) {
+    if (asciiStart == null || pos >= text.length()) {
+      return false;
+    }
+    char ch = text.charAt(pos);
+    return ch < 128 && asciiStart[ch];
+  }
+
+  private static boolean isBeginLine(String text, int pos, boolean unixLines) {
+    if (pos == 0) {
+      return !text.isEmpty();
+    }
+    if (pos >= text.length()) {
+      return false;
+    }
+    char prev = text.charAt(pos - 1);
+    if (unixLines) {
+      return prev == '\n';
+    }
+    return prev == '\n'
+        || prev == '\u0085'
+        || prev == '\u2028'
+        || prev == '\u2029'
+        || (prev == '\r' && text.charAt(pos) != '\n');
   }
   /**
    * Tries BitState first (for small texts), falls back to NFA. This is the final capture-extraction

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -108,6 +108,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasAnchorInQuant;
   private final transient boolean hasEndConstraint;
   private final transient boolean[] charClassPrefixAscii;
+  private final transient StartAcceleration startAcceleration;
 
   /**
    * Precomputed character class data for the "repeated character class" fast path in
@@ -184,7 +185,7 @@ public final class Pattern implements Serializable {
       String literalMatch, boolean hasLazy, boolean hasAlternation,
       boolean hasNullableAlternation,
       boolean hasBoundedRepeat, boolean hasAnchorInQuant, boolean hasEndConstraint,
-      boolean[] charClassPrefixAscii,
+      boolean[] charClassPrefixAscii, StartAcceleration startAcceleration,
       int[] charClassMatchRanges, long charClassMatchBitmap0, long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty) {
     this.pattern = pattern;
@@ -202,6 +203,7 @@ public final class Pattern implements Serializable {
     this.hasAnchorInQuant = hasAnchorInQuant;
     this.hasEndConstraint = hasEndConstraint;
     this.charClassPrefixAscii = charClassPrefixAscii;
+    this.startAcceleration = startAcceleration;
     this.charClassMatchRanges = charClassMatchRanges;
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
@@ -251,12 +253,14 @@ public final class Pattern implements Serializable {
     // Extract character-class prefix for acceleration when no literal prefix exists.
     boolean[] ccPrefixAscii = (prefix == null)
         ? extractCharClassPrefixAscii(re) : null;
+    StartAcceleration startAcceleration =
+        (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(re) : null;
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(re);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(regex, flags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
-        hasEndConst, ccPrefixAscii,
+        hasEndConst, ccPrefixAscii, startAcceleration,
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
@@ -744,6 +748,11 @@ public final class Pattern implements Serializable {
     return charClassPrefixAscii;
   }
 
+  /** Returns conservative start-position acceleration data, or {@code null} if unavailable. */
+  StartAcceleration startAcceleration() {
+    return startAcceleration;
+  }
+
   /**
    * Returns the precomputed ranges for the character-class-match fast path, or {@code null} if
    * the pattern is not a simple repeated character class. When non-null, {@code matches()} can
@@ -1151,6 +1160,26 @@ public final class Pattern implements Serializable {
   private record PrefixResult(String prefix, boolean foldCase) {}
 
   /**
+   * Conservative start-position accelerator.
+   *
+   * <p>When {@code requireLineStart} is true, every match must start at a multiline {@code ^}
+   * position, optionally with the first consumed ASCII character in {@code asciiStart}. Otherwise,
+   * a match may start at a line start if {@code allowLineStart} is true, or at a position whose
+   * first consumed ASCII character is in {@code asciiStart}.
+   */
+  static final class StartAcceleration {
+    final boolean requireLineStart;
+    final boolean allowLineStart;
+    final boolean[] asciiStart;
+
+    StartAcceleration(boolean requireLineStart, boolean allowLineStart, boolean[] asciiStart) {
+      this.requireLineStart = requireLineStart;
+      this.allowLineStart = allowLineStart;
+      this.asciiStart = asciiStart;
+    }
+  }
+
+  /**
    * Extracts a literal prefix from the simplified AST for prefix acceleration. Returns a {@link
    * PrefixResult} containing the literal string that every match must start with (or {@code null}
    * if no fixed prefix exists) and whether the prefix is case-folded.
@@ -1261,6 +1290,130 @@ public final class Pattern implements Serializable {
       }
     }
     return bitmap;
+  }
+
+  private static StartAcceleration extractStartAcceleration(Regexp re) {
+    Regexp node = unwrapCaptures(re);
+    if (node == null) {
+      return null;
+    }
+
+    if (node.op == RegexpOp.CONCAT && node.nsub() > 0) {
+      Regexp first = unwrapCaptures(node.subs.get(0));
+      if (first != null && first.op == RegexpOp.BEGIN_LINE) {
+        boolean[] requiredStart = null;
+        if (node.nsub() > 1) {
+          requiredStart = requiredFirstAscii(node.subs.get(1));
+        }
+        return new StartAcceleration(true, false, requiredStart);
+      }
+      return extractAlternateStartAcceleration(first);
+    }
+
+    if (node.op == RegexpOp.BEGIN_LINE) {
+      return new StartAcceleration(true, false, null);
+    }
+    return extractAlternateStartAcceleration(node);
+  }
+
+  private static StartAcceleration extractAlternateStartAcceleration(Regexp node) {
+    if (node == null || node.op != RegexpOp.ALTERNATE || node.subs == null) {
+      return null;
+    }
+
+    boolean allowLineStart = false;
+    boolean[] asciiStart = null;
+    for (Regexp branch : node.subs) {
+      Regexp first = firstMeaningfulNode(branch);
+      if (first == null) {
+        return null;
+      }
+      if (first.op == RegexpOp.BEGIN_LINE) {
+        allowLineStart = true;
+        continue;
+      }
+      boolean[] branchStart = requiredFirstAscii(first);
+      if (branchStart == null) {
+        return null;
+      }
+      if (asciiStart == null) {
+        asciiStart = new boolean[128];
+      }
+      for (int i = 0; i < branchStart.length; i++) {
+        asciiStart[i] |= branchStart[i];
+      }
+    }
+
+    return (allowLineStart || asciiStart != null)
+        ? new StartAcceleration(false, allowLineStart, asciiStart)
+        : null;
+  }
+
+  private static Regexp firstMeaningfulNode(Regexp re) {
+    Regexp node = unwrapCaptures(re);
+    if (node == null) {
+      return null;
+    }
+    if (node.op == RegexpOp.CONCAT && node.nsub() > 0) {
+      return unwrapCaptures(node.subs.get(0));
+    }
+    return node;
+  }
+
+  private static Regexp unwrapCaptures(Regexp re) {
+    Regexp node = re;
+    while (node != null && node.op == RegexpOp.CAPTURE) {
+      node = node.sub();
+    }
+    return node;
+  }
+
+  private static boolean[] requiredFirstAscii(Regexp re) {
+    Regexp node = firstMeaningfulNode(re);
+    if (node == null) {
+      return null;
+    }
+    if (node.op == RegexpOp.PLUS
+        || (node.op == RegexpOp.REPEAT && node.min >= 1)) {
+      node = firstMeaningfulNode(node.sub());
+    }
+    if (node == null) {
+      return null;
+    }
+
+    boolean[] bitmap = new boolean[128];
+    if (node.op == RegexpOp.LITERAL) {
+      if ((node.flags & ParseFlags.FOLD_CASE) != 0 || node.rune >= 128) {
+        return null;
+      }
+      bitmap[node.rune] = true;
+      return bitmap;
+    }
+    if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
+      if ((node.flags & ParseFlags.FOLD_CASE) != 0 || node.runes[0] >= 128) {
+        return null;
+      }
+      bitmap[node.runes[0]] = true;
+      return bitmap;
+    }
+    if (node.op == RegexpOp.CHAR_CLASS && node.charClass != null) {
+      CharClass cc = node.charClass;
+      if (cc.isEmpty()) {
+        return null;
+      }
+      for (int i = 0; i < cc.numRanges(); i++) {
+        if (cc.hi(i) >= 128) {
+          return null;
+        }
+      }
+      for (int i = 0; i < cc.numRanges(); i++) {
+        for (int cp = cc.lo(i); cp <= cc.hi(i); cp++) {
+          bitmap[cp] = true;
+        }
+      }
+      return bitmap;
+    }
+    return null;
   }
 
   /** Holds precomputed data for the character-class-match fast path. */

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1162,10 +1162,9 @@ public final class Pattern implements Serializable {
   /**
    * Conservative start-position accelerator.
    *
-   * <p>When {@code requireLineStart} is true, every match must start at a multiline {@code ^}
-   * position, optionally with the first consumed ASCII character in {@code asciiStart}. Otherwise,
-   * a match may start at a line start if {@code allowLineStart} is true, or at a position whose
-   * first consumed ASCII character is in {@code asciiStart}.
+   * <p>Every match must start at a multiline {@code ^} position, optionally with the first
+   * consumed ASCII character in {@code asciiStart}. The accelerator only advances the initial
+   * search position before handing off to the normal linear engine pipeline.
    */
   static final class StartAcceleration {
     final boolean requireLineStart;
@@ -1307,46 +1306,13 @@ public final class Pattern implements Serializable {
         }
         return new StartAcceleration(true, false, requiredStart);
       }
-      return extractAlternateStartAcceleration(first);
+      return null;
     }
 
     if (node.op == RegexpOp.BEGIN_LINE) {
       return new StartAcceleration(true, false, null);
     }
-    return extractAlternateStartAcceleration(node);
-  }
-
-  private static StartAcceleration extractAlternateStartAcceleration(Regexp node) {
-    if (node == null || node.op != RegexpOp.ALTERNATE || node.subs == null) {
-      return null;
-    }
-
-    boolean allowLineStart = false;
-    boolean[] asciiStart = null;
-    for (Regexp branch : node.subs) {
-      Regexp first = firstMeaningfulNode(branch);
-      if (first == null) {
-        return null;
-      }
-      if (first.op == RegexpOp.BEGIN_LINE) {
-        allowLineStart = true;
-        continue;
-      }
-      boolean[] branchStart = requiredFirstAscii(first);
-      if (branchStart == null) {
-        return null;
-      }
-      if (asciiStart == null) {
-        asciiStart = new boolean[128];
-      }
-      for (int i = 0; i < branchStart.length; i++) {
-        asciiStart[i] |= branchStart[i];
-      }
-    }
-
-    return (allowLineStart || asciiStart != null)
-        ? new StartAcceleration(false, allowLineStart, asciiStart)
-        : null;
+    return null;
   }
 
   private static Regexp firstMeaningfulNode(Regexp re) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -412,6 +412,54 @@ class MatcherTest {
       assertThat(m.find()).isFalse();
     }
 
+    @Test
+    @DisplayName("find() start acceleration matches JDK for comma-or-line-start CSV fields")
+    void findStartAccelerationForCsvFields() {
+      assertAllFindsMatchJdk(
+          "(?m)(?:^|,)(?:\"([^\"]*)\"|([^,\r\n]+))",
+          "id,name,email\r\n42,\"Ada Lovelace\",ada@example.com\n"
+              + "43,\"Grace Hopper\",grace@example.com");
+    }
+
+    @Test
+    @DisplayName("find() start acceleration matches JDK for multiline line-start whitespace")
+    void findStartAccelerationForLineStartWhitespace() {
+      assertAllFindsMatchJdk(
+          "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
+          "java.lang.IllegalStateException: failed\n"
+              + "\tat org.example.api.Handler.handle(Handler.java:87)\n"
+              + "Caused by: java.io.IOException: timeout\r\n"
+              + "\tat org.example.net.Client.read(Client.java:203)");
+    }
+
+    @Test
+    @DisplayName("find() start acceleration handles Unicode line terminators")
+    void findStartAccelerationWithUnicodeLineTerminators() {
+      assertAllFindsMatchJdk("(?m)^\\s+at\\s+(\\w+)$", "header\u2028\tat alpha\u2029\tat beta");
+    }
+
+    private void assertAllFindsMatchJdk(String regex, String input) {
+      Matcher m = Pattern.compile(regex).matcher(input);
+      java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(input);
+
+      while (true) {
+        boolean safereFound = m.find();
+        boolean jdkFound = jdk.find();
+        assertThat(safereFound).isEqualTo(jdkFound);
+        if (!jdkFound) {
+          return;
+        }
+        assertThat(m.group()).isEqualTo(jdk.group());
+        assertThat(m.start()).isEqualTo(jdk.start());
+        assertThat(m.end()).isEqualTo(jdk.end());
+        for (int group = 1; group <= jdk.groupCount(); group++) {
+          assertThat(m.group(group)).isEqualTo(jdk.group(group));
+          assertThat(m.start(group)).isEqualTo(jdk.start(group));
+          assertThat(m.end(group)).isEqualTo(jdk.end(group));
+        }
+      }
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
       "(bcd|abcde)",


### PR DESCRIPTION
## Summary

- derive conservative start-position acceleration for patterns that are required to start at multiline line starts, optionally followed by a known ASCII first character
- use that analysis only to advance the initial `Matcher.find()` search position before handing off to the normal linear DFA/BitState/NFA pipeline
- remove the broad repeated-candidate anchored fallback path so the optimization cannot turn failing searches quadratic
- add JDK-comparison coverage for CSV comma-or-line-start fields, multiline line-start whitespace, CRLF, and Unicode line terminators

Fixes #186

## Validation

- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere test -q`
- `git diff --check`

## Quick Benchmark Impact

Quick mode is for development signal only, not publication-quality results. Lower is better.

Command:

- `./run-java-benchmarks.sh --quick 'ApplicationBenchmark.(csvFieldScan|stackTraceExtract)_safere'`

| Benchmark | Before #186 (`db6cb90`) | After #186 (`dc2dcd0`) | Change |
| --- | ---: | ---: | ---: |
| `csvFieldScan_safere` | 3200.019 ± 205.468 ns/op | 3268.544 ± 344.585 ns/op | 2.1% slower |
| `stackTraceExtract_safere` | 6398.724 ± 604.578 ns/op | 4141.890 ± 156.175 ns/op | 35.3% faster |

The original candidate-loop version was faster for both workloads, but could repeatedly invoke the full fallback engine and violate SafeRE’s linear-time guarantee. This version keeps the optimization to a linear pre-scan for required line-start patterns and then uses the existing linear engine pipeline. The CSV result is effectively neutral/slightly slower in this quick run because the unsafe comma-candidate accelerator was removed; stack trace extraction keeps a substantial improvement.