### PR TITLE
Fix repeated empty capture groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,10 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   Do not add special cases, flags, or if-statements that paper over symptoms.
   A correct fix addresses the underlying design flaw — if a DFA cache key is
   missing a dimension, fix the cache key; don't add a post-hoc correction.
+- **Do not make point fixes.** A fix must generalize to the semantic class of
+  the bug, not just the specific repro, issue, fuzz seed, or benchmark case.
+  Avoid pattern-string checks, input-shape checks, and other one-off guards
+  unless they directly encode a documented regex/API rule.
 - **Verify the invariant, not just the test.** After a fix, articulate *why*
   it is correct in general, not just why it makes a specific test pass.  If
   you can construct a new input that would still break, the fix is wrong.

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -400,8 +400,10 @@ final class Compiler extends Walker<Compiler.Frag> {
       }
       case CAPTURE -> {
         if (isAnchorStartImpl(re.sub(), depth + 1)) {
-          yield Regexp.capture(
+          Regexp capture = Regexp.capture(
               stripAnchorStartImpl(re.sub(), depth + 1), re.flags, re.cap, re.name);
+          capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
+          yield capture;
         }
         yield re;
       }
@@ -467,8 +469,10 @@ final class Compiler extends Walker<Compiler.Frag> {
       }
       case CAPTURE -> {
         if (isAnchorEndImpl(re.sub(), depth + 1)) {
-          yield Regexp.capture(
+          Regexp capture = Regexp.capture(
               stripAnchorEndImpl(re.sub(), depth + 1), re.flags, re.cap, re.name);
+          capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
+          yield capture;
         }
         yield re;
       }
@@ -730,6 +734,49 @@ final class Compiler extends Walker<Compiler.Frag> {
     return new Frag(id, PatchList.mk(id2 << 1), a.nullable);
   }
 
+  private void suppressCapture(Frag a, int cap) {
+    if (isNoMatch(a) || a.end.head != a.end.tail || (a.end.head & 1) != 0) {
+      return;
+    }
+    Inst start = prog.mutableInst(a.begin);
+    int endId = a.end.head >> 1;
+    Inst end = prog.mutableInst(endId);
+    if (start.op == InstOp.CAPTURE && start.arg == 2 * cap
+        && end.op == InstOp.CAPTURE && end.arg == 2 * cap + 1) {
+      start.initNop(start.out);
+      end.initNop(end.out);
+    }
+  }
+
+  private static boolean isDirectRepeatedPureEmptyCapture(Regexp re) {
+    return re.op == RegexpOp.CAPTURE
+        && re.cap > 0
+        && !re.sourceNonCapturingGroup
+        && isPureEmpty(re.sub());
+  }
+
+  private static boolean isPureEmpty(Regexp re) {
+    return switch (re.op) {
+      case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
+           NO_WORD_BOUNDARY -> true;
+      case CAPTURE -> isPureEmpty(re.sub());
+      case CONCAT -> {
+        if (re.subs == null) {
+          yield true;
+        }
+        boolean pure = true;
+        for (Regexp sub : re.subs) {
+          if (!isPureEmpty(sub)) {
+            pure = false;
+            break;
+          }
+        }
+        yield pure;
+      }
+      default -> false;
+    };
+  }
+
   private Frag literal(int rune, boolean foldCase) {
     // In our code-point model, a literal is just a single CHAR_RANGE.
     return charRange(rune, rune, foldCase);
@@ -801,7 +848,13 @@ final class Compiler extends Walker<Compiler.Frag> {
         yield f;
       }
 
-      case STAR -> star(childArgs.get(0), re.nonGreedy());
+      case STAR -> {
+        Frag child = childArgs.get(0);
+        if (isDirectRepeatedPureEmptyCapture(re.sub())) {
+          suppressCapture(child, re.sub().cap);
+        }
+        yield star(child, re.nonGreedy());
+      }
 
       case PLUS -> plus(childArgs.get(0), re.nonGreedy());
 

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -764,6 +764,7 @@ final class Parser {
       Regexp re = Regexp.capture(r1.re, flags, r2.cap, r2.name);
       pushRegexp(re);
     } else {
+      r1.re.sourceNonCapturingGroup = true;
       pushRegexp(r1.re);
     }
   }

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -75,6 +75,13 @@ final class Regexp {
   /** Match ID for multi-pattern matching. Used by HAVE_MATCH. */
   public int matchId;
 
+  /**
+   * Whether this node came directly from a source-level non-capturing group. Non-capturing groups
+   * are usually transparent, but the JDK exposes this distinction for zero-width quantified
+   * captures such as {@code ()*} versus {@code (?:())*}.
+   */
+  boolean sourceNonCapturingGroup;
+
   private Regexp(RegexpOp op, int flags) {
     this.op = op;
     this.flags = flags;

--- a/safere/src/main/java/org/safere/Simplifier.java
+++ b/safere/src/main/java/org/safere/Simplifier.java
@@ -166,7 +166,8 @@ final class Simplifier {
             && a.min == b.min && a.max == b.max;
 
       case CAPTURE:
-        return a.cap == b.cap && Objects.equals(a.name, b.name);
+        return a.cap == b.cap && Objects.equals(a.name, b.name)
+            && a.sourceNonCapturingGroup == b.sourceNonCapturingGroup;
 
       case HAVE_MATCH:
         return a.matchId == b.matchId;
@@ -271,7 +272,9 @@ final class Simplifier {
       case REPEAT:
         return Regexp.repeat(newSubs.getFirst(), re.flags, re.min, re.max);
       case CAPTURE:
-        return Regexp.capture(newSubs.getFirst(), re.flags, re.cap, re.name);
+        Regexp capture = Regexp.capture(newSubs.getFirst(), re.flags, re.cap, re.name);
+        capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
+        return capture;
       case STAR:
         return Regexp.star(newSubs.getFirst(), re.flags);
       case PLUS:
@@ -490,7 +493,9 @@ final class Simplifier {
           if (newsub == re.subs.getFirst()) {
             return re;
           }
-          return Regexp.capture(newsub, re.flags, re.cap, re.name);
+          Regexp capture = Regexp.capture(newsub, re.flags, re.cap, re.name);
+          capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
+          return capture;
         }
 
         case STAR:

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -671,6 +671,17 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() matches JDK captures for repeated empty groups")
+    void findMatchesJdkCapturesForRepeatedEmptyGroups() {
+      assertFirstFindMatchesJdk("()*", "");
+      assertFirstFindMatchesJdk("(())*", "");
+      assertFirstFindMatchesJdk("(?:())*", "");
+      assertFirstFindMatchesJdk("(a?)*", "");
+      assertFirstFindMatchesJdk("(?:((^){2}))*", "");
+      assertFirstFindMatchesJdk("$|^Fe|()\u00fc|()*|||||^D*4", "\u007f*\u007f");
+    }
+
+    @Test
     @DisplayName("find() preserves counted-repeat captures retained by JDK")
     void findPreservesCountedRepeatCapturesRetainedByJdk() {
       assertFirstFindMatchesJdk("(?:(a){1}){0}$", "ab");


### PR DESCRIPTION
## Summary

- align repeated pure-empty capture group participation with JDK behavior
- preserve source-level non-capturing group origin through parse and simplify rebuilds
- add regression coverage for direct and wrapped repeated empty captures
- document the project preference for principled fixes over point fixes

Fixes #249

## Verification

- `git diff --check`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
