### PR TITLE
Fix lazy split stream and results mutation checks

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -736,7 +736,9 @@ public final class Matcher implements MatchResult {
             if (!find()) {
               return false;
             }
+            int expectedModCount = modCount;
             action.accept(toMatchResult());
+            checkConcurrentModification(expectedModCount);
             return true;
           }
         };

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -17,9 +17,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A compiled regular expression backed by a linear-time NFA engine. This class provides a drop-in
@@ -503,7 +505,10 @@ public final class Pattern implements Serializable {
    *     pattern
    */
   public Stream<String> splitAsStream(CharSequence input) {
-    return Arrays.stream(split(input, 0));
+    return StreamSupport.stream(
+        () -> Arrays.spliterator(split(input, 0)),
+        Spliterator.ORDERED | Spliterator.NONNULL,
+        false);
   }
 
   /**

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1296,6 +1296,21 @@ class MatcherTest {
       assertThat(results.get(1).start()).isEqualTo(12);
       assertThat(results.get(1).end()).isEqualTo(15);
     }
+
+    @Test
+    @DisplayName("results() detects matcher mutation during stream traversal")
+    void resultsDetectsMatcherMutation() {
+      Pattern p = Pattern.compile("a");
+      Matcher m = p.matcher("aa");
+
+      assertThatThrownBy(() -> m.results()
+          .map(result -> {
+            m.find();
+            return result.group();
+          })
+          .collect(java.util.stream.Collectors.toList()))
+          .isInstanceOf(java.util.ConcurrentModificationException.class);
+    }
   }
 
   @Nested

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -49,6 +49,34 @@ class PatternTest {
     }
   }
 
+  private static final class MutableCharSequence implements CharSequence {
+    private final StringBuilder value;
+
+    MutableCharSequence(String value) {
+      this.value = new StringBuilder(value);
+    }
+
+    void set(String newValue) {
+      value.setLength(0);
+      value.append(newValue);
+    }
+
+    @Override
+    public int length() {
+      return value.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      return value.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return value.subSequence(start, end);
+    }
+  }
+
   @Nested
   @DisplayName("compile()")
   class Compile {
@@ -974,6 +1002,19 @@ class PatternTest {
           p.splitAsStream(new LiteralCharSequence("a,b,c"))
               .collect(java.util.stream.Collectors.toList());
       assertThat(parts).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("splitAsStream reads input lazily when stream is consumed")
+    void splitAsStreamReadsInputLazily() {
+      Pattern p = Pattern.compile(",");
+      MutableCharSequence input = new MutableCharSequence("a,b");
+      Stream<String> stream = p.splitAsStream(input);
+
+      input.set("x,y,z");
+
+      assertThat(stream.collect(java.util.stream.Collectors.toList()))
+          .containsExactly("x", "y", "z");
     }
   }
 


### PR DESCRIPTION
## Summary
- make Pattern.splitAsStream defer reading the input until stream traversal
- preserve trailing-empty trimming while keeping splitAsStream lazy
- make Matcher.results() detect matcher mutation during stream traversal
- add regression coverage for both behaviors

## Tests
- mvn -pl safere -Dtest=PatternTest test -q
- mvn -pl safere -Dtest=MatcherTest test -q
- mvn -pl safere test -q