### PR TITLE
Expand generated crosscheck coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,10 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   merges.
 - Before making a PR, also run the public API crosscheck invariant:
   `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test`. This runs
-  generated copies of allowlisted SafeRE public API tests through
+  generated copies of SafeRE public API test candidates through
   `org.safere.crosscheck` so each test operation is compared with the JDK.
+  Use `@DisabledForCrosscheck("reason")` on original SafeRE tests for cases
+  that should be visible as disabled only in generated crosscheck coverage.
 - **Update existing PRs — do not close and reopen.** Push commits (or
   force-push if rebasing) to the existing branch. Closing and reopening PRs
   loses review context and clutters the issue tracker.

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -123,23 +123,30 @@ The crosscheck facade covers:
 
 ## Crosschecking SafeRE Tests
 
-The `crosscheck-public-api-tests` Maven profile runs generated copies of
-selected SafeRE public API tests through the crosscheck facade:
+The `crosscheck-public-api-tests` Maven profile runs generated copies of SafeRE
+public API test candidates through the crosscheck facade:
 
 ```bash
 mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test
 ```
 
-The generated sources are not checked in. The profile copies allowlisted test
-classes from `safere/src/test/java/org/safere`, rewrites them into a generated
-package, and imports `org.safere.crosscheck.Pattern` and
+The generated sources are not checked in. The profile copies broad public API
+test candidates from `safere/src/test/java/org/safere`, rewrites them into a
+generated package, and imports `org.safere.crosscheck.Pattern` and
 `org.safere.crosscheck.Matcher`. This keeps one source of truth for the test
 logic while making JDK compatibility an executable invariant.
 
-Only tests whose whole class is expected to match JDK behavior should be added
-to the allowlist in `safere-crosscheck/pom.xml`. Tests for SafeRE internals,
-linear-time performance, unsupported JDK features, or intentional SafeRE/JDK
-syntax differences should remain in the normal SafeRE test suite.
+Use `@DisabledForCrosscheck("reason")` in the original SafeRE test source for
+test methods or classes that should be disabled only in generated crosscheck
+coverage. The generator rewrites that annotation to JUnit's `@Disabled`, so the
+gap is visible in test reports. Use issue references in the reason for fixable
+SafeRE/JDK divergences, and plain reasons for tests that are intentionally not
+relevant to crosscheck, such as SafeRE-only syntax or JDK stack-overflow stress
+cases.
+
+The profile still excludes source files that are structurally not crosscheck
+candidates, such as SafeRE internals, SafeRE-only APIs, or tests requiring
+crosscheck facade methods that are not implemented yet.
 
 ### Not Covered (yet)
 

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -75,6 +75,14 @@
     <profile>
       <id>crosscheck-public-api-tests</id>
       <build>
+        <testResources>
+          <testResource>
+            <directory>${project.basedir}/src/test/resources</directory>
+          </testResource>
+          <testResource>
+            <directory>${project.basedir}/../safere/src/test/resources</directory>
+          </testResource>
+        </testResources>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -99,14 +107,42 @@
                         flatten="true"
                         overwrite="true">
                       <fileset dir="${project.basedir}/../safere/src/test/java/org/safere">
-                        <include name="CommentsTest.java"/>
-                        <include name="LiteralFlagTest.java"/>
-                        <include name="UnicodeCaseTest.java"/>
+                        <include name="*Test.java"/>
+                        <include name="ExhaustiveUtils.java"/>
+                        <exclude name="AnchorOptTest.java"/>
+                        <exclude name="BitStateTest.java"/>
+                        <exclude name="CharClassTest.java"/>
+                        <exclude name="CompilerTest.java"/>
+                        <exclude name="DfaNfaTest.java"/>
+                        <exclude name="DfaTest.java"/>
+                        <exclude name="EmptyOpTest.java"/>
+                        <exclude name="InstOpTest.java"/>
+                        <exclude name="InstTest.java"/>
+                        <exclude name="LicenseHeaderTest.java"/>
+                        <exclude name="MatcherTest.java"/>
+                        <exclude name="NfaTest.java"/>
+                        <exclude name="OnePassTest.java"/>
+                        <exclude name="ParseFlagsTest.java"/>
+                        <exclude name="ParserTest.java"/>
+                        <exclude name="PatternSetTest.java"/>
+                        <exclude name="PatternTest.java"/>
+                        <exclude name="ProgTest.java"/>
+                        <exclude name="RandomTest.java"/>
+                        <exclude name="RegexpOpTest.java"/>
+                        <exclude name="RegexpTest.java"/>
+                        <exclude name="SimplifierTest.java"/>
+                        <exclude name="UnicodeJdkConsistencyTest.java"/>
+                        <exclude name="UnicodeTablesTest.java"/>
+                        <exclude name="UtilsTest.java"/>
+                        <exclude name="WalkerTest.java"/>
                       </fileset>
                       <filterchain>
                         <replaceregex
                             pattern="package org\.safere;"
-                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
+                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.junit.jupiter.api.Disabled;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
+                        <replaceregex
+                            pattern="@DisabledForCrosscheck\("
+                            replace="@Disabled("/>
                       </filterchain>
                     </copy>
                   </target>

--- a/safere/src/test/java/org/safere/CrossEngineExhaustiveTest.java
+++ b/safere/src/test/java/org/safere/CrossEngineExhaustiveTest.java
@@ -616,6 +616,8 @@ class CrossEngineExhaustiveTest {
     }
 
     @Test
+    @DisabledForCrosscheck(
+        "#219 SafeRE drops capture groups in zero-count repetitions")
     @DisplayName("Repetition operators on long text")
     void repetitionLongText() {
       int tests =

--- a/safere/src/test/java/org/safere/DisabledForCrosscheck.java
+++ b/safere/src/test/java/org/safere/DisabledForCrosscheck.java
@@ -1,0 +1,25 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a SafeRE test or test class that should be disabled only in generated crosscheck tests.
+ *
+ * <p>The crosscheck test generator rewrites this annotation to JUnit's {@code @Disabled}. Use an
+ * issue reference in the reason for fixable SafeRE/JDK divergences, and a plain reason for tests
+ * that are intentionally not relevant to crosscheck.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@interface DisabledForCrosscheck {
+  /** Explains why this test is disabled in generated crosscheck coverage. */
+  String value();
+}

--- a/safere/src/test/java/org/safere/JavaCharacterClassesTest.java
+++ b/safere/src/test/java/org/safere/JavaCharacterClassesTest.java
@@ -177,6 +177,8 @@ class JavaCharacterClassesTest {
   }
 
   @Test
+  @DisabledForCrosscheck(
+      "#210 SafeRE accepts \\p{^javaLowerCase}, but java.util.regex rejects it")
   @DisplayName("Negation with \\p{^...} works")
   void caretNegationWorks() {
     var p = Pattern.compile("\\p{^javaLowerCase}+");

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -427,6 +427,8 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @ParameterizedTest
+    @DisabledForCrosscheck(
+        "#220 SafeRE differs from java.util.regex for empty-left-side intersections")
     @ValueSource(strings = {"[&&`+]˫]*", "[&&abc]", "[a&&&&b]"})
     @DisplayName("empty left side of class intersection matches like JDK")
     void emptyLeftSideOfIntersection(String regex) {

--- a/safere/src/test/java/org/safere/RE2ExhaustiveTest.java
+++ b/safere/src/test/java/org/safere/RE2ExhaustiveTest.java
@@ -44,6 +44,8 @@ class RE2ExhaustiveTest {
   private static final int MAX_FAILURES = 200;
 
   @Test
+  @DisabledForCrosscheck(
+      "#219 SafeRE drops capture groups in zero-count repetitions")
   void testExhaustive() throws IOException {
     InputStream is = RE2ExhaustiveTest.class.getResourceAsStream("/re2-exhaustive.txt.gz");
     assertThat(is).as("re2-exhaustive.txt.gz must be in test resources").isNotNull();

--- a/safere/src/test/java/org/safere/RE2FindTest.java
+++ b/safere/src/test/java/org/safere/RE2FindTest.java
@@ -214,6 +214,8 @@ class RE2FindTest {
   }
 
   @ParameterizedTest(name = "{0}")
+  @DisabledForCrosscheck(
+      "#219 SafeRE drops capture groups in zero-count repetitions")
   @MethodSource("findTests")
   void testFirstMatchSubgroups(FindTestCase tc) {
     Pattern p = Pattern.compile(tc.pattern());
@@ -235,6 +237,8 @@ class RE2FindTest {
   }
 
   @ParameterizedTest(name = "{0}")
+  @DisabledForCrosscheck(
+      "#219 SafeRE drops capture groups in zero-count repetitions")
   @MethodSource("findTests")
   void testFirstMatchPositions(FindTestCase tc) {
     Pattern p = Pattern.compile(tc.pattern());
@@ -263,6 +267,8 @@ class RE2FindTest {
   }
 
   @ParameterizedTest(name = "{0}")
+  @DisabledForCrosscheck(
+      "#219 SafeRE drops capture groups in zero-count repetitions")
   @MethodSource("findTests")
   void testFindFirst(FindTestCase tc) {
     Pattern p = Pattern.compile(tc.pattern());

--- a/safere/src/test/java/org/safere/RE2PosixTest.java
+++ b/safere/src/test/java/org/safere/RE2PosixTest.java
@@ -268,6 +268,8 @@ class RE2PosixTest {
   }
 
   @ParameterizedTest(name = "{0}")
+  @DisabledForCrosscheck(
+      "POSIX test data includes submatch semantics that differ from java.util.regex")
   @MethodSource("basicTests")
   void testBasic(PosixTestCase tc) {
     runTest(tc);

--- a/safere/src/test/java/org/safere/RE2RegressionTest.java
+++ b/safere/src/test/java/org/safere/RE2RegressionTest.java
@@ -194,6 +194,7 @@ class RE2RegressionTest {
     }
 
     @Test
+    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("Multiple named and unnamed groups")
     void multipleNamedGroups() {
       Pattern p = Pattern.compile("(?P<A>expr(?P<B>expr)(?P<C>expr))((expr)(?P<D>expr))");
@@ -208,6 +209,7 @@ class RE2RegressionTest {
     }
 
     @Test
+    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("Named group match extraction")
     void namedGroupMatch() {
       Pattern p = Pattern.compile("directions from (?P<S>.*) to (?P<D>.*)");
@@ -361,6 +363,7 @@ class RE2RegressionTest {
     }
 
     @Test
+    @DisabledForCrosscheck("JDK stack overflows on this linear-time SafeRE stress case")
     @DisplayName("Long input with deep recursion pattern")
     void longInputDeepRecursion() {
       // RE2 C++ test: ((?:\s|xx.*\n|x[*](?:\n|.)*?[*]x)*)

--- a/safere/src/test/java/org/safere/RE2SearchTest.java
+++ b/safere/src/test/java/org/safere/RE2SearchTest.java
@@ -221,6 +221,8 @@ class RE2SearchTest {
   }
 
   @ParameterizedTest(name = "{0}")
+  @DisabledForCrosscheck(
+      "RE2 search data includes non-JDK syntax and RE2-specific expectations")
   @MethodSource("searchTests")
   void testMatches(SearchTestCase tc) {
     Pattern p;
@@ -237,6 +239,8 @@ class RE2SearchTest {
   }
 
   @ParameterizedTest(name = "{0}")
+  @DisabledForCrosscheck(
+      "RE2 search data includes non-JDK syntax and RE2-specific expectations")
   @MethodSource("searchTests")
   void testFind(SearchTestCase tc) {
     Pattern p;

--- a/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
+++ b/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
@@ -662,6 +662,7 @@ class UnicodePropertySyntaxTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#210 java.util.regex rejects caret negation in property names")
     @DisplayName("\\p{^IsLatin} negation via caret")
     void caretNegation() {
       assertThat(find("\\p{^IsLatin}", "α")).isTrue();
@@ -790,6 +791,7 @@ class UnicodePropertySyntaxTest {
   class BackwardCompatibilityTest {
 
     @Test
+    @DisabledForCrosscheck("SafeRE backward-compatible direct script alias is not JDK syntax")
     @DisplayName("\\p{Latin} still works (no prefix)")
     void directScriptName() {
       assertThat(find("\\p{Latin}", "A")).isTrue();
@@ -811,6 +813,7 @@ class UnicodePropertySyntaxTest {
     }
 
     @Test
+    @DisabledForCrosscheck("SafeRE backward-compatible direct block alias is not JDK syntax")
     @DisplayName("\\p{Braille} still works")
     void directBraille() {
       assertThat(find("\\p{Braille}", "\u2800")).isTrue();
@@ -839,6 +842,7 @@ class UnicodePropertySyntaxTest {
     }
 
     @Test
+    @DisabledForCrosscheck("SafeRE backward-compatible Any property alias is not JDK syntax")
     @DisplayName("\\p{Any} still works")
     void anyClass() {
       assertThat(find("\\p{Any}", "A")).isTrue();


### PR DESCRIPTION
## Summary

- expand generated crosscheck coverage from a small allowlist to broad public API candidates
- add `@DisabledForCrosscheck` so original SafeRE tests document generated-only crosscheck skips
- include exhaustive/resource-driven candidate suites and SafeRE test resources in the crosscheck profile
- annotate known generated-only gaps for #210, #219, #220, and non-JDK/linear-time stress cases

## Testing

- `mvn -pl safere test -q`
- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q`

Refs #212
