### PR TITLE
Reject caret negation in Unicode property names

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1372,11 +1372,6 @@ final class Parser {
       pos = end + 1; // skip '}'
     }
 
-    if (!name.isEmpty() && name.charAt(0) == '^') {
-      sign = -sign;
-      name = name.substring(1);
-    }
-
     int[][] table = lookupUnicodeGroup(name, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
     if (table == null) {
       throw new PatternSyntaxException(

--- a/safere/src/test/java/org/safere/JavaCharacterClassesTest.java
+++ b/safere/src/test/java/org/safere/JavaCharacterClassesTest.java
@@ -6,7 +6,9 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -177,13 +179,10 @@ class JavaCharacterClassesTest {
   }
 
   @Test
-  @DisabledForCrosscheck(
-      "#210 SafeRE accepts \\p{^javaLowerCase}, but java.util.regex rejects it")
-  @DisplayName("Negation with \\p{^...} works")
-  void caretNegationWorks() {
-    var p = Pattern.compile("\\p{^javaLowerCase}+");
-    assertThat(p.matcher("ABC").find()).isTrue();
-    assertThat(p.matcher("abc").find()).isFalse();
+  @DisplayName("Caret negation in java character class names is rejected")
+  void caretNegationRejected() {
+    assertThatThrownBy(() -> Pattern.compile("\\p{^javaLowerCase}+"))
+        .isInstanceOf(PatternSyntaxException.class);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -408,12 +408,10 @@ class ParserTest {
       assertThat(re.charClass.contains('a')).isFalse();
     }
 
-    @Test
-    void unicodePropertyNegatedCaretSyntax() {
-      // \p{^Braille} is the same as \P{Braille}
-      Regexp re = parse("\\p{^Braille}");
-      assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains(0x2800)).isFalse();
+    @ParameterizedTest
+    @ValueSource(strings = {"\\p{^Braille}", "\\p{^Lu}", "\\P{^Braille}"})
+    void unicodePropertyCaretNegationRejected(String regex) {
+      assertThatThrownBy(() -> parse(regex)).isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
+++ b/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
@@ -621,11 +621,11 @@ class UnicodePropertySyntaxTest {
   }
 
   // =========================================================================
-  // Negation — \P{...} and \p{^...}
+  // Negation — \P{...}
   // =========================================================================
 
   @Nested
-  @DisplayName("Negation with \\P{} and \\p{^}")
+  @DisplayName("Negation with \\P{}")
   class NegationTest {
 
     @Test
@@ -662,14 +662,6 @@ class UnicodePropertySyntaxTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#210 java.util.regex rejects caret negation in property names")
-    @DisplayName("\\p{^IsLatin} negation via caret")
-    void caretNegation() {
-      assertThat(find("\\p{^IsLatin}", "α")).isTrue();
-      assertThat(find("\\p{^IsLatin}", "A")).isFalse();
-    }
-
-    @Test
     @DisplayName("\\P{IsAlphabetic} matches non-alphabetic characters")
     void negatedBinaryProperty() {
       assertThat(find("\\P{IsAlphabetic}", "1")).isTrue();
@@ -699,6 +691,19 @@ class UnicodePropertySyntaxTest {
     void lowercaseInPrefix() {
       assertThatThrownBy(() -> Pattern.compile("\\p{inBasicLatin}"))
           .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "\\p{^IsLatin}",
+      "\\p{^InBasicLatin}",
+      "\\p{^script=Latin}",
+      "\\p{^gc=Lu}",
+      "\\p{^javaLowerCase}",
+    })
+    @DisplayName("Caret negation in property names is rejected")
+    void caretNegationInPropertyNameRejected(String regex) {
+      assertThatThrownBy(() -> Pattern.compile(regex)).isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- reject caret-prefixed Unicode property names like `\p{^javaLowerCase}` for JDK compatibility
- keep `\P{...}` as the supported negation syntax
- remove the issue #210 crosscheck disables and update parser/public API regression coverage

Fixes #210

## Validation

- `mvn -pl safere -Dtest=JavaCharacterClassesTest,UnicodePropertySyntaxTest test`
- `mvn -pl safere -Dtest=ParserTest,JavaCharacterClassesTest,UnicodePropertySyntaxTest test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere install -DskipTests -q`
- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q`

Note: `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test` was also attempted twice, but both runs stopped in the `safere` module before reaching `safere-crosscheck` due to an unrelated timing-sensitive `MatcherTest` assertion. Tracked separately in #235.
