### PR TITLE
Preserve counted repeat captures for crosscheck

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -8,6 +8,7 @@ package org.safere;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -89,6 +90,7 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean lastHitEnd;
   private boolean lastRequireEnd;
+  private boolean lastMatchWasFind;
   private int modCount;
 
   /**
@@ -494,6 +496,7 @@ public final class Matcher implements MatchResult {
         }
       }
       updateEndState(MatchOperation.MATCHES);
+      lastMatchWasFind = false;
     }
   }
 
@@ -614,6 +617,7 @@ public final class Matcher implements MatchResult {
         }
       }
       updateEndState(MatchOperation.LOOKING_AT);
+      lastMatchWasFind = false;
     }
   }
 
@@ -788,6 +792,7 @@ public final class Matcher implements MatchResult {
         }
       }
       updateEndState(MatchOperation.FIND);
+      lastMatchWasFind = hasMatch;
     }
   }
 
@@ -1524,6 +1529,8 @@ public final class Matcher implements MatchResult {
         eagerFallbackCaptures = true;
       }
       resolveCaptures();
+      applyRetainedFindCaptures();
+      applyRetainedRepeatCaptures();
     }
     return groups[2 * group];
   }
@@ -1559,6 +1566,8 @@ public final class Matcher implements MatchResult {
         eagerFallbackCaptures = true;
       }
       resolveCaptures();
+      applyRetainedFindCaptures();
+      applyRetainedRepeatCaptures();
     }
     return groups[2 * group + 1];
   }
@@ -2177,6 +2186,132 @@ public final class Matcher implements MatchResult {
     }
     capturesResolved = true;
     groupZeroResolved = true;
+  }
+
+  private void applyRetainedFindCaptures() {
+    if (!lastMatchWasFind || groups == null || groups[0] != groups[1]) {
+      return;
+    }
+    List<Prog> retainedCaptureProgs = parentPattern.retainedCaptureProgs();
+    if (retainedCaptureProgs.isEmpty() || searchFrom >= groups[0]) {
+      return;
+    }
+
+    int matchStart = groups[0];
+    for (Prog retainedProg : retainedCaptureProgs) {
+      int pos = searchFrom;
+      int[] retainedGroups = null;
+      while (pos < matchStart) {
+        int[] candidate = Nfa.search(
+            retainedProg,
+            text,
+            pos,
+            matchStart,
+            matchStart,
+            Nfa.Anchor.UNANCHORED,
+            Nfa.MatchKind.FIRST_MATCH,
+            retainedProg.numCaptures());
+        if (candidate == null || candidate[1] > matchStart) {
+          break;
+        }
+        if (candidate[1] > candidate[0]) {
+          retainedGroups = candidate;
+        }
+        pos = nextSearchPosition(candidate[0], matchStart);
+      }
+      if (retainedGroups != null) {
+        mergeRetainedCaptures(retainedGroups);
+      }
+    }
+  }
+
+  private void applyRetainedRepeatCaptures() {
+    List<Pattern.RetainedRepeatCapture> retainedRepeatCaptures =
+        parentPattern.retainedRepeatCaptures();
+    if (retainedRepeatCaptures.isEmpty() || groups == null || groups[0] < 0) {
+      return;
+    }
+
+    int matchStart = groups[0];
+    int matchEnd = groups[1];
+    for (Pattern.RetainedRepeatCapture retained : retainedRepeatCaptures) {
+      int[] firstGroups = findRetainedFirstRepeatGroups(retained, matchStart, matchEnd);
+      if (firstGroups != null) {
+        mergeRetainedCaptures(firstGroups, true);
+      }
+    }
+  }
+
+  private int[] findRetainedFirstRepeatGroups(
+      Pattern.RetainedRepeatCapture retained, int matchStart, int matchEnd) {
+    if (matchEnd - matchStart <= retained.minimumInputLength()) {
+      return null;
+    }
+    int pos = matchEnd;
+    while (pos >= matchStart) {
+      int[] firstGroups = Nfa.search(
+          retained.firstProg(),
+          text,
+          matchStart,
+          pos,
+          pos,
+          Nfa.Anchor.ANCHORED,
+          Nfa.MatchKind.FULL_MATCH,
+          retained.firstProg().numCaptures());
+      if (firstGroups != null) {
+        int[] restGroups = Nfa.search(
+            retained.restProg(),
+            text,
+            pos,
+            matchEnd,
+            matchEnd,
+            Nfa.Anchor.ANCHORED,
+            Nfa.MatchKind.FULL_MATCH,
+            1);
+        if (restGroups != null) {
+          if (pos - matchStart <= retained.firstMinimumInputLength()) {
+            return null;
+          }
+          return firstGroups;
+        }
+      }
+      if (pos == matchStart) {
+        break;
+      }
+      pos = previousSearchPosition(pos, matchStart);
+    }
+    return null;
+  }
+
+  private int nextSearchPosition(int pos, int limit) {
+    if (pos >= limit) {
+      return limit;
+    }
+    int cp = text.codePointAt(pos);
+    return pos + Character.charCount(cp);
+  }
+
+  private int previousSearchPosition(int pos, int limit) {
+    if (pos <= limit) {
+      return limit;
+    }
+    return text.offsetByCodePoints(pos, -1);
+  }
+
+  private void mergeRetainedCaptures(int[] retainedGroups) {
+    mergeRetainedCaptures(retainedGroups, false);
+  }
+
+  private void mergeRetainedCaptures(int[] retainedGroups, boolean overwrite) {
+    int groupsToMerge = Math.min(groups.length, retainedGroups.length) / 2;
+    for (int group = 1; group < groupsToMerge; group++) {
+      int startIdx = 2 * group;
+      int endIdx = startIdx + 1;
+      if ((overwrite || groups[startIdx] == -1) && retainedGroups[startIdx] != -1) {
+        groups[startIdx] = retainedGroups[startIdx];
+        groups[endIdx] = retainedGroups[endIdx];
+      }
+    }
   }
 
   /** Stores DFA-determined group 0 and defers inner capture extraction until requested. */

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -110,6 +110,8 @@ public final class Pattern implements Serializable {
   private final transient boolean[] charClassPrefixAscii;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
+  private final transient List<Prog> retainedCaptureProgs;
+  private final transient List<RetainedRepeatCapture> retainedRepeatCaptures;
 
   /**
    * Precomputed character class data for the "repeated character class" fast path in
@@ -181,6 +183,9 @@ public final class Pattern implements Serializable {
   private record OnePassAnalysis(
       OnePass onePass, boolean canPrimary, boolean canFind, boolean canSubmatch) {}
 
+  record RetainedRepeatCapture(
+      Prog firstProg, Prog restProg, int minimumInputLength, int firstMinimumInputLength) {}
+
   private Pattern(String pattern, int flags, Prog prog, Regexp ast,
       Map<String, Integer> namedGroups, String prefix, boolean prefixFoldCase,
       String literalMatch, boolean hasLazy, boolean hasAlternation,
@@ -188,6 +193,8 @@ public final class Pattern implements Serializable {
       boolean hasBoundedRepeat, boolean hasAnchorInQuant, boolean hasEndConstraint,
       boolean[] charClassPrefixAscii, StartAcceleration startAcceleration,
       KeywordAlternation keywordAlternation,
+      List<Prog> retainedCaptureProgs,
+      List<RetainedRepeatCapture> retainedRepeatCaptures,
       int[] charClassMatchRanges, long charClassMatchBitmap0, long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty) {
     this.pattern = pattern;
@@ -207,6 +214,8 @@ public final class Pattern implements Serializable {
     this.charClassPrefixAscii = charClassPrefixAscii;
     this.startAcceleration = startAcceleration;
     this.keywordAlternation = keywordAlternation;
+    this.retainedCaptureProgs = retainedCaptureProgs;
+    this.retainedRepeatCaptures = retainedRepeatCaptures;
     this.charClassMatchRanges = charClassMatchRanges;
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
@@ -260,12 +269,18 @@ public final class Pattern implements Serializable {
     StartAcceleration startAcceleration =
         (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(re) : null;
     KeywordAlternation keywordAlternation = extractKeywordAlternation(re, flags);
+    List<Prog> retainedCaptureProgs =
+        extractRetainedCaptureProgs(re, (effectiveFlags & UNIX_LINES) != 0);
+    List<RetainedRepeatCapture> retainedRepeatCaptures =
+        extractRetainedRepeatCaptures(re, (effectiveFlags & UNIX_LINES) != 0);
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(re);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(regex, effectiveFlags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
         hasEndConst, ccPrefixAscii, startAcceleration, keywordAlternation,
+        retainedCaptureProgs,
+        retainedRepeatCaptures,
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
@@ -757,6 +772,14 @@ public final class Pattern implements Serializable {
     return keywordAlternation;
   }
 
+  List<Prog> retainedCaptureProgs() {
+    return retainedCaptureProgs;
+  }
+
+  List<RetainedRepeatCapture> retainedRepeatCaptures() {
+    return retainedRepeatCaptures;
+  }
+
   /**
    * Returns the precomputed ranges for the character-class-match fast path, or {@code null} if
    * the pattern is not a simple repeated character class. When non-null, {@code matches()} can
@@ -1097,6 +1120,203 @@ public final class Pattern implements Serializable {
       }
     }
     return false;
+  }
+
+  private static List<Prog> extractRetainedCaptureProgs(Regexp re, boolean unixLines) {
+    List<Prog> progs = new ArrayList<>();
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (isOptionalRepeat(node) && hasExactCountedCapture(node.sub())) {
+        Prog retained = Compiler.compile(node.sub());
+        if (retained != null) {
+          retained.setUnixLines(unixLines);
+          progs.add(retained);
+        }
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return progs.isEmpty() ? List.of() : List.copyOf(progs);
+  }
+
+  private static boolean isOptionalRepeat(Regexp re) {
+    return re.op == RegexpOp.STAR
+        || (re.op == RegexpOp.REPEAT && re.min == 0 && (re.max == -1 || re.max >= 2));
+  }
+
+  private static boolean hasExactCountedCapture(Regexp re) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.REPEAT && node.min >= 1 && node.min == node.max
+          && hasCapture(node.sub())) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasCapture(Regexp re) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.CAPTURE && node.cap > 0) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private static List<RetainedRepeatCapture> extractRetainedRepeatCaptures(
+      Regexp re, boolean unixLines) {
+    List<RetainedRepeatCapture> retained = new ArrayList<>();
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.REPEAT && node.min >= 2 && (node.max == -1 || node.max >= node.min)
+          && hasUnboundedCaptureRepeat(node.sub())) {
+        Prog firstProg = Compiler.compile(node.sub());
+        Prog restProg = Compiler.compile(repeatCopies(node.sub(), node.min - 1, node.flags));
+        if (firstProg != null && restProg != null) {
+          firstProg.setUnixLines(unixLines);
+          restProg.setUnixLines(unixLines);
+          retained.add(new RetainedRepeatCapture(
+              firstProg, restProg, node.min * minRequiredCodeUnits(node.sub()),
+              minRequiredCodeUnits(node.sub())));
+        }
+      }
+      if (isRepeatWithRemainingCopies(node) && hasGreedyBoundedCaptureRepeat(node.sub())) {
+        Prog firstProg = Compiler.compile(node.sub());
+        Prog restProg = Compiler.compile(repeatAfterFirstCopy(node));
+        if (firstProg != null && restProg != null) {
+          firstProg.setUnixLines(unixLines);
+          restProg.setUnixLines(unixLines);
+          retained.add(new RetainedRepeatCapture(
+              firstProg, restProg, minRequiredCodeUnits(node),
+              minRequiredCodeUnits(node.sub())));
+        }
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return retained.isEmpty() ? List.of() : List.copyOf(retained);
+  }
+
+  private static boolean isRepeatWithRemainingCopies(Regexp re) {
+    return re.op == RegexpOp.STAR
+        || re.op == RegexpOp.PLUS
+        || (re.op == RegexpOp.REPEAT && (re.max == -1 || re.max >= 2));
+  }
+
+  private static Regexp repeatAfterFirstCopy(Regexp repeat) {
+    return switch (repeat.op) {
+      case STAR, PLUS -> Regexp.star(repeat.sub(), repeat.flags);
+      case REPEAT -> Regexp.repeat(
+          repeat.sub(), repeat.flags, Math.max(0, repeat.min - 1),
+          repeat.max == -1 ? -1 : repeat.max - 1);
+      default -> Regexp.emptyMatch(repeat.flags);
+    };
+  }
+
+  private static Regexp repeatCopies(Regexp sub, int copies, int flags) {
+    if (copies == 1) {
+      return sub;
+    }
+    List<Regexp> subs = new ArrayList<>(copies);
+    for (int i = 0; i < copies; i++) {
+      subs.add(sub);
+    }
+    return Regexp.concat(subs, flags);
+  }
+
+  private static boolean hasUnboundedCaptureRepeat(Regexp re) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if ((node.op == RegexpOp.PLUS
+              || (node.op == RegexpOp.REPEAT && node.min >= 1 && node.max == -1))
+          && !node.nonGreedy()
+          && hasCapture(node.sub())) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasGreedyBoundedCaptureRepeat(Regexp re) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.REPEAT && node.max >= 2 && node.max > node.min && !node.nonGreedy()
+          && hasCapture(node.sub())) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private static int minRequiredCodeUnits(Regexp re) {
+    return switch (re.op) {
+      case NO_MATCH, EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
+          NO_WORD_BOUNDARY -> 0;
+      case LITERAL, ANY_CHAR, CHAR_CLASS -> 1;
+      case LITERAL_STRING -> re.runes == null ? 0 : re.runes.length;
+      case CAPTURE, PLUS -> minRequiredCodeUnits(re.sub());
+      case STAR, QUEST -> 0;
+      case REPEAT -> re.min * minRequiredCodeUnits(re.sub());
+      case CONCAT -> {
+        int min = 0;
+        if (re.subs != null) {
+          for (Regexp sub : re.subs) {
+            min += minRequiredCodeUnits(sub);
+          }
+        }
+        yield min;
+      }
+      case ALTERNATE -> {
+        int min = Integer.MAX_VALUE;
+        if (re.subs != null) {
+          for (Regexp sub : re.subs) {
+            min = Math.min(min, minRequiredCodeUnits(sub));
+          }
+        }
+        yield min == Integer.MAX_VALUE ? 0 : min;
+      }
+      default -> 0;
+    };
   }
 
   /**

--- a/safere/src/main/java/org/safere/UnicodeTables.java
+++ b/safere/src/main/java/org/safere/UnicodeTables.java
@@ -35,7 +35,7 @@ final class UnicodeTables {
   public static final int[][] PERL_DIGIT = {{0x30, 0x39}};
 
   public static final int[][] PERL_SPACE = {
-    {0x09, 0x0A}, {0x0C, 0x0D}, {0x20, 0x20},
+    {0x09, 0x0D}, {0x20, 0x20},
   };
 
   public static final int[][] PERL_WORD = {

--- a/safere/src/test/java/org/safere/CrossEngineExhaustiveTest.java
+++ b/safere/src/test/java/org/safere/CrossEngineExhaustiveTest.java
@@ -616,8 +616,6 @@ class CrossEngineExhaustiveTest {
     }
 
     @Test
-    @DisabledForCrosscheck(
-        "#219 SafeRE drops capture groups in zero-count repetitions")
     @DisplayName("Repetition operators on long text")
     void repetitionLongText() {
       int tests =

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -370,6 +370,7 @@ class JdkSyntaxCompatibilityTest {
     void whitespaceClass() {
       assertMatchesSame("\\s", " ");
       assertMatchesSame("\\s", "\n");
+      assertMatchesSame("\\s", "\u000B");
       assertMatchesFull("\\s", "a");  // should not match
     }
 
@@ -378,6 +379,7 @@ class JdkSyntaxCompatibilityTest {
     void nonWhitespaceClass() {
       assertMatchesSame("\\S", "a");
       assertMatchesFull("\\S", " ");  // should not match
+      assertMatchesFull("\\S", "\u000B");  // should not match
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -643,6 +643,39 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() preserves counted-repeat captures retained by JDK")
+    void findPreservesCountedRepeatCapturesRetainedByJdk() {
+      assertFirstFindMatchesJdk("(?:(a){1}){0}$", "ab");
+      assertFirstFindMatchesJdk("(?:(a){1}){0,1}$", "ab");
+      assertFirstFindMatchesJdk("(?:(a){1})*$", "ab");
+      assertFirstFindMatchesJdk("(?:(a){1}){0,2}$", "ab");
+      assertFirstFindMatchesJdk("(?:(a){2})*$", "aab");
+      assertFirstFindMatchesJdk("(?:(a){2})*$", "aaab");
+      assertFirstFindMatchesJdk("(?:(?:(?:(a){1}){0,}))$", "ab");
+      assertFirstFindMatchesJdk("(?:(?:(?:(a){1}){0,2}))$", "ab");
+      assertFirstFindMatchesJdk("(?:(a){1,}){2}", "aaa");
+      assertFullMatchMatchesJdk("(?:(a){1,}){2}", "aaa");
+      assertFirstFindMatchesJdk("(?:(a){1,}){2}", "aa");
+      assertFullMatchMatchesJdk("(?:(a){1,}){2}", "aa");
+      assertFirstFindMatchesJdk("(?:(a){1,}){2,}", "aaa");
+      assertFullMatchMatchesJdk("(?:(a){1,}){2,}", "aaa");
+      assertFirstFindMatchesJdk("(?:(a){1,}){2,3}", "aaaaa");
+      assertFullMatchMatchesJdk("(?:(a){1,}){2,3}", "aaaaa");
+      assertFirstFindMatchesJdk("(?:(a){0,2})*", "aaa");
+      assertFullMatchMatchesJdk("(?:(a){0,2})*", "aaa");
+      assertFirstFindMatchesJdk("(?:(a){1,2})*", "aaa");
+      assertFullMatchMatchesJdk("(?:(a){1,2})*", "aaa");
+      assertFirstFindMatchesJdk("(?:(a){1,2}){2}", "aa");
+      assertFullMatchMatchesJdk("(?:(a){1,2}){2}", "aa");
+      assertFirstFindMatchesJdk("(?:(a){1,2}){2}", "aaa");
+      assertFullMatchMatchesJdk("(?:(a){1,2}){2}", "aaa");
+      assertFirstFindMatchesJdk("(?:(a){3,4})*", "aaaaaa");
+      assertFullMatchMatchesJdk("(?:(a){3,4})*", "aaaaaa");
+      assertFirstFindMatchesJdk("(?:(a){0,1})*", "aaa");
+      assertFullMatchMatchesJdk("(?:(a){0,1})*", "aaa");
+    }
+
+    @Test
     @DisplayName("non-participating group returns null")
     void nonParticipatingGroup() {
       Pattern p = Pattern.compile("(a)|(b)");
@@ -2384,6 +2417,50 @@ class MatcherTest {
     assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
     assertThat(safere.matches()).isEqualTo(jdk.matches());
     assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
+    for (int group = 1; group <= jdk.groupCount(); group++) {
+      assertThat(safere.group(group))
+          .as("group(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.group(group));
+      assertThat(safere.start(group))
+          .as("start(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.start(group));
+      assertThat(safere.end(group))
+          .as("end(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.end(group));
+    }
+  }
+
+  private static void assertFirstFindMatchesJdk(String regex, String input) {
+    java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(input);
+    Matcher safere = Pattern.compile(regex).matcher(input);
+
+    assertThat(safere.find()).isEqualTo(jdk.find());
+    assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
+    assertThat(safere.group()).isEqualTo(jdk.group());
+    assertThat(safere.start()).isEqualTo(jdk.start());
+    assertThat(safere.end()).isEqualTo(jdk.end());
+    for (int group = 1; group <= jdk.groupCount(); group++) {
+      assertThat(safere.group(group))
+          .as("group(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.group(group));
+      assertThat(safere.start(group))
+          .as("start(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.start(group));
+      assertThat(safere.end(group))
+          .as("end(%d) for /%s/ on %s", group, regex, input)
+          .isEqualTo(jdk.end(group));
+    }
+  }
+
+  private static void assertFullMatchMatchesJdk(String regex, String input) {
+    java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(input);
+    Matcher safere = Pattern.compile(regex).matcher(input);
+
+    assertThat(safere.matches()).isEqualTo(jdk.matches());
+    assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
+    assertThat(safere.group()).isEqualTo(jdk.group());
+    assertThat(safere.start()).isEqualTo(jdk.start());
+    assertThat(safere.end()).isEqualTo(jdk.end());
     for (int group = 1; group <= jdk.groupCount(); group++) {
       assertThat(safere.group(group))
           .as("group(%d) for /%s/ on %s", group, regex, input)

--- a/safere/src/test/java/org/safere/RE2ExhaustiveTest.java
+++ b/safere/src/test/java/org/safere/RE2ExhaustiveTest.java
@@ -44,8 +44,6 @@ class RE2ExhaustiveTest {
   private static final int MAX_FAILURES = 200;
 
   @Test
-  @DisabledForCrosscheck(
-      "#219 SafeRE drops capture groups in zero-count repetitions")
   void testExhaustive() throws IOException {
     InputStream is = RE2ExhaustiveTest.class.getResourceAsStream("/re2-exhaustive.txt.gz");
     assertThat(is).as("re2-exhaustive.txt.gz must be in test resources").isNotNull();

--- a/safere/src/test/java/org/safere/RE2FindTest.java
+++ b/safere/src/test/java/org/safere/RE2FindTest.java
@@ -214,8 +214,6 @@ class RE2FindTest {
   }
 
   @ParameterizedTest(name = "{0}")
-  @DisabledForCrosscheck(
-      "#219 SafeRE drops capture groups in zero-count repetitions")
   @MethodSource("findTests")
   void testFirstMatchSubgroups(FindTestCase tc) {
     Pattern p = Pattern.compile(tc.pattern());
@@ -237,8 +235,6 @@ class RE2FindTest {
   }
 
   @ParameterizedTest(name = "{0}")
-  @DisabledForCrosscheck(
-      "#219 SafeRE drops capture groups in zero-count repetitions")
   @MethodSource("findTests")
   void testFirstMatchPositions(FindTestCase tc) {
     Pattern p = Pattern.compile(tc.pattern());
@@ -267,8 +263,6 @@ class RE2FindTest {
   }
 
   @ParameterizedTest(name = "{0}")
-  @DisabledForCrosscheck(
-      "#219 SafeRE drops capture groups in zero-count repetitions")
   @MethodSource("findTests")
   void testFindFirst(FindTestCase tc) {
     Pattern p = Pattern.compile(tc.pattern());

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -63,16 +63,16 @@ class SimplifierTest {
 
         // Perl character classes
         Arguments.of("\\d", "[0-9]"),
-        Arguments.of("\\s", "[\\t-\\n\\f-\\r ]"),
+        Arguments.of("\\s", "[\\t-\\r ]"),
         Arguments.of("\\w", "[0-9A-Z_a-z]"),
         Arguments.of("\\D", "[^0-9]"),
-        Arguments.of("\\S", "[^\\t-\\n\\f-\\r ]"),
+        Arguments.of("\\S", "[^\\t-\\r ]"),
         Arguments.of("\\W", "[^0-9A-Z_a-z]"),
         Arguments.of("[\\d]", "[0-9]"),
-        Arguments.of("[\\s]", "[\\t-\\n\\f-\\r ]"),
+        Arguments.of("[\\s]", "[\\t-\\r ]"),
         Arguments.of("[\\w]", "[0-9A-Z_a-z]"),
         Arguments.of("[\\D]", "[^0-9]"),
-        Arguments.of("[\\S]", "[^\\t-\\n\\f-\\r ]"),
+        Arguments.of("[\\S]", "[^\\t-\\r ]"),
         Arguments.of("[\\W]", "[^0-9A-Z_a-z]"),
 
         // Posix repetitions

--- a/safere/src/test/java/org/safere/UnicodeTablesTest.java
+++ b/safere/src/test/java/org/safere/UnicodeTablesTest.java
@@ -33,8 +33,9 @@ class UnicodeTablesTest {
     int[][] ranges = UnicodeTables.PERL_GROUPS.get("\\s");
     assertThat(ranges).isNotNull();
     assertThat(ranges.length >= 2).isTrue();
-    // Should include tab (0x09) and space (0x20)
+    // Should include tab (0x09), vertical tab (0x0B), and space (0x20).
     assertThat(containsCodePoint(ranges, 0x09)).isTrue();
+    assertThat(containsCodePoint(ranges, 0x0B)).isTrue();
     assertThat(containsCodePoint(ranges, 0x20)).isTrue();
   }
 


### PR DESCRIPTION
## Summary

- Preserve JDK-compatible captures for counted repeats that survive regex simplification.
- Re-enable the generated crosscheck coverage that was disabled for #219.
- Align default `\s` / `\S` handling for vertical tab so the re-enabled generated exhaustive test passes.

Fixes #219
Refs #223

## Verification

- `mvn -pl safere -Dtest='MatcherTest$GroupTests#findPreservesCountedRepeatCapturesRetainedByJdk' test -q`
- `mvn -pl safere -Dtest='UnicodeTablesTest#perlSpace_matchesWhitespace,JdkSyntaxCompatibilityTest$PredefinedCharacterClasses#whitespaceClass,JdkSyntaxCompatibilityTest$PredefinedCharacterClasses#nonWhitespaceClass' test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=RE2ExhaustiveTest -DfailIfNoTests=false`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=RE2FindTest,RE2ExhaustiveTest,CrossEngineExhaustiveTest -DfailIfNoTests=false`
