### PR TITLE
Define semantic AST invariants for fast paths

### DIFF
--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -338,7 +338,7 @@ final class Compiler extends Walker<Compiler.Frag> {
             NO_WORD_BOUNDARY -> 0;
         case LITERAL, ANY_CHAR, CHAR_CLASS -> 1;
         case LITERAL_STRING -> re.runes == null ? 0 : re.runes.length;
-        case CAPTURE, PLUS -> childArgs.isEmpty() ? 0 : childArgs.get(0);
+        case NON_CAPTURE, CAPTURE, PLUS -> childArgs.isEmpty() ? 0 : childArgs.get(0);
         case STAR, QUEST -> 0;
         case REPEAT -> re.min * (childArgs.isEmpty() ? 0 : childArgs.get(0));
         case CONCAT -> {
@@ -375,7 +375,7 @@ final class Compiler extends Walker<Compiler.Frag> {
     return switch (re.op) {
       case BEGIN_TEXT -> true;
       case CONCAT -> re.nsub() > 0 && isAnchorStartImpl(re.subs.getFirst(), depth + 1);
-      case CAPTURE -> isAnchorStartImpl(re.sub(), depth + 1);
+      case NON_CAPTURE, CAPTURE -> isAnchorStartImpl(re.sub(), depth + 1);
       default -> false;
     };
   }
@@ -398,12 +398,16 @@ final class Compiler extends Walker<Compiler.Frag> {
         }
         yield re;
       }
+      case NON_CAPTURE -> {
+        if (isAnchorStartImpl(re.sub(), depth + 1)) {
+          yield Regexp.nonCapture(stripAnchorStartImpl(re.sub(), depth + 1), re.flags);
+        }
+        yield re;
+      }
       case CAPTURE -> {
         if (isAnchorStartImpl(re.sub(), depth + 1)) {
-          Regexp capture = Regexp.capture(
-              stripAnchorStartImpl(re.sub(), depth + 1), re.flags, re.cap, re.name);
-          capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
-          yield capture;
+          yield Regexp.capture(stripAnchorStartImpl(re.sub(), depth + 1), re.flags, re.cap,
+              re.name);
         }
         yield re;
       }
@@ -431,7 +435,7 @@ final class Compiler extends Walker<Compiler.Frag> {
       case END_TEXT -> (re.flags & ParseFlags.WAS_DOLLAR) != 0;
       case CONCAT -> re.nsub() > 0
           && isDollarAnchorEndImpl(re.subs.get(re.nsub() - 1), depth + 1);
-      case CAPTURE -> isDollarAnchorEndImpl(re.sub(), depth + 1);
+      case NON_CAPTURE, CAPTURE -> isDollarAnchorEndImpl(re.sub(), depth + 1);
       default -> false;
     };
   }
@@ -443,7 +447,7 @@ final class Compiler extends Walker<Compiler.Frag> {
     return switch (re.op) {
       case END_TEXT -> true;
       case CONCAT -> re.nsub() > 0 && isAnchorEndImpl(re.subs.get(re.nsub() - 1), depth + 1);
-      case CAPTURE -> isAnchorEndImpl(re.sub(), depth + 1);
+      case NON_CAPTURE, CAPTURE -> isAnchorEndImpl(re.sub(), depth + 1);
       default -> false;
     };
   }
@@ -467,12 +471,16 @@ final class Compiler extends Walker<Compiler.Frag> {
         }
         yield re;
       }
+      case NON_CAPTURE -> {
+        if (isAnchorEndImpl(re.sub(), depth + 1)) {
+          yield Regexp.nonCapture(stripAnchorEndImpl(re.sub(), depth + 1), re.flags);
+        }
+        yield re;
+      }
       case CAPTURE -> {
         if (isAnchorEndImpl(re.sub(), depth + 1)) {
-          Regexp capture = Regexp.capture(
-              stripAnchorEndImpl(re.sub(), depth + 1), re.flags, re.cap, re.name);
-          capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
-          yield capture;
+          yield Regexp.capture(stripAnchorEndImpl(re.sub(), depth + 1), re.flags, re.cap,
+              re.name);
         }
         yield re;
       }
@@ -751,30 +759,31 @@ final class Compiler extends Walker<Compiler.Frag> {
   private static boolean isDirectRepeatedPureEmptyCapture(Regexp re) {
     return re.op == RegexpOp.CAPTURE
         && re.cap > 0
-        && !re.sourceNonCapturingGroup
         && isPureEmpty(re.sub());
   }
 
   private static boolean isPureEmpty(Regexp re) {
-    return switch (re.op) {
-      case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
-           NO_WORD_BOUNDARY -> true;
-      case CAPTURE -> isPureEmpty(re.sub());
-      case CONCAT -> {
-        if (re.subs == null) {
-          yield true;
-        }
-        boolean pure = true;
-        for (Regexp sub : re.subs) {
-          if (!isPureEmpty(sub)) {
-            pure = false;
-            break;
+    ArrayDeque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      switch (node.op) {
+        case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
+             NO_WORD_BOUNDARY -> {}
+        case NON_CAPTURE, CAPTURE -> stack.push(node.sub());
+        case CONCAT -> {
+          if (node.subs != null) {
+            for (Regexp sub : node.subs) {
+              stack.push(sub);
+            }
           }
         }
-        yield pure;
+        default -> {
+          return false;
+        }
       }
-      default -> false;
-    };
+    }
+    return true;
   }
 
   private Frag literal(int rune, boolean foldCase) {
@@ -847,6 +856,8 @@ final class Compiler extends Walker<Compiler.Frag> {
         }
         yield f;
       }
+
+      case NON_CAPTURE -> childArgs.get(0);
 
       case STAR -> {
         Frag child = childArgs.get(0);

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1697,19 +1697,6 @@ public final class Matcher implements MatchResult {
     ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
 
     reset();
-    Prog prog = parentPattern.prog();
-
-    // Direct BitState path: when captures will always be needed (group references in the
-    // replacement) and the text fits BitState, skip the DFA sandwich entirely. Instead of
-    // DFA forward + reverse + anchored (3 passes) then BitState for captures (1 pass), run
-    // BitState once per match for combined find + capture. For short text with dense matches,
-    // this eliminates ~12% overhead from the per-match DFA engine setup.
-    if (templateHasGroupRefs(template)
-        && !parentPattern.canOnePassPrimary()
-        && BitState.maxTextSize(prog) >= text.length()) {
-      return replaceAllDirectBitState(template, prog);
-    }
-
     StringBuilder sb = new StringBuilder();
     while (find()) {
       resolveCaptures();
@@ -1743,93 +1730,6 @@ public final class Matcher implements MatchResult {
       appendReplacement(sb, replacement);
     }
     appendTail(sb);
-    return sb.toString();
-  }
-
-  /**
-   * Returns {@code true} if the compiled template contains any group references (numbered or
-   * named). When true, captures will be accessed for every match, making the direct BitState path
-   * worthwhile.
-   */
-  private static boolean templateHasGroupRefs(ReplacementSegment[] template) {
-    for (ReplacementSegment seg : template) {
-      if (seg instanceof ReplacementSegment.GroupRef
-          || seg instanceof ReplacementSegment.NamedGroupRef) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Specialized replaceAll loop that uses BitState directly for find + capture in a single pass,
-   * bypassing the DFA sandwich. Falls back to prefix acceleration when available.
-   */
-  private String replaceAllDirectBitState(ReplacementSegment[] template, Prog prog) {
-    StringBuilder sb = new StringBuilder();
-    int ncap = prog.numCaptures();
-    int pos = 0;
-    int appPos = 0;
-
-    while (pos <= text.length()) {
-      int effectiveStart = pos;
-      boolean anchoredStart = prog.anchorStart();
-      if (anchoredStart && pos > 0) {
-        break;
-      }
-
-      // Apply prefix acceleration if available.
-      String prefix = parentPattern.prefix();
-      if (prefix != null && !anchoredStart) {
-        int idx;
-        if (parentPattern.prefixFoldCase()) {
-          idx = indexOfIgnoreCase(text, prefix, pos);
-        } else {
-          idx = text.indexOf(prefix, pos);
-        }
-        if (idx < 0) {
-          break;
-        }
-        effectiveStart = idx;
-      }
-
-      // Apply char-class prefix acceleration if available.
-      boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
-      if (ccPrefixAscii != null && !anchoredStart) {
-        int idx = indexOfCharClass(text, ccPrefixAscii, pos);
-        if (idx < 0) {
-          break;
-        }
-        effectiveStart = idx;
-      }
-
-      int[] result = searchWithBitStateOrNfa(
-          prog, text, effectiveStart, text.length(), text.length(),
-          false, false, false, ncap);
-      if (result == null) {
-        break;
-      }
-      groups = result;
-      capturesResolved = true;
-      groupZeroResolved = true;
-      captureDebugResolved = false;
-      hasMatch = true;
-      sb.append(text, appPos, groups[0]);
-      applyReplacementTemplate(sb, template);
-      appPos = groups[1];
-
-      // Advance past the match; handle empty matches by advancing one character.
-      if (groups[1] == groups[0]) {
-        if (groups[0] < text.length()) {
-          sb.append(text, groups[0], groups[0] + Character.charCount(text.codePointAt(groups[0])));
-          appPos = groups[0] + Character.charCount(text.codePointAt(groups[0]));
-        }
-        pos = groups[0] + 1;
-      } else {
-        pos = groups[1];
-      }
-    }
-    sb.append(text, appPos, text.length());
     return sb.toString();
   }
 
@@ -2409,7 +2309,7 @@ public final class Matcher implements MatchResult {
           addSample(re.subs.get(0), samples);
         }
       }
-      case CAPTURE -> collectTerminalRepeatSamples(re.subs.get(0), samples);
+      case NON_CAPTURE, CAPTURE -> collectTerminalRepeatSamples(re.subs.get(0), samples);
       case CONCAT -> {
         for (int i = re.subs.size() - 1; i >= 0; i--) {
           Regexp sub = re.subs.get(i);
@@ -2443,7 +2343,7 @@ public final class Matcher implements MatchResult {
           ? null
           : new String(Character.toChars(re.charClass.lo(0)));
       case ANY_CHAR -> "a";
-      case CAPTURE -> sampleString(re.subs.get(0));
+      case NON_CAPTURE, CAPTURE -> sampleString(re.subs.get(0));
       case CONCAT -> {
         StringBuilder sb = new StringBuilder();
         for (Regexp sub : re.subs) {

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -764,8 +764,7 @@ final class Parser {
       Regexp re = Regexp.capture(r1.re, flags, r2.cap, r2.name);
       pushRegexp(re);
     } else {
-      r1.re.sourceNonCapturingGroup = true;
-      pushRegexp(r1.re);
+      pushRegexp(Regexp.nonCapture(r1.re, flags));
     }
   }
 

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -242,11 +242,18 @@ public final class Pattern implements Serializable {
     Regexp re = Parser.parse(regex, parseFlags);
     Prog compiled = Compiler.compile(re);
     compiled.setUnixLines((effectiveFlags & UNIX_LINES) != 0);
+    // Language-shape accelerators should see through source-only grouping. Correctness guards
+    // below still inspect the source AST because source quantifiers carry matching semantics that
+    // simplification deliberately lowers away.
+    Regexp metadataAst = Simplifier.simplify(re);
+    if (metadataAst == null) {
+      throw new PatternSyntaxException("pattern too large to simplify", regex, -1);
+    }
     Map<String, Integer> named = extractNamedGroups(re);
-    PrefixResult prefixResult = extractPrefix(re);
+    PrefixResult prefixResult = extractPrefix(metadataAst);
     String prefix = prefixResult.prefix();
     boolean prefixFoldCase = prefixResult.foldCase();
-    String literalMatch = extractLiteralMatch(re);
+    String literalMatch = extractLiteralMatch(metadataAst);
     boolean hasLazy = hasLazyQuantifiers(re);
     boolean hasAlt = hasAlternation(re);
     boolean hasNullableAlt = hasAlt && hasNullableAlternation(re);
@@ -255,12 +262,12 @@ public final class Pattern implements Serializable {
     boolean hasEndConst = hasEndConstraint(re);
     // Extract character-class prefix for acceleration when no literal prefix exists.
     boolean[] ccPrefixAscii = (prefix == null)
-        ? extractCharClassPrefixAscii(re) : null;
+        ? extractCharClassPrefixAscii(metadataAst) : null;
     StartAcceleration startAcceleration =
-        (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(re) : null;
-    KeywordAlternation keywordAlternation = extractKeywordAlternation(re, flags);
+        (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(metadataAst) : null;
+    KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
     // Detect "repeated character class" pattern for matches() fast path.
-    CharClassMatchInfo ccMatch = extractCharClassMatch(re);
+    CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(regex, effectiveFlags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
@@ -1038,39 +1045,44 @@ public final class Pattern implements Serializable {
    * alternation branches where OnePass's longest-match semantics may differ from first-match.
    */
   static boolean canMatchEmpty(Regexp re) {
-    return switch (re.op) {
-      case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
-           NO_WORD_BOUNDARY -> true;
-      case STAR, QUEST -> true; // min=0
-      case REPEAT -> re.min == 0;
-      case PLUS -> re.subs != null && !re.subs.isEmpty() && canMatchEmpty(re.subs.get(0));
-      case CAPTURE -> re.subs != null && !re.subs.isEmpty() && canMatchEmpty(re.subs.get(0));
-      case CONCAT -> {
-        if (re.subs == null) {
+    return new CanMatchEmptyWalker().walk(re, false);
+  }
+
+  private static final class CanMatchEmptyWalker extends Walker<Boolean> {
+
+    @Override
+    protected Boolean shortVisit(Regexp re, Boolean parentArg) {
+      return false;
+    }
+
+    @Override
+    protected Boolean postVisit(
+        Regexp re, Boolean parentArg, Boolean preArg, List<Boolean> childArgs) {
+      return switch (re.op) {
+        case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
+             NO_WORD_BOUNDARY -> true;
+        case STAR, QUEST -> true;
+        case REPEAT -> re.min == 0;
+        case PLUS, NON_CAPTURE, CAPTURE -> !childArgs.isEmpty() && childArgs.getFirst();
+        case CONCAT -> {
+          for (boolean childCanMatchEmpty : childArgs) {
+            if (!childCanMatchEmpty) {
+              yield false;
+            }
+          }
           yield true;
         }
-        for (Regexp sub : re.subs) {
-          if (!canMatchEmpty(sub)) {
-            yield false;
+        case ALTERNATE -> {
+          for (boolean childCanMatchEmpty : childArgs) {
+            if (childCanMatchEmpty) {
+              yield true;
+            }
           }
+          yield childArgs.isEmpty();
         }
-        yield true;
-      }
-      case ALTERNATE -> {
-        if (re.subs == null) {
-          yield true;
-        }
-        for (Regexp sub : re.subs) {
-          if (canMatchEmpty(sub)) {
-            yield true;
-          }
-        }
-        yield false;
-      }
-      default ->
-        // LITERAL, LITERAL_STRING, CHAR_CLASS, ANY_CHAR, etc. — must consume at least one char.
-        false;
-    };
+        default -> false;
+      };
+    }
   }
 
   /**

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -45,7 +45,10 @@ final class Regexp {
   /** Parse flags in effect for this node. */
   public final int flags;
 
-  /** Sub-expressions (children). Used by CONCAT, ALTERNATE, STAR, PLUS, QUEST, REPEAT, CAPTURE. */
+  /**
+   * Sub-expressions (children). Used by CONCAT, ALTERNATE, STAR, PLUS, QUEST, REPEAT, NON_CAPTURE,
+   * and CAPTURE.
+   */
   public List<Regexp> subs;
 
   /**
@@ -74,13 +77,6 @@ final class Regexp {
 
   /** Match ID for multi-pattern matching. Used by HAVE_MATCH. */
   public int matchId;
-
-  /**
-   * Whether this node came directly from a source-level non-capturing group. Non-capturing groups
-   * are usually transparent, but the JDK exposes this distinction for zero-width quantified
-   * captures such as {@code ()*} versus {@code (?:())*}.
-   */
-  boolean sourceNonCapturingGroup;
 
   private Regexp(RegexpOp op, int flags) {
     this.op = op;
@@ -184,6 +180,13 @@ final class Regexp {
     re.subs = List.of(sub);
     re.min = min;
     re.max = max;
+    return re;
+  }
+
+  /** Creates a NON_CAPTURE node preserving a source-level {@code (?:...)} group boundary. */
+  public static Regexp nonCapture(Regexp sub, int flags) {
+    Regexp re = new Regexp(RegexpOp.NON_CAPTURE, flags);
+    re.subs = List.of(sub);
     return re;
   }
 
@@ -327,6 +330,10 @@ final class Regexp {
           }
           yield PREC_ALTERNATE;
         }
+        case NON_CAPTURE -> {
+          sb.append("(?:");
+          yield PREC_PAREN;
+        }
         case CAPTURE -> {
           sb.append('(');
           if (re.cap == 0) {
@@ -439,6 +446,7 @@ final class Regexp {
         case WORD_BOUNDARY -> sb.append("\\b");
         case NO_WORD_BOUNDARY -> sb.append("\\B");
         case CHAR_CLASS -> appendCharClass(sb, re.charClass);
+        case NON_CAPTURE -> sb.append(')');
         case CAPTURE -> sb.append(')');
         case HAVE_MATCH -> sb.append("(?HaveMatch:").append(re.matchId).append(')');
         default -> sb.append("[").append(re.op).append("]");

--- a/safere/src/main/java/org/safere/RegexpOp.java
+++ b/safere/src/main/java/org/safere/RegexpOp.java
@@ -47,6 +47,9 @@ enum RegexpOp {
    */
   REPEAT,
 
+  /** Source-level non-capturing parenthesized subexpression. */
+  NON_CAPTURE,
+
   /** Parenthesized (capturing) subexpression with capture index and optional name. */
   CAPTURE,
 

--- a/safere/src/main/java/org/safere/Simplifier.java
+++ b/safere/src/main/java/org/safere/Simplifier.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -74,6 +75,7 @@ final class Simplifier {
       case PLUS:
       case QUEST:
       case REPEAT:
+      case NON_CAPTURE:
       case CAPTURE:
         break;
       default:
@@ -100,6 +102,7 @@ final class Simplifier {
         case PLUS:
         case QUEST:
         case REPEAT:
+        case NON_CAPTURE:
         case CAPTURE:
           Regexp a2 = a.subs.get(0);
           Regexp b2 = b.subs.get(0);
@@ -165,9 +168,11 @@ final class Simplifier {
         return ((a.flags ^ b.flags) & ParseFlags.NON_GREEDY) == 0
             && a.min == b.min && a.max == b.max;
 
+      case NON_CAPTURE:
+        return true;
+
       case CAPTURE:
-        return a.cap == b.cap && Objects.equals(a.name, b.name)
-            && a.sourceNonCapturingGroup == b.sourceNonCapturingGroup;
+        return a.cap == b.cap && Objects.equals(a.name, b.name);
 
       case HAVE_MATCH:
         return a.matchId == b.matchId;
@@ -271,10 +276,10 @@ final class Simplifier {
     switch (re.op) {
       case REPEAT:
         return Regexp.repeat(newSubs.getFirst(), re.flags, re.min, re.max);
+      case NON_CAPTURE:
+        return Regexp.nonCapture(newSubs.getFirst(), re.flags);
       case CAPTURE:
-        Regexp capture = Regexp.capture(newSubs.getFirst(), re.flags, re.cap, re.name);
-        capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
-        return capture;
+        return Regexp.capture(newSubs.getFirst(), re.flags, re.cap, re.name);
       case STAR:
         return Regexp.star(newSubs.getFirst(), re.flags);
       case PLUS:
@@ -488,14 +493,23 @@ final class Simplifier {
           }
         }
 
+        case NON_CAPTURE: {
+          Regexp newsub = childArgs.get(0);
+          if (!isPureEmpty(newsub) || !hasCapture(newsub)) {
+            return newsub;
+          }
+          if (newsub == re.subs.getFirst()) {
+            return re;
+          }
+          return Regexp.nonCapture(newsub, re.flags);
+        }
+
         case CAPTURE: {
           Regexp newsub = childArgs.get(0);
           if (newsub == re.subs.getFirst()) {
             return re;
           }
-          Regexp capture = Regexp.capture(newsub, re.flags, re.cap, re.name);
-          capture.sourceNonCapturingGroup = re.sourceNonCapturingGroup;
-          return capture;
+          return Regexp.capture(newsub, re.flags, re.cap, re.name);
         }
 
         case STAR:
@@ -513,9 +527,7 @@ final class Simplifier {
           if (re.op == newsub.op && re.flags == newsub.flags) {
             return newsub;
           }
-          // Create the node directly — do NOT use the cross-op squashing factory.
-          // The C++ SimplifyWalker also creates nodes directly here.
-          return rawQuantifier(re.op, newsub, re.flags);
+          return starPlusOrQuest(re.op, newsub, re.flags);
         }
 
         case REPEAT: {
@@ -543,6 +555,45 @@ final class Simplifier {
         || re.op == RegexpOp.NO_WORD_BOUNDARY
         || re.op == RegexpOp.BEGIN_TEXT
         || re.op == RegexpOp.END_TEXT;
+  }
+
+  private static boolean isPureEmpty(Regexp re) {
+    ArrayDeque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      switch (node.op) {
+        case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
+             NO_WORD_BOUNDARY -> {}
+        case NON_CAPTURE, CAPTURE -> stack.push(node.sub());
+        case CONCAT -> {
+          for (Regexp sub : node.subs) {
+            stack.push(sub);
+          }
+        }
+        default -> {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static boolean hasCapture(Regexp re) {
+    ArrayDeque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.CAPTURE && node.cap > 0) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -577,6 +628,8 @@ final class Simplifier {
         return true;
       case CHAR_CLASS:
         return !re.charClass.isEmpty() && !isFull(re.charClass);
+      case NON_CAPTURE:
+        return false;
       case CAPTURE:
         return computeSimple(re.subs.getFirst());
       case STAR:

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -43,6 +43,10 @@ class ParserTest {
     return Parser.parse(pattern, flags);
   }
 
+  private static Regexp simplify(String pattern) {
+    return Simplifier.simplify(parse(pattern));
+  }
+
   // ---------------------------------------------------------------------------
   // 1. Literals
   // ---------------------------------------------------------------------------
@@ -621,7 +625,8 @@ class ParserTest {
     void quantifierOnNonCapturingGroup() {
       Regexp re = parse("(?:ab)*");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
-      assertThat(re.sub().toString()).isEqualTo("ab");
+      assertThat(re.sub().op).isEqualTo(RegexpOp.NON_CAPTURE);
+      assertThat(re.sub().sub().toString()).isEqualTo("ab");
     }
 
     @Test
@@ -678,9 +683,16 @@ class ParserTest {
     }
 
     @Test
-    void nonCapturingGroup_simplifiesAway() {
-      // (?:a) optimizes to just the literal
+    void nonCapturingGroup_preservesSourceBoundary() {
       Regexp re = parse("(?:a)");
+      assertThat(re.op).isEqualTo(RegexpOp.NON_CAPTURE);
+      assertThat(re.sub().op).isEqualTo(RegexpOp.LITERAL);
+      assertThat(re.sub().rune).isEqualTo('a');
+    }
+
+    @Test
+    void nonCapturingGroup_simplifiesAway() {
+      Regexp re = simplify("(?:a)");
       assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
       assertThat(re.rune).isEqualTo('a');
     }
@@ -688,13 +700,13 @@ class ParserTest {
     @Test
     void nonCapturingGroupConcat() {
       // (?:ab)(?:cd) should coalesce to "abcd"
-      Regexp re = parse("(?:ab)(?:cd)");
+      Regexp re = simplify("(?:ab)(?:cd)");
       assertThat(re.toString()).isEqualTo("abcd");
     }
 
     @Test
     void nonCapturingGroupWithAlternation() {
-      Regexp re = parse("(?:ab|cd)");
+      Regexp re = simplify("(?:ab|cd)");
       assertThat(re.op).isEqualTo(RegexpOp.ALTERNATE);
     }
 
@@ -1189,7 +1201,8 @@ class ParserTest {
     @Test
     void caseInsensitive_scoped() {
       Regexp re = parse("(?i:abc)");
-      assertThat(re.foldCase()).isTrue();
+      assertThat(re.op).isEqualTo(RegexpOp.NON_CAPTURE);
+      assertThat(re.sub().foldCase()).isTrue();
     }
 
     @Test
@@ -1527,7 +1540,7 @@ class ParserTest {
     @Test
     void nestedRepetition_starStar() {
       // (?:(?:a)*)* simplifies to a*
-      Regexp re = parse("(?:(?:a)*)*");
+      Regexp re = simplify("(?:(?:a)*)*");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
       assertThat(re.sub().op).isEqualTo(RegexpOp.LITERAL);
       assertThat(re.sub().rune).isEqualTo('a');
@@ -1536,7 +1549,7 @@ class ParserTest {
     @Test
     void nestedRepetition_plusPlus() {
       // (?:(?:a)+)+ simplifies to a+
-      Regexp re = parse("(?:(?:a)+)+");
+      Regexp re = simplify("(?:(?:a)+)+");
       assertThat(re.op).isEqualTo(RegexpOp.PLUS);
       assertThat(re.sub().op).isEqualTo(RegexpOp.LITERAL);
     }
@@ -1544,55 +1557,55 @@ class ParserTest {
     @Test
     void nestedRepetition_questQuest() {
       // (?:(?:a)?)? simplifies to a?
-      Regexp re = parse("(?:(?:a)?)?");
+      Regexp re = simplify("(?:(?:a)?)?");
       assertThat(re.op).isEqualTo(RegexpOp.QUEST);
     }
 
     @Test
     void nestedRepetition_starPlus() {
       // (?:(?:a)*)+ simplifies to a*
-      Regexp re = parse("(?:(?:a)*)+");
+      Regexp re = simplify("(?:(?:a)*)+");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
     }
 
     @Test
     void nestedRepetition_starQuest() {
       // (?:(?:a)*)? simplifies to a*
-      Regexp re = parse("(?:(?:a)*)?");
+      Regexp re = simplify("(?:(?:a)*)?");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
     }
 
     @Test
     void nestedRepetition_plusStar() {
       // (?:(?:a)+)* simplifies to a*
-      Regexp re = parse("(?:(?:a)+)*");
+      Regexp re = simplify("(?:(?:a)+)*");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
     }
 
     @Test
     void nestedRepetition_plusQuest() {
       // (?:(?:a)+)? simplifies to a*
-      Regexp re = parse("(?:(?:a)+)?");
+      Regexp re = simplify("(?:(?:a)+)?");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
     }
 
     @Test
     void nestedRepetition_questStar() {
       // (?:(?:a)?)* simplifies to a*
-      Regexp re = parse("(?:(?:a)?)*");
+      Regexp re = simplify("(?:(?:a)?)*");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
     }
 
     @Test
     void nestedRepetition_questPlus() {
       // (?:(?:a)?)+ simplifies to a*
-      Regexp re = parse("(?:(?:a)?)+");
+      Regexp re = simplify("(?:(?:a)?)+");
       assertThat(re.op).isEqualTo(RegexpOp.STAR);
     }
 
     @Test
     void nonCapturingNoop() {
-      Regexp re = parse("(?:a)");
+      Regexp re = simplify("(?:a)");
       assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
       assertThat(re.rune).isEqualTo('a');
     }

--- a/safere/src/test/java/org/safere/PatternSafeReApiTest.java
+++ b/safere/src/test/java/org/safere/PatternSafeReApiTest.java
@@ -10,6 +10,7 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Method;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,41 @@ class PatternSafeReApiTest {
   void numGroupsNoCaptures() {
     Pattern p = Pattern.compile("abc");
     assertThat(p.numGroups()).isZero();
+  }
+
+  @Test
+  void transparentGroupsPreserveLiteralAccelerators() {
+    Pattern p = Pattern.compile("(?:abcdef)");
+
+    assertThat(invokePatternMetadata(p, "literalMatch")).isEqualTo("abcdef");
+    assertThat(invokePatternMetadata(p, "prefix")).isEqualTo("abcdef");
+  }
+
+  @Test
+  void transparentGroupsPreserveCharacterClassAccelerators() {
+    Pattern p = Pattern.compile("(?:[A-Z]+)");
+
+    boolean[] prefix = (boolean[]) invokePatternMetadata(p, "charClassPrefixAscii");
+    assertThat(prefix).isNotNull();
+    assertThat(prefix['A']).isTrue();
+    assertThat(invokePatternMetadata(p, "charClassMatchRanges")).isNotNull();
+  }
+
+  @Test
+  void transparentGroupsPreserveKeywordAlternationAccelerator() {
+    Pattern p = Pattern.compile("(?i)\\b(?:error|warning)\\b");
+
+    assertThat(invokePatternMetadata(p, "keywordAlternation")).isNotNull();
+  }
+
+  private static Object invokePatternMetadata(Pattern pattern, String methodName) {
+    try {
+      Method method = Pattern.class.getDeclaredMethod(methodName);
+      method.setAccessible(true);
+      return method.invoke(pattern);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Could not read Pattern metadata: " + methodName, e);
+    }
   }
 
   @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -8,6 +8,7 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
@@ -80,6 +81,22 @@ class PatternTest {
       assertThat(p.pattern()).isEmpty();
       assertThat(p.matcher("").matches()).isTrue();
       assertThat(p.matcher("abc").find()).isTrue();
+    }
+
+    @Test
+    @DisabledForCrosscheck("JDK stack overflows on this SafeRE stack-safety stress case")
+    void deeplyNestedTransparentGroupsRemainStackSafe() {
+      int depth = 20_000;
+      StringBuilder regex = new StringBuilder(depth * 3 + 4);
+      for (int i = 0; i < depth; i++) {
+        regex.append("(?:");
+      }
+      regex.append("()");
+      regex.append(")".repeat(depth));
+      regex.append("*");
+
+      assertThatCode(() -> Pattern.compile(regex.toString()))
+          .doesNotThrowAnyException();
     }
   }
 

--- a/safere/src/test/java/org/safere/RegexpOpTest.java
+++ b/safere/src/test/java/org/safere/RegexpOpTest.java
@@ -15,8 +15,7 @@ class RegexpOpTest {
 
   @Test
   void allOpsAreDefined() {
-    // 21 operators as defined in RE2's regexp.h
-    assertThat(RegexpOp.values().length).isEqualTo(21);
+    assertThat(RegexpOp.values()).contains(RegexpOp.NON_CAPTURE);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -95,9 +95,9 @@ class SimplifierTest {
         Arguments.of("(?:a{1,}){1,}", "a+"),
         Arguments.of("(a{1,}b{1,})", "(a+b+)"),
         Arguments.of("a{1,}|b{1,}", "a+|b+"),
-        Arguments.of("(?:a{1,})*", "(?:a+)*"),
+        Arguments.of("(?:a{1,})*", "a*"),
         Arguments.of("(?:a{1,})+", "a+"),
-        Arguments.of("(?:a{1,})?", "(?:a+)?"),
+        Arguments.of("(?:a{1,})?", "a*"),
         Arguments.of("a{0}", ""),
 
         // Character class simplification


### PR DESCRIPTION
## Summary
- preserve source-level non-capturing groups as `NON_CAPTURE` nodes and simplify them only when semantically transparent
- split `Pattern.compile` metadata into source-semantic correctness guards and normalized language-shape accelerator extraction
- route group-reference `replaceAll` through shared `find()` semantics by removing the direct BitState replacement loop
- make empty-match structural predicates iterative to preserve stack safety

## Tests
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
