### PR TITLE
Match JDK POSIX bracket class semantics

### DIFF
--- a/safere/src/main/java/org/safere/ParseFlags.java
+++ b/safere/src/main/java/org/safere/ParseFlags.java
@@ -23,8 +23,7 @@ final class ParseFlags {
   public static final int LITERAL = 1 << 1;
 
   /**
-   * Allow character classes like {@code [^a-z]}, {@code \D}, {@code \s}, and {@code [[:space:]]} to
-   * match newline.
+   * Allow character classes like {@code [^a-z]}, {@code \D}, and {@code \s} to match newline.
    */
   public static final int CLASS_NL = 1 << 2;
 

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -972,22 +972,7 @@ final class Parser {
       }
       first = false;
 
-      // Look for [:alnum:] etc.
-      if (pos + 2 < pattern.length()
-          && pattern.charAt(pos) == '['
-          && pattern.charAt(pos + 1) == ':') {
-        int result = parseCCName(ccb);
-        if (result == PARSE_OK) {
-          continue;
-        } else if (result == PARSE_ERROR) {
-          // error already thrown
-          return null;
-        }
-        // PARSE_NOTHING: fall through
-      }
-
       // Look for nested character class like [[A-F]] (Java-style union).
-      // At this point we know pattern.charAt(pos) == '[' and it's not a POSIX class.
       if (pos < pattern.length() && pattern.charAt(pos) == '[') {
         Regexp nested = parseCharClass();
         ccb.addCharClass(nested.charClass);
@@ -1418,52 +1403,6 @@ final class Parser {
       case "GENERALCATEGORY", "GC" -> UnicodeProperties.lookupCategory(value);
       default -> null;
     };
-  }
-
-  // ---- POSIX class name parsing ([:alnum:], etc.) ----
-
-  private int parseCCName(CharClassBuilder ccb) {
-    // Check begins with [:
-    if (pos + 2 >= pattern.length()
-        || pattern.charAt(pos) != '['
-        || pattern.charAt(pos + 1) != ':') {
-      return PARSE_NOTHING;
-    }
-
-    // Look for closing :].
-    int q = pattern.indexOf(":]", pos + 2);
-    if (q < 0) {
-      return PARSE_NOTHING;
-    }
-    q += 2; // past :]
-
-    String name = pattern.substring(pos, q);
-    // name is like "[:alnum:]" or "[:^alpha:]"
-
-    // Check for negation: [:^...]
-    boolean negated = false;
-    String lookupName = name;
-    if (name.length() > 4 && name.charAt(2) == '^') {
-      negated = true;
-      // Convert [:^alpha:] to [:alpha:]
-      lookupName = "[:" + name.substring(3);
-    }
-
-    int[][] table = (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0
-        ? UnicodeTables.unicodePosixGroups().get(lookupName)
-        : UnicodeTables.POSIX_GROUPS.get(lookupName);
-    if (table == null) {
-      throw new PatternSyntaxException("invalid POSIX class: " + name, pattern, pos);
-    }
-
-    pos = q; // advance past the class name
-
-    if (negated) {
-      addGroupNegated(ccb, table);
-    } else {
-      addGroupPositive(ccb, table);
-    }
-    return PARSE_OK;
   }
 
   // ---- Group add helpers ----

--- a/safere/src/main/java/org/safere/UnicodeTables.java
+++ b/safere/src/main/java/org/safere/UnicodeTables.java
@@ -75,24 +75,7 @@ final class UnicodeTables {
   public static final int[][] POSIX_PUNCT = {{0x21, 0x2F}, {0x3A, 0x40}, {0x5B, 0x60}, {0x7B, 0x7E}};
   public static final int[][] POSIX_SPACE = {{0x09, 0x0D}, {0x20, 0x20}};
   public static final int[][] POSIX_UPPER = {{0x41, 0x5A}};
-  public static final int[][] POSIX_WORD = {{0x30, 0x39}, {0x41, 0x5A}, {0x5F, 0x5F}, {0x61, 0x7A}};
   public static final int[][] POSIX_XDIGIT = {{0x30, 0x39}, {0x41, 0x46}, {0x61, 0x66}};
-
-  public static final Map<String, int[][]> POSIX_GROUPS = Map.ofEntries(
-      Map.entry("[:alnum:]", POSIX_ALNUM),
-      Map.entry("[:alpha:]", POSIX_ALPHA),
-      Map.entry("[:ascii:]", POSIX_ASCII),
-      Map.entry("[:blank:]", POSIX_BLANK),
-      Map.entry("[:cntrl:]", POSIX_CNTRL),
-      Map.entry("[:digit:]", POSIX_DIGIT),
-      Map.entry("[:graph:]", POSIX_GRAPH),
-      Map.entry("[:lower:]", POSIX_LOWER),
-      Map.entry("[:print:]", POSIX_PRINT),
-      Map.entry("[:punct:]", POSIX_PUNCT),
-      Map.entry("[:space:]", POSIX_SPACE),
-      Map.entry("[:upper:]", POSIX_UPPER),
-      Map.entry("[:word:]", POSIX_WORD),
-      Map.entry("[:xdigit:]", POSIX_XDIGIT));
 
   /**
    * POSIX character class names for use with the {@code \p{...}} property syntax (e.g., {@code
@@ -146,30 +129,10 @@ final class UnicodeTables {
             Map.entry("XDigit", UNICODE_XDIGIT),
             Map.entry("Space", unicodeSpace()));
 
-    static final Map<String, int[][]> UNICODE_POSIX_GROUPS =
-        Map.ofEntries(
-            Map.entry("[:alnum:]", UNICODE_ALNUM),
-            Map.entry("[:alpha:]", UNICODE_ALPHA),
-            Map.entry("[:ascii:]", POSIX_ASCII),
-            Map.entry("[:blank:]", HORIZ_SPACE),
-            Map.entry("[:cntrl:]", UNICODE_CNTRL),
-            Map.entry("[:digit:]", UNICODE_DIGIT),
-            Map.entry("[:graph:]", UNICODE_GRAPH),
-            Map.entry("[:lower:]", UnicodeProperties.lookupBinaryProperty("Lowercase")),
-            Map.entry("[:print:]", UNICODE_PRINT),
-            Map.entry("[:punct:]", UNICODE_PUNCT),
-            Map.entry("[:space:]", unicodeSpace()),
-            Map.entry("[:upper:]", UnicodeProperties.lookupBinaryProperty("Uppercase")),
-            Map.entry("[:word:]", unicodeWord()),
-            Map.entry("[:xdigit:]", UNICODE_XDIGIT));
   }
 
   static Map<String, int[][]> unicodePosixPropertyGroups() {
     return UnicodePosixHolder.UNICODE_POSIX_PROPERTY_GROUPS;
-  }
-
-  static Map<String, int[][]> unicodePosixGroups() {
-    return UnicodePosixHolder.UNICODE_POSIX_GROUPS;
   }
 
   private static boolean isUnicodeWhiteSpace(int cp) {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -548,6 +548,39 @@ class JdkSyntaxCompatibilityTest {
       assertMatchesSame(regex, shouldMatch);
       assertMatchesFull(regex, shouldNotMatch);
     }
+
+    static Stream<Arguments> posixBracketClassSyntax() {
+      return Stream.of(
+          Arguments.of("[[:lower:]]", "l", true),
+          Arguments.of("[[:lower:]]", "a", false),
+          Arguments.of("[[:lower:]]", ":", true),
+          Arguments.of("[[:alpha:]]", "p", true),
+          Arguments.of("[[:alpha:]]", "Z", false),
+          Arguments.of("[[:digit:]]", "d", true),
+          Arguments.of("[[:digit:]]", "5", false),
+          Arguments.of("[[:^space:]]", "^", true),
+          Arguments.of("[[:^space:]]", "s", true),
+          Arguments.of("[[:^space:]]", " ", false),
+          Arguments.of("[^[:lower:]]", "a", true),
+          Arguments.of("[^[:lower:]]", "l", false),
+          Arguments.of("[^[:lower:]]", ":", false));
+    }
+
+    @ParameterizedTest(name = "{0} on \"{1}\"")
+    @MethodSource("posixBracketClassSyntax")
+    @DisplayName("POSIX bracket class spelling is ordinary character-class text")
+    void posixBracketClassSyntaxIsOrdinaryText(
+        String regex, String input, boolean expectedMatch) {
+      boolean jdkMatches = java.util.regex.Pattern.compile(regex).matcher(input).matches();
+      boolean safeMatches = Pattern.compile(regex).matcher(input).matches();
+
+      assertThat(jdkMatches)
+          .as("JDK baseline for /%s/ on \"%s\"", regex, input)
+          .isEqualTo(expectedMatch);
+      assertThat(safeMatches)
+          .as("SafeRE for /%s/ on \"%s\"", regex, input)
+          .isEqualTo(expectedMatch);
+    }
   }
 
   // ===========================================================================

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -274,47 +274,59 @@ class ParserTest {
       assertThat(re.charClass.contains('D')).isFalse();
     }
 
-    // -- POSIX classes --
+    // -- POSIX bracket-class spelling is ordinary JDK character-class text --
 
     @Test
-    void posixLower() {
+    void posixLowerSpellingIsLiteralText() {
       Regexp re = parse("[[:lower:]]");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains('a')).isTrue();
-      assertThat(re.charClass.contains('z')).isTrue();
+      assertThat(re.charClass.contains(':')).isTrue();
+      assertThat(re.charClass.contains('l')).isTrue();
+      assertThat(re.charClass.contains('r')).isTrue();
+      assertThat(re.charClass.contains('a')).isFalse();
+      assertThat(re.charClass.contains('z')).isFalse();
     }
 
     @Test
-    void posixAlpha() {
+    void posixAlphaSpellingIsLiteralText() {
       Regexp re = parse("[[:alpha:]]");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
       assertThat(re.charClass.contains('a')).isTrue();
-      assertThat(re.charClass.contains('Z')).isTrue();
+      assertThat(re.charClass.contains('p')).isTrue();
+      assertThat(re.charClass.contains(':')).isTrue();
       assertThat(re.charClass.contains('0')).isFalse();
+      assertThat(re.charClass.contains('Z')).isFalse();
     }
 
     @Test
-    void posixDigit() {
+    void posixDigitSpellingIsLiteralText() {
       Regexp re = parse("[[:digit:]]");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains('0')).isTrue();
-      assertThat(re.charClass.contains('9')).isTrue();
-      assertThat(re.charClass.contains('a')).isFalse();
+      assertThat(re.charClass.contains('d')).isTrue();
+      assertThat(re.charClass.contains('t')).isTrue();
+      assertThat(re.charClass.contains(':')).isTrue();
+      assertThat(re.charClass.contains('0')).isFalse();
+      assertThat(re.charClass.contains('9')).isFalse();
     }
 
     @Test
-    void posixNegated() {
+    void posixNegatedSpellingIsLiteralText() {
       Regexp re = parse("[[:^space:]]");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
+      assertThat(re.charClass.contains('^')).isTrue();
+      assertThat(re.charClass.contains('s')).isTrue();
+      assertThat(re.charClass.contains(':')).isTrue();
       assertThat(re.charClass.contains(' ')).isFalse();
-      assertThat(re.charClass.contains('a')).isTrue();
+      assertThat(re.charClass.contains('x')).isFalse();
     }
 
     @Test
-    void negatedPosixClass() {
+    void negatedPosixSpellingNegatesLiteralText() {
       Regexp re = parse("[^[:lower:]]");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains('a')).isFalse();
+      assertThat(re.charClass.contains('l')).isFalse();
+      assertThat(re.charClass.contains(':')).isFalse();
+      assertThat(re.charClass.contains('a')).isTrue();
       assertThat(re.charClass.contains('A')).isTrue();
     }
 
@@ -1248,11 +1260,14 @@ class ParserTest {
     }
 
     @Test
-    void caseInsensitive_posixLower() {
+    void caseInsensitive_posixLowerSpellingIsLiteralText() {
       Regexp re = parse("(?i)[[:lower:]]");
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
-      assertThat(re.charClass.contains('A')).isTrue();
-      assertThat(re.charClass.contains('a')).isTrue();
+      assertThat(re.charClass.contains('L')).isTrue();
+      assertThat(re.charClass.contains('l')).isTrue();
+      assertThat(re.charClass.contains(':')).isTrue();
+      assertThat(re.charClass.contains('A')).isFalse();
+      assertThat(re.charClass.contains('a')).isFalse();
     }
   }
 

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -47,19 +47,19 @@ class SimplifierTest {
         Arguments.of("[ac]", "[ac]"),
         Arguments.of("[^ac]", "[^ac]"),
 
-        // Posix character classes
-        Arguments.of("[[:alnum:]]", "[0-9A-Za-z]"),
-        Arguments.of("[[:alpha:]]", "[A-Za-z]"),
-        Arguments.of("[[:blank:]]", "[\\t ]"),
-        Arguments.of("[[:cntrl:]]", "[\\x00-\\x1f\\x7f]"),
-        Arguments.of("[[:digit:]]", "[0-9]"),
-        Arguments.of("[[:graph:]]", "[!-~]"),
-        Arguments.of("[[:lower:]]", "[a-z]"),
-        Arguments.of("[[:print:]]", "[ -~]"),
-        Arguments.of("[[:punct:]]", "[!-/:-@\\[-`{-~]"),
-        Arguments.of("[[:space:]]", "[\\t-\\r ]"),
-        Arguments.of("[[:upper:]]", "[A-Z]"),
-        Arguments.of("[[:xdigit:]]", "[0-9A-Fa-f]"),
+        // JDK treats POSIX bracket-class spelling as ordinary character-class text.
+        Arguments.of("[[:alnum:]]", "[:al-nu]"),
+        Arguments.of("[[:alpha:]]", "[:ahlp]"),
+        Arguments.of("[[:blank:]]", "[:a-bk-ln]"),
+        Arguments.of("[[:cntrl:]]", "[:clnrt]"),
+        Arguments.of("[[:digit:]]", "[:dgit]"),
+        Arguments.of("[[:graph:]]", "[:ag-hpr]"),
+        Arguments.of("[[:lower:]]", "[:elorw]"),
+        Arguments.of("[[:print:]]", "[:inprt]"),
+        Arguments.of("[[:punct:]]", "[:cnpt-u]"),
+        Arguments.of("[[:space:]]", "[:aceps]"),
+        Arguments.of("[[:upper:]]", "[:epru]"),
+        Arguments.of("[[:xdigit:]]", "[:dgitx]"),
 
         // Perl character classes
         Arguments.of("\\d", "[0-9]"),
@@ -112,11 +112,11 @@ class SimplifierTest {
         Arguments.of("[a-ma-ha-e]", "[a-m]"),
         Arguments.of("[a-zA-Z0-9 -~]", "[ -~]"),
 
-        // Empty character classes
-        Arguments.of("[^[:cntrl:][:^cntrl:]]", "[^\\x00-\\x{10ffff}]"),
+        // Negated literal text character classes
+        Arguments.of("[^[:cntrl:][:^cntrl:]]", "[^:\\^clnrt]"),
 
-        // Full character classes
-        Arguments.of("[[:cntrl:][:^cntrl:]]", "."),
+        // Literal text character classes
+        Arguments.of("[[:cntrl:][:^cntrl:]]", "[:\\^clnrt]"),
 
         // Unicode case folding
         Arguments.of("(?i)A", "[Aa]"),

--- a/safere/src/test/java/org/safere/UnicodeTablesTest.java
+++ b/safere/src/test/java/org/safere/UnicodeTablesTest.java
@@ -51,32 +51,32 @@ class UnicodeTablesTest {
     assertThat(containsCodePoint(ranges, 'z')).isTrue();
   }
 
-  // --- POSIX groups ---
+  // --- POSIX property groups ---
 
   @Test
-  void posixGroups_hasFourteenEntries() {
-    assertThat(UnicodeTables.POSIX_GROUPS.size()).isEqualTo(14);
+  void posixPropertyGroups_hasThirteenEntries() {
+    assertThat(UnicodeTables.POSIX_PROPERTY_GROUPS.size()).isEqualTo(13);
   }
 
   @Test
-  void posixDigit_matchesZeroToNine() {
-    int[][] ranges = UnicodeTables.POSIX_GROUPS.get("[:digit:]");
+  void posixPropertyDigit_matchesZeroToNine() {
+    int[][] ranges = UnicodeTables.POSIX_PROPERTY_GROUPS.get("Digit");
     assertThat(ranges).isNotNull();
     assertThat(ranges.length).isEqualTo(1);
     assertThat(ranges[0]).isEqualTo(new int[] {0x30, 0x39});
   }
 
   @Test
-  void posixAscii_matchesFullRange() {
-    int[][] ranges = UnicodeTables.POSIX_GROUPS.get("[:ascii:]");
+  void posixPropertyAscii_matchesFullRange() {
+    int[][] ranges = UnicodeTables.POSIX_PROPERTY_GROUPS.get("ASCII");
     assertThat(ranges).isNotNull();
     assertThat(ranges.length).isEqualTo(1);
     assertThat(ranges[0]).isEqualTo(new int[] {0x00, 0x7F});
   }
 
   @Test
-  void posixUpper_matchesUppercase() {
-    int[][] ranges = UnicodeTables.POSIX_GROUPS.get("[:upper:]");
+  void posixPropertyUpper_matchesUppercase() {
+    int[][] ranges = UnicodeTables.POSIX_PROPERTY_GROUPS.get("Upper");
     assertThat(ranges).isNotNull();
     assertThat(ranges.length).isEqualTo(1);
     assertThat(ranges[0]).isEqualTo(new int[] {0x41, 0x5A});


### PR DESCRIPTION
## Summary

- Match JDK semantics for POSIX bracket-class spellings like `[[:lower:]]`
- Treat those spellings as ordinary character-class text instead of expanding them as POSIX classes
- Keep POSIX property support on the JDK `\p{Lower}`-style syntax

Fixes #216

## Testing

- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
