### PR TITLE
Split mixed API tests for generated crosscheck

### DIFF
--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -138,11 +138,12 @@ logic while making JDK compatibility an executable invariant.
 
 Use `@DisabledForCrosscheck("reason")` in the original SafeRE test source for
 test methods or classes that should be disabled only in generated crosscheck
-coverage. The generator rewrites that annotation to JUnit's `@Disabled`, so the
-gap is visible in test reports. Use issue references in the reason for fixable
-SafeRE/JDK divergences, and plain reasons for tests that are intentionally not
-relevant to crosscheck, such as SafeRE-only syntax or JDK stack-overflow stress
-cases.
+coverage. The annotation is backed by a JUnit execution condition and is active
+only when the generated crosscheck profile sets
+`org.safere.crosscheck.generatedTests=true`, so the gap is visible in test
+reports. Use issue references in the reason for fixable SafeRE/JDK divergences,
+and plain reasons for tests that are intentionally not relevant to crosscheck,
+such as SafeRE-only syntax or JDK stack-overflow stress cases.
 
 The profile still excludes source files that are structurally not crosscheck
 candidates, such as SafeRE internals, SafeRE-only APIs, or tests requiring

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -145,9 +145,12 @@ reports. Use issue references in the reason for fixable SafeRE/JDK divergences,
 and plain reasons for tests that are intentionally not relevant to crosscheck,
 such as SafeRE-only syntax or JDK stack-overflow stress cases.
 
-The profile still excludes source files that are structurally not crosscheck
-candidates, such as SafeRE internals, SafeRE-only APIs, or tests requiring
-crosscheck facade methods that are not implemented yet.
+The profile still has compile-time structural excludes for source files that
+cannot be generated into the crosscheck package, such as SafeRE internals,
+SafeRE-only APIs, or tests requiring crosscheck facade methods that are not
+implemented yet. Those source files should still be annotated with
+`@DisabledForCrosscheck` so the reason remains discoverable in the original
+test source.
 
 ### Not Covered (yet)
 

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -110,6 +110,8 @@
                         <include name="*Test.java"/>
                         <include name="DisabledForCrosscheck.java"/>
                         <include name="ExhaustiveUtils.java"/>
+                        <!-- Compile-time structural excludes. Each excluded test class is also
+                             annotated with @DisabledForCrosscheck in the original source. -->
                         <exclude name="AnchorOptTest.java"/>
                         <exclude name="BitStateTest.java"/>
                         <exclude name="CharClassTest.java"/>
@@ -119,16 +121,12 @@
                         <exclude name="EmptyOpTest.java"/>
                         <exclude name="InstOpTest.java"/>
                         <exclude name="InstTest.java"/>
-                        <exclude name="LicenseHeaderTest.java"/>
-                        <exclude name="MatcherTest.java"/>
                         <exclude name="NfaTest.java"/>
                         <exclude name="OnePassTest.java"/>
                         <exclude name="ParseFlagsTest.java"/>
                         <exclude name="ParserTest.java"/>
                         <exclude name="PatternSetTest.java"/>
-                        <exclude name="PatternTest.java"/>
                         <exclude name="ProgTest.java"/>
-                        <exclude name="RandomTest.java"/>
                         <exclude name="RegexpOpTest.java"/>
                         <exclude name="RegexpTest.java"/>
                         <exclude name="SimplifierTest.java"/>

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -108,6 +108,7 @@
                         overwrite="true">
                       <fileset dir="${project.basedir}/../safere/src/test/java/org/safere">
                         <include name="*Test.java"/>
+                        <include name="DisabledForCrosscheck.java"/>
                         <include name="ExhaustiveUtils.java"/>
                         <exclude name="AnchorOptTest.java"/>
                         <exclude name="BitStateTest.java"/>
@@ -139,10 +140,7 @@
                       <filterchain>
                         <replaceregex
                             pattern="package org\.safere;"
-                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.junit.jupiter.api.Disabled;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
-                        <replaceregex
-                            pattern="@DisabledForCrosscheck\("
-                            replace="@Disabled("/>
+                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
                       </filterchain>
                     </copy>
                   </target>
@@ -168,6 +166,16 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.5.2</version>
+            <configuration>
+              <systemPropertyVariables>
+                <org.safere.crosscheck.generatedTests>true</org.safere.crosscheck.generatedTests>
+              </systemPropertyVariables>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -6,7 +6,9 @@ package org.safere.crosscheck;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.MatchResult;
+import java.util.stream.Stream;
 
 /**
  * A crosscheck wrapper that delegates every matcher operation to both SafeRE and
@@ -22,7 +24,7 @@ import java.util.regex.MatchResult;
  */
 public final class Matcher implements MatchResult {
 
-  private final Pattern crosscheckPattern;
+  private Pattern crosscheckPattern;
   private final org.safere.Matcher safereMatcher;
   private final java.util.regex.Matcher jdkMatcher;
   private final TraceRecorder trace = new TraceRecorder();
@@ -183,6 +185,22 @@ public final class Matcher implements MatchResult {
     String sr = safereMatcher.replaceAll(replacement);
     String jr = jdkMatcher.replaceAll(replacement);
     checkEqual("replaceAll", quote(replacement), sr, jr);
+    return sr;
+  }
+
+  /** Replaces the first match with a replacement computed from the match result. */
+  public String replaceFirst(Function<MatchResult, String> replacer) {
+    String sr = safereMatcher.replaceFirst(replacer);
+    String jr = jdkMatcher.replaceFirst(replacer);
+    checkEqual("replaceFirst", "<function>", sr, jr);
+    return sr;
+  }
+
+  /** Replaces all matches with replacements computed from match results. */
+  public String replaceAll(Function<MatchResult, String> replacer) {
+    String sr = safereMatcher.replaceAll(replacer);
+    String jr = jdkMatcher.replaceAll(replacer);
+    checkEqual("replaceAll", "<function>", sr, jr);
     return sr;
   }
 
@@ -349,6 +367,18 @@ public final class Matcher implements MatchResult {
     return crosscheckPattern;
   }
 
+  /** Changes the pattern used by this matcher. */
+  public Matcher usePattern(Pattern newPattern) {
+    if (newPattern == null) {
+      throw new IllegalArgumentException("Pattern must not be null");
+    }
+    safereMatcher.usePattern(newPattern.saferePattern());
+    jdkMatcher.usePattern(newPattern.jdkPattern());
+    crosscheckPattern = newPattern;
+    trace.recordMatch("usePattern", newPattern.pattern(), "void");
+    return this;
+  }
+
   /** Returns the named groups from the pattern. */
   public Map<String, Integer> namedGroups() {
     return crosscheckPattern.namedGroups();
@@ -358,6 +388,11 @@ public final class Matcher implements MatchResult {
   public MatchResult toMatchResult() {
     // Return SafeRE's result — the match state has already been crosschecked.
     return safereMatcher.toMatchResult();
+  }
+
+  /** Returns a stream of match-result snapshots. */
+  public Stream<MatchResult> results() {
+    return safereMatcher.results();
   }
 
   // ---------------------------------------------------------------------------

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
@@ -6,7 +6,9 @@ package org.safere.crosscheck;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
 
 /**
  * A crosscheck wrapper that compiles and executes regular expressions on both SafeRE and
@@ -200,9 +202,29 @@ public final class Pattern {
     return sr;
   }
 
+  /** Splits the input lazily around matches of this pattern. */
+  public Stream<String> splitAsStream(CharSequence input) {
+    return saferePattern.splitAsStream(input);
+  }
+
+  /** Creates a predicate that returns true when this pattern is found in the input. */
+  public Predicate<String> asPredicate() {
+    return input -> matcher(input).find();
+  }
+
+  /** Creates a predicate that returns true when this pattern matches the entire input. */
+  public Predicate<String> asMatchPredicate() {
+    return input -> matcher(input).matches();
+  }
+
   /** Returns the named capturing groups in this pattern. */
   public Map<String, Integer> namedGroups() {
     return saferePattern.namedGroups();
+  }
+
+  /** Returns the number of capturing groups in this pattern. */
+  public int numGroups() {
+    return saferePattern.matcher("").groupCount();
   }
 
   /** Returns the pattern string. */

--- a/safere/src/test/java/org/safere/AnchorOptTest.java
+++ b/safere/src/test/java/org/safere/AnchorOptTest.java
@@ -8,6 +8,7 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
+@DisabledForCrosscheck("implementation-path assertions use package-private SafeRE internals")
 class AnchorOptTest {
   @Test
   void httpPatternIsOnePassAndAnchored() {

--- a/safere/src/test/java/org/safere/BitStateTest.java
+++ b/safere/src/test/java/org/safere/BitStateTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * <p>Tests verify that BitState produces the same results as the NFA for both anchored and
  * unanchored searches across a variety of patterns and inputs.
  */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class BitStateTest {
 
   private static final int FLAGS =

--- a/safere/src/test/java/org/safere/CharClassTest.java
+++ b/safere/src/test/java/org/safere/CharClassTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link CharClass} and {@link CharClassBuilder}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class CharClassTest {
 
   @Test

--- a/safere/src/test/java/org/safere/CompilerTest.java
+++ b/safere/src/test/java/org/safere/CompilerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Compiler}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class CompilerTest {
 
   private static final int DEFAULT_FLAGS =

--- a/safere/src/test/java/org/safere/DfaNfaTest.java
+++ b/safere/src/test/java/org/safere/DfaNfaTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * on match/no-match.
  */
 @DisplayName("DFA vs NFA consistency")
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class DfaNfaTest {
 
   private static final int FLAGS =

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
  * only reports match boundaries (not capture groups), so tests focus on match detection and end
  * position.
  */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class DfaTest {
 
   private static final int FLAGS =

--- a/safere/src/test/java/org/safere/DisabledForCrosscheck.java
+++ b/safere/src/test/java/org/safere/DisabledForCrosscheck.java
@@ -9,17 +9,41 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Marks a SafeRE test or test class that should be disabled only in generated crosscheck tests.
  *
- * <p>The crosscheck test generator rewrites this annotation to JUnit's {@code @Disabled}. Use an
- * issue reference in the reason for fixable SafeRE/JDK divergences, and a plain reason for tests
- * that are intentionally not relevant to crosscheck.
+ * <p>The annotation is active only when the generated crosscheck test profile sets the
+ * {@code org.safere.crosscheck.generatedTests} system property. Use an issue reference in the
+ * reason for fixable SafeRE/JDK divergences, and a plain reason for tests that are intentionally not
+ * relevant to crosscheck.
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
+@ExtendWith(DisabledForCrosscheckCondition.class)
 @interface DisabledForCrosscheck {
   /** Explains why this test is disabled in generated crosscheck coverage. */
   String value();
+}
+
+/** JUnit condition backing {@link DisabledForCrosscheck}. */
+final class DisabledForCrosscheckCondition implements ExecutionCondition {
+  static final String GENERATED_TESTS_PROPERTY = "org.safere.crosscheck.generatedTests";
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (!Boolean.getBoolean(GENERATED_TESTS_PROPERTY)) {
+      return ConditionEvaluationResult.enabled("not a generated crosscheck test run");
+    }
+
+    return context
+        .getElement()
+        .map(element -> element.getAnnotation(DisabledForCrosscheck.class))
+        .map(annotation -> ConditionEvaluationResult.disabled(annotation.value()))
+        .orElseGet(() -> ConditionEvaluationResult.enabled("not disabled for crosscheck"));
+  }
 }

--- a/safere/src/test/java/org/safere/EmptyOpTest.java
+++ b/safere/src/test/java/org/safere/EmptyOpTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link EmptyOp}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class EmptyOpTest {
 
   @Test

--- a/safere/src/test/java/org/safere/InstOpTest.java
+++ b/safere/src/test/java/org/safere/InstOpTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link InstOp}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class InstOpTest {
 
   @Test

--- a/safere/src/test/java/org/safere/InstTest.java
+++ b/safere/src/test/java/org/safere/InstTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Inst}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class InstTest {
 
   @Test

--- a/safere/src/test/java/org/safere/LicenseHeaderTest.java
+++ b/safere/src/test/java/org/safere/LicenseHeaderTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 /** Verifies that all Java source files include the required license header. */
+@DisabledForCrosscheck("repository source-file validation is not regex API compatibility coverage")
 class LicenseHeaderTest {
 
   // Standard header (4 lines) — files derived from C++ RE2 only.

--- a/safere/src/test/java/org/safere/MatcherFunctionalReplaceTest.java
+++ b/safere/src/test/java/org/safere/MatcherFunctionalReplaceTest.java
@@ -1,0 +1,151 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.regex.MatchResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Matcher} functional replacement methods. */
+class MatcherFunctionalReplaceTest {
+
+  @Test
+  @DisplayName("replaceAll(Function) expands group references in returned replacement")
+  void replaceAllFunctionExpandsGroupReferences() {
+    Pattern p = Pattern.compile("(\\w+)");
+    Matcher m = p.matcher("hello world");
+    assertThat(m.replaceAll(result -> "[$1]")).isEqualTo("[hello] [world]");
+  }
+
+  @Test
+  @DisplayName("replaceFirst(Function) expands group references in returned replacement")
+  void replaceFirstFunctionExpandsGroupReferences() {
+    Pattern p = Pattern.compile("(\\w+)");
+    Matcher m = p.matcher("hello world");
+    assertThat(m.replaceFirst(result -> "[$1]")).isEqualTo("[hello] world");
+  }
+
+  @Test
+  @DisplayName("replaceAll(Function) rejects null replacement result")
+  void replaceAllFunctionRejectsNullReplacementResult() {
+    Pattern p = Pattern.compile("a");
+    Matcher m = p.matcher("a");
+    assertThatThrownBy(() -> m.replaceAll(result -> null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("replaceFirst(Function) rejects null replacement result")
+  void replaceFirstFunctionRejectsNullReplacementResult() {
+    Pattern p = Pattern.compile("a");
+    Matcher m = p.matcher("a");
+    assertThatThrownBy(() -> m.replaceFirst(result -> null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("replaceAll(Function) replaces all matches using function")
+  void replaceAllFunction() {
+    Pattern p = Pattern.compile("\\d+");
+    Matcher m = p.matcher("a1b22c333");
+    String result = m.replaceAll(mr -> "[" + mr.group() + "]");
+    assertThat(result).isEqualTo("a[1]b[22]c[333]");
+  }
+
+  @Test
+  @DisplayName("replaceFirst(Function) replaces only first match using function")
+  void replaceFirstFunction() {
+    Pattern p = Pattern.compile("\\d+");
+    Matcher m = p.matcher("a1b22c333");
+    String result = m.replaceFirst(mr -> "[" + mr.group() + "]");
+    assertThat(result).isEqualTo("a[1]b22c333");
+  }
+
+  @Test
+  @DisplayName("replaceAll(Function) with no matches returns original")
+  void replaceAllFunctionNoMatch() {
+    Pattern p = Pattern.compile("\\d+");
+    Matcher m = p.matcher("no digits");
+    String result = m.replaceAll(mr -> "X");
+    assertThat(result).isEqualTo("no digits");
+  }
+
+  @Test
+  @DisplayName("replaceFirst(Function) with no matches returns original")
+  void replaceFirstFunctionNoMatch() {
+    Pattern p = Pattern.compile("\\d+");
+    Matcher m = p.matcher("no digits");
+    String result = m.replaceFirst(mr -> "X");
+    assertThat(result).isEqualTo("no digits");
+  }
+
+  @Test
+  @DisplayName("replaceAll(Function) can access capture groups")
+  void replaceAllFunctionWithGroups() {
+    Pattern p = Pattern.compile("(\\w+)=(\\w+)");
+    Matcher m = p.matcher("a=1 b=2");
+    String result = m.replaceAll(mr -> mr.group(2) + ":" + mr.group(1));
+    assertThat(result).isEqualTo("1:a 2:b");
+  }
+
+  @Test
+  @DisplayName("replaceAll(Function) throws on null replacer")
+  void replaceAllFunctionNullThrows() {
+    Pattern p = Pattern.compile("x");
+    Matcher m = p.matcher("x");
+    assertThatThrownBy(() -> m.replaceAll((java.util.function.Function<MatchResult, String>) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("replaceFirst(Function) throws on null replacer")
+  void replaceFirstFunctionNullThrows() {
+    Pattern p = Pattern.compile("x");
+    Matcher m = p.matcher("x");
+    assertThatThrownBy(
+            () -> m.replaceFirst((java.util.function.Function<MatchResult, String>) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisabledForCrosscheck("crosscheck wrapper cannot observe replacer mutation checks")
+  @DisplayName("replaceAll(Function) detects matcher mutation from replacer")
+  void replaceAllFunctionDetectsMatcherMutation() {
+    Pattern p = Pattern.compile("a");
+    Matcher m = p.matcher("aa");
+
+    assertThatThrownBy(
+            () ->
+                m.replaceAll(
+                    result -> {
+                      m.find();
+                      return "x";
+                    }))
+        .isInstanceOf(java.util.ConcurrentModificationException.class);
+  }
+
+  @Test
+  @DisabledForCrosscheck("crosscheck wrapper cannot observe replacer mutation checks")
+  @DisplayName("replaceFirst(Function) detects matcher mutation from replacer")
+  void replaceFirstFunctionDetectsMatcherMutation() {
+    Pattern p = Pattern.compile("a");
+    Matcher m = p.matcher("aa");
+
+    assertThatThrownBy(
+            () ->
+                m.replaceFirst(
+                    result -> {
+                      m.find();
+                      return "x";
+                    }))
+        .isInstanceOf(java.util.ConcurrentModificationException.class);
+  }
+}

--- a/safere/src/test/java/org/safere/MatcherResultsStreamTest.java
+++ b/safere/src/test/java/org/safere/MatcherResultsStreamTest.java
@@ -1,0 +1,70 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.regex.MatchResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Matcher#results()}. */
+class MatcherResultsStreamTest {
+
+  @Test
+  @DisplayName("results() returns all matches as a stream")
+  void resultsStream() {
+    Pattern p = Pattern.compile("\\d+");
+    Matcher m = p.matcher("abc 123 def 456 ghi");
+    java.util.List<String> matches =
+        m.results().map(MatchResult::group).collect(java.util.stream.Collectors.toList());
+    assertThat(matches).containsExactly("123", "456");
+  }
+
+  @Test
+  @DisplayName("results() returns empty stream when no matches")
+  void resultsNoMatch() {
+    Pattern p = Pattern.compile("\\d+");
+    Matcher m = p.matcher("no digits here");
+    assertThat(m.results().count()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("results() match results have correct positions")
+  void resultsPositions() {
+    Pattern p = Pattern.compile("[a-z]+");
+    Matcher m = p.matcher("123 abc 456 def");
+    java.util.List<MatchResult> results =
+        m.results().collect(java.util.stream.Collectors.toList());
+    assertThat(results).hasSize(2);
+    assertThat(results.get(0).start()).isEqualTo(4);
+    assertThat(results.get(0).end()).isEqualTo(7);
+    assertThat(results.get(1).start()).isEqualTo(12);
+    assertThat(results.get(1).end()).isEqualTo(15);
+  }
+
+  @Test
+  @DisabledForCrosscheck("crosscheck wrapper cannot observe results traversal mutation checks")
+  @DisplayName("results() detects matcher mutation during stream traversal")
+  void resultsDetectsMatcherMutation() {
+    Pattern p = Pattern.compile("a");
+    Matcher m = p.matcher("aa");
+
+    assertThatThrownBy(
+            () ->
+                m.results()
+                    .map(
+                        result -> {
+                          m.find();
+                          return result.group();
+                        })
+                    .collect(java.util.stream.Collectors.toList()))
+        .isInstanceOf(java.util.ConcurrentModificationException.class);
+  }
+}

--- a/safere/src/test/java/org/safere/MatcherSafeReApiTest.java
+++ b/safere/src/test/java/org/safere/MatcherSafeReApiTest.java
@@ -1,0 +1,132 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.regex.MatchResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for Matcher APIs that are SafeRE-specific extensions. */
+@DisabledForCrosscheck("SafeRE-only Matcher APIs and (?P<name>...) syntax have no JDK equivalent")
+class MatcherSafeReApiTest {
+
+  @Test
+  void replaceFirstNamedGroupRef() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Matcher m = p.matcher("hello world");
+    String result = m.replaceFirst("${word}!");
+    assertThat(result).isEqualTo("hello! world");
+  }
+
+  @Test
+  @DisplayName("toMatchResult() snapshot supports named-group lookup")
+  void toMatchResultNamedGroups() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Matcher m = p.matcher("hello");
+    assertThat(m.find()).isTrue();
+
+    MatchResult mr = m.toMatchResult();
+    assertThat(mr.namedGroups()).containsEntry("word", 1);
+    assertThat(mr.group("word")).isEqualTo("hello");
+    assertThat(mr.start("word")).isEqualTo(0);
+    assertThat(mr.end("word")).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("start(String) and end(String) return named group positions")
+  void namedGroupStartEnd() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)@(?P<host>\\w+)");
+    Matcher m = p.matcher("user@host");
+    assertThat(m.find()).isTrue();
+    assertThat(m.start("word")).isEqualTo(0);
+    assertThat(m.end("word")).isEqualTo(4);
+    assertThat(m.start("host")).isEqualTo(5);
+    assertThat(m.end("host")).isEqualTo(9);
+  }
+
+  @Test
+  @DisplayName("start(String) throws for unknown group name")
+  void startUnknownNameThrows() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Matcher m = p.matcher("hello");
+    m.find();
+    assertThatThrownBy(() -> m.start("missing")).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("end(String) throws for unknown group name")
+  void endUnknownNameThrows() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Matcher m = p.matcher("hello");
+    m.find();
+    assertThatThrownBy(() -> m.end("missing")).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("named group that did not participate returns -1")
+  void nonParticipatingNamedGroup() {
+    Pattern p = Pattern.compile("(?P<a>a)|(?P<b>b)");
+    Matcher m = p.matcher("b");
+    assertThat(m.find()).isTrue();
+    assertThat(m.start("a")).isEqualTo(-1);
+    assertThat(m.end("a")).isEqualTo(-1);
+    assertThat(m.start("b")).isEqualTo(0);
+    assertThat(m.end("b")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("namedGroups() returns named groups from pattern")
+  void namedGroupsReturnsMap() {
+    Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+    Matcher m = p.matcher("user@host");
+    assertThat(m.namedGroups()).containsEntry("user", 1);
+    assertThat(m.namedGroups()).containsEntry("host", 2);
+  }
+
+  @Test
+  @DisplayName("namedGroups() returns empty map for no named groups")
+  void namedGroupsEmpty() {
+    Pattern p = Pattern.compile("(\\w+)@(\\w+)");
+    Matcher m = p.matcher("user@host");
+    assertThat(m.namedGroups()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("namedGroups() is unmodifiable")
+  void namedGroupsUnmodifiable() {
+    Pattern p = Pattern.compile("(?P<name>\\w+)");
+    Matcher m = p.matcher("hello");
+    assertThatThrownBy(() -> m.namedGroups().put("foo", 99))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  @DisplayName("namedGroups() returns from MatchResult interface")
+  void namedGroupsFromMatchResult() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Matcher m = p.matcher("hello");
+    assertThat(m.find()).isTrue();
+    MatchResult result = m.toMatchResult();
+    assertThat(result.namedGroups()).containsEntry("word", 1);
+  }
+
+  @Test
+  @DisplayName("named group methods reject null names")
+  void namedGroupMethodsRejectNullNames() {
+    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Matcher m = p.matcher("hello");
+    assertThat(m.find()).isTrue();
+
+    assertThatThrownBy(() -> m.group((String) null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> m.start((String) null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> m.end((String) null)).isInstanceOf(NullPointerException.class);
+  }
+}

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -159,6 +159,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("matches() stays linear for repeated dot-star with bounded captures")
     void matchesWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
@@ -176,6 +177,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("lookingAt() stays linear for repeated dot-star with bounded captures")
     void lookingAtWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
@@ -207,6 +209,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("matches() stays linear for repeated dot-star bodies with multiple captures")
     void matchesWithRepeatedDotStarBodiesAndMultipleCaptures() {
       assertNoSuperlinearRepeatedDotStarCaptureScaling(
@@ -228,6 +231,7 @@ class MatcherTest {
   class FindTests {
 
     @Test
+    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("group access after find() stays linear for repeated dot-star captures")
     void findGroupWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
@@ -600,6 +604,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("group(String) returns named group text")
     void namedGroup() {
       Pattern p = Pattern.compile("(?P<first>\\w+) (?P<last>\\w+)");
@@ -610,6 +615,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("group(String) throws for unknown name")
     void namedGroupUnknown() {
       Pattern p = Pattern.compile("(?P<first>\\w+)");
@@ -842,6 +848,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("replaceAll() with named backreference")
     void replaceAllWithNamedBackref() {
       Pattern p = Pattern.compile("(?P<word>\\w+)");
@@ -940,14 +947,6 @@ class MatcherTest {
     }
 
     @Test
-    void replaceFirstNamedGroupRef() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
-      Matcher m = p.matcher("hello world");
-      String result = m.replaceFirst("${word}!");
-      assertThat(result).isEqualTo("hello! world");
-    }
-
-    @Test
     @DisplayName("replaceAll with backreference wrapping")
     void replaceAllBackrefWrapping() {
       Pattern p = Pattern.compile("(\\w+):(\\d+)");
@@ -987,40 +986,6 @@ class MatcherTest {
       Matcher m = p.matcher("b");
       // $1 didn't participate (null), should be replaced with empty string
       assertThat(m.replaceFirst("[$1][$2]")).isEqualTo("[][b]");
-    }
-
-    @Test
-    @DisplayName("replaceAll(Function) expands group references in returned replacement")
-    void replaceAllFunctionExpandsGroupReferences() {
-      Pattern p = Pattern.compile("(\\w+)");
-      Matcher m = p.matcher("hello world");
-      assertThat(m.replaceAll(result -> "[$1]")).isEqualTo("[hello] [world]");
-    }
-
-    @Test
-    @DisplayName("replaceFirst(Function) expands group references in returned replacement")
-    void replaceFirstFunctionExpandsGroupReferences() {
-      Pattern p = Pattern.compile("(\\w+)");
-      Matcher m = p.matcher("hello world");
-      assertThat(m.replaceFirst(result -> "[$1]")).isEqualTo("[hello] world");
-    }
-
-    @Test
-    @DisplayName("replaceAll(Function) rejects null replacement result")
-    void replaceAllFunctionRejectsNullReplacementResult() {
-      Pattern p = Pattern.compile("a");
-      Matcher m = p.matcher("a");
-      assertThatThrownBy(() -> m.replaceAll(result -> null))
-          .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("replaceFirst(Function) rejects null replacement result")
-    void replaceFirstFunctionRejectsNullReplacementResult() {
-      Pattern p = Pattern.compile("a");
-      Matcher m = p.matcher("a");
-      assertThatThrownBy(() -> m.replaceFirst(result -> null))
-          .isInstanceOf(NullPointerException.class);
     }
 
   }
@@ -1069,6 +1034,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("SafeRE supports CharSequence group access that JDK cannot")
     @DisplayName("matcher works with CharSequence that does not override toString()")
     void customCharSequenceWithoutToString() {
       // A CharSequence backed by a byte array that does NOT override toString().
@@ -1114,6 +1080,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("Matcher.toString() format is implementation-specific")
     @DisplayName("toString() reports pattern, region, and last match")
     void toStringReportsMatcherState() {
       Matcher m = Pattern.compile("a").matcher("ba");
@@ -1167,20 +1134,6 @@ class MatcherTest {
       assertThat(mr.group(2)).isNull();
       assertThat(mr.start(2)).isEqualTo(-1);
       assertThat(mr.end(2)).isEqualTo(-1);
-    }
-
-    @Test
-    @DisplayName("toMatchResult() snapshot supports named-group lookup")
-    void toMatchResultNamedGroups() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
-      Matcher m = p.matcher("hello");
-      assertThat(m.find()).isTrue();
-
-      MatchResult mr = m.toMatchResult();
-      assertThat(mr.namedGroups()).containsEntry("word", 1);
-      assertThat(mr.group("word")).isEqualTo("hello");
-      assertThat(mr.start("word")).isEqualTo(0);
-      assertThat(mr.end("word")).isEqualTo(5);
     }
 
     @Test
@@ -1252,200 +1205,6 @@ class MatcherTest {
   }
 
   @Nested
-  @DisplayName("Named group start/end")
-  class NamedGroupPositionTests {
-
-    @Test
-    @DisplayName("start(String) and end(String) return named group positions")
-    void namedGroupStartEnd() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)@(?P<host>\\w+)");
-      Matcher m = p.matcher("user@host");
-      assertThat(m.find()).isTrue();
-      assertThat(m.start("word")).isEqualTo(0);
-      assertThat(m.end("word")).isEqualTo(4);
-      assertThat(m.start("host")).isEqualTo(5);
-      assertThat(m.end("host")).isEqualTo(9);
-    }
-
-    @Test
-    @DisplayName("start(String) throws for unknown group name")
-    void startUnknownNameThrows() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
-      Matcher m = p.matcher("hello");
-      m.find();
-      assertThatThrownBy(() -> m.start("missing"))
-          .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    @DisplayName("end(String) throws for unknown group name")
-    void endUnknownNameThrows() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
-      Matcher m = p.matcher("hello");
-      m.find();
-      assertThatThrownBy(() -> m.end("missing"))
-          .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    @DisplayName("named group that did not participate returns -1")
-    void nonParticipatingNamedGroup() {
-      Pattern p = Pattern.compile("(?P<a>a)|(?P<b>b)");
-      Matcher m = p.matcher("b");
-      assertThat(m.find()).isTrue();
-      assertThat(m.start("a")).isEqualTo(-1);
-      assertThat(m.end("a")).isEqualTo(-1);
-      assertThat(m.start("b")).isEqualTo(0);
-      assertThat(m.end("b")).isEqualTo(1);
-    }
-  }
-
-  @Nested
-  @DisplayName("results() stream")
-  class ResultsStreamTests {
-
-    @Test
-    @DisplayName("results() returns all matches as a stream")
-    void resultsStream() {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("abc 123 def 456 ghi");
-      java.util.List<String> matches =
-          m.results().map(MatchResult::group).collect(java.util.stream.Collectors.toList());
-      assertThat(matches).containsExactly("123", "456");
-    }
-
-    @Test
-    @DisplayName("results() returns empty stream when no matches")
-    void resultsNoMatch() {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("no digits here");
-      assertThat(m.results().count()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("results() match results have correct positions")
-    void resultsPositions() {
-      Pattern p = Pattern.compile("[a-z]+");
-      Matcher m = p.matcher("123 abc 456 def");
-      java.util.List<MatchResult> results =
-          m.results().collect(java.util.stream.Collectors.toList());
-      assertThat(results).hasSize(2);
-      assertThat(results.get(0).start()).isEqualTo(4);
-      assertThat(results.get(0).end()).isEqualTo(7);
-      assertThat(results.get(1).start()).isEqualTo(12);
-      assertThat(results.get(1).end()).isEqualTo(15);
-    }
-
-    @Test
-    @DisplayName("results() detects matcher mutation during stream traversal")
-    void resultsDetectsMatcherMutation() {
-      Pattern p = Pattern.compile("a");
-      Matcher m = p.matcher("aa");
-
-      assertThatThrownBy(() -> m.results()
-          .map(result -> {
-            m.find();
-            return result.group();
-          })
-          .collect(java.util.stream.Collectors.toList()))
-          .isInstanceOf(java.util.ConcurrentModificationException.class);
-    }
-  }
-
-  @Nested
-  @DisplayName("Functional replacement")
-  class FunctionalReplaceTests {
-
-    @Test
-    @DisplayName("replaceAll(Function) replaces all matches using function")
-    void replaceAllFunction() {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("a1b22c333");
-      String result = m.replaceAll(mr -> "[" + mr.group() + "]");
-      assertThat(result).isEqualTo("a[1]b[22]c[333]");
-    }
-
-    @Test
-    @DisplayName("replaceFirst(Function) replaces only first match using function")
-    void replaceFirstFunction() {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("a1b22c333");
-      String result = m.replaceFirst(mr -> "[" + mr.group() + "]");
-      assertThat(result).isEqualTo("a[1]b22c333");
-    }
-
-    @Test
-    @DisplayName("replaceAll(Function) with no matches returns original")
-    void replaceAllFunctionNoMatch() {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("no digits");
-      String result = m.replaceAll(mr -> "X");
-      assertThat(result).isEqualTo("no digits");
-    }
-
-    @Test
-    @DisplayName("replaceFirst(Function) with no matches returns original")
-    void replaceFirstFunctionNoMatch() {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("no digits");
-      String result = m.replaceFirst(mr -> "X");
-      assertThat(result).isEqualTo("no digits");
-    }
-
-    @Test
-    @DisplayName("replaceAll(Function) can access capture groups")
-    void replaceAllFunctionWithGroups() {
-      Pattern p = Pattern.compile("(\\w+)=(\\w+)");
-      Matcher m = p.matcher("a=1 b=2");
-      String result = m.replaceAll(mr -> mr.group(2) + ":" + mr.group(1));
-      assertThat(result).isEqualTo("1:a 2:b");
-    }
-
-    @Test
-    @DisplayName("replaceAll(Function) throws on null replacer")
-    void replaceAllFunctionNullThrows() {
-      Pattern p = Pattern.compile("x");
-      Matcher m = p.matcher("x");
-      assertThatThrownBy(() -> m.replaceAll((java.util.function.Function<MatchResult, String>) null))
-          .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("replaceFirst(Function) throws on null replacer")
-    void replaceFirstFunctionNullThrows() {
-      Pattern p = Pattern.compile("x");
-      Matcher m = p.matcher("x");
-      assertThatThrownBy(
-              () -> m.replaceFirst((java.util.function.Function<MatchResult, String>) null))
-          .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("replaceAll(Function) detects matcher mutation from replacer")
-    void replaceAllFunctionDetectsMatcherMutation() {
-      Pattern p = Pattern.compile("a");
-      Matcher m = p.matcher("aa");
-
-      assertThatThrownBy(() -> m.replaceAll(result -> {
-        m.find();
-        return "x";
-      })).isInstanceOf(java.util.ConcurrentModificationException.class);
-    }
-
-    @Test
-    @DisplayName("replaceFirst(Function) detects matcher mutation from replacer")
-    void replaceFirstFunctionDetectsMatcherMutation() {
-      Pattern p = Pattern.compile("a");
-      Matcher m = p.matcher("aa");
-
-      assertThatThrownBy(() -> m.replaceFirst(result -> {
-        m.find();
-        return "x";
-      })).isInstanceOf(java.util.ConcurrentModificationException.class);
-    }
-  }
-
-  @Nested
   @DisplayName("StringBuffer append methods")
   class StringBufferAppendTests {
 
@@ -1488,66 +1247,6 @@ class MatcherTest {
       m.appendTail(sb);
 
       assertThat(sb.toString()).isEqualTo("abXcdXef");
-    }
-  }
-
-  @Nested
-  @DisplayName("usePattern()")
-  class UsePatternTests {
-
-    @Test
-    @DisplayName("usePattern swaps pattern and preserves position")
-    void usePatternSwapsPattern() {
-      Pattern p1 = Pattern.compile("\\d+");
-      Pattern p2 = Pattern.compile("[a-z]+");
-      Matcher m = p1.matcher("123abc456def");
-      assertThat(m.find()).isTrue();
-      assertThat(m.group()).isEqualTo("123");
-      m.usePattern(p2);
-      assertThat(m.find()).isTrue();
-      assertThat(m.group()).isEqualTo("abc");
-    }
-
-    @Test
-    @DisplayName("usePattern continues searching after the previous match")
-    void usePatternContinuesAfterPreviousMatchEnd() {
-      Matcher m = Pattern.compile("a").matcher("ab");
-      assertThat(m.find()).isTrue();
-
-      m.usePattern(Pattern.compile("."));
-
-      assertThat(m.find()).isTrue();
-      assertThat(m.start()).isEqualTo(1);
-      assertThat(m.group()).isEqualTo("b");
-    }
-
-    @Test
-    @DisplayName("usePattern returns this matcher")
-    void usePatternReturnsSelf() {
-      Pattern p1 = Pattern.compile("a");
-      Pattern p2 = Pattern.compile("b");
-      Matcher m = p1.matcher("ab");
-      assertThat(m.usePattern(p2)).isSameAs(m);
-    }
-
-    @Test
-    @DisplayName("usePattern with null throws")
-    void usePatternNullThrows() {
-      Pattern p = Pattern.compile("a");
-      Matcher m = p.matcher("a");
-      assertThatThrownBy(() -> m.usePattern(null))
-          .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    @DisplayName("pattern() reflects usePattern change")
-    void patternReflectsChange() {
-      Pattern p1 = Pattern.compile("a");
-      Pattern p2 = Pattern.compile("b");
-      Matcher m = p1.matcher("ab");
-      assertThat(m.pattern()).isSameAs(p1);
-      m.usePattern(p2);
-      assertThat(m.pattern()).isSameAs(p2);
     }
   }
 
@@ -1638,6 +1337,7 @@ class MatcherTest {
   class RegionTests {
 
     @Test
+    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("region find stays linear for repeated dot-star captures")
     void regionFindWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
@@ -1760,6 +1460,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#226 hitEnd/requireEnd state differs after region reset")
     @DisplayName("region clears stale requireEnd state")
     void regionClearsRequireEndState() {
       Pattern p = Pattern.compile("a$");
@@ -2414,6 +2115,7 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#226 SafeRE and java.util.regex differ on requireEnd state after reset")
     @DisplayName("requireEnd() is false after reset")
     void requireEndFalseAfterReset() {
       Pattern p = Pattern.compile("abc$");
@@ -2460,62 +2162,6 @@ class MatcherTest {
       assertThat(m.matches()).isTrue();
       // No end assertions in pattern — match doesn't depend on end position.
       assertThat(m.requireEnd()).isFalse();
-    }
-  }
-
-  @Nested
-  @DisplayName("namedGroups()")
-  class NamedGroupsTests {
-
-    @Test
-    @DisplayName("namedGroups() returns named groups from pattern")
-    void namedGroupsReturnsMap() {
-      Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
-      Matcher m = p.matcher("user@host");
-      assertThat(m.namedGroups()).containsEntry("user", 1);
-      assertThat(m.namedGroups()).containsEntry("host", 2);
-    }
-
-    @Test
-    @DisplayName("namedGroups() returns empty map for no named groups")
-    void namedGroupsEmpty() {
-      Pattern p = Pattern.compile("(\\w+)@(\\w+)");
-      Matcher m = p.matcher("user@host");
-      assertThat(m.namedGroups()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("namedGroups() is unmodifiable")
-    void namedGroupsUnmodifiable() {
-      Pattern p = Pattern.compile("(?P<name>\\w+)");
-      Matcher m = p.matcher("hello");
-      assertThatThrownBy(() -> m.namedGroups().put("foo", 99))
-          .isInstanceOf(UnsupportedOperationException.class);
-    }
-
-    @Test
-    @DisplayName("namedGroups() returns from MatchResult interface")
-    void namedGroupsFromMatchResult() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
-      Matcher m = p.matcher("hello");
-      assertThat(m.find()).isTrue();
-      MatchResult result = m.toMatchResult();
-      assertThat(result.namedGroups()).containsEntry("word", 1);
-    }
-
-    @Test
-    @DisplayName("named group methods reject null names")
-    void namedGroupMethodsRejectNullNames() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
-      Matcher m = p.matcher("hello");
-      assertThat(m.find()).isTrue();
-
-      assertThatThrownBy(() -> m.group((String) null))
-          .isInstanceOf(NullPointerException.class);
-      assertThatThrownBy(() -> m.start((String) null))
-          .isInstanceOf(NullPointerException.class);
-      assertThatThrownBy(() -> m.end((String) null))
-          .isInstanceOf(NullPointerException.class);
     }
   }
 
@@ -2658,6 +2304,7 @@ class MatcherTest {
   }
 
   @Test
+  @DisabledForCrosscheck("#227 BitState crash for this generated regression case")
   @DisplayName("find() with empty branch before complex char class")
   void findEmptyBranchBeforeComplexCharClass() {
     Matcher m =

--- a/safere/src/test/java/org/safere/MatcherUsePatternTest.java
+++ b/safere/src/test/java/org/safere/MatcherUsePatternTest.java
@@ -1,0 +1,73 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Matcher#usePattern(Pattern)}. */
+class MatcherUsePatternTest {
+
+  @Test
+  @DisplayName("usePattern swaps pattern and preserves position")
+  void usePatternSwapsPattern() {
+    Pattern p1 = Pattern.compile("\\d+");
+    Pattern p2 = Pattern.compile("[a-z]+");
+    Matcher m = p1.matcher("123abc456def");
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("123");
+    m.usePattern(p2);
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("abc");
+  }
+
+  @Test
+  @DisabledForCrosscheck("#225 search position differs after usePattern")
+  @DisplayName("usePattern continues searching after the previous match")
+  void usePatternContinuesAfterPreviousMatchEnd() {
+    Matcher m = Pattern.compile("a").matcher("ab");
+    assertThat(m.find()).isTrue();
+
+    m.usePattern(Pattern.compile("."));
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(1);
+    assertThat(m.group()).isEqualTo("b");
+  }
+
+  @Test
+  @DisplayName("usePattern returns this matcher")
+  void usePatternReturnsSelf() {
+    Pattern p1 = Pattern.compile("a");
+    Pattern p2 = Pattern.compile("b");
+    Matcher m = p1.matcher("ab");
+    assertThat(m.usePattern(p2)).isSameAs(m);
+  }
+
+  @Test
+  @DisplayName("usePattern with null throws")
+  void usePatternNullThrows() {
+    Pattern p = Pattern.compile("a");
+    Matcher m = p.matcher("a");
+    assertThatThrownBy(() -> m.usePattern(null)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("pattern() reflects usePattern change")
+  void patternReflectsChange() {
+    Pattern p1 = Pattern.compile("a");
+    Pattern p2 = Pattern.compile("b");
+    Matcher m = p1.matcher("ab");
+    assertThat(m.pattern()).isSameAs(p1);
+    m.usePattern(p2);
+    assertThat(m.pattern()).isSameAs(p2);
+  }
+}

--- a/safere/src/test/java/org/safere/NfaTest.java
+++ b/safere/src/test/java/org/safere/NfaTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Nfa}. End-to-end tests: parse → compile → match. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class NfaTest {
 
   private static final int FLAGS =

--- a/safere/src/test/java/org/safere/OnePassTest.java
+++ b/safere/src/test/java/org/safere/OnePassTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
  * <p>Tests verify: (1) correct one-pass detection, (2) match results agree with the NFA, and (3)
  * capture groups are correctly extracted.
  */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class OnePassTest {
 
   private static final int FLAGS =

--- a/safere/src/test/java/org/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/org/safere/ParseFlagsTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link ParseFlags}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class ParseFlagsTest {
 
   @Test

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link Parser}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class ParserTest {
 
   /** Perl-compatible flags, used as the default for most tests. */

--- a/safere/src/test/java/org/safere/PatternPredicateTest.java
+++ b/safere/src/test/java/org/safere/PatternPredicateTest.java
@@ -1,0 +1,31 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Pattern#asPredicate()} and {@link Pattern#asMatchPredicate()}. */
+class PatternPredicateTest {
+
+  @Test
+  void asPredicatePartialMatch() {
+    Predicate<String> pred = Pattern.compile("\\d+").asPredicate();
+    assertThat(pred.test("abc123def")).isTrue();
+    assertThat(pred.test("abcdef")).isFalse();
+  }
+
+  @Test
+  void asMatchPredicateFullMatch() {
+    Predicate<String> pred = Pattern.compile("\\d+").asMatchPredicate();
+    assertThat(pred.test("123")).isTrue();
+    assertThat(pred.test("abc123")).isFalse();
+  }
+}

--- a/safere/src/test/java/org/safere/PatternSafeReApiTest.java
+++ b/safere/src/test/java/org/safere/PatternSafeReApiTest.java
@@ -1,0 +1,81 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.regex.PatternSyntaxException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Tests for Pattern APIs that are SafeRE-specific extensions. */
+@DisabledForCrosscheck("SafeRE-only Pattern APIs and (?P<name>...) syntax have no JDK equivalent")
+class PatternSafeReApiTest {
+
+  @Test
+  void extractsNamedGroups() {
+    Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+    assertThat(p.namedGroups()).containsEntry("user", 1);
+    assertThat(p.namedGroups()).containsEntry("host", 2);
+  }
+
+  @Test
+  void noNamedGroups() {
+    Pattern p = Pattern.compile("(\\w+)@(\\w+)");
+    assertThat(p.namedGroups()).isEmpty();
+  }
+
+  @Test
+  void numGroupsCounting() {
+    Pattern p = Pattern.compile("(a)(b)(c)");
+    assertThat(p.numGroups()).isEqualTo(3);
+  }
+
+  @Test
+  void numGroupsNoCaptures() {
+    Pattern p = Pattern.compile("abc");
+    assertThat(p.numGroups()).isZero();
+  }
+
+  @Test
+  @DisplayName("namedGroups() returns unmodifiable map")
+  void namedGroupsUnmodifiable() {
+    Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+    assertThatThrownBy(() -> p.namedGroups().put("foo", 99))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  @DisplayName("duplicate named capturing groups are rejected")
+  void duplicateNamedGroupsRejected() {
+    assertThatThrownBy(() -> Pattern.compile("(?<word>a)(?<word>b)"))
+        .isInstanceOf(PatternSyntaxException.class);
+    assertThatThrownBy(() -> Pattern.compile("(?P<word>a)(?P<word>b)"))
+        .isInstanceOf(PatternSyntaxException.class);
+  }
+
+  @ParameterizedTest(name = "compile(\"{0}\").numGroups() == {1}")
+  @CsvSource({
+      "'',         0",
+      "'.*',        0",
+      "'abba',      0",
+      "'ab(b)a',    1",
+      "'ab(.*)a',   1",
+      "'(.*)ab(.*)a',  2",
+      "'(.*)(ab)(.*)a', 3",
+      "'(.*)((a)b)(.*)a', 4",
+      "'(.*)(\\(ab)(.*)a', 3",
+      "'(.*)(\\(a\\)b)(.*)a', 3",
+  })
+  void numGroups(String pattern, int expected) {
+    assertThat(Pattern.compile(pattern).numGroups()).isEqualTo(expected);
+  }
+}

--- a/safere/src/test/java/org/safere/PatternSetTest.java
+++ b/safere/src/test/java/org/safere/PatternSetTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link PatternSet}. */
+@DisabledForCrosscheck("PatternSet is a SafeRE-only API with no java.util.regex equivalent")
 class PatternSetTest {
 
   // ---------------------------------------------------------------------------

--- a/safere/src/test/java/org/safere/PatternSplitAsStreamTest.java
+++ b/safere/src/test/java/org/safere/PatternSplitAsStreamTest.java
@@ -1,0 +1,139 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Pattern#splitAsStream(CharSequence)}. */
+class PatternSplitAsStreamTest {
+  private static final class LiteralCharSequence implements CharSequence {
+    private final String value;
+
+    LiteralCharSequence(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public int length() {
+      return value.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      return value.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return value.subSequence(start, end);
+    }
+  }
+
+  private static final class MutableCharSequence implements CharSequence {
+    private final StringBuilder value;
+
+    MutableCharSequence(String value) {
+      this.value = new StringBuilder(value);
+    }
+
+    void set(String newValue) {
+      value.setLength(0);
+      value.append(newValue);
+    }
+
+    @Override
+    public int length() {
+      return value.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      return value.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return value.subSequence(start, end);
+    }
+
+    @Override
+    public String toString() {
+      return value.toString();
+    }
+  }
+
+  @Test
+  @DisplayName("splitAsStream splits input around matches")
+  void splitAsStreamBasic() {
+    Pattern p = Pattern.compile(",");
+    java.util.List<String> parts =
+        p.splitAsStream("a,b,c").collect(java.util.stream.Collectors.toList());
+    assertThat(parts).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  @DisplayName("splitAsStream with no match returns entire input")
+  void splitAsStreamNoMatch() {
+    Pattern p = Pattern.compile(",");
+    java.util.List<String> parts =
+        p.splitAsStream("abc").collect(java.util.stream.Collectors.toList());
+    assertThat(parts).containsExactly("abc");
+  }
+
+  @Test
+  @DisplayName("splitAsStream with regex pattern")
+  void splitAsStreamRegex() {
+    Pattern p = Pattern.compile("\\s+");
+    java.util.List<String> parts =
+        p.splitAsStream("hello  world\tfoo").collect(java.util.stream.Collectors.toList());
+    assertThat(parts).containsExactly("hello", "world", "foo");
+  }
+
+  @Test
+  @DisplayName("splitAsStream count() works without collecting")
+  void splitAsStreamCount() {
+    Pattern p = Pattern.compile(",");
+    long count = p.splitAsStream("a,b,c,d").count();
+    assertThat(count).isEqualTo(4);
+  }
+
+  @Test
+  @DisplayName("splitAsStream discards trailing empty strings")
+  void splitAsStreamTrailingEmpty() {
+    Pattern p = Pattern.compile(",");
+    java.util.List<String> parts =
+        p.splitAsStream("a,b,").collect(java.util.stream.Collectors.toList());
+    assertThat(parts).containsExactly("a", "b");
+  }
+
+  @Test
+  @DisplayName("splitAsStream reads custom CharSequence content via charAt()")
+  void splitAsStreamCustomCharSequence() {
+    Pattern p = Pattern.compile(",");
+    java.util.List<String> parts =
+        p.splitAsStream(new LiteralCharSequence("a,b,c"))
+            .collect(java.util.stream.Collectors.toList());
+    assertThat(parts).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  @DisplayName("splitAsStream reads input lazily when stream is consumed")
+  void splitAsStreamReadsInputLazily() {
+    Pattern p = Pattern.compile(",");
+    MutableCharSequence input = new MutableCharSequence("a,b");
+    Stream<String> stream = p.splitAsStream(input);
+
+    input.set("x,y,z");
+
+    assertThat(stream.collect(java.util.stream.Collectors.toList())).containsExactly("x", "y", "z");
+  }
+}

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -31,34 +29,6 @@ class PatternTest {
 
     LiteralCharSequence(String value) {
       this.value = value;
-    }
-
-    @Override
-    public int length() {
-      return value.length();
-    }
-
-    @Override
-    public char charAt(int index) {
-      return value.charAt(index);
-    }
-
-    @Override
-    public CharSequence subSequence(int start, int end) {
-      return value.subSequence(start, end);
-    }
-  }
-
-  private static final class MutableCharSequence implements CharSequence {
-    private final StringBuilder value;
-
-    MutableCharSequence(String value) {
-      this.value = new StringBuilder(value);
-    }
-
-    void set(String newValue) {
-      value.setLength(0);
-      value.append(newValue);
     }
 
     @Override
@@ -489,24 +459,6 @@ class PatternTest {
   }
 
   @Nested
-  @DisplayName("asPredicate() / asMatchPredicate()")
-  class Predicates {
-    @Test
-    void asPredicatePartialMatch() {
-      Predicate<String> pred = Pattern.compile("\\d+").asPredicate();
-      assertThat(pred.test("abc123def")).isTrue();
-      assertThat(pred.test("abcdef")).isFalse();
-    }
-
-    @Test
-    void asMatchPredicateFullMatch() {
-      Predicate<String> pred = Pattern.compile("\\d+").asMatchPredicate();
-      assertThat(pred.test("123")).isTrue();
-      assertThat(pred.test("abc123")).isFalse();
-    }
-  }
-
-  @Nested
   @DisplayName("toString() / pattern() / flags()")
   class Accessors {
     @Test
@@ -541,51 +493,6 @@ class PatternTest {
 
       assertThat(p.flags())
           .isEqualTo(Pattern.UNICODE_CHARACTER_CLASS | Pattern.UNICODE_CASE);
-    }
-  }
-
-  @Nested
-  @DisplayName("Named groups")
-  class NamedGroups {
-    @Test
-    void extractsNamedGroups() {
-      Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
-      assertThat(p.namedGroups()).containsEntry("user", 1);
-      assertThat(p.namedGroups()).containsEntry("host", 2);
-    }
-
-    @Test
-    void noNamedGroups() {
-      Pattern p = Pattern.compile("(\\w+)@(\\w+)");
-      assertThat(p.namedGroups()).isEmpty();
-    }
-
-    @Test
-    void numGroupsCounting() {
-      Pattern p = Pattern.compile("(a)(b)(c)");
-      assertThat(p.numGroups()).isEqualTo(3);
-    }
-
-    @Test
-    void numGroupsNoCaptures() {
-      Pattern p = Pattern.compile("abc");
-      assertThat(p.numGroups()).isZero();
-    }
-    @Test
-    @DisplayName("namedGroups() returns unmodifiable map")
-    void namedGroupsUnmodifiable() {
-      Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
-      assertThatThrownBy(() -> p.namedGroups().put("foo", 99))
-          .isInstanceOf(UnsupportedOperationException.class);
-    }
-
-    @Test
-    @DisplayName("duplicate named capturing groups are rejected")
-    void duplicateNamedGroupsRejected() {
-      assertThatThrownBy(() -> Pattern.compile("(?<word>a)(?<word>b)"))
-          .isInstanceOf(PatternSyntaxException.class);
-      assertThatThrownBy(() -> Pattern.compile("(?P<word>a)(?P<word>b)"))
-          .isInstanceOf(PatternSyntaxException.class);
     }
   }
 
@@ -918,28 +825,6 @@ class PatternTest {
   }
 
   @Nested
-  @DisplayName("groupCount (ported from RE2/J RE2TestNumSubexps)")
-  class GroupCount {
-
-    @ParameterizedTest(name = "compile(\"{0}\").numGroups() == {1}")
-    @CsvSource({
-        "'',         0",
-        "'.*',        0",
-        "'abba',      0",
-        "'ab(b)a',    1",
-        "'ab(.*)a',   1",
-        "'(.*)ab(.*)a',  2",
-        "'(.*)(ab)(.*)a', 3",
-        "'(.*)((a)b)(.*)a', 4",
-        "'(.*)(\\(ab)(.*)a', 3",
-        "'(.*)(\\(a\\)b)(.*)a', 3",
-    })
-    void numGroups(String pattern, int expected) {
-      assertThat(Pattern.compile(pattern).numGroups()).isEqualTo(expected);
-    }
-  }
-
-  @Nested
   @DisplayName("quote() round-trip (ported from RE2/J RE2QuoteMetaTest)")
   class QuoteRoundTrip {
 
@@ -961,78 +846,6 @@ class PatternTest {
       Pattern p = Pattern.compile(quoted);
       String replaced = p.matcher(source).replaceAll("xyz");
       assertThat(replaced).isEqualTo(expected);
-    }
-  }
-
-  @Nested
-  @DisplayName("splitAsStream()")
-  class SplitAsStreamTests {
-
-    @Test
-    @DisplayName("splitAsStream splits input around matches")
-    void splitAsStreamBasic() {
-      Pattern p = Pattern.compile(",");
-      java.util.List<String> parts =
-          p.splitAsStream("a,b,c").collect(java.util.stream.Collectors.toList());
-      assertThat(parts).containsExactly("a", "b", "c");
-    }
-
-    @Test
-    @DisplayName("splitAsStream with no match returns entire input")
-    void splitAsStreamNoMatch() {
-      Pattern p = Pattern.compile(",");
-      java.util.List<String> parts =
-          p.splitAsStream("abc").collect(java.util.stream.Collectors.toList());
-      assertThat(parts).containsExactly("abc");
-    }
-
-    @Test
-    @DisplayName("splitAsStream with regex pattern")
-    void splitAsStreamRegex() {
-      Pattern p = Pattern.compile("\\s+");
-      java.util.List<String> parts =
-          p.splitAsStream("hello  world\tfoo").collect(java.util.stream.Collectors.toList());
-      assertThat(parts).containsExactly("hello", "world", "foo");
-    }
-
-    @Test
-    @DisplayName("splitAsStream count() works without collecting")
-    void splitAsStreamCount() {
-      Pattern p = Pattern.compile(",");
-      long count = p.splitAsStream("a,b,c,d").count();
-      assertThat(count).isEqualTo(4);
-    }
-
-    @Test
-    @DisplayName("splitAsStream discards trailing empty strings")
-    void splitAsStreamTrailingEmpty() {
-      Pattern p = Pattern.compile(",");
-      java.util.List<String> parts =
-          p.splitAsStream("a,b,").collect(java.util.stream.Collectors.toList());
-      assertThat(parts).containsExactly("a", "b");
-    }
-
-    @Test
-    @DisplayName("splitAsStream reads custom CharSequence content via charAt()")
-    void splitAsStreamCustomCharSequence() {
-      Pattern p = Pattern.compile(",");
-      java.util.List<String> parts =
-          p.splitAsStream(new LiteralCharSequence("a,b,c"))
-              .collect(java.util.stream.Collectors.toList());
-      assertThat(parts).containsExactly("a", "b", "c");
-    }
-
-    @Test
-    @DisplayName("splitAsStream reads input lazily when stream is consumed")
-    void splitAsStreamReadsInputLazily() {
-      Pattern p = Pattern.compile(",");
-      MutableCharSequence input = new MutableCharSequence("a,b");
-      Stream<String> stream = p.splitAsStream(input);
-
-      input.set("x,y,z");
-
-      assertThat(stream.collect(java.util.stream.Collectors.toList()))
-          .containsExactly("x", "y", "z");
     }
   }
 
@@ -1087,6 +900,7 @@ class PatternTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#220 empty-left-side character-class intersection diverges from JDK")
     @DisplayName("[^a&&[ab]] applies intersection before negating the left side")
     void negatedIntersectionKeepsNegatedLeftHandClass() {
       Pattern p = Pattern.compile("[^a&&[ab]]");
@@ -1096,6 +910,7 @@ class PatternTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#220 empty-left-side character-class intersection diverges from JDK")
     @DisplayName("[a-z&&[def]1] intersects with the whole right-hand union")
     void intersectionRightHandSideIncludesRangesAfterNestedClass() {
       Pattern p = Pattern.compile("[a-z&&[def]1]");
@@ -1118,6 +933,7 @@ class PatternTest {
   class OctalEscapeTests {
 
     @Test
+    @DisabledForCrosscheck("#224 SafeRE accepts octal syntax that java.util.regex rejects")
     @DisplayName("\\0 without octal digits is rejected")
     void zeroOctalEscapeRequiresDigits() {
       assertThatThrownBy(() -> Pattern.compile("\\0"))
@@ -1125,6 +941,7 @@ class PatternTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#224 SafeRE accepts octal syntax that java.util.regex rejects")
     @DisplayName("\\08 is rejected because \\0 requires an octal digit")
     void zeroOctalEscapeRejectsNonOctalDigit() {
       assertThatThrownBy(() -> Pattern.compile("\\08"))
@@ -1132,6 +949,7 @@ class PatternTest {
     }
 
     @Test
+    @DisabledForCrosscheck("#224 large octal escapes diverge from java.util.regex")
     @DisplayName("octal escapes above 0377 do not become Unicode code points")
     void largeOctalEscapesDoNotBecomeUnicodeCodePoints() {
       assertThat(Pattern.compile("\\400").matcher("\u0100").matches()).isFalse();

--- a/safere/src/test/java/org/safere/ProgTest.java
+++ b/safere/src/test/java/org/safere/ProgTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Prog}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class ProgTest {
 
   @Test

--- a/safere/src/test/java/org/safere/RandomTest.java
+++ b/safere/src/test/java/org/safere/RandomTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
  * {@code java.util.regex} agree on match/no-match results and matched text. Uses fixed seeds for
  * reproducibility.
  */
+@DisabledForCrosscheck("random differential fuzzing already compares SafeRE with java.util.regex")
 @DisplayName("Random Fuzz Tests (ported from RE2 C++ random_test.cc)")
 class RandomTest {
 

--- a/safere/src/test/java/org/safere/RegexpOpTest.java
+++ b/safere/src/test/java/org/safere/RegexpOpTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link RegexpOp}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class RegexpOpTest {
 
   @Test

--- a/safere/src/test/java/org/safere/RegexpTest.java
+++ b/safere/src/test/java/org/safere/RegexpTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Regexp}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class RegexpTest {
 
   @Test

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Tests for {@link Simplifier}, ported from RE2's {@code simplify_test.cc}. Tests parse each
  * regexp, simplify it, then compare the toString() output against the expected simplified form.
  */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class SimplifierTest {
 
   private static final int FLAGS =

--- a/safere/src/test/java/org/safere/UnicodeJdkConsistencyTest.java
+++ b/safere/src/test/java/org/safere/UnicodeJdkConsistencyTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
  * <p>See <a href="https://github.com/eaftan/safere/issues/107">#107</a>.
  */
 @DisplayName("Unicode JDK consistency canary tests")
+@DisabledForCrosscheck("Unicode table canary uses package-private SafeRE internals")
 class UnicodeJdkConsistencyTest {
 
   // --- Category and script consistency (runtime-generated, should always match) ---

--- a/safere/src/test/java/org/safere/UnicodeTablesTest.java
+++ b/safere/src/test/java/org/safere/UnicodeTablesTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link UnicodeTables}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class UnicodeTablesTest {
 
   // --- Perl groups ---

--- a/safere/src/test/java/org/safere/UtilsTest.java
+++ b/safere/src/test/java/org/safere/UtilsTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link Utils}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class UtilsTest {
 
   @Test

--- a/safere/src/test/java/org/safere/WalkerTest.java
+++ b/safere/src/test/java/org/safere/WalkerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link Walker}. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class WalkerTest {
 
   private static final int FLAGS =


### PR DESCRIPTION
## Summary

- Split `MatcherTest` and `PatternTest` mixed API coverage into focused test classes so generated crosscheck can run the crosscheckable portions.
- Keep SafeRE-only and known divergent cases visible with `@DisabledForCrosscheck` reasons.
- Expand the crosscheck facade for JDK-equivalent `Matcher`/`Pattern` APIs used by the split tests.
- Document that POM excludes are compile-time structural excludes while source annotations remain the reason source of truth.

Refs #212.

Follow-up issues discovered by generated crosscheck: #224, #225, #226, #227.

## Validation

- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q`
- `mvn -pl safere test -q`
