### PR TITLE
Use JUnit condition for crosscheck disables

### DIFF
--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -138,11 +138,12 @@ logic while making JDK compatibility an executable invariant.
 
 Use `@DisabledForCrosscheck("reason")` in the original SafeRE test source for
 test methods or classes that should be disabled only in generated crosscheck
-coverage. The generator rewrites that annotation to JUnit's `@Disabled`, so the
-gap is visible in test reports. Use issue references in the reason for fixable
-SafeRE/JDK divergences, and plain reasons for tests that are intentionally not
-relevant to crosscheck, such as SafeRE-only syntax or JDK stack-overflow stress
-cases.
+coverage. The annotation is backed by a JUnit execution condition and is active
+only when the generated crosscheck profile sets
+`org.safere.crosscheck.generatedTests=true`, so the gap is visible in test
+reports. Use issue references in the reason for fixable SafeRE/JDK divergences,
+and plain reasons for tests that are intentionally not relevant to crosscheck,
+such as SafeRE-only syntax or JDK stack-overflow stress cases.
 
 The profile still excludes source files that are structurally not crosscheck
 candidates, such as SafeRE internals, SafeRE-only APIs, or tests requiring

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -108,6 +108,7 @@
                         overwrite="true">
                       <fileset dir="${project.basedir}/../safere/src/test/java/org/safere">
                         <include name="*Test.java"/>
+                        <include name="DisabledForCrosscheck.java"/>
                         <include name="ExhaustiveUtils.java"/>
                         <exclude name="AnchorOptTest.java"/>
                         <exclude name="BitStateTest.java"/>
@@ -139,10 +140,7 @@
                       <filterchain>
                         <replaceregex
                             pattern="package org\.safere;"
-                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.junit.jupiter.api.Disabled;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
-                        <replaceregex
-                            pattern="@DisabledForCrosscheck\("
-                            replace="@Disabled("/>
+                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
                       </filterchain>
                     </copy>
                   </target>
@@ -168,6 +166,16 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.5.2</version>
+            <configuration>
+              <systemPropertyVariables>
+                <org.safere.crosscheck.generatedTests>true</org.safere.crosscheck.generatedTests>
+              </systemPropertyVariables>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/safere/src/test/java/org/safere/DisabledForCrosscheck.java
+++ b/safere/src/test/java/org/safere/DisabledForCrosscheck.java
@@ -9,17 +9,41 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Marks a SafeRE test or test class that should be disabled only in generated crosscheck tests.
  *
- * <p>The crosscheck test generator rewrites this annotation to JUnit's {@code @Disabled}. Use an
- * issue reference in the reason for fixable SafeRE/JDK divergences, and a plain reason for tests
- * that are intentionally not relevant to crosscheck.
+ * <p>The annotation is active only when the generated crosscheck test profile sets the
+ * {@code org.safere.crosscheck.generatedTests} system property. Use an issue reference in the
+ * reason for fixable SafeRE/JDK divergences, and a plain reason for tests that are intentionally not
+ * relevant to crosscheck.
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
+@ExtendWith(DisabledForCrosscheckCondition.class)
 @interface DisabledForCrosscheck {
   /** Explains why this test is disabled in generated crosscheck coverage. */
   String value();
+}
+
+/** JUnit condition backing {@link DisabledForCrosscheck}. */
+final class DisabledForCrosscheckCondition implements ExecutionCondition {
+  static final String GENERATED_TESTS_PROPERTY = "org.safere.crosscheck.generatedTests";
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (!Boolean.getBoolean(GENERATED_TESTS_PROPERTY)) {
+      return ConditionEvaluationResult.enabled("not a generated crosscheck test run");
+    }
+
+    return context
+        .getElement()
+        .map(element -> element.getAnnotation(DisabledForCrosscheck.class))
+        .map(annotation -> ConditionEvaluationResult.disabled(annotation.value()))
+        .orElseGet(() -> ConditionEvaluationResult.enabled("not disabled for crosscheck"));
+  }
 }


### PR DESCRIPTION
## Summary

- make `@DisabledForCrosscheck` a real JUnit execution condition
- activate it only when the generated crosscheck profile sets `org.safere.crosscheck.generatedTests=true`
- copy the annotation helper into generated crosscheck sources instead of rewriting annotations to JUnit `@Disabled`

## Testing

- `mvn -pl safere test -q`
- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q`

Follow-up to #221.
