### PR TITLE
Fix anchored replacement fast path

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1773,10 +1773,14 @@ public final class Matcher implements MatchResult {
 
     while (pos <= text.length()) {
       int effectiveStart = pos;
+      boolean anchoredStart = prog.anchorStart();
+      if (anchoredStart && pos > 0) {
+        break;
+      }
 
       // Apply prefix acceleration if available.
       String prefix = parentPattern.prefix();
-      if (prefix != null) {
+      if (prefix != null && !anchoredStart) {
         int idx;
         if (parentPattern.prefixFoldCase()) {
           idx = indexOfIgnoreCase(text, prefix, pos);
@@ -1791,7 +1795,7 @@ public final class Matcher implements MatchResult {
 
       // Apply char-class prefix acceleration if available.
       boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
-      if (ccPrefixAscii != null) {
+      if (ccPrefixAscii != null && !anchoredStart) {
         int idx = indexOfCharClass(text, ccPrefixAscii, pos);
         if (idx < 0) {
           break;

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -866,6 +866,31 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceAll with group references preserves start-anchor find semantics")
+    void replaceAllWithGroupReferencesPreservesStartAnchorFindSemantics() {
+      String[][] cases = {
+        {"^(.*)", "ExistingValue", "An$1"},
+        {"\\A(.*)", "ExistingValue", "An$1"},
+        {"^(a*)", "aaa", "[$1]"},
+        {"\\A(a*)", "aaa", "[$1]"},
+        {"^(a*)", "bbb", "[$1]"},
+        {"\\A(a*)", "bbb", "[$1]"},
+        {"^([0-9].*)", "abc123", "<$1>"},
+        {"\\A([0-9].*)", "abc123", "<$1>"},
+      };
+
+      for (String[] tc : cases) {
+        String pattern = tc[0];
+        String input = tc[1];
+        String replacement = tc[2];
+        assertThat(Pattern.compile(pattern).matcher(input).replaceAll(replacement))
+            .as("replaceAll(%s) for /%s/ on %s", replacement, pattern, input)
+            .isEqualTo(java.util.regex.Pattern.compile(pattern).matcher(input)
+                .replaceAll(replacement));
+      }
+    }
+
+    @Test
     @DisplayName("numeric replacement references keep trailing digits literal when needed")
     void numericReplacementReferencesUseLongestLegalGroup() {
       Pattern p = Pattern.compile("(\\w+)");


### PR DESCRIPTION
## Summary

- Preserve start-anchor semantics in the direct BitState replaceAll fast path when replacements reference groups.
- Prevent prefix and character-class acceleration from moving start-anchored replacement searches away from position 0.
- Add JDK cross-check coverage for ^ and \A anchored group-reference replacements.

## Verification

- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
