### PR TITLE
Preserve captures in zero-count repetitions

### DIFF
--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -7,6 +7,7 @@
 
 package org.safere;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,6 +70,7 @@ final class Compiler extends Walker<Compiler.Frag> {
   static Prog compile(Regexp re, boolean reversed) {
     Compiler c = new Compiler();
     c.reversed = reversed;
+    int numCaptures = maxCapture(re) + 1;
 
     // Simplify to remove REPEAT, complex char classes, etc.
     Regexp sre = Simplifier.simplify(re);
@@ -117,24 +119,28 @@ final class Compiler extends Walker<Compiler.Frag> {
     // Freeze the instruction list into a flat array for fast indexed access.
     c.prog.freeze();
 
-    // Count captures by scanning instructions.
-    int maxCap = 0;
-    for (int i = 0; i < c.prog.size(); i++) {
-      Inst inst = c.prog.inst(i);
-      if (inst.op == InstOp.CAPTURE) {
-        int capIdx = inst.arg;
-        // cap register index is 2*cap for start, 2*cap+1 for end
-        // so the capture group number is capIdx/2
-        int capNum = capIdx / 2;
-        if (capNum > maxCap) {
-          maxCap = capNum;
-        }
-      }
-    }
-    c.prog.setNumCaptures(maxCap + 1);
+    c.prog.setNumCaptures(numCaptures);
     c.prog.setNumLoopRegs(c.nextLoopReg);
 
     return c.prog;
+  }
+
+  private static int maxCapture(Regexp re) {
+    int max = 0;
+    ArrayDeque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.CAPTURE && node.cap > max) {
+        max = node.cap;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return max;
   }
 
   // ---------------------------------------------------------------------------

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -635,6 +635,16 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("zero-count repetitions preserve capturing group count")
+    void zeroCountRepetitionsPreserveCapturingGroupCount() {
+      assertZeroCountGroupBehavior("(a){0}", "");
+      assertZeroCountGroupBehavior("(?:(a){0})", "");
+      assertZeroCountGroupBehavior("(?:(?:(a){0}))", "");
+      assertZeroCountGroupBehavior("(a){0}(b)", "b");
+      assertZeroCountGroupBehavior("((a){0})", "");
+    }
+
+    @Test
     @DisplayName("non-participating group returns null")
     void nonParticipatingGroup() {
       Pattern p = Pattern.compile("(a)|(b)");
@@ -2368,6 +2378,26 @@ class MatcherTest {
           task.run();
           return System.nanoTime() - start;
         });
+  }
+
+  private static void assertZeroCountGroupBehavior(String regex, String input) {
+    java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(input);
+    Matcher safere = Pattern.compile(regex).matcher(input);
+
+    assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
+    assertThat(safere.matches()).isEqualTo(jdk.matches());
+    assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
+    for (int group = 1; group <= jdk.groupCount(); group++) {
+      assertThat(safere.group(group))
+          .as("group(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.group(group));
+      assertThat(safere.start(group))
+          .as("start(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.start(group));
+      assertThat(safere.end(group))
+          .as("end(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.end(group));
+    }
   }
 
   private static String repeatedDotStarCapturePattern(int repetitions, int captures) {


### PR DESCRIPTION
## Summary

- Preserve capture group count from the original parsed AST instead of the optimized instruction stream
- Add JDK-comparison coverage for zero-count repetitions and inaccessible captures

Fixes #219

## Verification

- `mvn -pl safere -Dtest='MatcherTest$GroupTests#zeroCountRepetitionsPreserveCapturingGroupCount' test -q`
- `mvn -pl safere -Dtest='MatcherTest$GroupTests' test -q`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
