### PR TITLE
Reject bare Unicode property names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,9 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   fundamental to SafeRE's approach (e.g., linear-time guarantees require
   rejecting backreferences) or (b) the JDK's behavior is likely a bug
   (e.g., JDK is internally inconsistent). When diverging, document the
-  reason.
+  reason. When changing behavior to match `java.util.regex`, use the
+  official JDK Javadoc as the specification; do not rely on memory or infer
+  semantics from implementation details.
 - **Linear time**: No backreferences, no lookahead/lookbehind, no possessive
   quantifiers. These features violate linear-time guarantees and must be
   rejected at parse time with a clear error.

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1369,9 +1369,6 @@ final class Parser {
   }
 
   private static int[][] lookupUnicodeGroup(String name, boolean unicodeCharacterClass) {
-    if ("Any".equals(name)) {
-      return new int[][] {{0, Utils.MAX_RUNE}};
-    }
     int[][] table = JavaCharacterClasses.lookup(name);
     if (table != null) {
       return table;
@@ -1407,8 +1404,9 @@ final class Parser {
       return UnicodeProperties.lookupBlock(name.substring(2));
     }
 
-    // Direct lookup in UNICODE_GROUPS (e.g., "Latin", "Lu").
-    return UnicodeTables.UNICODE_GROUPS.get(name);
+    // Bare Unicode properties are valid only for general categories such as "L" or "Lu".
+    // JDK Pattern requires scripts to use Is/script=/sc= and blocks to use In/block=/blk=.
+    return UnicodeProperties.lookupCategory(name);
   }
 
   private static int[][] lookupKeywordProperty(String key, String value) {
@@ -1416,9 +1414,9 @@ final class Parser {
     String normalizedKey =
         key.toUpperCase(java.util.Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
     return switch (normalizedKey) {
-      case "SCRIPT", "SC" -> UnicodeProperties.lookupScriptOrCategory(value);
+      case "SCRIPT", "SC" -> UnicodeProperties.lookupScript(value);
       case "BLOCK", "BLK" -> UnicodeProperties.lookupBlock(value);
-      case "GENERALCATEGORY", "GC" -> UnicodeProperties.lookupScriptOrCategory(value);
+      case "GENERALCATEGORY", "GC" -> UnicodeProperties.lookupCategory(value);
       default -> null;
     };
   }

--- a/safere/src/main/java/org/safere/UnicodeGroups.java
+++ b/safere/src/main/java/org/safere/UnicodeGroups.java
@@ -168,7 +168,7 @@ final class UnicodeGroups {
   }
 
   /** Converts a {@link Character.UnicodeScript} enum constant to its Unicode canonical name. */
-  private static String scriptName(Character.UnicodeScript script) {
+  static String scriptName(Character.UnicodeScript script) {
     String enumName = script.name();
     String override = SCRIPT_NAME_OVERRIDES.get(enumName);
     if (override != null) {

--- a/safere/src/main/java/org/safere/UnicodeProperties.java
+++ b/safere/src/main/java/org/safere/UnicodeProperties.java
@@ -6,6 +6,7 @@
 package org.safere;
 
 import java.lang.Character.UnicodeBlock;
+import java.lang.Character.UnicodeScript;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -190,6 +191,40 @@ final class UnicodeProperties {
     } catch (IllegalArgumentException e) {
       return null;
     }
+  }
+
+  /**
+   * Looks up a Unicode script by name using the same names accepted by {@link
+   * Character.UnicodeScript#forName(String)}.
+   *
+   * @return the range table, or {@code null} if not a recognized script
+   */
+  static int[][] lookupScript(String name) {
+    try {
+      UnicodeScript script = UnicodeScript.forName(name);
+      return UnicodeTables.UNICODE_GROUPS.get(UnicodeGroups.scriptName(script));
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Looks up a Unicode general category by its one- or two-letter abbreviation.
+   *
+   * @return the range table, or {@code null} if not a recognized category
+   */
+  static int[][] lookupCategory(String name) {
+    return switch (name) {
+      case "L", "M", "N", "P", "S", "Z", "C",
+          "Lu", "Ll", "Lt", "Lm", "Lo",
+          "Mn", "Me", "Mc",
+          "Nd", "Nl", "No",
+          "Zs", "Zl", "Zp",
+          "Cc", "Cf", "Co", "Cs",
+          "Pd", "Ps", "Pe", "Pc", "Po", "Pi", "Pf",
+          "Sm", "Sc", "Sk", "So" -> UnicodeTables.UNICODE_GROUPS.get(name);
+      default -> null;
+    };
   }
 
   /**

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -52,6 +52,16 @@ class JdkSyntaxCompatibilityTest {
         .isThrownBy(() -> Pattern.compile(regex));
   }
 
+  /** Asserts JDK and SafeRE both reject the pattern. */
+  private static void assertRejectedByJdkAndSafeRe(String regex) {
+    assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
+        .as("JDK should reject: %s", regex)
+        .isInstanceOf(PatternSyntaxException.class);
+    assertThatThrownBy(() -> Pattern.compile(regex))
+        .as("SafeRE should reject: %s", regex)
+        .isInstanceOf(PatternSyntaxException.class);
+  }
+
   /** Asserts SafeRE compiles and matches identically to JDK on the given input. */
   private static void assertMatchesSame(String regex, String input) {
     // Sanity: JDK must accept it.
@@ -603,6 +613,13 @@ class JdkSyntaxCompatibilityTest {
     void scKeywordLatin() {
       assertMatchesSame("\\p{sc=Latin}", "A");
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\p{Latin}", "\\P{Latin}", "[\\p{Latin}]", "\\p{script=Lu}"})
+    @DisplayName("rejects non-JDK script property spellings")
+    void rejectsNonJdkScriptPropertySpellings(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
+    }
   }
 
   @Nested
@@ -638,6 +655,19 @@ class JdkSyntaxCompatibilityTest {
     void notInGreek() {
       assertMatchesSame("\\P{InGreek}", "A");
       assertMatchesFull("\\P{InGreek}", "\u0391");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "\\p{Braille}",
+        "\\P{Braille}",
+        "\\p{^Braille}",
+        "[\\p{Braille}]",
+        "\\p{general_category=Latin}"
+    })
+    @DisplayName("rejects non-JDK block property spellings")
+    void rejectsNonJdkBlockPropertySpellings(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
     }
   }
 
@@ -702,6 +732,13 @@ class JdkSyntaxCompatibilityTest {
     @DisplayName("\\\\p{gc=Lu}")
     void gcShortKeywordLu() {
       assertMatchesSame("\\p{gc=Lu}", "A");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\p{lu}", "\\p{gc=Latin}", "\\p{gc=Letter}"})
+    @DisplayName("rejects non-JDK category property spellings")
+    void rejectsNonJdkCategoryPropertySpellings(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
     }
 
     @Test
@@ -783,6 +820,13 @@ class JdkSyntaxCompatibilityTest {
     @DisplayName("\\\\p{IsExtended_Pictographic}")
     void isExtendedPictographic() {
       assertCompiles("\\p{IsExtended_Pictographic}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\p{Alphabetic}", "\\P{Alphabetic}", "[\\p{Alphabetic}]"})
+    @DisplayName("rejects binary properties without Is prefix")
+    void rejectsBinaryPropertiesWithoutIsPrefix(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
     }
   }
 

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -385,18 +385,18 @@ class ParserTest {
     // -- Unicode property classes --
 
     @Test
-    void unicodePropertyBraille() {
-      Regexp re = parse("\\p{Braille}");
+    void unicodePropertyGreekBlock() {
+      Regexp re = parse("\\p{InGreek}");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains(0x2800)).isTrue();
-      assertThat(re.charClass.contains(0x28FF)).isTrue();
+      assertThat(re.charClass.contains(0x0391)).isTrue();
+      assertThat(re.charClass.contains('A')).isFalse();
     }
 
     @Test
-    void unicodePropertyBrailleNegated() {
-      Regexp re = parse("\\P{Braille}");
+    void unicodePropertyGreekBlockNegated() {
+      Regexp re = parse("\\P{InGreek}");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains(0x2800)).isFalse();
+      assertThat(re.charClass.contains(0x0391)).isFalse();
       assertThat(re.charClass.contains('a')).isTrue();
     }
 
@@ -415,11 +415,17 @@ class ParserTest {
     }
 
     @Test
-    void unicodePropertyLatin() {
-      Regexp re = parse("\\p{Latin}");
+    void unicodePropertyLatinScript() {
+      Regexp re = parse("\\p{IsLatin}");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
       assertThat(re.charClass.contains('a')).isTrue();
       assertThat(re.charClass.contains('z')).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\p{Braille}", "\\P{Braille}", "\\p{Latin}", "[\\p{Latin}]"})
+    void bareUnicodeScriptAndBlockNamesRejected(String pattern) {
+      assertThatThrownBy(() -> parse(pattern)).isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/PatternSetTest.java
+++ b/safere/src/test/java/org/safere/PatternSetTest.java
@@ -283,7 +283,7 @@ class PatternSetTest {
     void unicodePatterns() {
       PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.UNANCHORED);
       b.add("caf\u00e9");
-      b.add("\\p{Greek}+");
+      b.add("\\p{IsGreek}+");
       PatternSet set = b.compile();
 
       assertThat(set.match("caf\u00e9")).containsExactly(0);

--- a/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
+++ b/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
@@ -788,20 +788,12 @@ class UnicodePropertySyntaxTest {
   }
 
   // =========================================================================
-  // Backward compatibility — existing \p{...} forms still work
+  // Bare JDK category forms
   // =========================================================================
 
   @Nested
-  @DisplayName("Backward compatibility with existing \\p{} forms")
-  class BackwardCompatibilityTest {
-
-    @Test
-    @DisabledForCrosscheck("SafeRE backward-compatible direct script alias is not JDK syntax")
-    @DisplayName("\\p{Latin} still works (no prefix)")
-    void directScriptName() {
-      assertThat(find("\\p{Latin}", "A")).isTrue();
-      assertThat(find("\\p{Latin}", "α")).isFalse();
-    }
+  @DisplayName("Bare JDK category forms")
+  class BareCategoryTest {
 
     @Test
     @DisplayName("\\p{Lu} still works (no prefix)")
@@ -815,14 +807,6 @@ class UnicodePropertySyntaxTest {
     void directMajorCategory() {
       assertThat(find("\\p{L}", "A")).isTrue();
       assertThat(find("\\p{L}", "1")).isFalse();
-    }
-
-    @Test
-    @DisabledForCrosscheck("SafeRE backward-compatible direct block alias is not JDK syntax")
-    @DisplayName("\\p{Braille} still works")
-    void directBraille() {
-      assertThat(find("\\p{Braille}", "\u2800")).isTrue();
-      assertThat(find("\\p{Braille}", "A")).isFalse();
     }
 
     @Test
@@ -846,12 +830,14 @@ class UnicodePropertySyntaxTest {
       assertThat(find("\\p{javaLowerCase}", "A")).isFalse();
     }
 
-    @Test
-    @DisabledForCrosscheck("SafeRE backward-compatible Any property alias is not JDK syntax")
-    @DisplayName("\\p{Any} still works")
-    void anyClass() {
-      assertThat(find("\\p{Any}", "A")).isTrue();
-      assertThat(find("\\p{Any}", "α")).isTrue();
+    @ParameterizedTest
+    @ValueSource(strings = {"\\p{Latin}", "\\p{Braille}", "\\p{Any}"})
+    @DisplayName("RE2-style bare Unicode property names are rejected")
+    void re2StyleBareUnicodePropertyNamesAreRejected(String regex) {
+      assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
+          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .isInstanceOf(PatternSyntaxException.class);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Reject RE2-style bare Unicode property names such as `\p{Latin}`, `\p{Braille}`, and `\p{Any}` to match `java.util.regex.Pattern`
- Keep JDK-compatible Unicode property spellings, including `Is`, `In`, `script=`, `block=`, `gc=`, and bare category abbreviations
- Add parser/API regression coverage and document that JDK compatibility changes should use the official `java.util.regex` Javadoc as the spec

Fixes #214

## Tests

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest,ParserTest,UnicodePropertySyntaxTest,PatternSetTest test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test`
