### PR TITLE
Fix matcher end state and region append bugs

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -488,8 +488,7 @@ public final class Matcher implements MatchResult {
           }
         }
       }
-      lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
-      lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
+      updateEndState(false);
     }
   }
 
@@ -609,8 +608,7 @@ public final class Matcher implements MatchResult {
           }
         }
       }
-      lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
-      lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
+      updateEndState(false);
     }
   }
 
@@ -784,9 +782,7 @@ public final class Matcher implements MatchResult {
           deferredMatchEnd += regionStart;
         }
       }
-      // Track hitEnd: true if no match found (engine scanned to end) or match reaches regionEnd.
-      lastHitEnd = !hasMatch || (groups != null && groups[1] == regionEnd);
-      lastRequireEnd = hasMatch && lastHitEnd && parentPattern.hasEndConstraint();
+      updateEndState(true);
     }
   }
 
@@ -1946,7 +1942,7 @@ public final class Matcher implements MatchResult {
     modCount++;
     hasMatch = false;
     searchFrom = start;
-    appendPos = start;
+    appendPos = 0;
     groups = null;
     capturesResolved = true;
     groupZeroResolved = true;
@@ -2023,6 +2019,23 @@ public final class Matcher implements MatchResult {
    */
   public Pattern pattern() {
     return parentPattern;
+  }
+
+  @Override
+  public String toString() {
+    String lastMatch = "";
+    if (hasMatch && groups != null && groups[0] >= 0 && groups[1] >= groups[0]) {
+      lastMatch = text.substring(groups[0], groups[1]);
+    }
+    return "org.safere.Matcher[pattern="
+        + parentPattern.pattern()
+        + " region="
+        + regionStart
+        + ","
+        + regionEnd
+        + " lastmatch="
+        + lastMatch
+        + "]";
   }
 
   /**
@@ -2190,6 +2203,26 @@ public final class Matcher implements MatchResult {
     if (modCount != expectedModCount) {
       throw new ConcurrentModificationException();
     }
+  }
+
+  private void updateEndState(boolean findOperation) {
+    if (!hasMatch || groups == null) {
+      lastHitEnd = findOperation;
+      lastRequireEnd = false;
+      return;
+    }
+    boolean endSensitive = parentPattern.hasEndConstraint() && matchEndsAtSensitiveEnd();
+    lastHitEnd = endSensitive;
+    lastRequireEnd = endSensitive;
+  }
+
+  private boolean matchEndsAtSensitiveEnd() {
+    if (groups[1] == regionEnd) {
+      return true;
+    }
+    Prog prog = parentPattern.prog();
+    return prog.dollarAnchorEnd()
+        && Nfa.isAtTrailingLineTerminator(text, groups[1], prog.unixLines());
   }
 
   /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -39,6 +39,11 @@ import java.util.stream.StreamSupport;
  * </ul>
  */
 public final class Matcher implements MatchResult {
+  private enum MatchOperation {
+    MATCHES,
+    LOOKING_AT,
+    FIND
+  }
 
   /**
    * Minimum text length for the reverse-first optimization on end-anchored patterns. For shorter
@@ -488,7 +493,7 @@ public final class Matcher implements MatchResult {
           }
         }
       }
-      updateEndState(false);
+      updateEndState(MatchOperation.MATCHES);
     }
   }
 
@@ -608,7 +613,7 @@ public final class Matcher implements MatchResult {
           }
         }
       }
-      updateEndState(false);
+      updateEndState(MatchOperation.LOOKING_AT);
     }
   }
 
@@ -782,7 +787,7 @@ public final class Matcher implements MatchResult {
           deferredMatchEnd += regionStart;
         }
       }
-      updateEndState(true);
+      updateEndState(MatchOperation.FIND);
     }
   }
 
@@ -2211,15 +2216,15 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  private void updateEndState(boolean findOperation) {
+  private void updateEndState(MatchOperation operation) {
     if (!hasMatch || groups == null) {
-      lastHitEnd = findOperation;
+      lastHitEnd = operation == MatchOperation.FIND;
       lastRequireEnd = false;
       return;
     }
-    boolean endSensitive = parentPattern.hasEndConstraint() && matchEndsAtSensitiveEnd();
-    lastHitEnd = endSensitive;
-    lastRequireEnd = endSensitive;
+    boolean endedAtSensitiveEnd = matchEndsAtSensitiveEnd();
+    lastRequireEnd = endedAtSensitiveEnd && parentPattern.hasEndConstraint();
+    lastHitEnd = lastRequireEnd || (endedAtSensitiveEnd && matchCanExtendAtEnd(operation));
   }
 
   private boolean matchEndsAtSensitiveEnd() {
@@ -2229,6 +2234,104 @@ public final class Matcher implements MatchResult {
     Prog prog = parentPattern.prog();
     return prog.dollarAnchorEnd()
         && Nfa.isAtTrailingLineTerminator(text, groups[1], prog.unixLines());
+  }
+
+  private boolean matchCanExtendAtEnd(MatchOperation operation) {
+    java.util.List<String> samples = new java.util.ArrayList<>();
+    collectTerminalRepeatSamples(parentPattern.ast(), samples);
+    if (samples.isEmpty()) {
+      return false;
+    }
+    int relativeStart = groups[0] - regionStart;
+    int relativeEnd = groups[1] - regionStart;
+    String regionText = text.substring(regionStart, regionEnd);
+    Prog prog = parentPattern.prog();
+    for (String sample : samples) {
+      if (sample.isEmpty()) {
+        continue;
+      }
+      String probeText = regionText + sample;
+      int[] result = switch (operation) {
+        case MATCHES -> Nfa.search(
+            prog, probeText, 0, probeText.length(),
+            Nfa.Anchor.ANCHORED, Nfa.MatchKind.FULL_MATCH, 1);
+        case LOOKING_AT, FIND -> Nfa.search(
+            prog, probeText, relativeStart, probeText.length(),
+            Nfa.Anchor.ANCHORED, Nfa.MatchKind.LONGEST_MATCH, 1);
+      };
+      if (result != null && result[0] == relativeStart && result[1] > relativeEnd) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void collectTerminalRepeatSamples(Regexp re, java.util.List<String> samples) {
+    switch (re.op) {
+      case STAR, PLUS -> addSample(re.subs.get(0), samples);
+      case REPEAT -> {
+        if (re.max < 0) {
+          addSample(re.subs.get(0), samples);
+        }
+      }
+      case CAPTURE -> collectTerminalRepeatSamples(re.subs.get(0), samples);
+      case CONCAT -> {
+        for (int i = re.subs.size() - 1; i >= 0; i--) {
+          Regexp sub = re.subs.get(i);
+          collectTerminalRepeatSamples(sub, samples);
+          if (!Pattern.canMatchEmpty(sub)) {
+            break;
+          }
+        }
+      }
+      case ALTERNATE -> {
+        for (Regexp sub : re.subs) {
+          collectTerminalRepeatSamples(sub, samples);
+        }
+      }
+      default -> {}
+    }
+  }
+
+  private static void addSample(Regexp re, java.util.List<String> samples) {
+    String sample = sampleString(re);
+    if (sample != null && !sample.isEmpty()) {
+      samples.add(sample);
+    }
+  }
+
+  private static String sampleString(Regexp re) {
+    return switch (re.op) {
+      case LITERAL -> new String(Character.toChars(re.rune));
+      case LITERAL_STRING -> new String(re.runes, 0, re.runes.length);
+      case CHAR_CLASS -> re.charClass.isEmpty()
+          ? null
+          : new String(Character.toChars(re.charClass.lo(0)));
+      case ANY_CHAR -> "a";
+      case CAPTURE -> sampleString(re.subs.get(0));
+      case CONCAT -> {
+        StringBuilder sb = new StringBuilder();
+        for (Regexp sub : re.subs) {
+          String sample = sampleString(sub);
+          if (sample == null) {
+            yield null;
+          }
+          sb.append(sample);
+        }
+        yield sb.toString();
+      }
+      case ALTERNATE -> {
+        String sample = null;
+        for (Regexp sub : re.subs) {
+          sample = sampleString(sub);
+          if (sample != null) {
+            break;
+          }
+        }
+        yield sample;
+      }
+      default -> null;
+    };
   }
 
   /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2052,6 +2052,12 @@ public final class Matcher implements MatchResult {
       throw new IllegalArgumentException("Pattern cannot be null");
     }
     modCount++;
+    if (hasMatch && groups != null) {
+      searchFrom = groups[1];
+      if (groups[0] == groups[1] && searchFrom < regionEnd) {
+        searchFrom++;
+      }
+    }
     this.parentPattern = newPattern;
     // Invalidate cached DFA references since they belong to the old pattern.
     cachedForwardDfa = null;

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -355,8 +355,27 @@ final class Parser {
     }
 
     // Regular escape
+    if (isUnsupportedLargeNonZeroOctalEscape()) {
+      pos += 4; // '\', digit, digit, digit
+      pushRegexp(Regexp.noMatch(flags));
+      return;
+    }
     int r = parseEscape();
     pushLiteral(r);
+  }
+
+  private boolean isUnsupportedLargeNonZeroOctalEscape() {
+    if (pos + 3 >= pattern.length() || pattern.charAt(pos) != '\\') {
+      return false;
+    }
+    char d0 = pattern.charAt(pos + 1);
+    char d1 = pattern.charAt(pos + 2);
+    char d2 = pattern.charAt(pos + 3);
+    if (d0 < '4' || d0 > '7' || d1 < '0' || d1 > '7' || d2 < '0' || d2 > '7') {
+      return false;
+    }
+    int value = (d0 - '0') * 64 + (d1 - '0') * 8 + (d2 - '0');
+    return value > 0377;
   }
 
   // ---- Stack operations ----
@@ -923,27 +942,16 @@ final class Parser {
         }
         // Parse the right-hand side of the intersection.
         CharClassBuilder rhs = new CharClassBuilder();
-        if (pos < pattern.length() && pattern.charAt(pos) == '[') {
-          // &&[...] — parse nested class as the right side.
-          Regexp nested = parseCharClass();
-          rhs.addCharClass(nested.charClass);
-        } else {
-          // &&<ranges> — parse remaining ranges until ']' as the right side.
-          while (pos < pattern.length() && pattern.charAt(pos) != ']'
-              && !(pos + 1 < pattern.length()
-                  && pattern.charAt(pos) == '&' && pattern.charAt(pos + 1) == '&')) {
-            if (pos < pattern.length() && pattern.charAt(pos) == '[') {
-              Regexp nested = parseCharClass();
-              rhs.addCharClass(nested.charClass);
-            } else {
-              int[] rr = parseCCRange();
-              addRangeFlags(rhs, rr[0], rr[1], flags | ParseFlags.CLASS_NL);
-            }
+        while (pos < pattern.length() && pattern.charAt(pos) != ']'
+            && !(pos + 1 < pattern.length()
+                && pattern.charAt(pos) == '&' && pattern.charAt(pos + 1) == '&')) {
+          if (pos < pattern.length() && pattern.charAt(pos) == '[') {
+            Regexp nested = parseCharClass();
+            rhs.addCharClass(nested.charClass);
+          } else {
+            int[] rr = parseCCRange();
+            addRangeFlags(rhs, rr[0], rr[1], flags | ParseFlags.CLASS_NL);
           }
-        }
-        if (negated) {
-          ccb.negate();
-          negated = false;
         }
         ccb.intersect(rhs);
         continue;
@@ -1134,8 +1142,11 @@ final class Parser {
           pos++;
           if (pos < pattern.length() && pattern.charAt(pos) >= '0'
               && pattern.charAt(pos) <= '7') {
-            code = code * 8 + pattern.charAt(pos) - '0';
-            pos++;
+            int next = code * 8 + pattern.charAt(pos) - '0';
+            if (next <= 0377) {
+              code = next;
+              pos++;
+            }
           }
         }
         if (code > runeMax) {
@@ -1145,6 +1156,11 @@ final class Parser {
       }
       case '0' -> {
         // JDK: \0nnn — up to three octal digits after \0 (max value 0377 = 255).
+        if (pos >= pattern.length()
+            || pattern.charAt(pos) < '0'
+            || pattern.charAt(pos) > '7') {
+          throw new PatternSyntaxException("Illegal octal escape sequence", pattern, pos);
+        }
         int code = 0;
         int digits = 0;
         while (digits < 3 && pos < pattern.length()

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -918,6 +918,9 @@ final class Parser {
           && pattern.charAt(pos) == '&'
           && pattern.charAt(pos + 1) == '&') {
         pos += 2; // skip '&&'
+        if (pos < pattern.length() && pattern.charAt(pos) == ']') {
+          break;
+        }
         // Parse the right-hand side of the intersection.
         CharClassBuilder rhs = new CharClassBuilder();
         if (pos < pattern.length() && pattern.charAt(pos) == '[') {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1038,7 +1038,7 @@ public final class Pattern implements Serializable {
    * Returns {@code true} if the given regexp can match the empty string. Used to detect nullable
    * alternation branches where OnePass's longest-match semantics may differ from first-match.
    */
-  private static boolean canMatchEmpty(Regexp re) {
+  static boolean canMatchEmpty(Regexp re) {
     return switch (re.op) {
       case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
            NO_WORD_BOUNDARY -> true;

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1509,6 +1509,19 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("usePattern continues searching after the previous match")
+    void usePatternContinuesAfterPreviousMatchEnd() {
+      Matcher m = Pattern.compile("a").matcher("ab");
+      assertThat(m.find()).isTrue();
+
+      m.usePattern(Pattern.compile("."));
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.group()).isEqualTo("b");
+    }
+
+    @Test
     @DisplayName("usePattern returns this matcher")
     void usePatternReturnsSelf() {
       Pattern p1 = Pattern.compile("a");

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1114,6 +1114,23 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("toString() reports pattern, region, and last match")
+    void toStringReportsMatcherState() {
+      Matcher m = Pattern.compile("a").matcher("ba");
+
+      assertThat(m.toString())
+          .contains("pattern=a")
+          .contains("region=0,2")
+          .contains("lastmatch=");
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.toString())
+          .contains("pattern=a")
+          .contains("region=0,2")
+          .contains("lastmatch=a");
+    }
+
+    @Test
     @DisplayName("toMatchResult() returns an independent snapshot")
     void toMatchResult() {
       Pattern p = Pattern.compile("(\\d+)");
@@ -1455,6 +1472,22 @@ class MatcherTest {
       m.appendReplacement(sb, "$2/$1");
       m.appendTail(sb);
       assertThat(sb.toString()).isEqualTo("host/user");
+    }
+
+    @Test
+    @DisplayName("appendReplacement with region preserves text outside the region")
+    void stringBufferAppendReplacementPreservesTextOutsideRegion() {
+      Pattern p = Pattern.compile("\\d");
+      Matcher m = p.matcher("ab1cd2ef");
+      m.region(2, 6);
+      StringBuffer sb = new StringBuffer();
+
+      while (m.find()) {
+        m.appendReplacement(sb, "X");
+      }
+      m.appendTail(sb);
+
+      assertThat(sb.toString()).isEqualTo("abXcdXef");
     }
   }
 
@@ -1851,13 +1884,13 @@ class MatcherTest {
   class HitEndTests {
 
     @Test
-    @DisplayName("hitEnd is true when match extends to end of input")
-    void hitEndMatchAtEnd() {
+    @DisplayName("hitEnd is false for a complete literal match")
+    void hitEndFalseForCompleteLiteralMatch() {
       Pattern p = Pattern.compile("\\w+");
       Matcher m = p.matcher("abc");
       assertThat(m.find()).isTrue();
       assertThat(m.group()).isEqualTo("abc");
-      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.hitEnd()).isFalse();
     }
 
     @Test
@@ -1880,14 +1913,14 @@ class MatcherTest {
     }
 
     @Test
-    @DisplayName("hitEnd respects region boundaries")
-    void hitEndWithRegion() {
+    @DisplayName("hitEnd is false for a complete literal match at region end")
+    void hitEndFalseForCompleteLiteralMatchAtRegionEnd() {
       Pattern p = Pattern.compile("\\d+");
       Matcher m = p.matcher("abc123def456ghi");
       m.region(3, 6); // "123"
       assertThat(m.find()).isTrue();
       assertThat(m.group()).isEqualTo("123");
-      assertThat(m.hitEnd()).isTrue(); // match extends to regionEnd
+      assertThat(m.hitEnd()).isFalse();
     }
 
     @Test
@@ -1902,21 +1935,30 @@ class MatcherTest {
     }
 
     @Test
-    @DisplayName("hitEnd true with matches()")
-    void hitEndWithMatches() {
+    @DisplayName("hitEnd is false for literal matches()")
+    void hitEndFalseForLiteralMatches() {
       Pattern p = Pattern.compile("abc");
       Matcher m = p.matcher("abc");
       assertThat(m.matches()).isTrue();
-      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.hitEnd()).isFalse();
     }
 
     @Test
-    @DisplayName("hitEnd true with lookingAt() matching to end")
-    void hitEndWithLookingAtToEnd() {
+    @DisplayName("hitEnd is false for literal lookingAt()")
+    void hitEndFalseForLiteralLookingAt() {
       Pattern p = Pattern.compile("abc");
       Matcher m = p.matcher("abc");
       assertThat(m.lookingAt()).isTrue();
-      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.hitEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("hitEnd is false for failed matches() that does not need more input")
+    void hitEndFalseForFailedLiteralMatches() {
+      Pattern p = Pattern.compile("abc");
+      Matcher m = p.matcher("abx");
+      assertThat(m.matches()).isFalse();
+      assertThat(m.hitEnd()).isFalse();
     }
 
     @Test
@@ -2314,6 +2356,15 @@ class MatcherTest {
     void requireEndTrueForDollarAnchor() {
       Pattern p = Pattern.compile("abc$");
       Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+    }
+
+    @Test
+    @DisplayName("requireEnd() is true for dollar anchor before trailing terminator")
+    void requireEndTrueForDollarAnchorBeforeTrailingTerminator() {
+      Pattern p = Pattern.compile("abc$");
+      Matcher m = p.matcher("abc\n");
       assertThat(m.find()).isTrue();
       assertThat(m.requireEnd()).isTrue();
     }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1897,13 +1897,14 @@ class MatcherTest {
   class HitEndTests {
 
     @Test
-    @DisplayName("hitEnd is false for a complete literal match")
-    void hitEndFalseForCompleteLiteralMatch() {
+    @DisplayName("hitEnd is true when a variable-length match reaches end")
+    void hitEndTrueForVariableLengthMatchAtEnd() {
       Pattern p = Pattern.compile("\\w+");
       Matcher m = p.matcher("abc");
       assertThat(m.find()).isTrue();
       assertThat(m.group()).isEqualTo("abc");
-      assertThat(m.hitEnd()).isFalse();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isFalse();
     }
 
     @Test
@@ -1926,14 +1927,15 @@ class MatcherTest {
     }
 
     @Test
-    @DisplayName("hitEnd is false for a complete literal match at region end")
-    void hitEndFalseForCompleteLiteralMatchAtRegionEnd() {
+    @DisplayName("hitEnd is true when a variable-length match reaches region end")
+    void hitEndTrueForVariableLengthMatchAtRegionEnd() {
       Pattern p = Pattern.compile("\\d+");
       Matcher m = p.matcher("abc123def456ghi");
       m.region(3, 6); // "123"
       assertThat(m.find()).isTrue();
       assertThat(m.group()).isEqualTo("123");
-      assertThat(m.hitEnd()).isFalse();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isFalse();
     }
 
     @Test
@@ -1954,6 +1956,16 @@ class MatcherTest {
       Matcher m = p.matcher("abc");
       assertThat(m.matches()).isTrue();
       assertThat(m.hitEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("hitEnd is true for variable-length matches() at end")
+    void hitEndTrueForVariableLengthMatchesAtEnd() {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("123");
+      assertThat(m.matches()).isTrue();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isFalse();
     }
 
     @Test

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1045,9 +1045,8 @@ class ParserTest {
 
     @Test
     void octal_nul() {
-      Regexp re = parse("\\0");
-      assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
-      assertThat(re.rune).isEqualTo(0x00);
+      assertThatThrownBy(() -> parse("\\0"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1078,6 +1078,15 @@ class PatternTest {
     }
 
     @Test
+    @DisplayName("[a-z&&] keeps the left-hand class when intersection has no right operand")
+    void trailingIntersectionKeepsLeftHandClass() {
+      Pattern p = Pattern.compile("[a-z&&]");
+      assertThat(p.matcher("a").matches()).isTrue();
+      assertThat(p.matcher("z").matches()).isTrue();
+      assertThat(p.matcher("&").matches()).isFalse();
+    }
+
+    @Test
     @DisplayName("[^[A-F]] negates the union")
     void negatedNestedCharClass() {
       Pattern p = Pattern.compile("[^[A-F]]");

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1087,11 +1087,57 @@ class PatternTest {
     }
 
     @Test
+    @DisplayName("[^a&&[ab]] applies intersection before negating the left side")
+    void negatedIntersectionKeepsNegatedLeftHandClass() {
+      Pattern p = Pattern.compile("[^a&&[ab]]");
+      assertThat(p.matcher("a").matches()).isFalse();
+      assertThat(p.matcher("b").matches()).isTrue();
+      assertThat(p.matcher("z").matches()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[a-z&&[def]1] intersects with the whole right-hand union")
+    void intersectionRightHandSideIncludesRangesAfterNestedClass() {
+      Pattern p = Pattern.compile("[a-z&&[def]1]");
+      assertThat(p.matcher("d").matches()).isTrue();
+      assertThat(p.matcher("f").matches()).isTrue();
+      assertThat(p.matcher("1").matches()).isFalse();
+    }
+
+    @Test
     @DisplayName("[^[A-F]] negates the union")
     void negatedNestedCharClass() {
       Pattern p = Pattern.compile("[^[A-F]]");
       assertThat(p.matcher("A").find()).isFalse();
       assertThat(p.matcher("G").find()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("octal escapes")
+  class OctalEscapeTests {
+
+    @Test
+    @DisplayName("\\0 without octal digits is rejected")
+    void zeroOctalEscapeRequiresDigits() {
+      assertThatThrownBy(() -> Pattern.compile("\\0"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    @DisplayName("\\08 is rejected because \\0 requires an octal digit")
+    void zeroOctalEscapeRejectsNonOctalDigit() {
+      assertThatThrownBy(() -> Pattern.compile("\\08"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    @DisplayName("octal escapes above 0377 do not become Unicode code points")
+    void largeOctalEscapesDoNotBecomeUnicodeCodePoints() {
+      assertThat(Pattern.compile("\\400").matcher("\u0100").matches()).isFalse();
+      assertThat(Pattern.compile("\\777").matcher("\u01ff").matches()).isFalse();
+      assertThat(Pattern.compile("\\400").matcher(" 0").matches()).isFalse();
+      assertThat(Pattern.compile("\\777").matcher("?7").matches()).isFalse();
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix Matcher hitEnd/requireEnd state for complete literal matches, failed operations, and dollar anchors before trailing line terminators
- preserve appendReplacement/appendTail text before an active region
- add JDK-style Matcher.toString state reporting
- preserve the left-hand class for trailing character-class intersections like [a-z&&]

## Verification
- fail-first focused tests were verified before fixes
- mvn -pl safere -Dtest=MatcherTest,PatternTest test -q
- mvn -pl safere test -q
- per request, tests were not rerun after rebasing onto main