### PR TITLE
Reject malformed counted repetition syntax

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -207,10 +207,7 @@ final class Parser {
           int opStart = pos;
           int[] lohi = maybeParseRepetition();
           if (lohi == null) {
-            // Treat like a literal.
-            pushLiteral('{');
-            pos++; // '{'
-            break;
+            throw new PatternSyntaxException("Illegal repetition", pattern, opStart);
           }
           int lo = lohi[0];
           int hi = lohi[1];

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -854,6 +854,18 @@ class JdkSyntaxCompatibilityTest {
       assertMatchesSame("a{2,4}", "aaaaa");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"{", "{?", "a{?", "a{,2}", "a{x}", "\\\\Q{?\\\\E"})
+    @DisplayName("malformed unescaped counted repetition")
+    void malformedUnescapedCountedRepetition(String regex) {
+      assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
+          .as("JDK should reject malformed counted repetition: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .as("SafeRE should reject malformed counted repetition: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
     // -- Reluctant --
 
     @Test
@@ -992,6 +1004,12 @@ class JdkSyntaxCompatibilityTest {
     @DisplayName("\\\\Q...\\\\E with normal regex after")
     void quotationWithRegexAfter() {
       assertMatchesSame("\\Q.+\\E.+", ".+ab");
+    }
+
+    @Test
+    @DisplayName("\\\\Q...\\\\E quotes braces")
+    void quotationWithBrace() {
+      assertMatchesSame("\\Q{?\\E", "{?");
     }
   }
 

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -180,8 +180,8 @@ class ParserTest {
     }
 
     @Test
-    void literalBrace() {
-      Regexp re = parse("{");
+    void escapedBrace() {
+      Regexp re = parse("\\{");
       assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
       assertThat(re.rune).isEqualTo('{');
     }
@@ -630,9 +630,8 @@ class ParserTest {
     }
 
     @Test
-    void starAfterBrace() {
-      // a*{ → concatenation of star(a) and literal({)
-      Regexp re = parse("a*{");
+    void starAfterEscapedBrace() {
+      Regexp re = parse("a*\\{");
       assertThat(re.op).isEqualTo(RegexpOp.CONCAT);
     }
   }
@@ -1284,6 +1283,13 @@ class ParserTest {
           .isInstanceOf(PatternSyntaxException.class);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"{", "{?", "a{?", "a{,2}", "a{x}", "\\\\Q{?\\\\E"})
+    void malformedUnescapedCountedRepetition(String pattern) {
+      assertThatThrownBy(() -> parse(pattern))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
     @Test
     void trailingBackslash() {
       assertThatThrownBy(() -> parse("\\"))
@@ -1569,9 +1575,8 @@ class ParserTest {
     }
 
     @Test
-    void commaNotRepeat() {
-      // a{,2} is not a valid repeat syntax → treated as literal.
-      Regexp re = parse("a{,2}");
+    void escapedBraceWithCommaIsLiteral() {
+      Regexp re = parse("a\\{,2}");
       assertThat(re.toString()).isEqualTo("a\\{,2\\}");
     }
 


### PR DESCRIPTION
## Summary
- reject unescaped `{` when it does not form valid counted repetition syntax
- keep escaped and `\Q...\E` quoted braces as literals
- add parser and JDK syntax compatibility regression coverage for malformed `{` cases

Fixes #199

## Tests
- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest,ParserTest test -q`
- `mvn -pl safere test -q`