### PR TITLE
Fast path case-insensitive keyword alternation

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -786,6 +786,11 @@ public final class Matcher implements MatchResult {
 
     Prog prog = parentPattern.prog();
 
+    Pattern.KeywordAlternation keywordAlternation = parentPattern.keywordAlternation();
+    if (!regionActive && keywordAlternation != null) {
+      return findKeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures());
+    }
+
     // Anchored start: if the pattern requires a match at the beginning of the text (e.g., ^
     // without MULTILINE, or \A), there can be no match starting after position 0 (or regionStart
     // when a region is active). Return false immediately to avoid the DFA matching at every
@@ -1133,6 +1138,54 @@ public final class Matcher implements MatchResult {
     }
     hasMatch = true;
     return true;
+  }
+
+  private boolean findKeywordAlternation(
+      Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
+    for (int i = Math.max(0, startPos); i < text.length(); i++) {
+      char ch = text.charAt(i);
+      if (ch < 128 && keywordAlternation.firstAscii[asciiLower(ch)]
+          && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
+        for (String keyword : keywordAlternation.keywords) {
+          int end = i + keyword.length();
+          if (end <= text.length()
+              && text.regionMatches(true, i, keyword, 0, keyword.length())
+              && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
+            groups = new int[2 * ncap];
+            Arrays.fill(groups, -1);
+            groups[0] = i;
+            groups[1] = end;
+            if (keywordAlternation.captureGroup > 0) {
+              int group = keywordAlternation.captureGroup;
+              groups[2 * group] = i;
+              groups[2 * group + 1] = end;
+            }
+            hasMatch = true;
+            return true;
+          }
+        }
+      }
+      int cp = text.codePointAt(i);
+      i += Character.charCount(cp) - 1;
+    }
+    hasMatch = false;
+    return false;
+  }
+
+  private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {
+    boolean prevWord =
+        pos > 0 && isBoundaryWordChar(text.codePointBefore(pos), unicodeWordBoundary);
+    boolean nextWord =
+        pos < text.length() && isBoundaryWordChar(text.codePointAt(pos), unicodeWordBoundary);
+    return prevWord != nextWord;
+  }
+
+  private static boolean isBoundaryWordChar(int cp, boolean unicodeWordBoundary) {
+    return unicodeWordBoundary ? Nfa.isUnicodeWordChar(cp) : Nfa.isWordChar(cp);
+  }
+
+  private static int asciiLower(int ch) {
+    return ('A' <= ch && ch <= 'Z') ? ch + ('a' - 'A') : ch;
   }
 
   /** Case-insensitive indexOf using Unicode case folding. */

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -109,6 +109,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasEndConstraint;
   private final transient boolean[] charClassPrefixAscii;
   private final transient StartAcceleration startAcceleration;
+  private final transient KeywordAlternation keywordAlternation;
 
   /**
    * Precomputed character class data for the "repeated character class" fast path in
@@ -186,6 +187,7 @@ public final class Pattern implements Serializable {
       boolean hasNullableAlternation,
       boolean hasBoundedRepeat, boolean hasAnchorInQuant, boolean hasEndConstraint,
       boolean[] charClassPrefixAscii, StartAcceleration startAcceleration,
+      KeywordAlternation keywordAlternation,
       int[] charClassMatchRanges, long charClassMatchBitmap0, long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty) {
     this.pattern = pattern;
@@ -204,6 +206,7 @@ public final class Pattern implements Serializable {
     this.hasEndConstraint = hasEndConstraint;
     this.charClassPrefixAscii = charClassPrefixAscii;
     this.startAcceleration = startAcceleration;
+    this.keywordAlternation = keywordAlternation;
     this.charClassMatchRanges = charClassMatchRanges;
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
@@ -255,12 +258,13 @@ public final class Pattern implements Serializable {
         ? extractCharClassPrefixAscii(re) : null;
     StartAcceleration startAcceleration =
         (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(re) : null;
+    KeywordAlternation keywordAlternation = extractKeywordAlternation(re, flags);
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(re);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(regex, flags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
-        hasEndConst, ccPrefixAscii, startAcceleration,
+        hasEndConst, ccPrefixAscii, startAcceleration, keywordAlternation,
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
@@ -753,6 +757,11 @@ public final class Pattern implements Serializable {
     return startAcceleration;
   }
 
+  /** Returns case-insensitive keyword-alternation fast-path data, or {@code null}. */
+  KeywordAlternation keywordAlternation() {
+    return keywordAlternation;
+  }
+
   /**
    * Returns the precomputed ranges for the character-class-match fast path, or {@code null} if
    * the pattern is not a simple repeated character class. When non-null, {@code matches()} can
@@ -1178,6 +1187,22 @@ public final class Pattern implements Serializable {
     }
   }
 
+  /** Fast-path data for {@code (?i)\b(keyword|...)\b}. */
+  static final class KeywordAlternation {
+    final String[] keywords;
+    final boolean[] firstAscii;
+    final int captureGroup;
+    final boolean unicodeWordBoundary;
+
+    KeywordAlternation(
+        String[] keywords, boolean[] firstAscii, int captureGroup, boolean unicodeWordBoundary) {
+      this.keywords = keywords;
+      this.firstAscii = firstAscii;
+      this.captureGroup = captureGroup;
+      this.unicodeWordBoundary = unicodeWordBoundary;
+    }
+  }
+
   /**
    * Extracts a literal prefix from the simplified AST for prefix acceleration. Returns a {@link
    * PrefixResult} containing the literal string that every match must start with (or {@code null}
@@ -1313,6 +1338,165 @@ public final class Pattern implements Serializable {
       return new StartAcceleration(true, false, null);
     }
     return null;
+  }
+
+  private static KeywordAlternation extractKeywordAlternation(Regexp re, int patternFlags) {
+    if ((patternFlags & UNICODE_CASE) != 0) {
+      return null;
+    }
+
+    Regexp node = unwrapImplicitCapture(re);
+    if (node == null || node.op != RegexpOp.CONCAT || node.nsub() != 3) {
+      return null;
+    }
+    Regexp before = unwrapImplicitCapture(node.subs.get(0));
+    Regexp middle = unwrapImplicitCapture(node.subs.get(1));
+    Regexp after = unwrapImplicitCapture(node.subs.get(2));
+    if (before == null || before.op != RegexpOp.WORD_BOUNDARY
+        || after == null || after.op != RegexpOp.WORD_BOUNDARY) {
+      return null;
+    }
+
+    int captureGroup = -1;
+    if (middle != null && middle.op == RegexpOp.CAPTURE && middle.cap > 0) {
+      captureGroup = middle.cap;
+      middle = unwrapImplicitCapture(middle.sub());
+    }
+    if (middle == null || middle.op != RegexpOp.ALTERNATE || middle.subs == null
+        || middle.subs.isEmpty()) {
+      return null;
+    }
+    if (hasOtherUserCaptures(middle, captureGroup)) {
+      return null;
+    }
+
+    String[] keywords = new String[middle.subs.size()];
+    boolean[] firstAscii = new boolean[128];
+    for (int i = 0; i < middle.subs.size(); i++) {
+      String keyword = extractAsciiCaseInsensitiveLiteral(middle.subs.get(i));
+      if (keyword == null || keyword.isEmpty()) {
+        return null;
+      }
+      keywords[i] = keyword;
+      firstAscii[keyword.charAt(0)] = true;
+    }
+    boolean unicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
+    return new KeywordAlternation(keywords, firstAscii, captureGroup, unicodeWordBoundary);
+  }
+
+  private static boolean hasOtherUserCaptures(Regexp re, int allowedCapture) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.CAPTURE && node.cap > 0 && node.cap != allowedCapture) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private static Regexp unwrapImplicitCapture(Regexp re) {
+    Regexp node = re;
+    while (node != null && node.op == RegexpOp.CAPTURE && node.cap == 0) {
+      node = node.sub();
+    }
+    return node;
+  }
+
+  private static String extractAsciiCaseInsensitiveLiteral(Regexp re) {
+    Regexp node = unwrapImplicitCapture(re);
+    if (node == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean[] sawCaseInsensitive = new boolean[1];
+    if (!appendAsciiCaseInsensitiveLiteral(node, sb, sawCaseInsensitive)
+        || !sawCaseInsensitive[0]) {
+      return null;
+    }
+    return sb.toString();
+  }
+
+  private static boolean appendAsciiCaseInsensitiveLiteral(
+      Regexp node, StringBuilder sb, boolean[] sawCaseInsensitive) {
+    node = unwrapImplicitCapture(node);
+    if (node == null) {
+      return false;
+    }
+    switch (node.op) {
+      case CONCAT -> {
+        if (node.subs == null || node.subs.isEmpty()) {
+          return false;
+        }
+        for (Regexp sub : node.subs) {
+          if (!appendAsciiCaseInsensitiveLiteral(sub, sb, sawCaseInsensitive)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      case LITERAL -> {
+        int cp = node.rune;
+        if (cp < 0 || cp >= 128 || !isAsciiLiteralKeywordChar(cp)) {
+          return false;
+        }
+        sawCaseInsensitive[0] |= (node.flags & ParseFlags.FOLD_CASE) != 0;
+        sb.append((char) asciiLower(cp));
+        return true;
+      }
+      case LITERAL_STRING -> {
+        if (node.runes == null || node.runes.length == 0) {
+          return false;
+        }
+        for (int cp : node.runes) {
+          if (cp < 0 || cp >= 128 || !isAsciiLiteralKeywordChar(cp)) {
+            return false;
+          }
+          sawCaseInsensitive[0] |= (node.flags & ParseFlags.FOLD_CASE) != 0;
+          sb.append((char) asciiLower(cp));
+        }
+        return true;
+      }
+      case CHAR_CLASS -> {
+        int cp = asciiFoldedLiteralChar(node.charClass);
+        if (cp < 0) {
+          return false;
+        }
+        sawCaseInsensitive[0] = true;
+        sb.append((char) cp);
+        return true;
+      }
+      default -> {
+        return false;
+      }
+    }
+  }
+
+  private static boolean isAsciiLiteralKeywordChar(int cp) {
+    return ('A' <= cp && cp <= 'Z') || ('a' <= cp && cp <= 'z')
+        || ('0' <= cp && cp <= '9') || cp == '_';
+  }
+
+  private static int asciiLower(int cp) {
+    return ('A' <= cp && cp <= 'Z') ? cp + ('a' - 'A') : cp;
+  }
+
+  private static int asciiFoldedLiteralChar(CharClass cc) {
+    if (cc == null || cc.numRunes() != 2) {
+      return -1;
+    }
+    for (int cp = 'a'; cp <= 'z'; cp++) {
+      if (cc.contains(cp) && cc.contains(cp - ('a' - 'A'))) {
+        return cp;
+      }
+    }
+    return -1;
   }
 
   private static Regexp firstMeaningfulNode(Regexp re) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1415,16 +1415,13 @@ public final class Pattern implements Serializable {
       return null;
     }
     StringBuilder sb = new StringBuilder();
-    boolean[] sawCaseInsensitive = new boolean[1];
-    if (!appendAsciiCaseInsensitiveLiteral(node, sb, sawCaseInsensitive)
-        || !sawCaseInsensitive[0]) {
+    if (!appendAsciiCaseInsensitiveLiteral(node, sb)) {
       return null;
     }
     return sb.toString();
   }
 
-  private static boolean appendAsciiCaseInsensitiveLiteral(
-      Regexp node, StringBuilder sb, boolean[] sawCaseInsensitive) {
+  private static boolean appendAsciiCaseInsensitiveLiteral(Regexp node, StringBuilder sb) {
     node = unwrapImplicitCapture(node);
     if (node == null) {
       return false;
@@ -1435,7 +1432,7 @@ public final class Pattern implements Serializable {
           return false;
         }
         for (Regexp sub : node.subs) {
-          if (!appendAsciiCaseInsensitiveLiteral(sub, sb, sawCaseInsensitive)) {
+          if (!appendAsciiCaseInsensitiveLiteral(sub, sb)) {
             return false;
           }
         }
@@ -1446,7 +1443,9 @@ public final class Pattern implements Serializable {
         if (cp < 0 || cp >= 128 || !isAsciiLiteralKeywordChar(cp)) {
           return false;
         }
-        sawCaseInsensitive[0] |= (node.flags & ParseFlags.FOLD_CASE) != 0;
+        if ((node.flags & ParseFlags.FOLD_CASE) == 0) {
+          return false;
+        }
         sb.append((char) asciiLower(cp));
         return true;
       }
@@ -1454,11 +1453,13 @@ public final class Pattern implements Serializable {
         if (node.runes == null || node.runes.length == 0) {
           return false;
         }
+        if ((node.flags & ParseFlags.FOLD_CASE) == 0) {
+          return false;
+        }
         for (int cp : node.runes) {
           if (cp < 0 || cp >= 128 || !isAsciiLiteralKeywordChar(cp)) {
             return false;
           }
-          sawCaseInsensitive[0] |= (node.flags & ParseFlags.FOLD_CASE) != 0;
           sb.append((char) asciiLower(cp));
         }
         return true;
@@ -1468,7 +1469,6 @@ public final class Pattern implements Serializable {
         if (cp < 0) {
           return false;
         }
-        sawCaseInsensitive[0] = true;
         sb.append((char) cp);
         return true;
       }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -413,6 +413,31 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() keyword alternation fast path matches JDK across case and punctuation")
+    void findKeywordAlternationFastPathMatchesJdk() {
+      assertAllFindsMatchJdk(
+          "(?i)\\b(error|warning|timeout|failed)\\b",
+          "Info: Warning, request failed after TIMEOUT; ERROR-rate ignored");
+    }
+
+    @Test
+    @DisplayName("find() keyword alternation rejects adjacent ASCII word characters")
+    void findKeywordAlternationRejectsAdjacentAsciiWordCharacters() {
+      assertAllFindsMatchJdk(
+          "(?i)\\b(error|warning|timeout|failed)\\b",
+          "preerror error2 _warning warning-post failed");
+    }
+
+    @Test
+    @DisplayName("find() keyword alternation uses Unicode boundaries when requested")
+    void findKeywordAlternationUsesUnicodeBoundaries() {
+      assertAllFindsMatchJdk(
+          "(?i)\\b(error|warning)\\b",
+          Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS,
+          "éerroré error βwarning warning!");
+    }
+
+    @Test
     @DisplayName("find() start acceleration matches JDK for comma-or-line-start CSV fields")
     void findStartAccelerationForCsvFields() {
       assertAllFindsMatchJdk(
@@ -439,8 +464,12 @@ class MatcherTest {
     }
 
     private void assertAllFindsMatchJdk(String regex, String input) {
-      Matcher m = Pattern.compile(regex).matcher(input);
-      java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(input);
+      assertAllFindsMatchJdk(regex, 0, input);
+    }
+
+    private void assertAllFindsMatchJdk(String regex, int flags, String input) {
+      Matcher m = Pattern.compile(regex, flags).matcher(input);
+      java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex, flags).matcher(input);
 
       while (true) {
         boolean safereFound = m.find();

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -438,6 +438,12 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() keyword alternation rejects partly case-sensitive scoped flags")
+    void findKeywordAlternationRejectsPartlyCaseSensitiveScopedFlags() {
+      assertAllFindsMatchJdk("\\b((?i:a)B|(?i:x)Y)\\b", "ab aB AB xy xY XY");
+    }
+
+    @Test
     @DisplayName("find() start acceleration matches JDK for comma-or-line-start CSV fields")
     void findStartAccelerationForCsvFields() {
       assertAllFindsMatchJdk(


### PR DESCRIPTION
## Summary
- add a conservative fast path for ASCII case-insensitive keyword alternations guarded by word boundaries
- preserve group 0 and the alternation capture group, with JDK parity coverage for boundary and scoped-flag cases
- require every keyword character to be under fold-case before enabling the fast path

Fixes #187

## Validation
- mvn -pl safere -Dtest=MatcherTest test -q
- mvn -pl safere test -q
- git diff --check

## Benchmarks
Quick development benchmark, not for BENCHMARKS.md:

Command: ./run-java-benchmarks.sh --quick 'ApplicationBenchmark.caseInsensitiveKeywords_(safere|jdk|re2j|re2ffm)'

Target workload: ApplicationBenchmark.caseInsensitiveKeywords_safere
- Baseline c715d54: 4394.942 ns/op
- This branch fdd2e45: 347.078 ns/op
- Improvement: 12.7x faster, 92.1% lower time/op

Same fixed-branch quick run competitor values:
- JDK: 1237.372 ns/op
- RE2-FFM: 1303.235 ns/op
- RE2/J: 6707.152 ns/op