### PR TITLE
Fix parser and matcher compatibility bugs

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2052,6 +2052,12 @@ public final class Matcher implements MatchResult {
       throw new IllegalArgumentException("Pattern cannot be null");
     }
     modCount++;
+    if (hasMatch && groups != null) {
+      searchFrom = groups[1];
+      if (groups[0] == groups[1] && searchFrom < regionEnd) {
+        searchFrom++;
+      }
+    }
     this.parentPattern = newPattern;
     // Invalidate cached DFA references since they belong to the old pattern.
     cachedForwardDfa = null;

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -355,8 +355,27 @@ final class Parser {
     }
 
     // Regular escape
+    if (isUnsupportedLargeNonZeroOctalEscape()) {
+      pos += 4; // '\', digit, digit, digit
+      pushRegexp(Regexp.noMatch(flags));
+      return;
+    }
     int r = parseEscape();
     pushLiteral(r);
+  }
+
+  private boolean isUnsupportedLargeNonZeroOctalEscape() {
+    if (pos + 3 >= pattern.length() || pattern.charAt(pos) != '\\') {
+      return false;
+    }
+    char d0 = pattern.charAt(pos + 1);
+    char d1 = pattern.charAt(pos + 2);
+    char d2 = pattern.charAt(pos + 3);
+    if (d0 < '4' || d0 > '7' || d1 < '0' || d1 > '7' || d2 < '0' || d2 > '7') {
+      return false;
+    }
+    int value = (d0 - '0') * 64 + (d1 - '0') * 8 + (d2 - '0');
+    return value > 0377;
   }
 
   // ---- Stack operations ----
@@ -923,27 +942,16 @@ final class Parser {
         }
         // Parse the right-hand side of the intersection.
         CharClassBuilder rhs = new CharClassBuilder();
-        if (pos < pattern.length() && pattern.charAt(pos) == '[') {
-          // &&[...] — parse nested class as the right side.
-          Regexp nested = parseCharClass();
-          rhs.addCharClass(nested.charClass);
-        } else {
-          // &&<ranges> — parse remaining ranges until ']' as the right side.
-          while (pos < pattern.length() && pattern.charAt(pos) != ']'
-              && !(pos + 1 < pattern.length()
-                  && pattern.charAt(pos) == '&' && pattern.charAt(pos + 1) == '&')) {
-            if (pos < pattern.length() && pattern.charAt(pos) == '[') {
-              Regexp nested = parseCharClass();
-              rhs.addCharClass(nested.charClass);
-            } else {
-              int[] rr = parseCCRange();
-              addRangeFlags(rhs, rr[0], rr[1], flags | ParseFlags.CLASS_NL);
-            }
+        while (pos < pattern.length() && pattern.charAt(pos) != ']'
+            && !(pos + 1 < pattern.length()
+                && pattern.charAt(pos) == '&' && pattern.charAt(pos + 1) == '&')) {
+          if (pos < pattern.length() && pattern.charAt(pos) == '[') {
+            Regexp nested = parseCharClass();
+            rhs.addCharClass(nested.charClass);
+          } else {
+            int[] rr = parseCCRange();
+            addRangeFlags(rhs, rr[0], rr[1], flags | ParseFlags.CLASS_NL);
           }
-        }
-        if (negated) {
-          ccb.negate();
-          negated = false;
         }
         ccb.intersect(rhs);
         continue;
@@ -1134,8 +1142,11 @@ final class Parser {
           pos++;
           if (pos < pattern.length() && pattern.charAt(pos) >= '0'
               && pattern.charAt(pos) <= '7') {
-            code = code * 8 + pattern.charAt(pos) - '0';
-            pos++;
+            int next = code * 8 + pattern.charAt(pos) - '0';
+            if (next <= 0377) {
+              code = next;
+              pos++;
+            }
           }
         }
         if (code > runeMax) {
@@ -1145,6 +1156,11 @@ final class Parser {
       }
       case '0' -> {
         // JDK: \0nnn — up to three octal digits after \0 (max value 0377 = 255).
+        if (pos >= pattern.length()
+            || pattern.charAt(pos) < '0'
+            || pattern.charAt(pos) > '7') {
+          throw new PatternSyntaxException("Illegal octal escape sequence", pattern, pos);
+        }
         int code = 0;
         int digits = 0;
         while (digits < 3 && pos < pattern.length()

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1509,6 +1509,19 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("usePattern continues searching after the previous match")
+    void usePatternContinuesAfterPreviousMatchEnd() {
+      Matcher m = Pattern.compile("a").matcher("ab");
+      assertThat(m.find()).isTrue();
+
+      m.usePattern(Pattern.compile("."));
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.group()).isEqualTo("b");
+    }
+
+    @Test
     @DisplayName("usePattern returns this matcher")
     void usePatternReturnsSelf() {
       Pattern p1 = Pattern.compile("a");

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1045,9 +1045,8 @@ class ParserTest {
 
     @Test
     void octal_nul() {
-      Regexp re = parse("\\0");
-      assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
-      assertThat(re.rune).isEqualTo(0x00);
+      assertThatThrownBy(() -> parse("\\0"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1087,11 +1087,57 @@ class PatternTest {
     }
 
     @Test
+    @DisplayName("[^a&&[ab]] applies intersection before negating the left side")
+    void negatedIntersectionKeepsNegatedLeftHandClass() {
+      Pattern p = Pattern.compile("[^a&&[ab]]");
+      assertThat(p.matcher("a").matches()).isFalse();
+      assertThat(p.matcher("b").matches()).isTrue();
+      assertThat(p.matcher("z").matches()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[a-z&&[def]1] intersects with the whole right-hand union")
+    void intersectionRightHandSideIncludesRangesAfterNestedClass() {
+      Pattern p = Pattern.compile("[a-z&&[def]1]");
+      assertThat(p.matcher("d").matches()).isTrue();
+      assertThat(p.matcher("f").matches()).isTrue();
+      assertThat(p.matcher("1").matches()).isFalse();
+    }
+
+    @Test
     @DisplayName("[^[A-F]] negates the union")
     void negatedNestedCharClass() {
       Pattern p = Pattern.compile("[^[A-F]]");
       assertThat(p.matcher("A").find()).isFalse();
       assertThat(p.matcher("G").find()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("octal escapes")
+  class OctalEscapeTests {
+
+    @Test
+    @DisplayName("\\0 without octal digits is rejected")
+    void zeroOctalEscapeRequiresDigits() {
+      assertThatThrownBy(() -> Pattern.compile("\\0"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    @DisplayName("\\08 is rejected because \\0 requires an octal digit")
+    void zeroOctalEscapeRejectsNonOctalDigit() {
+      assertThatThrownBy(() -> Pattern.compile("\\08"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    @DisplayName("octal escapes above 0377 do not become Unicode code points")
+    void largeOctalEscapesDoNotBecomeUnicodeCodePoints() {
+      assertThat(Pattern.compile("\\400").matcher("\u0100").matches()).isFalse();
+      assertThat(Pattern.compile("\\777").matcher("\u01ff").matches()).isFalse();
+      assertThat(Pattern.compile("\\400").matcher(" 0").matches()).isFalse();
+      assertThat(Pattern.compile("\\777").matcher("?7").matches()).isFalse();
     }
   }
 }


### PR DESCRIPTION
## Summary
- preserve Matcher.usePattern search position after a successful previous match
- fix Java character-class intersection semantics for negated left-hand classes and RHS unions after nested classes
- align octal escape handling with JDK behavior for malformed zero escapes and large octal escapes

## Verification
- fail-first focused tests were verified before fixes
- mvn -pl safere -Dtest=MatcherTest,PatternTest,ParserTest test -q
- mvn -pl safere test -q
- direct JDK-vs-SafeRE probe for the changed edge cases matched after the final octal adjustment
- per request, tests were not rerun after fetching/rebasing current refs