### PR TITLE
Fix transparent bounds and functional replacements

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -7,6 +7,7 @@ package org.safere;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Function;
@@ -456,6 +457,7 @@ public final class Matcher implements MatchResult {
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     String savedText = text;
+    boolean regionSubstituted = false;
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
@@ -463,12 +465,16 @@ public final class Matcher implements MatchResult {
         hasMatch = false;
         return false;
       }
+      if (regionActive && transparentBounds) {
+        return matchesTransparentRegion();
+      }
       if (regionActive) {
         text = savedText.substring(regionStart, regionEnd);
+        regionSubstituted = true;
       }
       return matchesCore();
     } finally {
-      if (regionActive) {
+      if (regionSubstituted) {
         text = savedText;
         if (groups != null) {
           for (int i = 0; i < groups.length; i++) {
@@ -571,6 +577,7 @@ public final class Matcher implements MatchResult {
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     String savedText = text;
+    boolean regionSubstituted = false;
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
@@ -578,12 +585,16 @@ public final class Matcher implements MatchResult {
         hasMatch = false;
         return false;
       }
+      if (regionActive && transparentBounds) {
+        return lookingAtTransparentRegion();
+      }
       if (regionActive) {
         text = savedText.substring(regionStart, regionEnd);
+        regionSubstituted = true;
       }
       return lookingAtCore();
     } finally {
-      if (regionActive) {
+      if (regionSubstituted) {
         text = savedText;
         if (groups != null) {
           for (int i = 0; i < groups.length; i++) {
@@ -731,6 +742,7 @@ public final class Matcher implements MatchResult {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     String savedText = text;
     int savedSearchFrom = searchFrom;
+    boolean regionSubstituted = false;
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
@@ -738,13 +750,17 @@ public final class Matcher implements MatchResult {
         hasMatch = false;
         return false;
       }
+      if (regionActive && transparentBounds) {
+        return doFindTransparentRegion();
+      }
       if (regionActive) {
         text = savedText.substring(regionStart, regionEnd);
         searchFrom = Math.max(0, savedSearchFrom - regionStart);
+        regionSubstituted = true;
       }
       return doFindCore(regionActive);
     } finally {
-      if (regionActive) {
+      if (regionSubstituted) {
         text = savedText;
         searchFrom = savedSearchFrom;
         if (groups != null) {
@@ -783,6 +799,43 @@ public final class Matcher implements MatchResult {
     }
     return prog.dollarAnchorEnd()
         && Nfa.isAtTrailingLineTerminator(text, regionEnd, prog.unixLines());
+  }
+
+  private boolean matchesTransparentRegion() {
+    capturesResolved = true;
+    groupZeroResolved = true;
+    Prog prog = parentPattern.prog();
+    groups = searchWithBitStateOrNfa(
+        prog, text, regionStart, regionStart, regionEnd,
+        true, false, true, prog.numCaptures());
+    hasMatch = groups != null;
+    return hasMatch;
+  }
+
+  private boolean lookingAtTransparentRegion() {
+    capturesResolved = true;
+    groupZeroResolved = true;
+    Prog prog = parentPattern.prog();
+    groups = searchWithBitStateOrNfa(
+        prog, text, regionStart, regionStart, regionEnd,
+        true, false, false, prog.numCaptures());
+    hasMatch = groups != null;
+    return hasMatch;
+  }
+
+  private boolean doFindTransparentRegion() {
+    if (searchFrom > regionEnd) {
+      hasMatch = false;
+      return false;
+    }
+    capturesResolved = true;
+    groupZeroResolved = true;
+    Prog prog = parentPattern.prog();
+    groups = searchWithBitStateOrNfa(
+        prog, text, searchFrom, regionEnd, regionEnd,
+        false, false, false, prog.numCaptures());
+    hasMatch = groups != null;
+    return hasMatch;
   }
 
   /**
@@ -1357,7 +1410,8 @@ public final class Matcher implements MatchResult {
     } else {
       nfaKind = Nfa.MatchKind.FIRST_MATCH;
     }
-    return Nfa.search(prog, text, startPos, searchLimit, nfaAnchor, nfaKind, nsubmatch);
+    return Nfa.search(
+        prog, text, startPos, searchLimit, endPos, nfaAnchor, nfaKind, nsubmatch);
   }
 
   // ---------------------------------------------------------------------------
@@ -1586,9 +1640,7 @@ public final class Matcher implements MatchResult {
     reset();
     StringBuilder sb = new StringBuilder();
     if (find()) {
-      sb.append(text, appendPos, start());
-      sb.append(replacer.apply(toMatchResult()));
-      appendPos = end();
+      appendReplacement(sb, Objects.requireNonNull(replacer.apply(toMatchResult())));
     }
     appendTail(sb);
     return sb.toString();
@@ -1654,9 +1706,7 @@ public final class Matcher implements MatchResult {
     reset();
     StringBuilder sb = new StringBuilder();
     while (find()) {
-      sb.append(text, appendPos, start());
-      sb.append(replacer.apply(toMatchResult()));
-      appendPos = end();
+      appendReplacement(sb, Objects.requireNonNull(replacer.apply(toMatchResult())));
     }
     appendTail(sb);
     return sb.toString();

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -59,6 +59,7 @@ final class Nfa {
   private final int threadArraySize;
   private final boolean longest;
   private final boolean endmatch;
+  private final int endPos;
 
   private boolean matched;
   private int[] bestMatch;
@@ -67,12 +68,13 @@ final class Nfa {
   private List<NfaThread> runq;
   private List<NfaThread> nextq;
 
-  private Nfa(Prog prog, int ncapture, boolean longest, boolean endmatch) {
+  private Nfa(Prog prog, int ncapture, boolean longest, boolean endmatch, int endPos) {
     this.prog = prog;
     this.ncapture = ncapture;
     this.threadArraySize = ncapture + prog.numLoopRegs();
     this.longest = longest;
     this.endmatch = endmatch;
+    this.endPos = endPos;
     this.runq = new ArrayList<>();
     this.nextq = new ArrayList<>();
     this.bestMatch = new int[ncapture];
@@ -92,7 +94,7 @@ final class Nfa {
    *     is the end. -1 means the group did not participate.
    */
   static int[] search(Prog prog, String text, Anchor anchor, MatchKind kind, int nsubmatch) {
-    return search(prog, text, 0, text.length(), anchor, kind, nsubmatch);
+    return search(prog, text, 0, text.length(), text.length(), anchor, kind, nsubmatch);
   }
 
   /**
@@ -109,7 +111,7 @@ final class Nfa {
    */
   static int[] search(
       Prog prog, String text, int startPos, Anchor anchor, MatchKind kind, int nsubmatch) {
-    return search(prog, text, startPos, text.length(), anchor, kind, nsubmatch);
+    return search(prog, text, startPos, text.length(), text.length(), anchor, kind, nsubmatch);
   }
 
   /**
@@ -129,6 +131,11 @@ final class Nfa {
    */
   static int[] search(Prog prog, String text, int startPos, int searchLimit, Anchor anchor,
       MatchKind kind, int nsubmatch) {
+    return search(prog, text, startPos, searchLimit, text.length(), anchor, kind, nsubmatch);
+  }
+
+  static int[] search(Prog prog, String text, int startPos, int searchLimit, int endPos,
+      Anchor anchor, MatchKind kind, int nsubmatch) {
     if (prog.start() == 0) {
       return null;
     }
@@ -148,13 +155,13 @@ final class Nfa {
     // We always need at least capture[0..1] to track the match boundaries.
     int ncapture = 2 * Math.max(nsubmatch, 1);
 
-    Nfa nfa = new Nfa(prog, ncapture, longestMode, endmatch);
+    Nfa nfa = new Nfa(prog, ncapture, longestMode, endmatch, endPos);
     nfa.doSearch(text, startPos, searchLimit, anchored);
 
     if (!nfa.matched) {
       return null;
     }
-    if (kind == MatchKind.FULL_MATCH && nfa.bestMatch[1] != text.length()) {
+    if (kind == MatchKind.FULL_MATCH && nfa.bestMatch[1] != endPos) {
       return null;
     }
 
@@ -179,16 +186,14 @@ final class Nfa {
    * @param anchored whether to anchor the search at {@code startPos}
    */
   private void doSearch(String text, int startPos, int searchLimit, boolean anchored) {
-    int textLen = text.length();
-
     // The set of instruction IDs in each queue, for deduplication in addToThreadq.
     Set<Integer> runqSet = new HashSet<>();
     Set<Integer> nextqSet = new HashSet<>();
 
     int pos = startPos;
     while (true) {
-      int cp = (pos < textLen) ? text.codePointAt(pos) : -1;
-      int nextPos = (pos < textLen) ? pos + Character.charCount(cp) : textLen + 1;
+      int cp = (pos < endPos) ? text.codePointAt(pos) : -1;
+      int nextPos = (pos < endPos) ? pos + Character.charCount(cp) : endPos + 1;
 
       // Start a new thread if there have not been any matches
       // (no point starting new threads to the right of an existing match).
@@ -212,7 +217,7 @@ final class Nfa {
         }
         // In unanchored mode with no match yet, advance to the next position
         // and try again. Clear the visited set so instructions can be re-added.
-        if (pos >= textLen) {
+        if (pos >= endPos) {
           break;
         }
         runqSet.clear();
@@ -237,7 +242,7 @@ final class Nfa {
         break;
       }
 
-      if (pos >= textLen) {
+      if (pos >= endPos) {
         break;
       }
 
@@ -427,7 +432,7 @@ final class Nfa {
         }
 
         case MATCH -> {
-          boolean skip = endmatch && matchPos != text.length()
+          boolean skip = endmatch && matchPos != endPos
               && (!prog.dollarAnchorEnd()
                   || !isAtTrailingLineTerminator(text, matchPos, prog.unixLines()));
           if (!skip) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -952,6 +952,40 @@ class MatcherTest {
       assertThat(m.replaceFirst("[$1][$2]")).isEqualTo("[][b]");
     }
 
+    @Test
+    @DisplayName("replaceAll(Function) expands group references in returned replacement")
+    void replaceAllFunctionExpandsGroupReferences() {
+      Pattern p = Pattern.compile("(\\w+)");
+      Matcher m = p.matcher("hello world");
+      assertThat(m.replaceAll(result -> "[$1]")).isEqualTo("[hello] [world]");
+    }
+
+    @Test
+    @DisplayName("replaceFirst(Function) expands group references in returned replacement")
+    void replaceFirstFunctionExpandsGroupReferences() {
+      Pattern p = Pattern.compile("(\\w+)");
+      Matcher m = p.matcher("hello world");
+      assertThat(m.replaceFirst(result -> "[$1]")).isEqualTo("[hello] world");
+    }
+
+    @Test
+    @DisplayName("replaceAll(Function) rejects null replacement result")
+    void replaceAllFunctionRejectsNullReplacementResult() {
+      Pattern p = Pattern.compile("a");
+      Matcher m = p.matcher("a");
+      assertThatThrownBy(() -> m.replaceAll(result -> null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("replaceFirst(Function) rejects null replacement result")
+    void replaceFirstFunctionRejectsNullReplacementResult() {
+      Pattern p = Pattern.compile("a");
+      Matcher m = p.matcher("a");
+      assertThatThrownBy(() -> m.replaceFirst(result -> null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
   }
 
   @Nested
@@ -1686,6 +1720,26 @@ class MatcherTest {
       // So this tests that reset() works correctly
       String result = m.replaceAll("N");
       assertThat(result).isEqualTo("aaNbbNcc");
+    }
+
+    @Test
+    @DisplayName("transparent bounds let word boundary see before region start")
+    void transparentBoundsWordBoundarySeesBeforeRegionStart() {
+      Pattern p = Pattern.compile("\\bfoo");
+      Matcher m = p.matcher("afoo");
+      m.region(1, 4); // "foo", preceded by word char outside the region
+      m.useTransparentBounds(true);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("transparent bounds let word boundary see after region end")
+    void transparentBoundsWordBoundarySeesAfterRegionEnd() {
+      Pattern p = Pattern.compile("foo\\b");
+      Matcher m = p.matcher("fooa");
+      m.region(0, 3); // "foo", followed by word char outside the region
+      m.useTransparentBounds(true);
+      assertThat(m.find()).isFalse();
     }
   }
 


### PR DESCRIPTION
## Summary
- make replaceAll(Function) and replaceFirst(Function) apply normal replacement parsing to returned strings
- reject null function replacement results with NullPointerException
- make transparent region bounds visible to word-boundary assertions while preserving region consumption limits
- add regression coverage for functional replacements and transparent word boundaries

## Tests
- mvn -pl safere -Dtest=MatcherTest test -q
- mvn -pl safere test -q

Tests passed locally before rebasing onto the merged #196 base; not rerun after rebase per request.