### PR TITLE
Align octal escape handling with JDK

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -355,27 +355,33 @@ final class Parser {
     }
 
     // Regular escape
-    if (isUnsupportedLargeNonZeroOctalEscape()) {
-      pos += 4; // '\', digit, digit, digit
-      pushRegexp(Regexp.noMatch(flags));
+    if (maybePushNumericBackreferenceEscape()) {
       return;
     }
     int r = parseEscape();
     pushLiteral(r);
   }
 
-  private boolean isUnsupportedLargeNonZeroOctalEscape() {
-    if (pos + 3 >= pattern.length() || pattern.charAt(pos) != '\\') {
+  private boolean maybePushNumericBackreferenceEscape() {
+    if (pos + 1 >= pattern.length() || pattern.charAt(pos) != '\\') {
       return false;
     }
-    char d0 = pattern.charAt(pos + 1);
-    char d1 = pattern.charAt(pos + 2);
-    char d2 = pattern.charAt(pos + 3);
-    if (d0 < '4' || d0 > '7' || d1 < '0' || d1 > '7' || d2 < '0' || d2 > '7') {
+    char firstDigit = pattern.charAt(pos + 1);
+    if (firstDigit < '1' || firstDigit > '9') {
       return false;
     }
-    int value = (d0 - '0') * 64 + (d1 - '0') * 8 + (d2 - '0');
-    return value > 0377;
+    if (firstDigit - '0' <= ncap) {
+      throw new PatternSyntaxException("backreferences are not supported", pattern, pos);
+    }
+
+    pos += 2;
+    while (pos < pattern.length()
+        && pattern.charAt(pos) >= '0'
+        && pattern.charAt(pos) <= '9') {
+      pos++;
+    }
+    pushRegexp(Regexp.noMatch(flags));
+    return true;
   }
 
   // ---- Stack operations ----
@@ -1129,31 +1135,7 @@ final class Parser {
       }
       // Octal escapes.
       case '1', '2', '3', '4', '5', '6', '7' -> {
-        // Single non-zero octal digit is a backreference; not supported.
-        if (pos >= pattern.length()
-            || pattern.charAt(pos) < '0'
-            || pattern.charAt(pos) > '7') {
-          throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);
-        }
-        // fall through to octal parsing
-        int code = c - '0';
-        if (pos < pattern.length() && pattern.charAt(pos) >= '0'
-            && pattern.charAt(pos) <= '7') {
-          code = code * 8 + pattern.charAt(pos) - '0';
-          pos++;
-          if (pos < pattern.length() && pattern.charAt(pos) >= '0'
-              && pattern.charAt(pos) <= '7') {
-            int next = code * 8 + pattern.charAt(pos) - '0';
-            if (next <= 0377) {
-              code = next;
-              pos++;
-            }
-          }
-        }
-        if (code > runeMax) {
-          throw new PatternSyntaxException("invalid escape sequence", pattern, pos);
-        }
-        return code;
+        throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);
       }
       case '0' -> {
         // JDK: \0nnn — up to three octal digits after \0 (max value 0377 = 255).

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -149,6 +149,47 @@ class JdkSyntaxCompatibilityTest {
       assertMatchesSame("\\0101", "A");  // 0101 octal = 65 = 'A'
     }
 
+    @Test
+    @DisplayName("octal \\\\0mnn above 0377 stops before overflow")
+    void octalStopsBeforeOverflow() {
+      assertMatchesSame("\\0400", " 0");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\0", "\\08"})
+    @DisplayName("malformed leading-zero octal escape is rejected")
+    void malformedLeadingZeroOctalEscapeRejected(String regex) {
+      assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
+          .as("JDK should reject malformed octal escape: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .as("SafeRE should reject malformed octal escape: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\400", "\\777", "\\123"})
+    @DisplayName("unresolved non-zero numeric escapes never match")
+    void unresolvedNonZeroNumericEscapesNeverMatch(String regex) {
+      assertMatchesSame(regex, "\u0100");
+      assertMatchesSame(regex, "\u01ff");
+      assertMatchesSame(regex, "S");
+      assertMatchesSame(regex, " 0");
+      assertMatchesSame(regex, "?7");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[\\123]", "[\\400]"})
+    @DisplayName("non-zero numeric escapes in character classes are rejected")
+    void nonZeroNumericEscapesInCharacterClassesRejected(String regex) {
+      assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
+          .as("JDK should reject non-zero numeric escape in class: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .as("SafeRE should reject non-zero numeric escape in class: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
     // -- Hex escapes --
 
     @Test
@@ -978,7 +1019,14 @@ class JdkSyntaxCompatibilityTest {
   class BackReferences {
 
     @ParameterizedTest
-    @ValueSource(strings = {"(a)\\1", "(a)(b)\\2", "(?<name>a)\\k<name>"})
+    @ValueSource(
+        strings = {
+          "(a)\\1",
+          "(a)(b)\\2",
+          "(a)\\123",
+          "(a)(b)(c)(d)\\400",
+          "(?<name>a)\\k<name>"
+        })
     @DisplayName("back reference")
     void backReference(String regex) {
       // JDK accepts these.

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1072,18 +1072,27 @@ class ParserTest {
     }
 
     @Test
-    void octal_nonZeroLeading_twoDigits() {
-      // \12 is a backreference in JDK, but RE2 treats two-digit as octal.
+    void numericBackreferenceWithoutGroup_twoDigits() {
       Regexp re = parse("\\12");
-      assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
-      assertThat(re.rune).isEqualTo(10); // 12 octal = 10
+      assertThat(re.op).isEqualTo(RegexpOp.NO_MATCH);
     }
 
     @Test
-    void octal_nonZeroLeading_threeDigits() {
+    void numericBackreferenceWithoutGroup_threeDigits() {
       Regexp re = parse("\\123");
-      assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
-      assertThat(re.rune).isEqualTo(0x53); // 123 octal = 83 = 'S'
+      assertThat(re.op).isEqualTo(RegexpOp.NO_MATCH);
+    }
+
+    @Test
+    void numericBackreferenceWithGroup_rejected() {
+      assertThatThrownBy(() -> parse("(a)\\123"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void numericBackreferenceInCharClass_rejected() {
+      assertThatThrownBy(() -> parse("[\\123]"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
 
     // ---- Escape char and control chars ----

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -933,7 +933,6 @@ class PatternTest {
   class OctalEscapeTests {
 
     @Test
-    @DisabledForCrosscheck("#224 SafeRE accepts octal syntax that java.util.regex rejects")
     @DisplayName("\\0 without octal digits is rejected")
     void zeroOctalEscapeRequiresDigits() {
       assertThatThrownBy(() -> Pattern.compile("\\0"))
@@ -941,7 +940,6 @@ class PatternTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#224 SafeRE accepts octal syntax that java.util.regex rejects")
     @DisplayName("\\08 is rejected because \\0 requires an octal digit")
     void zeroOctalEscapeRejectsNonOctalDigit() {
       assertThatThrownBy(() -> Pattern.compile("\\08"))
@@ -949,7 +947,6 @@ class PatternTest {
     }
 
     @Test
-    @DisabledForCrosscheck("#224 large octal escapes diverge from java.util.regex")
     @DisplayName("octal escapes above 0377 do not become Unicode code points")
     void largeOctalEscapesDoNotBecomeUnicodeCodePoints() {
       assertThat(Pattern.compile("\\400").matcher("\u0100").matches()).isFalse();

--- a/safere/src/test/java/org/safere/RE2RegressionTest.java
+++ b/safere/src/test/java/org/safere/RE2RegressionTest.java
@@ -484,7 +484,7 @@ class RE2RegressionTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
-          "a\\1",     // backreference
+          "(a)\\1",   // backreference
           "a[x",      // unclosed bracket
           "a[z-a]",   // invalid range
           "a(b",      // unclosed paren

--- a/safere/src/test/java/org/safere/RE2SearchTest.java
+++ b/safere/src/test/java/org/safere/RE2SearchTest.java
@@ -136,6 +136,22 @@ class RE2SearchTest {
     return text.substring(startChar, endChar);
   }
 
+  private static boolean hasRe2NonZeroNumericEscape(String pattern) {
+    int backslashes = 0;
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+      if (c == '\\') {
+        backslashes++;
+        continue;
+      }
+      if (backslashes % 2 == 1 && c >= '1' && c <= '9') {
+        return true;
+      }
+      backslashes = 0;
+    }
+    return false;
+  }
+
   static Stream<Arguments> searchTests() throws IOException {
     List<Arguments> tests = new ArrayList<>();
     InputStream is = RE2SearchTest.class.getResourceAsStream("/re2-search.txt");
@@ -225,6 +241,9 @@ class RE2SearchTest {
       "RE2 search data includes non-JDK syntax and RE2-specific expectations")
   @MethodSource("searchTests")
   void testMatches(SearchTestCase tc) {
+    if (hasRe2NonZeroNumericEscape(tc.pattern())) {
+      return;
+    }
     Pattern p;
     try {
       p = Pattern.compile(tc.pattern());
@@ -243,6 +262,9 @@ class RE2SearchTest {
       "RE2 search data includes non-JDK syntax and RE2-specific expectations")
   @MethodSource("searchTests")
   void testFind(SearchTestCase tc) {
+    if (hasRe2NonZeroNumericEscape(tc.pattern())) {
+      return;
+    }
     Pattern p;
     try {
       p = Pattern.compile(tc.pattern());


### PR DESCRIPTION
## Summary

- align octal escape parsing with java.util.regex for malformed leading-zero escapes and overflow behavior
- treat non-zero numeric escapes as JDK numeric backreference syntax instead of RE2-style octal literals
- re-enable #224 public API crosscheck coverage and skip only RE2 fixture rows whose expectations rely on RE2-specific numeric octal syntax

Fixes #224

## Testing

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest,PatternTest,ParserTest,CrossEngineTest,RE2SearchTest,RE2RegressionTest test -q`
- `mvn -pl safere-crosscheck -Pcrosscheck-public-api-tests test -q` after reinstalling the updated `safere` artifact
- skipped fresh full local test rerun at user request; previous full run had only unrelated load-sensitive `MatcherTest.matchesWithRepeatedDotStarBodiesAndMultipleCaptures` timing failure, which passed when run alone
