### PR TITLE
Re-enable BitState crosscheck regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,9 @@ jobs:
       - name: Build and test
         run: mvn verify -pl safere -Dtest.parallelism=4 --batch-mode --no-transfer-progress
 
-      - name: Install parent POM and safere to local repo
-        run: |
-          mvn install -N -DskipTests --batch-mode --no-transfer-progress -q
-          mvn install -pl safere -DskipTests --batch-mode --no-transfer-progress -q
-
       - name: Build and test crosscheck module
         run: >
-          mvn verify -pl safere-crosscheck -Pcrosscheck-public-api-tests
+          mvn verify -pl safere-crosscheck -am -Pcrosscheck-public-api-tests
           --batch-mode --no-transfer-progress
 
   benchmark-smoke-test-java:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,11 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   all tests pass** (`mvn -pl safere test`). CI failures waste time and block
   merges.
 - Before making a PR, also run the public API crosscheck invariant:
-  `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test`. This runs
+  `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test`. This runs
   generated copies of SafeRE public API test candidates through
   `org.safere.crosscheck` so each test operation is compared with the JDK.
+  The `-am` flag is required so the reactor rebuilds the local `safere` module
+  instead of testing against a stale artifact from the local Maven repository.
   Use `@DisabledForCrosscheck("reason")` on original SafeRE tests for cases
   that should be visible as disabled only in generated crosscheck coverage.
 - **Update existing PRs — do not close and reopen.** Push commits (or

--- a/TESTING.md
+++ b/TESTING.md
@@ -163,7 +163,7 @@ mvn test -pl safere -Dtest=ParserTest
 mvn verify -pl safere -Pcoverage
 
 # Run crosscheck module tests
-mvn test -pl safere-crosscheck
+mvn test -pl safere-crosscheck -am
 
 # Run Jazzer fuzz targets in regression mode
 mvn test -pl safere-fuzz

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -127,7 +127,7 @@ The `crosscheck-public-api-tests` Maven profile runs generated copies of SafeRE
 public API test candidates through the crosscheck facade:
 
 ```bash
-mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test
+mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test
 ```
 
 The generated sources are not checked in. The profile copies broad public API
@@ -135,6 +135,10 @@ test candidates from `safere/src/test/java/org/safere`, rewrites them into a
 generated package, and imports `org.safere.crosscheck.Pattern` and
 `org.safere.crosscheck.Matcher`. This keeps one source of truth for the test
 logic while making JDK compatibility an executable invariant.
+
+The `-am` flag tells Maven to also build required reactor dependencies, including
+the local `safere` module. Without it, Maven can resolve `safere` from the local
+repository and accidentally test against a stale installed artifact.
 
 Use `@DisabledForCrosscheck("reason")` in the original SafeRE test source for
 test methods or classes that should be disabled only in generated crosscheck

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -2304,7 +2304,6 @@ class MatcherTest {
   }
 
   @Test
-  @DisabledForCrosscheck("#227 BitState crash for this generated regression case")
   @DisplayName("find() with empty branch before complex char class")
   void findEmptyBranchBeforeComplexCharClass() {
     Matcher m =


### PR DESCRIPTION
## Summary
- re-enable the generated crosscheck regression for the empty-branch BitState case
- run crosscheck builds with Maven reactor dependency rebuilds via `-am`
- align CI and docs with the corrected crosscheck command

Fixes #227

## Tests
- `mvn -pl safere -Dtest=MatcherTest#findEmptyBranchBeforeComplexCharClass test -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=MatcherTest#findEmptyBranchBeforeComplexCharClass test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test -q`