### PR TITLE
Fix nullable repeated capture handling

### DIFF
--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -298,8 +298,14 @@ final class Nfa {
       // PROGRESS_CHECK is excluded from the visited set: it manages its own re-entry
       // via registers. Within one addToThreadq call, it is visited at most twice (once
       // to save the position, once to detect zero-width and redirect to exit).
+      //
+      // ALT and CAPTURE are also excluded because a nullable quantified body can revisit the
+      // same alternation or capture instruction at the same input position with different capture
+      // registers. The later zero-width iteration is JDK-visible and must not be discarded.
       Inst ip = prog.inst(id);
-      if (ip.op != InstOp.PROGRESS_CHECK) {
+      if (ip.op != InstOp.PROGRESS_CHECK
+          && ip.op != InstOp.ALT
+          && ip.op != InstOp.CAPTURE) {
         visited.add(id);
       }
       switch (ip.op) {

--- a/safere/src/test/java/org/safere/QuantifiedCaptureSemanticsTest.java
+++ b/safere/src/test/java/org/safere/QuantifiedCaptureSemanticsTest.java
@@ -32,6 +32,10 @@ class QuantifiedCaptureSemanticsTest {
         Arguments.of("(?:(a){1,2}?)*", "aaa"),
         Arguments.of("((ab)?)*", "abab"),
         Arguments.of("((a?))*", "aa"),
+        Arguments.of(
+            "(.*)+/([a-zA-Z]+)/([^/]+)", "projects/123/locations/test-location/foo/bar"),
+        Arguments.of("(.?)+/([a-z]+)/([^/]+)", "abc/foo/bar"),
+        Arguments.of("(.?)+([a-z]+)", "abc"),
         Arguments.of("x(?:(a){1,2})*y", "xaaay"),
         Arguments.of("x(?:(a){1,}){2}y", "xaaay"));
   }


### PR DESCRIPTION
## Summary

- Fix NFA epsilon-closure capture handling for nullable repeated bodies
- Preserve JDK-visible zero-width final iteration captures in quantified groups
- Add differential coverage for the real-world #250 pattern and adjacent quantified-capture cases

Fixes #250

## Verification

- `mvn -pl safere -Dtest=QuantifiedCaptureSemanticsTest test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
