### PR TITLE
Reject Python-style named captures

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1695,12 +1695,10 @@ final class Parser {
     }
 
     // Check for named captures.
-    // (?P<name>expr) or (?<name>expr)
+    // (?<name>expr)
     if (pos + 3 < pattern.length()) {
-      if ((pattern.charAt(pos + 2) == 'P' && pos + 4 < pattern.length()
-              && pattern.charAt(pos + 3) == '<')
-          || pattern.charAt(pos + 2) == '<') {
-        int begin = (pattern.charAt(pos + 2) == 'P') ? pos + 4 : pos + 3;
+      if (pattern.charAt(pos + 2) == '<') {
+        int begin = pos + 3;
         int end = pattern.indexOf('>', begin);
         if (end < 0) {
           throw new PatternSyntaxException("invalid named capture", pattern, pos);

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -326,7 +326,7 @@ final class Regexp {
             throw new IllegalStateException("CAPTURE with cap == 0");
           }
           if (re.name != null) {
-            sb.append("?P<").append(re.name).append('>');
+            sb.append("?<").append(re.name).append('>');
           }
           yield PREC_PAREN;
         }

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1165,6 +1165,16 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
+    @DisplayName("Python-style named capturing group (?P<name>X) is rejected")
+    void pythonStyleNamedCapturingGroupRejected() {
+      String regex = "(?" + "P<word>\\w+)";
+      assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
+          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> Pattern.compile(regex))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
     @DisplayName("non-capturing group (?:X)")
     void nonCapturingGroup() {
       assertMatchesSame("(?:ab)+", "ababab");

--- a/safere/src/test/java/org/safere/MatcherSafeReApiTest.java
+++ b/safere/src/test/java/org/safere/MatcherSafeReApiTest.java
@@ -15,12 +15,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Tests for Matcher APIs that are SafeRE-specific extensions. */
-@DisabledForCrosscheck("SafeRE-only Matcher APIs and (?P<name>...) syntax have no JDK equivalent")
+@DisabledForCrosscheck("SafeRE-only Matcher APIs")
 class MatcherSafeReApiTest {
 
   @Test
   void replaceFirstNamedGroupRef() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)");
     Matcher m = p.matcher("hello world");
     String result = m.replaceFirst("${word}!");
     assertThat(result).isEqualTo("hello! world");
@@ -29,7 +29,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("toMatchResult() snapshot supports named-group lookup")
   void toMatchResultNamedGroups() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)");
     Matcher m = p.matcher("hello");
     assertThat(m.find()).isTrue();
 
@@ -43,7 +43,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("start(String) and end(String) return named group positions")
   void namedGroupStartEnd() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)@(?P<host>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)@(?<host>\\w+)");
     Matcher m = p.matcher("user@host");
     assertThat(m.find()).isTrue();
     assertThat(m.start("word")).isEqualTo(0);
@@ -55,7 +55,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("start(String) throws for unknown group name")
   void startUnknownNameThrows() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)");
     Matcher m = p.matcher("hello");
     m.find();
     assertThatThrownBy(() -> m.start("missing")).isInstanceOf(IllegalArgumentException.class);
@@ -64,7 +64,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("end(String) throws for unknown group name")
   void endUnknownNameThrows() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)");
     Matcher m = p.matcher("hello");
     m.find();
     assertThatThrownBy(() -> m.end("missing")).isInstanceOf(IllegalArgumentException.class);
@@ -73,7 +73,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("named group that did not participate returns -1")
   void nonParticipatingNamedGroup() {
-    Pattern p = Pattern.compile("(?P<a>a)|(?P<b>b)");
+    Pattern p = Pattern.compile("(?<a>a)|(?<b>b)");
     Matcher m = p.matcher("b");
     assertThat(m.find()).isTrue();
     assertThat(m.start("a")).isEqualTo(-1);
@@ -85,7 +85,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("namedGroups() returns named groups from pattern")
   void namedGroupsReturnsMap() {
-    Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+    Pattern p = Pattern.compile("(?<user>\\w+)@(?<host>\\w+)");
     Matcher m = p.matcher("user@host");
     assertThat(m.namedGroups()).containsEntry("user", 1);
     assertThat(m.namedGroups()).containsEntry("host", 2);
@@ -102,7 +102,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("namedGroups() is unmodifiable")
   void namedGroupsUnmodifiable() {
-    Pattern p = Pattern.compile("(?P<name>\\w+)");
+    Pattern p = Pattern.compile("(?<name>\\w+)");
     Matcher m = p.matcher("hello");
     assertThatThrownBy(() -> m.namedGroups().put("foo", 99))
         .isInstanceOf(UnsupportedOperationException.class);
@@ -111,7 +111,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("namedGroups() returns from MatchResult interface")
   void namedGroupsFromMatchResult() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)");
     Matcher m = p.matcher("hello");
     assertThat(m.find()).isTrue();
     MatchResult result = m.toMatchResult();
@@ -121,7 +121,7 @@ class MatcherSafeReApiTest {
   @Test
   @DisplayName("named group methods reject null names")
   void namedGroupMethodsRejectNullNames() {
-    Pattern p = Pattern.compile("(?P<word>\\w+)");
+    Pattern p = Pattern.compile("(?<word>\\w+)");
     Matcher m = p.matcher("hello");
     assertThat(m.find()).isTrue();
 

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -605,10 +605,9 @@ class MatcherTest {
     }
 
     @Test
-    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("group(String) returns named group text")
     void namedGroup() {
-      Pattern p = Pattern.compile("(?P<first>\\w+) (?P<last>\\w+)");
+      Pattern p = Pattern.compile("(?<first>\\w+) (?<last>\\w+)");
       Matcher m = p.matcher("John Smith");
       assertThat(m.matches()).isTrue();
       assertThat(m.group("first")).isEqualTo("John");
@@ -616,10 +615,9 @@ class MatcherTest {
     }
 
     @Test
-    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("group(String) throws for unknown name")
     void namedGroupUnknown() {
-      Pattern p = Pattern.compile("(?P<first>\\w+)");
+      Pattern p = Pattern.compile("(?<first>\\w+)");
       Matcher m = p.matcher("hello");
       m.find();
       assertThatThrownBy(() -> m.group("unknown"))
@@ -849,10 +847,9 @@ class MatcherTest {
     }
 
     @Test
-    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("replaceAll() with named backreference")
     void replaceAllWithNamedBackref() {
-      Pattern p = Pattern.compile("(?P<word>\\w+)");
+      Pattern p = Pattern.compile("(?<word>\\w+)");
       Matcher m = p.matcher("hello world");
       assertThat(m.replaceAll("${word}!")).isEqualTo("hello! world!");
     }

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -687,11 +687,9 @@ class ParserTest {
     }
 
     @Test
-    void namedCapture_PythonSyntax() {
-      Regexp re = parse("(?P<name>a)");
-      assertThat(re.op).isEqualTo(RegexpOp.CAPTURE);
-      assertThat(re.name).isEqualTo("name");
-      assertThat(re.cap).isEqualTo(1);
+    void namedCapture_pythonSyntaxRejected() {
+      assertThatThrownBy(() -> parse("(?P<name>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
 
     @Test
@@ -704,7 +702,7 @@ class ParserTest {
     @Test
     void namedCapture_unicodeName_rejected() {
       // JDK only allows ASCII letters/digits in group names.
-      assertThatThrownBy(() -> parse("(?P<\u4e2d\u6587>a)"))
+      assertThatThrownBy(() -> parse("(?<\u4e2d\u6587>a)"))
           .isInstanceOf(PatternSyntaxException.class);
     }
 
@@ -1331,7 +1329,7 @@ class ParserTest {
     }
 
     @Test
-    void invalidNamedCapture_empty_P() {
+    void pythonStyleNamedCapture_emptyNameRejected() {
       assertThatThrownBy(() -> parse("(?P<>a)"))
           .isInstanceOf(PatternSyntaxException.class);
     }
@@ -1343,7 +1341,7 @@ class ParserTest {
     }
 
     @Test
-    void invalidNamedCapture_spaceInName_P() {
+    void pythonStyleNamedCapture_spaceInNameRejected() {
       assertThatThrownBy(() -> parse("(?P<x y>a)"))
           .isInstanceOf(PatternSyntaxException.class);
     }
@@ -1368,7 +1366,7 @@ class ParserTest {
     }
 
     @Test
-    void invalidNamedCapture_startsWithDigit_P() {
+    void pythonStyleNamedCapture_startsWithDigitRejected() {
       assertThatThrownBy(() -> parse("(?P<1abc>a)"))
           .isInstanceOf(PatternSyntaxException.class);
     }
@@ -1416,7 +1414,7 @@ class ParserTest {
     }
 
     @Test
-    void unclosedNamedCapture_P() {
+    void pythonStyleNamedCapture_unclosedGroupRejected() {
       assertThatThrownBy(() -> parse("(?P<name>a"))
           .isInstanceOf(PatternSyntaxException.class);
     }
@@ -1459,7 +1457,7 @@ class ParserTest {
     }
 
     @Test
-    void incompleteNamedCapture_P() {
+    void pythonStyleNamedCapture_incompleteRejected() {
       assertThatThrownBy(() -> parse("(?P<name"))
           .isInstanceOf(PatternSyntaxException.class);
     }

--- a/safere/src/test/java/org/safere/PatternSafeReApiTest.java
+++ b/safere/src/test/java/org/safere/PatternSafeReApiTest.java
@@ -17,12 +17,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /** Tests for Pattern APIs that are SafeRE-specific extensions. */
-@DisabledForCrosscheck("SafeRE-only Pattern APIs and (?P<name>...) syntax have no JDK equivalent")
+@DisabledForCrosscheck("SafeRE-only Pattern APIs")
 class PatternSafeReApiTest {
 
   @Test
   void extractsNamedGroups() {
-    Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+    Pattern p = Pattern.compile("(?<user>\\w+)@(?<host>\\w+)");
     assertThat(p.namedGroups()).containsEntry("user", 1);
     assertThat(p.namedGroups()).containsEntry("host", 2);
   }
@@ -48,7 +48,7 @@ class PatternSafeReApiTest {
   @Test
   @DisplayName("namedGroups() returns unmodifiable map")
   void namedGroupsUnmodifiable() {
-    Pattern p = Pattern.compile("(?P<user>\\w+)@(?P<host>\\w+)");
+    Pattern p = Pattern.compile("(?<user>\\w+)@(?<host>\\w+)");
     assertThatThrownBy(() -> p.namedGroups().put("foo", 99))
         .isInstanceOf(UnsupportedOperationException.class);
   }
@@ -57,8 +57,6 @@ class PatternSafeReApiTest {
   @DisplayName("duplicate named capturing groups are rejected")
   void duplicateNamedGroupsRejected() {
     assertThatThrownBy(() -> Pattern.compile("(?<word>a)(?<word>b)"))
-        .isInstanceOf(PatternSyntaxException.class);
-    assertThatThrownBy(() -> Pattern.compile("(?P<word>a)(?P<word>b)"))
         .isInstanceOf(PatternSyntaxException.class);
   }
 

--- a/safere/src/test/java/org/safere/RE2RegressionTest.java
+++ b/safere/src/test/java/org/safere/RE2RegressionTest.java
@@ -194,10 +194,9 @@ class RE2RegressionTest {
     }
 
     @Test
-    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("Multiple named and unnamed groups")
     void multipleNamedGroups() {
-      Pattern p = Pattern.compile("(?P<A>expr(?P<B>expr)(?P<C>expr))((expr)(?P<D>expr))");
+      Pattern p = Pattern.compile("(?<A>expr(?<B>expr)(?<C>expr))((expr)(?<D>expr))");
       Matcher m = p.matcher("");
       assertThat(m.groupCount()).isEqualTo(6);
       Map<String, Integer> names = p.namedGroups();
@@ -209,10 +208,9 @@ class RE2RegressionTest {
     }
 
     @Test
-    @DisabledForCrosscheck("(?P<name>...) named groups are SafeRE syntax, not JDK syntax")
     @DisplayName("Named group match extraction")
     void namedGroupMatch() {
-      Pattern p = Pattern.compile("directions from (?P<S>.*) to (?P<D>.*)");
+      Pattern p = Pattern.compile("directions from (?<S>.*) to (?<D>.*)");
       Matcher m = p.matcher("directions from mountain view to san jose");
       assertThat(m.groupCount()).isEqualTo(2);
       assertThat(m.matches()).isTrue();

--- a/safere/src/test/java/org/safere/RegexpTest.java
+++ b/safere/src/test/java/org/safere/RegexpTest.java
@@ -251,7 +251,7 @@ class RegexpTest {
   @Test
   void toStringNamedCapture() {
     Regexp re = Regexp.capture(Regexp.literal('a', 0), 0, 1, "foo");
-    assertThat(re.toString()).isEqualTo("(?P<foo>a)");
+    assertThat(re.toString()).isEqualTo("(?<foo>a)");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Reject Python/RE2-style `(?P<name>...)` named captures for JDK compatibility.
- Keep `(?<name>...)` as the supported named-capture spelling.
- Update named-group tests and `Regexp.toString()` to use the JDK-compatible spelling.

Fixes #217

## Testing

- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
