### PR TITLE
Disable Jazzer regex injection hook for fuzzing

### DIFF
--- a/safere-fuzz/README.md
+++ b/safere-fuzz/README.md
@@ -35,6 +35,11 @@ mvn -pl safere-fuzz -Dtest=MatchFuzzer test
 Set `JAZZER_FUZZ=1` to run coverage-guided fuzzing. Jazzer runs one fuzz test
 per Maven invocation, so select a single target with `-Dtest`.
 
+The Maven configuration disables Jazzer's `RegexInjection` sanitizer for these
+targets. SafeRE fuzzers intentionally compile generated patterns with both
+SafeRE and `java.util.regex`; sanitizer findings on the JDK oracle are noise for
+this crosscheck workflow.
+
 ```bash
 JAZZER_FUZZ=1 mvn -pl safere-fuzz -Dtest=MatchFuzzer test
 ```

--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -78,6 +78,7 @@
           <properties>
             <configurationParameters>
               junit.jupiter.execution.parallel.enabled = false
+              jazzer.disabled_hooks = com.code_intelligence.jazzer.sanitizers.RegexInjection
             </configurationParameters>
           </properties>
         </configuration>


### PR DESCRIPTION
## Summary

- Disable Jazzer's `RegexInjection` sanitizer for the `safere-fuzz` module.
- Document why the hook is disabled for crosscheck fuzzing.

Fixes #233

## Testing

- Not run at user request.
