### PR TITLE
Re-enable usePattern crosscheck regression

### DIFF
--- a/safere/src/test/java/org/safere/MatcherUsePatternTest.java
+++ b/safere/src/test/java/org/safere/MatcherUsePatternTest.java
@@ -30,7 +30,6 @@ class MatcherUsePatternTest {
   }
 
   @Test
-  @DisabledForCrosscheck("#225 search position differs after usePattern")
   @DisplayName("usePattern continues searching after the previous match")
   void usePatternContinuesAfterPreviousMatchEnd() {
     Matcher m = Pattern.compile("a").matcher("ab");


### PR DESCRIPTION
## Summary
- remove the stale @DisabledForCrosscheck annotation from the existing Matcher.usePattern regression
- re-enable generated public API crosscheck coverage for the #225 scenario

Fixes #225

## Verification
- PASS: mvn -pl safere -Dtest=MatcherUsePatternTest test -q
- PASS: mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=MatcherUsePatternTest#usePatternContinuesAfterPreviousMatchEnd test -q
- NOTE: mvn -pl safere test -q was attempted and hit an unrelated timing-ratio assertion in MatcherTest.matchesWithRepeatedDotStarBodiesAndMultipleCaptures before later appearing to hang in exhaustive tests.