### PR TITLE
Fix matcher end-state flags after reset and region

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,10 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
 - **Update existing PRs — do not close and reopen.** Push commits (or
   force-push if rebasing) to the existing branch. Closing and reopening PRs
   loses review context and clutters the issue tracker.
+- When creating or editing PR descriptions with `gh`, write the body to a
+  temporary file first and pass it with `--body-file`. Do not inline
+  multi-line Markdown in the shell command, because quoting and escaping are
+  easy to get wrong.
 - Whenever you create a PR, enable auto-merge on it:
   `gh pr merge <number> --auto --squash`
 - For performance optimization PRs, include before/after benchmark results in
@@ -182,6 +186,10 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   items are done, post a progress comment instead.
 - When referencing an issue in a commit message, use `Fixes #N` only if the
   commit fully resolves the issue. Otherwise use `Refs #N` or `Part of #N`.
+- When creating or commenting on issues with `gh`, write the body to a
+  temporary file first and pass it with `--body-file`. Do not inline
+  multi-line Markdown in the shell command, because quoting and escaping are
+  easy to get wrong.
 - **File issues for bugs found during other work.** If you discover a bug
   while working on an unrelated task, you *must* file a GitHub issue for it
   immediately. Do not silently work around it or leave it undocumented.

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1902,8 +1902,6 @@ public final class Matcher implements MatchResult {
     capturesResolved = true;
     groupZeroResolved = true;
     eagerFallbackCaptures = false;
-    lastHitEnd = false;
-    lastRequireEnd = false;
     return this;
   }
 
@@ -1951,8 +1949,6 @@ public final class Matcher implements MatchResult {
     groups = null;
     capturesResolved = true;
     groupZeroResolved = true;
-    lastHitEnd = false;
-    lastRequireEnd = false;
     return this;
   }
 

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1460,17 +1460,17 @@ class MatcherTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#226 hitEnd/requireEnd state differs after region reset")
-    @DisplayName("region clears stale requireEnd state")
-    void regionClearsRequireEndState() {
+    @DisplayName("region preserves end-state flags until next match attempt")
+    void regionPreservesEndStateFlagsUntilNextMatchAttempt() {
       Pattern p = Pattern.compile("a$");
       Matcher m = p.matcher("a");
       assertThat(m.find()).isTrue();
+      assertThat(m.hitEnd()).isTrue();
       assertThat(m.requireEnd()).isTrue();
 
       m.region(0, 1);
-      assertThat(m.hitEnd()).isFalse();
-      assertThat(m.requireEnd()).isFalse();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
     }
 
     @Test
@@ -2115,15 +2115,29 @@ class MatcherTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#226 SafeRE and java.util.regex differ on requireEnd state after reset")
-    @DisplayName("requireEnd() is false after reset")
-    void requireEndFalseAfterReset() {
+    @DisplayName("reset preserves end-state flags until next match attempt")
+    void resetPreservesEndStateFlagsUntilNextMatchAttempt() {
       Pattern p = Pattern.compile("abc$");
       Matcher m = p.matcher("abc");
       assertThat(m.find()).isTrue();
+      assertThat(m.hitEnd()).isTrue();
       assertThat(m.requireEnd()).isTrue();
       m.reset();
-      assertThat(m.requireEnd()).isFalse();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+    }
+
+    @Test
+    @DisplayName("reset(CharSequence) preserves end-state flags until next match attempt")
+    void resetWithNewInputPreservesEndStateFlagsUntilNextMatchAttempt() {
+      Pattern p = Pattern.compile("abc$");
+      Matcher m = p.matcher("abc");
+      assertThat(m.find()).isTrue();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
+      m.reset("x");
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve `hitEnd()` and `requireEnd()` state across `Matcher.reset()`, `reset(CharSequence)`, and `region()` until the next match attempt updates it, matching `java.util.regex`.
- Re-enable the affected generated crosscheck coverage by removing the `#226` disables and updating the regression expectations.
- Document the repo convention to pass GitHub issue/PR bodies through `--body-file`.

Fixes #226

## Validation

- `mvn -pl safere -Dtest=MatcherTest test -q` failed before the fix on the new reset/region expectations.
- `mvn -pl safere -Dtest=MatcherTest test -q` passed after the fix.
- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q` passed after installing the changed `safere` artifact.
- Full `mvn -pl safere test -q` was not clean because `MatcherTest$MatchesTests.matchesWithRepeatedDotStarBodiesAndMultipleCaptures` failed a timing-sensitive assertion; filed follow-up #231.
