### PR TITLE
Stabilize repeated capture stress test

### DIFF
--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -210,12 +210,13 @@ class MatcherTest {
 
     @Test
     @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
-    @DisplayName("matches() stays linear for repeated dot-star bodies with multiple captures")
+    @DisplayName("matches() completes for repeated dot-star bodies with multiple captures")
     void matchesWithRepeatedDotStarBodiesAndMultipleCaptures() {
-      assertNoSuperlinearRepeatedDotStarCaptureScaling(
-          repetitions -> {
-            String pattern = repeatedDotStarCapturePattern(repetitions, 3);
-            String input = repeatedDotStarCaptureInput(repetitions, 3);
+      String pattern = repeatedDotStarCapturePattern(500, 3);
+      String input = repeatedDotStarCaptureInput(500, 3);
+
+      assertCompletesWithinPerformanceTimeout(
+          () -> {
             Matcher m = Pattern.compile(pattern).matcher(input);
             assertThat(m.matches()).isTrue();
             assertThat(m.group(2)).endsWith("A");
@@ -2388,39 +2389,7 @@ class MatcherTest {
     return input.toString();
   }
 
-  private static void assertNoSuperlinearRepeatedDotStarCaptureScaling(IntConsumer scenario) {
-    scenario.accept(100);
-    scenario.accept(500);
-
-    int smallRepetitions = 100;
-    int largeRepetitions = 500;
-    long smallNanos = bestRuntimeNanos(5, () -> scenario.accept(smallRepetitions));
-    long largeNanos = bestRuntimeNanos(5, () -> scenario.accept(largeRepetitions));
-    long smallNanosPerRepetition = smallNanos / smallRepetitions;
-    long largeNanosPerRepetition = largeNanos / largeRepetitions;
-
-    // This is a regression guard for accidental superlinear capture extraction, not a
-    // microbenchmark. The wide per-repetition allowance absorbs ordinary full-suite
-    // timing noise while still failing on the dramatic cliff this test was added to catch.
-    assertThat(largeNanos)
-        .as("larger repeated-capture input should scale roughly with input size; "
-            + "small=%d ns, large=%d ns",
-            smallNanos, largeNanos)
-        .isLessThan(smallNanos * largeRepetitions / smallRepetitions * 12);
-    assertThat(largeNanosPerRepetition)
-        .as("larger repeated-capture input should not be dramatically slower per repetition; "
-            + "small=%d ns/repetition, large=%d ns/repetition",
-            smallNanosPerRepetition, largeNanosPerRepetition)
-        .isLessThan(smallNanosPerRepetition * 12);
-  }
-
-  private static long bestRuntimeNanos(int runs, Runnable task) {
-    long best = Long.MAX_VALUE;
-    for (int i = 0; i < runs; i++) {
-      long start = System.nanoTime();
-      task.run();
-      best = Math.min(best, System.nanoTime() - start);
-    }
-    return best;
+  private static void assertCompletesWithinPerformanceTimeout(Runnable task) {
+    assertTimeoutPreemptively(PERFORMANCE_SCENARIO_TIMEOUT, task::run);
   }
 }


### PR DESCRIPTION
## Summary

- Replace the load-sensitive repeated dot-star capture scaling ratio assertion with a bounded completion stress check.
- Keep the same multiple-capture correctness assertions on the large representative input.
- Remove the ad hoc best-of-N wall-clock timing helper from MatcherTest.

Fixes #235

## Testing

- `mvn -pl safere -Dtest=MatcherTest\$MatchesTests#matchesWithRepeatedDotStarBodiesAndMultipleCaptures test -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=org.safere.crosscheck.generated.MatcherTest\$MatchesTests#matchesWithRepeatedDotStarBodiesAndMultipleCaptures -Dsurefire.failIfNoSpecifiedTests=false test -q` confirms the generated crosscheck copy remains selected and skipped by `@DisabledForCrosscheck`; it does not exercise this stress case because java.util.regex backtracks on it.

Full local test suite not run per maintainer instruction.
