### PR TITLE
Enable empty-left intersection crosscheck coverage

### DIFF
--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -427,8 +427,6 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @ParameterizedTest
-    @DisabledForCrosscheck(
-        "#220 SafeRE differs from java.util.regex for empty-left-side intersections")
     @ValueSource(strings = {"[&&`+]˫]*", "[&&abc]", "[a&&&&b]"})
     @DisplayName("empty left side of class intersection matches like JDK")
     void emptyLeftSideOfIntersection(String regex) {

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -900,7 +900,6 @@ class PatternTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#220 empty-left-side character-class intersection diverges from JDK")
     @DisplayName("[^a&&[ab]] applies intersection before negating the left side")
     void negatedIntersectionKeepsNegatedLeftHandClass() {
       Pattern p = Pattern.compile("[^a&&[ab]]");
@@ -910,7 +909,6 @@ class PatternTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#220 empty-left-side character-class intersection diverges from JDK")
     @DisplayName("[a-z&&[def]1] intersects with the whole right-hand union")
     void intersectionRightHandSideIncludesRangesAfterNestedClass() {
       Pattern p = Pattern.compile("[a-z&&[def]1]");


### PR DESCRIPTION
## Summary

- re-enable generated crosscheck coverage for empty-left-side character-class intersections
- remove stale issue #220 crosscheck disables from related character-class tests

Fixes #220

## Testing

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest,PatternTest test -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=JdkSyntaxCompatibilityTest,PatternTest test -q`

Full local gates were skipped at maintainer request before opening this PR.
