### PR TITLE
Avoid duplicate SafeRE test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,10 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Build and test
-        run: mvn verify -pl safere -Dtest.parallelism=4 --batch-mode --no-transfer-progress
-
-      - name: Build and test crosscheck module
+      - name: Build and test SafeRE and crosscheck modules
         run: >
-          mvn verify -pl safere-crosscheck -am -Pcrosscheck-public-api-tests
+          mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests
+          -Dtest.parallelism=4
           --batch-mode --no-transfer-progress
 
   benchmark-smoke-test-java:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,14 +158,14 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
 ## Pull Requests
 
 - **Never push to a PR (or create one) without first verifying locally that
-  all tests pass** (`mvn -pl safere test`). CI failures waste time and block
-  merges.
-- Before making a PR, also run the public API crosscheck invariant:
-  `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test`. This runs
-  generated copies of SafeRE public API test candidates through
-  `org.safere.crosscheck` so each test operation is compared with the JDK.
-  The `-am` flag is required so the reactor rebuilds the local `safere` module
-  instead of testing against a stale artifact from the local Maven repository.
+  all SafeRE and public API crosscheck tests pass**:
+  `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`.
+  CI failures waste time and block merges. This single Maven reactor run tests
+  the `safere` module once, then runs generated copies of SafeRE public API test
+  candidates through `org.safere.crosscheck` so each test operation is compared
+  with the JDK. The `-am` flag is required so the reactor rebuilds the local
+  `safere` module instead of testing against a stale artifact from the local
+  Maven repository.
   Use `@DisabledForCrosscheck("reason")` on original SafeRE tests for cases
   that should be visible as disabled only in generated crosscheck coverage.
 - **Update existing PRs — do not close and reopen.** Push commits (or

--- a/TESTING.md
+++ b/TESTING.md
@@ -165,6 +165,12 @@ mvn verify -pl safere -Pcoverage
 # Run crosscheck module tests
 mvn test -pl safere-crosscheck -am
 
+# Run SafeRE tests and generated public API tests through the crosscheck facade
+mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests
+
+# Run generated public API tests only, after safere has already been built locally
+mvn verify -pl safere-crosscheck -Pcrosscheck-public-api-tests
+
 # Run Jazzer fuzz targets in regression mode
 mvn test -pl safere-fuzz
 ```
@@ -189,6 +195,11 @@ The facade records a trace of all API calls. When a divergence is detected,
 the exception includes the full trace, providing enough context to reproduce
 and report the bug. See
 [safere-crosscheck/README.md](../safere-crosscheck/README.md) for details.
+
+For pre-PR validation, use the combined reactor command above. It runs the
+`safere` tests once and then runs generated copies of SafeRE public API tests
+through the crosscheck facade. The `-am` flag ensures Maven rebuilds the local
+`safere` module instead of resolving a stale installed artifact.
 
 ## Fuzz Testing with Jazzer
 

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -127,7 +127,7 @@ The `crosscheck-public-api-tests` Maven profile runs generated copies of SafeRE
 public API test candidates through the crosscheck facade:
 
 ```bash
-mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test
+mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests
 ```
 
 The generated sources are not checked in. The profile copies broad public API
@@ -136,9 +136,11 @@ generated package, and imports `org.safere.crosscheck.Pattern` and
 `org.safere.crosscheck.Matcher`. This keeps one source of truth for the test
 logic while making JDK compatibility an executable invariant.
 
-The `-am` flag tells Maven to also build required reactor dependencies, including
-the local `safere` module. Without it, Maven can resolve `safere` from the local
-repository and accidentally test against a stale installed artifact.
+This single Maven reactor run tests the `safere` module once, then runs the
+generated crosscheck tests in `safere-crosscheck`. The `-am` flag tells Maven to
+also build required reactor dependencies, including the local `safere` module.
+Without it, Maven can resolve `safere` from the local repository and
+accidentally test against a stale installed artifact.
 
 Use `@DisabledForCrosscheck("reason")` in the original SafeRE test source for
 test methods or classes that should be disabled only in generated crosscheck


### PR DESCRIPTION
## Summary

- Replace the two-step SafeRE/crosscheck CI flow with one Maven reactor invocation.
- Document the combined public API crosscheck validation command.
- Clarify that the combined command runs SafeRE tests once and then generated crosscheck tests.

Fixes #241

## Testing

- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q`
