### PR TITLE
Run public API tests through crosscheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
           mvn install -pl safere -DskipTests --batch-mode --no-transfer-progress -q
 
       - name: Build and test crosscheck module
-        run: mvn verify -pl safere-crosscheck --batch-mode --no-transfer-progress
+        run: >
+          mvn verify -pl safere-crosscheck -Pcrosscheck-public-api-tests
+          --batch-mode --no-transfer-progress
 
   benchmark-smoke-test-java:
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
 - **Never push to a PR (or create one) without first verifying locally that
   all tests pass** (`mvn -pl safere test`). CI failures waste time and block
   merges.
+- Before making a PR, also run the public API crosscheck invariant:
+  `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test`. This runs
+  generated copies of allowlisted SafeRE public API tests through
+  `org.safere.crosscheck` so each test operation is compared with the JDK.
 - **Update existing PRs — do not close and reopen.** Push commits (or
   force-push if rebasing) to the existing branch. Closing and reopening PRs
   loses review context and clutters the issue tracker.

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -121,6 +121,26 @@ The crosscheck facade covers:
 | **State** | `reset()`, `region()`, `useTransparentBounds()`, `useAnchoringBounds()` |
 | **Other** | `hitEnd()`, `requireEnd()`, `toMatchResult()`, `namedGroups()` |
 
+## Crosschecking SafeRE Tests
+
+The `crosscheck-public-api-tests` Maven profile runs generated copies of
+selected SafeRE public API tests through the crosscheck facade:
+
+```bash
+mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test
+```
+
+The generated sources are not checked in. The profile copies allowlisted test
+classes from `safere/src/test/java/org/safere`, rewrites them into a generated
+package, and imports `org.safere.crosscheck.Pattern` and
+`org.safere.crosscheck.Matcher`. This keeps one source of truth for the test
+logic while making JDK compatibility an executable invariant.
+
+Only tests whose whole class is expected to match JDK behavior should be added
+to the allowlist in `safere-crosscheck/pom.xml`. Tests for SafeRE internals,
+linear-time performance, unsupported JDK features, or intentional SafeRE/JDK
+syntax differences should remain in the normal SafeRE test suite.
+
 ### Not Covered (yet)
 
 - Stream APIs: `splitAsStream()`, `results()`, `asPredicate()`,

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -70,4 +70,71 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>crosscheck-public-api-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>generate-crosscheck-public-api-tests</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <delete
+                        dir="${project.build.directory}/generated-test-sources/crosscheck"
+                        quiet="true"/>
+                    <mkdir
+                        dir="${project.build.directory}/generated-test-sources/crosscheck/org/safere/crosscheck/generated"/>
+                    <copy
+                        todir="${project.build.directory}/generated-test-sources/crosscheck/org/safere/crosscheck/generated"
+                        flatten="true"
+                        overwrite="true">
+                      <fileset dir="${project.basedir}/../safere/src/test/java/org/safere">
+                        <include name="CommentsTest.java"/>
+                        <include name="LiteralFlagTest.java"/>
+                        <include name="UnicodeCaseTest.java"/>
+                      </fileset>
+                      <filterchain>
+                        <replaceregex
+                            pattern="package org\.safere;"
+                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
+                      </filterchain>
+                    </copy>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.0</version>
+            <executions>
+              <execution>
+                <id>add-crosscheck-public-api-tests</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${project.build.directory}/generated-test-sources/crosscheck</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Summary

- add a `crosscheck-public-api-tests` profile that generates crosscheck-backed copies of selected SafeRE public API tests
- document the profile and add it to the PR validation instructions
- run the profile in CI for the crosscheck module

## Testing

- `mvn -pl safere test -q`
- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q`
