### PR TITLE
Fix Unicode flag and matching priority bugs

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -641,8 +641,8 @@ public final class Matcher implements MatchResult {
     Prog prog = parentPattern.prog();
 
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
-    OnePass onePass = parentPattern.onePass();
-    if (onePass != null) {
+    if (parentPattern.canOnePassPrimary()) {
+      OnePass onePass = parentPattern.onePass();
       groups = onePass.search(text, false, prog.numCaptures());
       hasMatch = (groups != null);
       return hasMatch;

--- a/safere/src/main/java/org/safere/ParseFlags.java
+++ b/safere/src/main/java/org/safere/ParseFlags.java
@@ -104,8 +104,11 @@ final class ParseFlags {
    */
   public static final int UNIX_LINES = 1 << 16;
 
+  /** Use Unicode-aware case folding when {@link #FOLD_CASE} is active. */
+  public static final int UNICODE_CASE = 1 << 17;
+
   /** Mask of all valid parse flags. */
-  public static final int ALL_FLAGS = (1 << 17) - 1;
+  public static final int ALL_FLAGS = (1 << 18) - 1;
 
   private ParseFlags() {} // Non-instantiable.
 }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -9,7 +9,9 @@ package org.safere;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -62,6 +64,7 @@ final class Parser {
   private StackEntry stacktop;
   private int ncap;
   private final int runeMax;
+  private final Set<String> namedCaptures = new HashSet<>();
 
   private Parser(String pattern, int flags) {
     this.pattern = pattern;
@@ -392,7 +395,7 @@ final class Parser {
       CharClass cc = re.charClass;
       if (cc.numRanges() == 1 && cc.lo(0) == cc.hi(0)) {
         int r = cc.lo(0);
-        re = Regexp.literal(r, flags);
+        re = Regexp.literal(r, re.flags);
       } else if (cc.numRanges() == 2) {
         int r = cc.lo(0);
         if ('A' <= r && r <= 'Z'
@@ -413,7 +416,13 @@ final class Parser {
   private void pushLiteral(int r) {
     // Do case folding if needed.
     if ((flags & ParseFlags.FOLD_CASE) != 0) {
-      if (cycleFoldRune(r) != r) {
+      if ((flags & ParseFlags.UNICODE_CASE) == 0) {
+        int folded = asciiFoldRune(r);
+        if (folded != r) {
+          pushRegexp(Regexp.literal(folded, flags));
+          return;
+        }
+      } else if (cycleFoldRune(r) != r) {
         CharClassBuilder ccb = new CharClassBuilder();
         int r1 = r;
         do {
@@ -435,11 +444,18 @@ final class Parser {
     }
 
     // No fancy stuff worked. Ordinary literal.
-    if (maybeConcatString(r, flags)) {
+    int literalFlags = flags;
+    if ((flags & ParseFlags.FOLD_CASE) != 0
+        && (flags & ParseFlags.UNICODE_CASE) == 0
+        && asciiFoldRune(r) == r
+        && !('a' <= r && r <= 'z')) {
+      literalFlags &= ~ParseFlags.FOLD_CASE;
+    }
+    if (maybeConcatString(r, literalFlags)) {
       return;
     }
 
-    Regexp re = Regexp.literal(r, flags);
+    Regexp re = Regexp.literal(r, literalFlags);
     pushRegexp(re);
   }
 
@@ -660,6 +676,10 @@ final class Parser {
   }
 
   private void doLeftParen(String name) {
+    if (name != null && !namedCaptures.add(name)) {
+      throw new PatternSyntaxException(
+          "named capturing group <" + name + "> is already defined", pattern, pos);
+    }
     StackEntry e = newMarker(LEFT_PAREN);
     e.cap = ++ncap;
     e.name = name;
@@ -1340,7 +1360,7 @@ final class Parser {
       name = name.substring(1);
     }
 
-    int[][] table = lookupUnicodeGroup(name);
+    int[][] table = lookupUnicodeGroup(name, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
     if (table == null) {
       throw new PatternSyntaxException(
           "invalid Unicode group: " + name, pattern, seqStart);
@@ -1354,7 +1374,7 @@ final class Parser {
     return PARSE_OK;
   }
 
-  private static int[][] lookupUnicodeGroup(String name) {
+  private static int[][] lookupUnicodeGroup(String name, boolean unicodeCharacterClass) {
     if ("Any".equals(name)) {
       return new int[][] {{0, Utils.MAX_RUNE}};
     }
@@ -1362,7 +1382,9 @@ final class Parser {
     if (table != null) {
       return table;
     }
-    table = UnicodeTables.POSIX_PROPERTY_GROUPS.get(name);
+    table = unicodeCharacterClass
+        ? UnicodeTables.unicodePosixPropertyGroups().get(name)
+        : UnicodeTables.POSIX_PROPERTY_GROUPS.get(name);
     if (table != null) {
       return table;
     }
@@ -1436,7 +1458,9 @@ final class Parser {
       lookupName = "[:" + name.substring(3);
     }
 
-    int[][] table = UnicodeTables.POSIX_GROUPS.get(lookupName);
+    int[][] table = (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0
+        ? UnicodeTables.unicodePosixGroups().get(lookupName)
+        : UnicodeTables.POSIX_GROUPS.get(lookupName);
     if (table == null) {
       throw new PatternSyntaxException("invalid POSIX class: " + name, pattern, pos);
     }
@@ -1504,6 +1528,10 @@ final class Parser {
 
     // If folding case, add fold-equivalent characters too.
     if ((parseFlags & ParseFlags.FOLD_CASE) != 0) {
+      if ((parseFlags & ParseFlags.UNICODE_CASE) == 0) {
+        addAsciiFoldedRange(ccb, lo, hi);
+        return;
+      }
       addFoldedRange(ccb, lo, hi, 0);
     } else {
       ccb.addRange(lo, hi);
@@ -1511,6 +1539,30 @@ final class Parser {
   }
 
   // ---- Case folding ----
+
+  private static int asciiFoldRune(int r) {
+    if ('A' <= r && r <= 'Z') {
+      return r + ('a' - 'A');
+    }
+    if ('a' <= r && r <= 'z') {
+      return r;
+    }
+    return r;
+  }
+
+  private static void addAsciiFoldedRange(CharClassBuilder ccb, int lo, int hi) {
+    ccb.addRange(lo, hi);
+    int upperLo = Math.max(lo, 'A');
+    int upperHi = Math.min(hi, 'Z');
+    if (upperLo <= upperHi) {
+      ccb.addRange(upperLo + ('a' - 'A'), upperHi + ('a' - 'A'));
+    }
+    int lowerLo = Math.max(lo, 'a');
+    int lowerHi = Math.min(hi, 'z');
+    if (lowerLo <= lowerHi) {
+      ccb.addRange(lowerLo - ('a' - 'A'), lowerHi - ('a' - 'A'));
+    }
+  }
 
   /**
    * Look up the case fold entry containing r. Returns the index into CASE_FOLD, or -1 if none
@@ -1710,15 +1762,17 @@ final class Parser {
         }
         case 'u' -> {
           sawflags = true;
-          if (negated) nflags &= ~ParseFlags.UNICODE_GROUPS;
-          else nflags |= ParseFlags.UNICODE_GROUPS;
+          if (negated) nflags &= ~ParseFlags.UNICODE_CASE;
+          else nflags |= ParseFlags.UNICODE_CASE;
         }
         case 'U' -> {
           sawflags = true;
           if (negated) {
-            nflags &= ~(ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS);
+            nflags &= ~(ParseFlags.UNICODE_CASE | ParseFlags.UNICODE_GROUPS
+                | ParseFlags.UNICODE_CHAR_CLASS);
           } else {
-            nflags |= ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS;
+            nflags |= ParseFlags.UNICODE_CASE | ParseFlags.UNICODE_GROUPS
+                | ParseFlags.UNICODE_CHAR_CLASS;
           }
         }
         case 'x' -> {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -238,10 +238,11 @@ public final class Pattern implements Serializable {
    */
   public static Pattern compile(String regex, int flags) {
     validateFlags(flags);
-    int parseFlags = toParseFlags(flags);
+    int effectiveFlags = effectiveFlags(flags);
+    int parseFlags = toParseFlags(effectiveFlags);
     Regexp re = Parser.parse(regex, parseFlags);
     Prog compiled = Compiler.compile(re);
-    compiled.setUnixLines((flags & UNIX_LINES) != 0);
+    compiled.setUnixLines((effectiveFlags & UNIX_LINES) != 0);
     Map<String, Integer> named = extractNamedGroups(re);
     PrefixResult prefixResult = extractPrefix(re);
     String prefix = prefixResult.prefix();
@@ -262,7 +263,7 @@ public final class Pattern implements Serializable {
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(re);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
-    return new Pattern(regex, flags, compiled, re, named, prefix, prefixFoldCase,
+    return new Pattern(regex, effectiveFlags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
         hasEndConst, ccPrefixAscii, startAcceleration, keywordAlternation,
         ccMatch != null ? ccMatch.ranges : null,
@@ -604,7 +605,8 @@ public final class Pattern implements Serializable {
       // with JDK's leftmost-first (biased) semantics for nullable alternations.
       boolean canPrimary = op != null
           && op.search("", false, 0) == null
-          && !hasLazy;
+          && !hasLazy
+          && !hasNullableAlternation;
       // canFind is canPrimary restricted to anchored patterns (legacy flag).
       boolean canFind = canPrimary && prog.anchorStart();
       // OnePass can be used for the sandwich submatch extraction step (anchored, endMatch=true)
@@ -887,6 +889,14 @@ public final class Pattern implements Serializable {
     }
   }
 
+  /** Returns JDK-compatible effective flags after applying implied flags. */
+  private static int effectiveFlags(int flags) {
+    if ((flags & UNICODE_CHARACTER_CLASS) != 0) {
+      flags |= UNICODE_CASE;
+    }
+    return flags;
+  }
+
   /**
    * Converts {@code java.util.regex.Pattern} flags to internal {@link ParseFlags}.
    *
@@ -915,7 +925,7 @@ public final class Pattern implements Serializable {
       pf |= ParseFlags.COMMENTS;
     }
     if ((flags & UNICODE_CASE) != 0) {
-      pf |= ParseFlags.UNICODE_GROUPS;
+      pf |= ParseFlags.UNICODE_CASE;
     }
     if ((flags & UNICODE_CHARACTER_CLASS) != 0) {
       pf |= ParseFlags.UNICODE_GROUPS | ParseFlags.UNICODE_CHAR_CLASS;

--- a/safere/src/main/java/org/safere/UnicodeTables.java
+++ b/safere/src/main/java/org/safere/UnicodeTables.java
@@ -7,7 +7,10 @@
 
 package org.safere;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.function.IntPredicate;
 
 /**
  * Unicode character data tables for the SafeRE regular expression library.
@@ -110,6 +113,87 @@ final class UnicodeTables {
       Map.entry("Cntrl", POSIX_CNTRL),
       Map.entry("XDigit", POSIX_XDIGIT),
       Map.entry("Space", POSIX_SPACE));
+
+  private static final class UnicodePosixHolder {
+    static final int[][] UNICODE_ALPHA = UnicodeProperties.lookupBinaryProperty("Alphabetic");
+    static final int[][] UNICODE_DIGIT = UnicodeProperties.lookupBinaryProperty("Digit");
+    static final int[][] UNICODE_ALNUM = mergeRangeTables(UNICODE_ALPHA, UNICODE_DIGIT);
+    static final int[][] UNICODE_PUNCT = UnicodeProperties.lookupBinaryProperty("Punctuation");
+    static final int[][] UNICODE_CNTRL = UnicodeProperties.lookupBinaryProperty("Control");
+    static final int[][] UNICODE_XDIGIT = UnicodeProperties.lookupBinaryProperty("Hex_Digit");
+    static final int[][] UNICODE_GRAPH =
+        buildRanges(
+            cp ->
+                Character.isDefined(cp)
+                    && Character.getType(cp) != Character.CONTROL
+                    && Character.getType(cp) != Character.SURROGATE
+                    && !isUnicodeWhiteSpace(cp));
+    static final int[][] UNICODE_PRINT = mergeRangeTables(UNICODE_GRAPH, HORIZ_SPACE);
+
+    static final Map<String, int[][]> UNICODE_POSIX_PROPERTY_GROUPS =
+        Map.ofEntries(
+            Map.entry("Lower", UnicodeProperties.lookupBinaryProperty("Lowercase")),
+            Map.entry("Upper", UnicodeProperties.lookupBinaryProperty("Uppercase")),
+            Map.entry("ASCII", POSIX_ASCII),
+            Map.entry("Alpha", UNICODE_ALPHA),
+            Map.entry("Digit", UNICODE_DIGIT),
+            Map.entry("Alnum", UNICODE_ALNUM),
+            Map.entry("Punct", UNICODE_PUNCT),
+            Map.entry("Graph", UNICODE_GRAPH),
+            Map.entry("Print", UNICODE_PRINT),
+            Map.entry("Blank", HORIZ_SPACE),
+            Map.entry("Cntrl", UNICODE_CNTRL),
+            Map.entry("XDigit", UNICODE_XDIGIT),
+            Map.entry("Space", unicodeSpace()));
+
+    static final Map<String, int[][]> UNICODE_POSIX_GROUPS =
+        Map.ofEntries(
+            Map.entry("[:alnum:]", UNICODE_ALNUM),
+            Map.entry("[:alpha:]", UNICODE_ALPHA),
+            Map.entry("[:ascii:]", POSIX_ASCII),
+            Map.entry("[:blank:]", HORIZ_SPACE),
+            Map.entry("[:cntrl:]", UNICODE_CNTRL),
+            Map.entry("[:digit:]", UNICODE_DIGIT),
+            Map.entry("[:graph:]", UNICODE_GRAPH),
+            Map.entry("[:lower:]", UnicodeProperties.lookupBinaryProperty("Lowercase")),
+            Map.entry("[:print:]", UNICODE_PRINT),
+            Map.entry("[:punct:]", UNICODE_PUNCT),
+            Map.entry("[:space:]", unicodeSpace()),
+            Map.entry("[:upper:]", UnicodeProperties.lookupBinaryProperty("Uppercase")),
+            Map.entry("[:word:]", unicodeWord()),
+            Map.entry("[:xdigit:]", UNICODE_XDIGIT));
+  }
+
+  static Map<String, int[][]> unicodePosixPropertyGroups() {
+    return UnicodePosixHolder.UNICODE_POSIX_PROPERTY_GROUPS;
+  }
+
+  static Map<String, int[][]> unicodePosixGroups() {
+    return UnicodePosixHolder.UNICODE_POSIX_GROUPS;
+  }
+
+  private static boolean isUnicodeWhiteSpace(int cp) {
+    return Character.isWhitespace(cp) || Character.isSpaceChar(cp);
+  }
+
+  private static int[][] buildRanges(IntPredicate predicate) {
+    List<int[]> ranges = new ArrayList<>();
+    int lo = -1;
+    for (int cp = 0; cp <= Character.MAX_CODE_POINT; cp++) {
+      if (predicate.test(cp)) {
+        if (lo < 0) {
+          lo = cp;
+        }
+      } else if (lo >= 0) {
+        ranges.add(new int[] {lo, cp - 1});
+        lo = -1;
+      }
+    }
+    if (lo >= 0) {
+      ranges.add(new int[] {lo, Character.MAX_CODE_POINT});
+    }
+    return ranges.toArray(new int[0][]);
+  }
 
   // Case folding sentinel values
   public static final int EVEN_ODD = 1;

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -87,6 +87,28 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("lookingAt() respects lazy quantifier priority")
+    void lookingAtRespectsLazyQuantifierPriority() {
+      Matcher m = Pattern.compile("(a+?)").matcher("aaa");
+
+      assertThat(m.lookingAt()).isTrue();
+      assertThat(m.group()).isEqualTo("a");
+      assertThat(m.group(1)).isEqualTo("a");
+      assertThat(m.end()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("lookingAt() respects empty alternative priority")
+    void lookingAtRespectsEmptyAlternativePriority() {
+      Matcher m = Pattern.compile("(|a)").matcher("a");
+
+      assertThat(m.lookingAt()).isTrue();
+      assertThat(m.group()).isEmpty();
+      assertThat(m.group(1)).isEmpty();
+      assertThat(m.end()).isEqualTo(0);
+    }
+
+    @Test
     @DisplayName("matches() with alternation and non-participating group")
     void matchesAlternation() {
       Pattern p = Pattern.compile("(a)|(b)");

--- a/safere/src/test/java/org/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/org/safere/ParseFlagsTest.java
@@ -53,7 +53,7 @@ class ParseFlagsTest {
 
   @Test
   void allFlagsCoversAllBits() {
-    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 17) - 1);
+    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 18) - 1);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1610,11 +1610,20 @@ class ParserTest {
     }
 
     @Test
-    void caseInsensitiveCharClass_addsUnicodeFolds() {
-      // (?i)[a-z] should include the Unicode K-with-stroke (0x212A) and long-s (0x17F).
-      Regexp re = parse("(?i)[a-z]");
+    void caseInsensitiveUnicodeCaseCharClassAddsUnicodeFolds() {
+      // (?iu)[a-z] should include the Kelvin sign (0x212A) and long-s (0x17F).
+      Regexp re = parse("(?iu)[a-z]");
       assertThat(re.charClass.contains(0x17F)).isTrue(); // ſ (long s)
       assertThat(re.charClass.contains(0x212A)).isTrue(); // K (Kelvin sign)
+    }
+
+    @Test
+    void caseInsensitiveCharClassUsesAsciiFoldsWithoutUnicodeCase() {
+      Regexp re = parse("(?i)[a-z]");
+      assertThat(re.charClass.contains('A')).isTrue();
+      assertThat(re.charClass.contains('Z')).isTrue();
+      assertThat(re.charClass.contains(0x17F)).isFalse();
+      assertThat(re.charClass.contains(0x212A)).isFalse();
     }
 
     @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -533,6 +533,15 @@ class PatternTest {
       Pattern p = Pattern.compile("hello", flags);
       assertThat(p.flags()).isEqualTo(flags);
     }
+
+    @Test
+    @DisplayName("UNICODE_CHARACTER_CLASS implies UNICODE_CASE in flags()")
+    void unicodeCharacterClassImpliesUnicodeCaseFlag() {
+      Pattern p = Pattern.compile("\\w+", Pattern.UNICODE_CHARACTER_CLASS);
+
+      assertThat(p.flags())
+          .isEqualTo(Pattern.UNICODE_CHARACTER_CLASS | Pattern.UNICODE_CASE);
+    }
   }
 
   @Nested
@@ -568,6 +577,15 @@ class PatternTest {
       Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
       assertThatThrownBy(() -> p.namedGroups().put("foo", 99))
           .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("duplicate named capturing groups are rejected")
+    void duplicateNamedGroupsRejected() {
+      assertThatThrownBy(() -> Pattern.compile("(?<word>a)(?<word>b)"))
+          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> Pattern.compile("(?P<word>a)(?P<word>b)"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
   }
 

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -120,10 +120,14 @@ class SimplifierTest {
         // Unicode case folding
         Arguments.of("(?i)A", "[Aa]"),
         Arguments.of("(?i)a", "[Aa]"),
-        Arguments.of("(?i)K", "[Kk\\x{212a}]"),
-        Arguments.of("(?i)k", "[Kk\\x{212a}]"),
-        Arguments.of("(?i)\\x{212a}", "[Kk\\x{212a}]"),
-        Arguments.of("(?i)[a-z]", "[A-Za-z\\x{17f}\\x{212a}]"),
+        Arguments.of("(?i)K", "[Kk]"),
+        Arguments.of("(?i)k", "[Kk]"),
+        Arguments.of("(?i)\\x{212a}", "\\x{212a}"),
+        Arguments.of("(?i)[a-z]", "[A-Za-z]"),
+        Arguments.of("(?iu)K", "[Kk\\x{212a}]"),
+        Arguments.of("(?iu)k", "[Kk\\x{212a}]"),
+        Arguments.of("(?iu)\\x{212a}", "[Kk\\x{212a}]"),
+        Arguments.of("(?iu)[a-z]", "[A-Za-z\\x{17f}\\x{212a}]"),
         Arguments.of("(?i)[\\x00-\\x{FFFD}]", "[\\x00-\\x{fffd}]"),
         Arguments.of("(?i)[\\x00-\\x{10ffff}]", "."),
 

--- a/safere/src/test/java/org/safere/UnicodeCaseTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCaseTest.java
@@ -15,10 +15,8 @@ import org.junit.jupiter.api.Test;
  * <p>{@code UNICODE_CASE} controls <i>how</i> case folding works (Unicode vs ASCII-only) when
  * {@link Pattern#CASE_INSENSITIVE} is also set. By itself, it should have no effect on matching.
  *
- * <p><b>Known divergence from JDK:</b> SafeRE always performs Unicode case folding when
- * {@link Pattern#CASE_INSENSITIVE} is set (because the RE2-derived engine uses Unicode tables by
- * default). In the JDK, {@code CASE_INSENSITIVE} alone only folds ASCII, and you must also set
- * {@code UNICODE_CASE} for Unicode folding.
+ * <p>{@code CASE_INSENSITIVE} alone folds ASCII only, matching the JDK. Add
+ * {@code UNICODE_CASE} for Unicode-aware folding.
  */
 class UnicodeCaseTest {
 
@@ -41,11 +39,10 @@ class UnicodeCaseTest {
   }
 
   @Test
-  void unicodeCaseFoldingWithCaseInsensitiveOnly() {
-    // SafeRE divergence: Unicode folding works with CASE_INSENSITIVE alone.
-    // In JDK, this would NOT match "CAFÉ" without UNICODE_CASE.
+  void unicodeCaseFoldingRequiresUnicodeCase() {
     Pattern p = Pattern.compile("café", Pattern.CASE_INSENSITIVE);
-    assertThat(p.matcher("CAFÉ").matches()).isTrue();
+    assertThat(p.matcher("CAFÉ").matches()).isFalse();
+    assertThat(p.matcher("Café").matches()).isTrue();
   }
 
   @Test
@@ -81,6 +78,13 @@ class UnicodeCaseTest {
     assertThat(p.matcher("Á").matches()).isTrue();
     assertThat(p.matcher("ã").matches()).isTrue();
     assertThat(p.matcher("Ã").matches()).isTrue();
+  }
+
+  @Test
+  void characterClassUnicodeCaseRequiresUnicodeCase() {
+    Pattern p = Pattern.compile("[à-ã]", Pattern.CASE_INSENSITIVE);
+    assertThat(p.matcher("á").matches()).isTrue();
+    assertThat(p.matcher("Á").matches()).isFalse();
   }
 
   @Test
@@ -125,8 +129,14 @@ class UnicodeCaseTest {
 
   @Test
   void inlineFlagCaseInsensitive() {
-    // (?i) enables case insensitive matching. SafeRE always does Unicode folding.
     Pattern p = Pattern.compile("(?i)café");
+    assertThat(p.matcher("CAFÉ").matches()).isFalse();
+    assertThat(p.matcher("Café").matches()).isTrue();
+  }
+
+  @Test
+  void inlineFlagUnicodeCaseEnablesUnicodeFolding() {
+    Pattern p = Pattern.compile("(?iu)café");
     assertThat(p.matcher("CAFÉ").matches()).isTrue();
   }
 

--- a/safere/src/test/java/org/safere/UnicodeCharClassTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCharClassTest.java
@@ -19,6 +19,35 @@ class UnicodeCharClassTest {
 
   private static final int UCC = Pattern.UNICODE_CHARACTER_CLASS;
 
+  @Nested
+  class PosixUnicodeCharacterClassTests {
+
+    @Test
+    void posixAlphaUsesUnicodeWithFlag() {
+      Pattern p = Pattern.compile("\\p{Alpha}+", UCC);
+      assertThat(p.matcher("é中").matches()).isTrue();
+    }
+
+    @Test
+    void posixLowerAndUpperUseUnicodeWithFlag() {
+      assertThat(Pattern.compile("\\p{Lower}", UCC).matcher("é").matches()).isTrue();
+      assertThat(Pattern.compile("\\p{Upper}", UCC).matcher("É").matches()).isTrue();
+    }
+
+    @Test
+    void posixDigitUsesUnicodeWithFlag() {
+      Pattern p = Pattern.compile("\\p{Digit}+", UCC);
+      assertThat(p.matcher("\u0661").matches()).isTrue();
+    }
+
+    @Test
+    void posixPunctUsesUnicodePunctuationWithFlag() {
+      Pattern p = Pattern.compile("\\p{Punct}", UCC);
+      assertThat(p.matcher("\u3002").matches()).isTrue();
+      assertThat(p.matcher("$").matches()).isFalse();
+    }
+  }
+
   // -------------------------------------------------------------------------
   // \d — Unicode digit (category Nd)
   // -------------------------------------------------------------------------

--- a/safere/src/test/java/org/safere/UnicodeTablesTest.java
+++ b/safere/src/test/java/org/safere/UnicodeTablesTest.java
@@ -280,11 +280,12 @@ class UnicodeTablesTest {
   @Test
   void caseInsensitiveMatching_unicodePairs() {
     // Verify case-insensitive matching works for some interesting Unicode pairs.
-    assertThat(Pattern.compile("é", Pattern.CASE_INSENSITIVE).matcher("É").matches()).isTrue();
-    assertThat(Pattern.compile("Ú", Pattern.CASE_INSENSITIVE).matcher("ú").matches()).isTrue();
-    assertThat(Pattern.compile("k", Pattern.CASE_INSENSITIVE).matcher("\u212A").matches())
+    int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+    assertThat(Pattern.compile("é", flags).matcher("É").matches()).isTrue();
+    assertThat(Pattern.compile("Ú", flags).matcher("ú").matches()).isTrue();
+    assertThat(Pattern.compile("k", flags).matcher("\u212A").matches())
         .isTrue();
-    assertThat(Pattern.compile("K", Pattern.CASE_INSENSITIVE).matcher("\u212A").matches())
+    assertThat(Pattern.compile("K", flags).matcher("\u212A").matches())
         .isTrue();
   }
 


### PR DESCRIPTION
## Summary
- Make CASE_INSENSITIVE fold ASCII-only unless UNICODE_CASE is enabled, and report UNICODE_CASE when UNICODE_CHARACTER_CLASS implies it
- Respect leftmost-first priority for lookingAt() with lazy quantifiers and nullable alternations
- Reject duplicate named capture groups and use Unicode POSIX properties under UNICODE_CHARACTER_CLASS

## Tests
- mvn -pl safere test -q (passed before rebasing onto merged #202)
- Post-rebase rerun was started, then stopped at user request to make the PR without rerunning tests