### PR TITLE
Reject nonzero numeric escapes as backrefs

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1133,10 +1133,9 @@ final class Parser {
               "unknown Unicode character name: " + name, pattern, nameStart);
         }
       }
-      // Octal escapes.
-      case '1', '2', '3', '4', '5', '6', '7' -> {
-        throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);
-      }
+      // JDK treats all non-zero numeric escapes as back references, not octal literals.
+      case '1', '2', '3', '4', '5', '6', '7', '8', '9' ->
+          throw new PatternSyntaxException("backreferences are not supported", pattern, pos - 2);
       case '0' -> {
         // JDK: \0nnn — up to three octal digits after \0 (max value 0377 = 255).
         if (pos >= pattern.length()

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1080,6 +1080,41 @@ class JdkSyntaxCompatibilityTest {
           .as("SafeRE should reject back reference: %s", regex)
           .isInstanceOf(PatternSyntaxException.class);
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\1", "\\9", "\\12"})
+    @DisplayName("unresolved numeric back reference forms never match")
+    void unresolvedNumericBackReferenceFormsNeverMatch(String regex) {
+      assertMatchesSame(regex, "");
+      assertMatchesSame(regex, "1");
+      assertMatchesSame(regex, "9");
+      assertMatchesSame(regex, "S");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"(a)\\12", "(a)\\123", "(a)(b)\\12"})
+    @DisplayName("numeric back reference shortened to an existing preceding group")
+    void numericBackReferenceShortenedToExistingPrecedingGroup(String regex) {
+      assertThatNoException()
+          .as("JDK should accept shortened numeric back reference: %s", regex)
+          .isThrownBy(() -> java.util.regex.Pattern.compile(regex));
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .as("SafeRE should reject numeric back reference: %s", regex)
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    @DisplayName("multi-digit numeric back reference to an existing preceding group")
+    void multiDigitNumericBackReferenceToExistingPrecedingGroup() {
+      String regex = "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)\\12";
+
+      assertThatNoException()
+          .as("JDK should accept numeric back reference to group 12")
+          .isThrownBy(() -> java.util.regex.Pattern.compile(regex));
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .as("SafeRE should reject numeric back reference to group 12")
+          .isInstanceOf(PatternSyntaxException.class);
+    }
   }
 
   // ===========================================================================

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1075,27 +1075,24 @@ class ParserTest {
       assertThat(re.rune).isEqualTo(63); // 077 octal = 63
     }
 
-    @Test
-    void numericBackreferenceWithoutGroup_twoDigits() {
-      Regexp re = parse("\\12");
+    @ParameterizedTest
+    @ValueSource(strings = {"\\1", "\\9", "\\12", "\\123"})
+    void numericBackreferenceWithoutGroupNeverMatches(String pattern) {
+      Regexp re = parse(pattern);
       assertThat(re.op).isEqualTo(RegexpOp.NO_MATCH);
     }
 
-    @Test
-    void numericBackreferenceWithoutGroup_threeDigits() {
-      Regexp re = parse("\\123");
-      assertThat(re.op).isEqualTo(RegexpOp.NO_MATCH);
-    }
-
-    @Test
-    void numericBackreferenceWithGroup_rejected() {
-      assertThatThrownBy(() -> parse("(a)\\123"))
+    @ParameterizedTest
+    @ValueSource(strings = {"(a)\\1", "(a)\\12", "(a)\\123", "(a)(b)\\12"})
+    void numericBackreferenceWithGroupRejected(String pattern) {
+      assertThatThrownBy(() -> parse(pattern))
           .isInstanceOf(PatternSyntaxException.class);
     }
 
-    @Test
-    void numericBackreferenceInCharClass_rejected() {
-      assertThatThrownBy(() -> parse("[\\123]"))
+    @ParameterizedTest
+    @ValueSource(strings = {"[\\1]", "[\\9]", "[\\12]", "[\\123]"})
+    void numericBackreferenceInCharClassRejected(String pattern) {
+      assertThatThrownBy(() -> parse(pattern))
           .isInstanceOf(PatternSyntaxException.class);
     }
 


### PR DESCRIPTION
## Summary

- reject nonzero numeric escapes as unsupported backreference syntax instead of RE2-style octal literals
- keep JDK-style `\0...` octal parsing unchanged
- add parser and JDK compatibility coverage for `\1`, `\9`, `\12`, `\123`, shortened numeric backrefs, and multi-digit group references

Fixes #215

## Tests

- `mvn -pl safere -Dtest=ParserTest,JdkSyntaxCompatibilityTest test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test`
