### PR TITLE
Fix region anchoring and split API behavior

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -456,11 +456,16 @@ public final class Matcher implements MatchResult {
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     String savedText = text;
-    if (regionActive) {
-      text = savedText.substring(regionStart, regionEnd);
-    }
 
     try {
+      if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
+        groups = null;
+        hasMatch = false;
+        return false;
+      }
+      if (regionActive) {
+        text = savedText.substring(regionStart, regionEnd);
+      }
       return matchesCore();
     } finally {
       if (regionActive) {
@@ -566,11 +571,16 @@ public final class Matcher implements MatchResult {
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     String savedText = text;
-    if (regionActive) {
-      text = savedText.substring(regionStart, regionEnd);
-    }
 
     try {
+      if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
+        groups = null;
+        hasMatch = false;
+        return false;
+      }
+      if (regionActive) {
+        text = savedText.substring(regionStart, regionEnd);
+      }
       return lookingAtCore();
     } finally {
       if (regionActive) {
@@ -721,12 +731,17 @@ public final class Matcher implements MatchResult {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     String savedText = text;
     int savedSearchFrom = searchFrom;
-    if (regionActive) {
-      text = savedText.substring(regionStart, regionEnd);
-      searchFrom = Math.max(0, savedSearchFrom - regionStart);
-    }
 
     try {
+      if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
+        groups = null;
+        hasMatch = false;
+        return false;
+      }
+      if (regionActive) {
+        text = savedText.substring(regionStart, regionEnd);
+        searchFrom = Math.max(0, savedSearchFrom - regionStart);
+      }
       return doFindCore(regionActive);
     } finally {
       if (regionActive) {
@@ -748,6 +763,26 @@ public final class Matcher implements MatchResult {
       lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
       lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
     }
+  }
+
+  /**
+   * Returns true when a stripped text anchor ({@code ^}, {@code \A}, {@code $}, {@code \Z}, or
+   * {@code \z}) cannot be satisfied at this region boundary because anchoring bounds are disabled.
+   */
+  private boolean regionTextAnchorCannotMatch() {
+    Prog prog = parentPattern.prog();
+    if (prog.anchorStart() && regionStart != 0) {
+      return true;
+    }
+    return prog.anchorEnd() && !regionEndCanSatisfyTextEnd(prog);
+  }
+
+  private boolean regionEndCanSatisfyTextEnd(Prog prog) {
+    if (regionEnd == text.length()) {
+      return true;
+    }
+    return prog.dollarAnchorEnd()
+        && Nfa.isAtTrailingLineTerminator(text, regionEnd, prog.unixLines());
   }
 
   /**
@@ -1976,9 +2011,6 @@ public final class Matcher implements MatchResult {
    * Sets the anchoring of region bounds for this matcher. Anchoring bounds cause {@code ^} and
    * {@code $} to match at the region boundaries rather than at the start and end of the entire
    * input. This is the default behavior.
-   *
-   * <p><b>Note:</b> This method currently stores the flag but region support is not yet
-   * implemented. The flag will take effect once region support is added.
    *
    * @param b a boolean indicating whether to use anchoring bounds
    * @return this matcher

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -10,18 +10,16 @@ package org.safere;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * A compiled regular expression backed by a linear-time NFA engine. This class provides a drop-in
@@ -285,6 +283,22 @@ public final class Pattern implements Serializable {
   }
 
   /**
+   * Materializes a {@link CharSequence} by reading through {@code charAt()}, so custom
+   * implementations that do not override {@code toString()} are handled correctly.
+   */
+  private static String charSequenceToString(CharSequence cs) {
+    if (cs instanceof String s) {
+      return s;
+    }
+    int len = cs.length();
+    char[] chars = new char[len];
+    for (int i = 0; i < len; i++) {
+      chars[i] = cs.charAt(i);
+    }
+    return new String(chars);
+  }
+
+  /**
    * Returns a literal pattern string for the specified string. Metacharacters and escape sequences
    * in the returned string will have no special meaning.
    *
@@ -366,7 +380,7 @@ public final class Pattern implements Serializable {
    * @return the array of strings computed by splitting the input around matches of this pattern
    */
   public String[] split(CharSequence input, int limit) {
-    String text = input.toString();
+    String text = charSequenceToString(input);
     Matcher m = matcher(text);
     List<String> parts = new ArrayList<>();
     int last = 0;
@@ -442,7 +456,7 @@ public final class Pattern implements Serializable {
    * @since 21
    */
   public String[] splitWithDelimiters(CharSequence input, int limit) {
-    String text = input.toString();
+    String text = charSequenceToString(input);
     Matcher m = matcher(text);
     List<String> parts = new ArrayList<>();
     int last = 0;
@@ -489,33 +503,7 @@ public final class Pattern implements Serializable {
    *     pattern
    */
   public Stream<String> splitAsStream(CharSequence input) {
-    String text = input.toString();
-    Matcher m = matcher(text);
-    Spliterator<String> spliterator =
-        new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE,
-            Spliterator.ORDERED | Spliterator.NONNULL) {
-          private int last = 0;
-          private boolean done = false;
-
-          @Override
-          public boolean tryAdvance(java.util.function.Consumer<? super String> action) {
-            if (done) {
-              return false;
-            }
-            if (m.find()) {
-              action.accept(text.substring(last, m.start()));
-              last = m.end();
-              return true;
-            } else {
-              // Emit the trailing segment.
-              action.accept(text.substring(last));
-              done = true;
-              return true;
-            }
-          }
-        };
-    // The JDK trims trailing empty strings; replicate that behavior.
-    return StreamSupport.stream(spliterator, false);
+    return Arrays.stream(split(input, 0));
   }
 
   /**

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1610,6 +1610,26 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("^ does not match region start when anchoring bounds are disabled")
+    void caretDoesNotMatchRegionStartWithoutAnchoringBounds() {
+      Pattern p = Pattern.compile("^\\d+");
+      Matcher m = p.matcher("abc123def");
+      m.region(3, 6); // "123"
+      m.useAnchoringBounds(false);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("$ does not match region end when anchoring bounds are disabled")
+    void dollarDoesNotMatchRegionEndWithoutAnchoringBounds() {
+      Pattern p = Pattern.compile("\\d+$");
+      Matcher m = p.matcher("abc123def");
+      m.region(3, 6); // "123"
+      m.useAnchoringBounds(false);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
     @DisplayName("successive find() calls within region")
     void successiveFindInRegion() {
       Pattern p = Pattern.compile("[a-z]+");

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -26,6 +26,28 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link Pattern}. */
 class PatternTest {
+  private static final class LiteralCharSequence implements CharSequence {
+    private final String value;
+
+    LiteralCharSequence(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public int length() {
+      return value.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      return value.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return value.subSequence(start, end);
+    }
+  }
 
   @Nested
   @DisplayName("compile()")
@@ -344,6 +366,14 @@ class PatternTest {
       String[] parts = p.split("hello   world  foo");
       assertThat(parts).containsExactly("hello", "world", "foo");
     }
+
+    @Test
+    @DisplayName("split reads custom CharSequence content via charAt()")
+    void splitCustomCharSequence() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.split(new LiteralCharSequence("a,b,c"));
+      assertThat(parts).containsExactly("a", "b", "c");
+    }
   }
 
   @Nested
@@ -419,6 +449,14 @@ class PatternTest {
       Pattern p = Pattern.compile(",");
       String[] parts = p.splitWithDelimiters(",a,b", -1);
       assertThat(parts).containsExactly("", ",", "a", ",", "b");
+    }
+
+    @Test
+    @DisplayName("splitWithDelimiters reads custom CharSequence content via charAt()")
+    void splitWithDelimitersCustomCharSequence() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters(new LiteralCharSequence("a,b"));
+      assertThat(parts).containsExactly("a", ",", "b");
     }
   }
 
@@ -917,6 +955,25 @@ class PatternTest {
       Pattern p = Pattern.compile(",");
       long count = p.splitAsStream("a,b,c,d").count();
       assertThat(count).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("splitAsStream discards trailing empty strings")
+    void splitAsStreamTrailingEmpty() {
+      Pattern p = Pattern.compile(",");
+      java.util.List<String> parts =
+          p.splitAsStream("a,b,").collect(java.util.stream.Collectors.toList());
+      assertThat(parts).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("splitAsStream reads custom CharSequence content via charAt()")
+    void splitAsStreamCustomCharSequence() {
+      Pattern p = Pattern.compile(",");
+      java.util.List<String> parts =
+          p.splitAsStream(new LiteralCharSequence("a,b,c"))
+              .collect(java.util.stream.Collectors.toList());
+      assertThat(parts).containsExactly("a", "b", "c");
     }
   }
 


### PR DESCRIPTION
## Summary
- respect disabled anchoring bounds for region searches with stripped text anchors
- materialize split inputs via CharSequence.charAt() instead of toString()
- make splitAsStream discard trailing empty strings like Pattern.split(input, 0)
- add regression coverage for the verified behavior gaps

## Tests
- mvn -pl safere -Dtest=PatternTest,MatcherTest test -q
- mvn -pl safere test -q