### PR TITLE
Fix leading ampersands in character classes

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -897,7 +897,8 @@ final class Parser {
       }
 
       // Character class intersection: &&
-      if (pos + 1 < pattern.length()
+      if (!first
+          && pos + 1 < pattern.length()
           && pattern.charAt(pos) == '&'
           && pattern.charAt(pos + 1) == '&') {
         pos += 2; // skip '&&'

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -426,6 +426,16 @@ class JdkSyntaxCompatibilityTest {
       assertMatchesFull("[a-z&&[def]]", "a");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"[&&`+]˫]*", "[&&abc]", "[a&&&&b]"})
+    @DisplayName("empty left side of class intersection matches like JDK")
+    void emptyLeftSideOfIntersection(String regex) {
+      assertMatchesSame(regex, "");
+      assertMatchesSame(regex, "a");
+      assertMatchesSame(regex, "`");
+      assertMatchesSame(regex, "˫");
+    }
+
     @Test
     @DisplayName("subtraction [a-z&&[^bc]]")
     void subtraction() {


### PR DESCRIPTION
## Summary
- Treat && as a character-class intersection operator only after a left-hand class item exists
- Add JDK compatibility regression coverage for the fuzzed pattern from #200 and related leading-ampersand forms

## Tests
- mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test -q
- mvn -pl safere test -q

Fixes #200