### PR TITLE
Fix matcher state edge cases

### DIFF
--- a/.agents/skills/bug-hunt-fix/SKILL.md
+++ b/.agents/skills/bug-hunt-fix/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: bug-hunt-fix
+description: Systematic code bug hunting with regression-test proof and fixes. Use when Codex is asked to review a codebase or module for potential bugs, write tests that demonstrate each bug, verify the tests fail before fixing, implement principled fixes, and rerun focused and appropriate broader tests.
+---
+
+# Bug Hunt Fix
+
+## Overview
+
+Use this workflow to turn exploratory bug review into evidence-backed fixes. The central rule is:
+do not fix a suspected bug until a focused regression test fails for the right reason.
+
+## Workflow
+
+1. Establish the work surface.
+   - Check branch, worktree status, and any open PR or in-progress work.
+   - Preserve unrelated user changes. Do not reset or revert files you did not intentionally edit.
+   - Read project instructions and local test conventions before adding tests.
+
+2. Review systematically.
+   - Walk files by subsystem rather than randomly: public API/state, parser/validation, compiler,
+     engines, utilities, then performance shortcuts.
+   - Prefer API and state-machine invariants first; they often reveal testable mismatches.
+   - Compare behavior against authoritative references when relevant, such as the JDK for
+     Java-compatible regex APIs.
+
+3. Form candidate bugs as falsifiable claims.
+   - State the expected behavior, the observed code path, and why the current implementation may
+     violate the contract.
+   - Reject candidates that are intentional documented divergences or unsupported features.
+   - For temporally stable platform behavior, small local reference programs are useful.
+
+4. Write regression tests before implementation.
+   - Add narrow tests that fail only if the suspected bug exists.
+   - Name tests for behavior, not issue numbers.
+   - Run a focused test command and capture the failure message.
+   - If the test passes, the candidate is not verified; remove or rethink it before moving on.
+
+5. Fix the root cause.
+   - Make the smallest principled production change that repairs the invariant.
+   - Prefer sharing existing helpers and semantics over adding special cases.
+   - Keep changes scoped to the verified bugs unless another bug blocks the fix.
+
+6. Verify after the fix.
+   - Rerun the focused failing tests and ensure they now pass.
+   - Run broader tests based on blast radius. For public API or shared engine changes, run the
+     relevant module or full suite when feasible.
+   - Report any test that could not be run.
+
+7. Summarize with evidence.
+   - List each verified bug, the regression test that proved it, and the fix.
+   - Include exact test commands and pass/fail outcomes.
+   - Mention remaining risk or deliberately skipped broader validation.
+
+## Bug-Finding Heuristics
+
+- Look for methods that claim compatibility with a platform API; compare edge cases with that
+  platform.
+- Inspect reset, region, cursor, snapshot, and mutation state transitions.
+- Audit fast paths against the slow path contract: literals, prefixes, shortcuts, caches, and
+  deferred work.
+- Check null handling and exception types where the API is intended to be a drop-in replacement.
+- Check snapshot/copy APIs for missing metadata, stale state, or accidental aliasing.
+- Check bounded searches and regions for assertions that should see different boundaries than
+  consumed text.
+
+## Test Discipline
+
+- Keep the fail-first and pass-after-fix runs separate in the narrative.
+- Do not leave passing exploratory tests for disproven candidates unless they add meaningful
+  coverage and fit the requested scope.
+- When running long suites, keep the process alive until it exits or the user redirects the task.
+- If the user requests a target count of bugs, keep hunting until that count is reached or explain
+  why further candidates were not verified.

--- a/.agents/skills/bug-hunt-fix/agents/openai.yaml
+++ b/.agents/skills/bug-hunt-fix/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bug Hunt Fix"
+  short_description: "Find, prove, fix, and verify bugs"
+  default_prompt: "Use $bug-hunt-fix to review code systematically, prove bugs with failing tests, fix them, and verify the tests pass."

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -6,6 +6,8 @@
 package org.safere;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -82,6 +84,7 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean lastHitEnd;
   private boolean lastRequireEnd;
+  private int modCount;
 
   /**
    * Cached BitState instance borrowed from the parent Pattern's thread-local cache, reused across
@@ -452,6 +455,7 @@ public final class Matcher implements MatchResult {
    * @return {@code true} if the entire input sequence matches this matcher's pattern
    */
   public boolean matches() {
+    modCount++;
     searchFrom = regionStart;
 
     // --- Region setup ---
@@ -572,6 +576,7 @@ public final class Matcher implements MatchResult {
    * @return {@code true} if a prefix of the input sequence matches this matcher's pattern
    */
   public boolean lookingAt() {
+    modCount++;
     searchFrom = regionStart;
 
     // --- Region setup ---
@@ -669,6 +674,7 @@ public final class Matcher implements MatchResult {
    * @return {@code true} if a subsequence of the input sequence matches this matcher's pattern
    */
   public boolean find() {
+    modCount++;
     if (hasMatch) {
       // Only resolve deferred captures before advancing when group 0 itself is not authoritative.
       // If group 0 is already exact, find-all loops that never read inner captures should not pay
@@ -703,7 +709,8 @@ public final class Matcher implements MatchResult {
       throw new IndexOutOfBoundsException(
           "start=" + start + ", length=" + text.length());
     }
-    hasMatch = false;
+    modCount++;
+    reset();
     searchFrom = start;
     return doFind();
   }
@@ -1475,6 +1482,7 @@ public final class Matcher implements MatchResult {
    */
   @Override
   public String group(String name) {
+    Objects.requireNonNull(name, "Group name");
     Integer idx = parentPattern.namedGroups().get(name);
     if (idx == null) {
       throw new IllegalArgumentException(
@@ -1563,6 +1571,7 @@ public final class Matcher implements MatchResult {
    */
   @Override
   public int start(String name) {
+    Objects.requireNonNull(name, "Group name");
     Integer idx = parentPattern.namedGroups().get(name);
     if (idx == null) {
       throw new IllegalArgumentException("No group with name <" + name + ">");
@@ -1582,6 +1591,7 @@ public final class Matcher implements MatchResult {
    */
   @Override
   public int end(String name) {
+    Objects.requireNonNull(name, "Group name");
     Integer idx = parentPattern.namedGroups().get(name);
     if (idx == null) {
       throw new IllegalArgumentException("No group with name <" + name + ">");
@@ -1640,7 +1650,10 @@ public final class Matcher implements MatchResult {
     reset();
     StringBuilder sb = new StringBuilder();
     if (find()) {
-      appendReplacement(sb, Objects.requireNonNull(replacer.apply(toMatchResult())));
+      int expectedModCount = modCount;
+      String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
+      checkConcurrentModification(expectedModCount);
+      appendReplacement(sb, replacement);
     }
     appendTail(sb);
     return sb.toString();
@@ -1706,7 +1719,10 @@ public final class Matcher implements MatchResult {
     reset();
     StringBuilder sb = new StringBuilder();
     while (find()) {
-      appendReplacement(sb, Objects.requireNonNull(replacer.apply(toMatchResult())));
+      int expectedModCount = modCount;
+      String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
+      checkConcurrentModification(expectedModCount);
+      appendReplacement(sb, replacement);
     }
     appendTail(sb);
     return sb.toString();
@@ -1872,6 +1888,7 @@ public final class Matcher implements MatchResult {
    * @return this matcher
    */
   public Matcher reset() {
+    modCount++;
     this.text = charSequenceToString(inputSequence);
     regionStart = 0;
     regionEnd = text.length();
@@ -1924,6 +1941,7 @@ public final class Matcher implements MatchResult {
     }
     regionStart = start;
     regionEnd = end;
+    modCount++;
     hasMatch = false;
     searchFrom = start;
     appendPos = start;
@@ -1931,6 +1949,7 @@ public final class Matcher implements MatchResult {
     capturesResolved = true;
     groupZeroResolved = true;
     lastHitEnd = false;
+    lastRequireEnd = false;
     return this;
   }
 
@@ -2017,6 +2036,7 @@ public final class Matcher implements MatchResult {
     if (newPattern == null) {
       throw new IllegalArgumentException("Pattern cannot be null");
     }
+    modCount++;
     this.parentPattern = newPattern;
     // Invalidate cached DFA references since they belong to the old pattern.
     cachedForwardDfa = null;
@@ -2091,7 +2111,7 @@ public final class Matcher implements MatchResult {
     checkMatch();
     eagerFallbackCaptures = true;
     resolveCaptures();
-    return new SnapshotMatchResult(groups.clone(), text, groupCount());
+    return new SnapshotMatchResult(groups.clone(), text, groupCount(), parentPattern.namedGroups());
   }
 
   // ---------------------------------------------------------------------------
@@ -2164,6 +2184,12 @@ public final class Matcher implements MatchResult {
     }
   }
 
+  private void checkConcurrentModification(int expectedModCount) {
+    if (modCount != expectedModCount) {
+      throw new ConcurrentModificationException();
+    }
+  }
+
   /**
    * Processes a replacement string and appends the result to {@code sb}. Handles {@code $0},
    * {@code $1}, {@code ${name}}, {@code \\} (literal backslash), and {@code \$} (literal
@@ -2231,11 +2257,14 @@ public final class Matcher implements MatchResult {
     private final int[] groups;
     private final String text;
     private final int groupCount;
+    private final Map<String, Integer> namedGroups;
 
-    SnapshotMatchResult(int[] groups, String text, int groupCount) {
+    SnapshotMatchResult(
+        int[] groups, String text, int groupCount, Map<String, Integer> namedGroups) {
       this.groups = groups;
       this.text = text;
       this.groupCount = groupCount;
+      this.namedGroups = Collections.unmodifiableMap(namedGroups);
     }
 
     @Override
@@ -2250,6 +2279,11 @@ public final class Matcher implements MatchResult {
     }
 
     @Override
+    public int start(String name) {
+      return start(groupIndex(name));
+    }
+
+    @Override
     public int end() {
       return end(0);
     }
@@ -2258,6 +2292,11 @@ public final class Matcher implements MatchResult {
     public int end(int group) {
       validateGroup(group);
       return groups[2 * group + 1];
+    }
+
+    @Override
+    public int end(String name) {
+      return end(groupIndex(name));
     }
 
     @Override
@@ -2276,8 +2315,27 @@ public final class Matcher implements MatchResult {
     }
 
     @Override
+    public String group(String name) {
+      return group(groupIndex(name));
+    }
+
+    @Override
     public int groupCount() {
       return groupCount;
+    }
+
+    @Override
+    public Map<String, Integer> namedGroups() {
+      return namedGroups;
+    }
+
+    private int groupIndex(String name) {
+      Objects.requireNonNull(name, "Group name");
+      Integer idx = namedGroups.get(name);
+      if (idx == null) {
+        throw new IllegalArgumentException("No group with name <" + name + ">");
+      }
+      return idx;
     }
 
     private void validateGroup(int group) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -246,6 +246,21 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find(int) resets region before searching")
+    void findStartResetsRegion() {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("abc123def456");
+      m.region(3, 6); // "123"
+
+      assertThat(m.find(6)).isTrue();
+      assertThat(m.regionStart()).isEqualTo(0);
+      assertThat(m.regionEnd()).isEqualTo(12);
+      assertThat(m.group()).isEqualTo("456");
+      assertThat(m.start()).isEqualTo(9);
+      assertThat(m.end()).isEqualTo(12);
+    }
+
+    @Test
     @DisplayName("find() handles empty matches by advancing one character")
     void findEmptyMatches() {
       Pattern p = Pattern.compile("a*");
@@ -1116,6 +1131,20 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("toMatchResult() snapshot supports named-group lookup")
+    void toMatchResultNamedGroups() {
+      Pattern p = Pattern.compile("(?P<word>\\w+)");
+      Matcher m = p.matcher("hello");
+      assertThat(m.find()).isTrue();
+
+      MatchResult mr = m.toMatchResult();
+      assertThat(mr.namedGroups()).containsEntry("word", 1);
+      assertThat(mr.group("word")).isEqualTo("hello");
+      assertThat(mr.start("word")).isEqualTo(0);
+      assertThat(mr.end("word")).isEqualTo(5);
+    }
+
+    @Test
     @DisplayName("reset(CharSequence) allows reuse with different input")
     void resetCharSequenceReuse() {
       Pattern p = Pattern.compile("(\\d+)");
@@ -1335,6 +1364,30 @@ class MatcherTest {
       assertThatThrownBy(
               () -> m.replaceFirst((java.util.function.Function<MatchResult, String>) null))
           .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("replaceAll(Function) detects matcher mutation from replacer")
+    void replaceAllFunctionDetectsMatcherMutation() {
+      Pattern p = Pattern.compile("a");
+      Matcher m = p.matcher("aa");
+
+      assertThatThrownBy(() -> m.replaceAll(result -> {
+        m.find();
+        return "x";
+      })).isInstanceOf(java.util.ConcurrentModificationException.class);
+    }
+
+    @Test
+    @DisplayName("replaceFirst(Function) detects matcher mutation from replacer")
+    void replaceFirstFunctionDetectsMatcherMutation() {
+      Pattern p = Pattern.compile("a");
+      Matcher m = p.matcher("aa");
+
+      assertThatThrownBy(() -> m.replaceFirst(result -> {
+        m.find();
+        return "x";
+      })).isInstanceOf(java.util.ConcurrentModificationException.class);
     }
   }
 
@@ -1621,6 +1674,19 @@ class MatcherTest {
           .isInstanceOf(IndexOutOfBoundsException.class);
       assertThatThrownBy(() -> m.region(3, 1))
           .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    @DisplayName("region clears stale requireEnd state")
+    void regionClearsRequireEndState() {
+      Pattern p = Pattern.compile("a$");
+      Matcher m = p.matcher("a");
+      assertThat(m.find()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+
+      m.region(0, 1);
+      assertThat(m.hitEnd()).isFalse();
+      assertThat(m.requireEnd()).isFalse();
     }
 
     @Test
@@ -2321,9 +2387,22 @@ class MatcherTest {
       Matcher m = p.matcher("hello");
       assertThat(m.find()).isTrue();
       MatchResult result = m.toMatchResult();
-      // MatchResult.namedGroups() should work via the override on SnapshotMatchResult
-      // or the default method. SafeRE's Matcher overrides it.
-      assertThat(m.namedGroups()).containsEntry("word", 1);
+      assertThat(result.namedGroups()).containsEntry("word", 1);
+    }
+
+    @Test
+    @DisplayName("named group methods reject null names")
+    void namedGroupMethodsRejectNullNames() {
+      Pattern p = Pattern.compile("(?P<word>\\w+)");
+      Matcher m = p.matcher("hello");
+      assertThat(m.find()).isTrue();
+
+      assertThatThrownBy(() -> m.group((String) null))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> m.start((String) null))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> m.end((String) null))
+          .isInstanceOf(NullPointerException.class);
     }
   }
 


### PR DESCRIPTION
## Summary
- make find(int) reset the matcher region before searching, matching JDK behavior
- clear stale requireEnd state when region() resets match state
- preserve named-group lookup on toMatchResult() snapshots
- reject null named-group method arguments with NullPointerException
- detect matcher mutation from replaceAll/replaceFirst functional replacers
- add repo-local bug-hunting skill under .agents/skills/bug-hunt-fix

## Tests
- mvn -pl safere -Dtest=MatcherTest test -q
- mvn -pl safere test -q

Tests passed before rebasing onto merged #197; full rerun after rebase was skipped per request.