### PR TITLE
Add engine path equivalence contracts

### DIFF
--- a/design/ENGINE_PATH_EQUIVALENCE.md
+++ b/design/ENGINE_PATH_EQUIVALENCE.md
@@ -494,3 +494,89 @@ This design is complete when:
 - Do not emulate unsupported JDK features such as backreferences or lookaround.
 - Do not add guards for individual regex strings; guards must correspond to
   semantic capabilities of an engine path.
+
+## Implemented Approach
+
+The implementation now covers the core enforcement shape described above.
+
+The implemented model is:
+
+- `EnginePathOptions` gives package-private tests a way to disable selected
+  engine paths without changing public API behavior;
+- `EnginePathContract` provides machine-readable contract metadata for every
+  controllable path, including its role, result authority, and semantic guard
+  categories;
+- `Matcher` uses typed internal engine results for core dispatch:
+  `NoMatchResult`, `FullMatchResult`, and `DeferredMatchResult`;
+- core dispatch paths apply those results through a shared helper instead of
+  freely mutating match state in each path;
+- `EnginePathEquivalenceTest` compares observable public traces under default
+  and forced-path configurations;
+- registry tests assert that every forced path has a declared contract and that
+  filter or partial-producer roles do not claim full-result authority;
+- negative guard tests deliberately disable semantic guards for representative
+  OnePass and DFA cases and verify divergence from the canonical path, proving
+  those guards have semantic content.
+
+This is intentionally package-private infrastructure.  Production matching does
+not run multiple engines to compare answers, and public `Pattern.compile`
+continues to use all engine paths enabled with semantic guards active.
+
+## Correctness Evidence
+
+Correctness for this design means:
+
+- disabling an optimization does not change the observable public trace for
+  cases where that optimization claims equivalence;
+- paths that are not generally equivalent are guarded out before they can
+  define public semantics;
+- partial producers cannot silently expose unresolved state as authoritative;
+- replacement fast paths produce the same replacement result as the canonical
+  `find()`-driven replacement loop;
+- the enforcement mechanism does not add production-time multi-engine voting or
+  post-match semantic repair.
+
+The implementation checks those claims in three ways.
+
+First, the forced-path trace tests compare observable API behavior across
+engine configurations.  The traces include:
+
+- `matches()`, `lookingAt()`, and full `find()` sequences;
+- `group()`, `start()`, and `end()` for every visible group;
+- `replaceAll`, `replaceFirst`, functional replacement, and
+  `appendReplacement`;
+- regions and anchoring-bound behavior;
+- multiline/CRLF anchor behavior;
+- `hitEnd()` and `requireEnd()`.
+
+Second, the registry tests make the contracts machine-checkable.  They verify
+that every controllable path has contract metadata, that default production
+options enable every path, and that filter or partial-producer roles cannot
+claim result authority they are not supposed to own.
+
+Third, negative guard tests demonstrate that representative guards are not just
+documentation.  For nullable alternation, forcing OnePass past its guard
+diverges from the canonical trace.  For unreliable DFA start detection, forcing
+the DFA sandwich past its guard diverges from the canonical trace.  Those tests
+prove that the guards protect real semantic differences.
+
+This does not constitute a formal proof of all possible regexes and matcher
+states.  The confidence comes from making the contract executable, then running
+it alongside the existing generated cross-engine and public API test suites.
+
+## Remaining Work
+
+The current implementation completes the main design direction, but there are
+reasonable follow-ups if this area continues to change:
+
+- add negative guard tests for more guard categories, especially BitState
+  capture-equivalence and replacement-only fast paths;
+- expand forced-path generated coverage so more regex/input matrices are
+  produced mechanically rather than hand-selected;
+- add more local comments near individual dispatch branches pointing back to
+  their `EnginePathContract` role;
+- consider moving more public matcher state transitions, such as lifecycle
+  reset and region transitions, into typed state helpers as part of the matcher
+  state-machine design;
+- keep the existing generated public API crosscheck as the broad JDK oracle for
+  behavior that is comparable with `java.util.regex`.

--- a/design/ENGINE_PATH_EQUIVALENCE.md
+++ b/design/ENGINE_PATH_EQUIVALENCE.md
@@ -58,6 +58,8 @@ to compute:
 - Some paths produce provisional bounds and defer captures.
 - Some paths update matcher state directly.
 - Replacement paths may loop over matches and update append cursors.
+- `charClassReplaceAll` is currently a replacement-only fast path that bypasses
+  `find()` entirely for simple replacements over character-class runs.
 
 Without a common classification and test obligation, it is easy to add a local
 optimization that is correct for match existence but wrong for anchors, empty
@@ -84,6 +86,12 @@ engine path must fit one of these roles:
 
 Any path that does not fit one of those roles should be removed or refactored
 to share the canonical operation.
+
+The positive design assumption is that this problem is solvable because SafeRE
+does not need every engine to implement every semantic detail.  It needs one
+general semantic authority plus machine-checkable boundaries around every
+shortcut.  A fast path is safe when it cannot claim more public-result authority
+than its declared role permits.
 
 ## Canonical Operations
 
@@ -125,6 +133,12 @@ Replacement APIs should consume this canonical result sequence.  They should
 not have a separate direct replacement loop unless that loop is proven to
 produce the same sequence, append positions, capture substitutions, and
 zero-width advancement behavior as canonical `find()`.
+
+A path's contract should name both the result fields it owns and the fields it
+must leave to shared code.  For example, a candidate-start accelerator may own
+only `effectiveStart`; it must not own match end, captures, replacement append
+position, or end-state flags.  A complete-result fast path may own group-zero
+bounds only if it also proves that no omitted public state can differ.
 
 ## Engine-Path Contracts
 
@@ -236,6 +250,49 @@ tests against the canonical loop.  Otherwise replacement should share the
 canonical search loop and optimize only inside well-bounded pieces such as
 literal copying or replacement-template expansion.
 
+The current concrete audit target is `charClassReplaceAll`.  It bypasses
+`find()` for patterns that are a single character class under a `+` quantifier
+and whose replacement string has no group references or escapes.  That can be a
+valid authoritative producer, but its contract must be explicit:
+
+- the pattern must be non-nullable, so replacement cannot depend on zero-width
+  match advancement;
+- there must be no user-visible capture substitution in the replacement;
+- active region behavior must either be unsupported by that path or proven
+  identical to the canonical replacement loop;
+- append position and copied text must match the sequence of canonical
+  `find()` results;
+- `hitEnd()` and `requireEnd()` must either be updated through shared code or
+  documented as unaffected by this public operation.
+
+If any of those conditions cannot be proven, `replaceAll` should use the
+canonical loop and reserve fast-path work for replacement-template parsing or
+literal copying.
+
+## End-State Boundary
+
+`hitEnd()` and `requireEnd()` are observable public state, but they are not
+ordinary engine outputs today.  SafeRE currently recomputes them after the
+match through shared `Matcher` logic, using match bounds, region bounds,
+end-constraint metadata, and limited AST-derived extension samples.
+
+This design should keep that recomputation centralized, but it must make the
+boundary explicit:
+
+- engine paths must provide authoritative match existence and group-zero bounds
+  before end-state is computed;
+- partial producers must mark provisional group-zero bounds so end-state is not
+  computed from stale or approximate data;
+- fast paths that bypass shared `Matcher` completion code must either call the
+  shared end-state updater or document why the public operation cannot expose a
+  different end state;
+- forced-path tests must compare `hitEnd()` and `requireEnd()` after the same
+  public operation, not only the immediate match result.
+
+This boundary keeps end-state handling in the matcher state-machine layer while
+still requiring every engine path to supply enough canonical facts for that
+layer to be correct.
+
 ## Proposed Work
 
 ### 1. Classify Existing Paths
@@ -250,6 +307,27 @@ Document every `Matcher` execution path in code as one of:
 The classification should live near engine dispatch, not only in this document.
 Comments should state the public result fields the path owns and the fields it
 must not decide.
+
+Initial inventory:
+
+- literal `matches()` and `lookingAt()` paths: authoritative producers for
+  group-zero-only literal patterns;
+- literal `find()` path: authoritative producer for group-zero-only literal
+  patterns, subject to cursor, region, and end-state completion;
+- character-class `matches()` path: authoritative producer only for the
+  specific whole-pattern character-class forms it recognizes;
+- prefix, character-class prefix, and start acceleration: filters that only
+  choose candidate start positions;
+- keyword alternation path: guarded optimization that must prove equivalent
+  match bounds and captures for its recognized pattern family;
+- OnePass paths: guarded authoritative producers;
+- DFA sandwich and reverse-first paths: filters or partial producers for
+  group-zero bounds, with deferred capture authority elsewhere;
+- BitState: guarded authoritative producer for small inputs when its bounded
+  visited-state model is semantically sufficient;
+- Pike VM NFA: general authoritative producer;
+- `charClassReplaceAll`: replacement-only authoritative producer candidate
+  that needs explicit proof or should be routed through the canonical loop.
 
 ### 2. Centralize Result Authority
 
@@ -267,6 +345,12 @@ without changing engine internals.
 Audit replacement APIs so they consume the canonical `find()` result sequence.
 Any direct replacement path should either be removed or proven equivalent with
 the same forced-path tests described below.
+
+This audit should start with `charClassReplaceAll`, because it is intentionally
+not just a faster implementation of replacement-template parsing.  It computes
+the entire replacement result without creating matcher results.  Keeping it is
+reasonable only if its preconditions and tests prove that it is equivalent to
+the canonical loop for the whole public operation.
 
 ### 4. Consolidate Guards
 
@@ -303,6 +387,59 @@ Generated crosscheck remains the public oracle against `java.util.regex`.
 Forced-path tests are the internal oracle that all SafeRE engine paths are
 equivalent to one another where they claim to be authoritative.
 
+The concrete mechanism should be a test-only engine configuration, exposed only
+to package-private tests.  It should let tests disable or force these choices:
+
+- literal fast paths;
+- character-class match and replacement fast paths;
+- keyword alternation;
+- prefix and start acceleration;
+- anchored and unanchored OnePass;
+- DFA sandwich and reverse-first DFA;
+- BitState;
+- lazy versus eager capture extraction.
+
+The test harness should run the same public API trace under multiple
+configurations and compare:
+
+- boolean operation results;
+- `group`, `start`, and `end` for every group that is legal to observe;
+- `toMatchResult()` snapshots;
+- replacement strings and append positions;
+- `hitEnd()` and `requireEnd()`;
+- subsequent `find()` behavior after empty and non-empty matches.
+
+For paths that are only filters, tests should verify that enabling the filter
+does not change the canonical public result.  For paths that are authoritative
+producers, tests should verify that forcing the path gives the same result as
+forcing the Pike VM NFA or canonical shared loop for the same supported case.
+
+### 6. Make Contracts Machine-Checkable
+
+The contracts should not remain only prose.  The implementation should make
+incorrect authority difficult to express and easy to test.
+
+The preferred enforcement shape is:
+
+- use typed internal results, or an equivalent authority wrapper, so a path
+  cannot return "matched" without declaring whether it owns no-match, candidate
+  start, group-zero bounds, captures, replacement result, and end-state facts;
+- use named guard predicates for semantic capabilities, not issue-specific
+  booleans;
+- keep a package-private path inventory or registry that tests can inspect to
+  require forced-path coverage for every authoritative or guarded path;
+- add test-only assertions that filters only change candidate starts, partial
+  producers mark unresolved fields, and complete producers populate all fields
+  they claim to own;
+- include negative guard tests where useful: force a guarded path on a pattern
+  it should reject and verify that the public trace diverges from the canonical
+  path, proving the guard has semantic content.
+
+This is not a formal proof of Java `Matcher` compatibility.  It is a practical
+machine-checkable contract: the type shape, guard predicates, path inventory,
+and forced-path tests should make a new optimization fail loudly if it tries to
+define independent public semantics.
+
 ## Linear-Time Argument
 
 This design must not weaken SafeRE's linear-time guarantee.
@@ -331,11 +468,18 @@ or another authoritative linear path.
 This design is complete when:
 
 - each `Matcher` engine path has an explicit contract;
+- the current path inventory above has either code comments, named predicates,
+  or tests enforcing each claimed role;
+- result authority is represented in code by typed results, an authority
+  wrapper, or an equivalent mechanism that tests can inspect;
+- each semantic guard has positive and, where practical, negative coverage;
 - replacement operations share canonical search semantics or have documented
   equivalence proofs;
+- `charClassReplaceAll` is either proven equivalent to canonical replacement
+  semantics or removed in favor of the canonical loop;
 - engine guards are named by semantic reason rather than by issue-specific
   conditions;
-- forced-path tests cover the matrix above;
+- a package-private forced-path test harness covers the matrix above;
 - generated public API crosscheck remains enabled for comparable behavior;
 - no public operation repairs semantics by running post-match searches over
   candidate explanations;

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -119,6 +119,7 @@
                         <exclude name="DfaNfaTest.java"/>
                         <exclude name="DfaTest.java"/>
                         <exclude name="EmptyOpTest.java"/>
+                        <exclude name="EnginePathEquivalenceTest.java"/>
                         <exclude name="InstOpTest.java"/>
                         <exclude name="InstTest.java"/>
                         <exclude name="NfaTest.java"/>

--- a/safere/src/main/java/org/safere/EnginePath.java
+++ b/safere/src/main/java/org/safere/EnginePath.java
@@ -1,0 +1,20 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Engine paths that can be forced or disabled by package-private equivalence tests. */
+enum EnginePath {
+  LITERAL_FAST_PATHS,
+  CHAR_CLASS_MATCH_FAST_PATHS,
+  CHAR_CLASS_REPLACEMENT_FAST_PATH,
+  KEYWORD_ALTERNATION_FAST_PATH,
+  START_ACCELERATION,
+  ONE_PASS,
+  DFA,
+  REVERSE_DFA,
+  BIT_STATE,
+  LAZY_CAPTURE_EXTRACTION
+}

--- a/safere/src/main/java/org/safere/EnginePathContract.java
+++ b/safere/src/main/java/org/safere/EnginePathContract.java
@@ -1,0 +1,99 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/** Machine-readable engine-path contract metadata for package-private tests. */
+record EnginePathContract(
+    EnginePath path,
+    EnginePathRole role,
+    Set<ResultAuthority> authorities,
+    Set<SemanticGuard> guards) {
+
+  private static final List<EnginePathContract> ALL =
+      List.of(
+          new EnginePathContract(
+              EnginePath.LITERAL_FAST_PATHS,
+              EnginePathRole.AUTHORITATIVE_PRODUCER,
+              EnumSet.of(
+                  ResultAuthority.NO_MATCH,
+                  ResultAuthority.GROUP_ZERO,
+                  ResultAuthority.SEARCH_CURSOR),
+              EnumSet.of(SemanticGuard.NO_USER_CAPTURES)),
+          new EnginePathContract(
+              EnginePath.CHAR_CLASS_MATCH_FAST_PATHS,
+              EnginePathRole.AUTHORITATIVE_PRODUCER,
+              EnumSet.of(ResultAuthority.NO_MATCH, ResultAuthority.GROUP_ZERO),
+              EnumSet.of(SemanticGuard.WHOLE_PATTERN_SHAPE)),
+          new EnginePathContract(
+              EnginePath.CHAR_CLASS_REPLACEMENT_FAST_PATH,
+              EnginePathRole.AUTHORITATIVE_PRODUCER,
+              EnumSet.of(ResultAuthority.REPLACEMENT_RESULT),
+              EnumSet.of(
+                  SemanticGuard.NON_NULLABLE_PATTERN,
+                  SemanticGuard.SIMPLE_REPLACEMENT,
+                  SemanticGuard.WHOLE_PATTERN_SHAPE)),
+          new EnginePathContract(
+              EnginePath.KEYWORD_ALTERNATION_FAST_PATH,
+              EnginePathRole.GUARDED_OPTIMIZATION,
+              EnumSet.of(
+                  ResultAuthority.NO_MATCH,
+                  ResultAuthority.GROUP_ZERO,
+                  ResultAuthority.CAPTURES,
+                  ResultAuthority.SEARCH_CURSOR),
+              EnumSet.of(
+                  SemanticGuard.WHOLE_PATTERN_SHAPE,
+                  SemanticGuard.LEFTMOST_FIRST_EQUIVALENT)),
+          new EnginePathContract(
+              EnginePath.START_ACCELERATION,
+              EnginePathRole.FILTER,
+              EnumSet.of(ResultAuthority.CANDIDATE_START),
+              EnumSet.of(SemanticGuard.CONSERVATIVE_START_SET)),
+          new EnginePathContract(
+              EnginePath.ONE_PASS,
+              EnginePathRole.GUARDED_OPTIMIZATION,
+              EnumSet.of(
+                  ResultAuthority.NO_MATCH,
+                  ResultAuthority.GROUP_ZERO,
+                  ResultAuthority.CAPTURES,
+                  ResultAuthority.SEARCH_CURSOR),
+              EnumSet.of(
+                  SemanticGuard.LEFTMOST_FIRST_EQUIVALENT,
+                  SemanticGuard.CAPTURE_EQUIVALENT)),
+          new EnginePathContract(
+              EnginePath.DFA,
+              EnginePathRole.PARTIAL_PRODUCER,
+              EnumSet.of(ResultAuthority.NO_MATCH, ResultAuthority.GROUP_ZERO),
+              EnumSet.of(SemanticGuard.GROUP_ZERO_EQUIVALENT)),
+          new EnginePathContract(
+              EnginePath.REVERSE_DFA,
+              EnginePathRole.FILTER,
+              EnumSet.of(ResultAuthority.CANDIDATE_START, ResultAuthority.NO_MATCH),
+              EnumSet.of(SemanticGuard.GROUP_ZERO_EQUIVALENT)),
+          new EnginePathContract(
+              EnginePath.BIT_STATE,
+              EnginePathRole.GUARDED_OPTIMIZATION,
+              EnumSet.of(
+                  ResultAuthority.NO_MATCH,
+                  ResultAuthority.GROUP_ZERO,
+                  ResultAuthority.CAPTURES,
+                  ResultAuthority.SEARCH_CURSOR),
+              EnumSet.of(
+                  SemanticGuard.BOUNDED_STATE,
+                  SemanticGuard.CAPTURE_EQUIVALENT)),
+          new EnginePathContract(
+              EnginePath.LAZY_CAPTURE_EXTRACTION,
+              EnginePathRole.PARTIAL_PRODUCER,
+              EnumSet.of(ResultAuthority.GROUP_ZERO, ResultAuthority.DEFERRED_CAPTURES),
+              EnumSet.of(SemanticGuard.CAPTURE_DEFERABLE)));
+
+  static List<EnginePathContract> all() {
+    return ALL;
+  }
+}

--- a/safere/src/main/java/org/safere/EnginePathOptions.java
+++ b/safere/src/main/java/org/safere/EnginePathOptions.java
@@ -1,0 +1,112 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/**
+ * Package-private engine-path controls for forced-path equivalence tests.
+ *
+ * <p>Production code uses {@link #allEnabled()}. Tests in this package can compile a pattern with
+ * selected shortcuts disabled to compare observable API traces against the default engine cascade.
+ */
+record EnginePathOptions(
+    boolean literalFastPaths,
+    boolean charClassMatchFastPaths,
+    boolean charClassReplacementFastPath,
+    boolean keywordAlternationFastPath,
+    boolean startAcceleration,
+    boolean onePass,
+    boolean dfa,
+    boolean reverseDfa,
+    boolean bitState,
+    boolean lazyCaptureExtraction) {
+
+  private static final EnginePathOptions ALL_ENABLED = builder().build();
+
+  static EnginePathOptions allEnabled() {
+    return ALL_ENABLED;
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static final class Builder {
+    private boolean literalFastPaths = true;
+    private boolean charClassMatchFastPaths = true;
+    private boolean charClassReplacementFastPath = true;
+    private boolean keywordAlternationFastPath = true;
+    private boolean startAcceleration = true;
+    private boolean onePass = true;
+    private boolean dfa = true;
+    private boolean reverseDfa = true;
+    private boolean bitState = true;
+    private boolean lazyCaptureExtraction = true;
+
+    Builder literalFastPaths(boolean enabled) {
+      literalFastPaths = enabled;
+      return this;
+    }
+
+    Builder charClassMatchFastPaths(boolean enabled) {
+      charClassMatchFastPaths = enabled;
+      return this;
+    }
+
+    Builder charClassReplacementFastPath(boolean enabled) {
+      charClassReplacementFastPath = enabled;
+      return this;
+    }
+
+    Builder keywordAlternationFastPath(boolean enabled) {
+      keywordAlternationFastPath = enabled;
+      return this;
+    }
+
+    Builder startAcceleration(boolean enabled) {
+      startAcceleration = enabled;
+      return this;
+    }
+
+    Builder onePass(boolean enabled) {
+      onePass = enabled;
+      return this;
+    }
+
+    Builder dfa(boolean enabled) {
+      dfa = enabled;
+      return this;
+    }
+
+    Builder reverseDfa(boolean enabled) {
+      reverseDfa = enabled;
+      return this;
+    }
+
+    Builder bitState(boolean enabled) {
+      bitState = enabled;
+      return this;
+    }
+
+    Builder lazyCaptureExtraction(boolean enabled) {
+      lazyCaptureExtraction = enabled;
+      return this;
+    }
+
+    EnginePathOptions build() {
+      return new EnginePathOptions(
+          literalFastPaths,
+          charClassMatchFastPaths,
+          charClassReplacementFastPath,
+          keywordAlternationFastPath,
+          startAcceleration,
+          onePass,
+          dfa,
+          reverseDfa,
+          bitState,
+          lazyCaptureExtraction);
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/EnginePathOptions.java
+++ b/safere/src/main/java/org/safere/EnginePathOptions.java
@@ -5,6 +5,9 @@
 
 package org.safere;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 /**
  * Package-private engine-path controls for forced-path equivalence tests.
  *
@@ -24,6 +27,7 @@ record EnginePathOptions(
     boolean lazyCaptureExtraction) {
 
   private static final EnginePathOptions ALL_ENABLED = builder().build();
+  private static final Map<EnginePath, OptionAccessor> ACCESSORS = buildAccessors();
 
   static EnginePathOptions allEnabled() {
     return ALL_ENABLED;
@@ -31,6 +35,33 @@ record EnginePathOptions(
 
   static Builder builder() {
     return new Builder();
+  }
+
+  static Map<EnginePath, OptionAccessor> accessors() {
+    return ACCESSORS;
+  }
+
+  private static Map<EnginePath, OptionAccessor> buildAccessors() {
+    EnumMap<EnginePath, OptionAccessor> accessors = new EnumMap<>(EnginePath.class);
+    accessors.put(EnginePath.LITERAL_FAST_PATHS, EnginePathOptions::literalFastPaths);
+    accessors.put(EnginePath.CHAR_CLASS_MATCH_FAST_PATHS,
+        EnginePathOptions::charClassMatchFastPaths);
+    accessors.put(EnginePath.CHAR_CLASS_REPLACEMENT_FAST_PATH,
+        EnginePathOptions::charClassReplacementFastPath);
+    accessors.put(EnginePath.KEYWORD_ALTERNATION_FAST_PATH,
+        EnginePathOptions::keywordAlternationFastPath);
+    accessors.put(EnginePath.START_ACCELERATION, EnginePathOptions::startAcceleration);
+    accessors.put(EnginePath.ONE_PASS, EnginePathOptions::onePass);
+    accessors.put(EnginePath.DFA, EnginePathOptions::dfa);
+    accessors.put(EnginePath.REVERSE_DFA, EnginePathOptions::reverseDfa);
+    accessors.put(EnginePath.BIT_STATE, EnginePathOptions::bitState);
+    accessors.put(EnginePath.LAZY_CAPTURE_EXTRACTION,
+        EnginePathOptions::lazyCaptureExtraction);
+    return Map.copyOf(accessors);
+  }
+
+  interface OptionAccessor {
+    boolean enabled(EnginePathOptions options);
   }
 
   static final class Builder {

--- a/safere/src/main/java/org/safere/EnginePathOptions.java
+++ b/safere/src/main/java/org/safere/EnginePathOptions.java
@@ -24,7 +24,8 @@ record EnginePathOptions(
     boolean dfa,
     boolean reverseDfa,
     boolean bitState,
-    boolean lazyCaptureExtraction) {
+    boolean lazyCaptureExtraction,
+    boolean semanticGuards) {
 
   private static final EnginePathOptions ALL_ENABLED = builder().build();
   private static final Map<EnginePath, OptionAccessor> ACCESSORS = buildAccessors();
@@ -75,6 +76,7 @@ record EnginePathOptions(
     private boolean reverseDfa = true;
     private boolean bitState = true;
     private boolean lazyCaptureExtraction = true;
+    private boolean semanticGuards = true;
 
     Builder literalFastPaths(boolean enabled) {
       literalFastPaths = enabled;
@@ -126,6 +128,11 @@ record EnginePathOptions(
       return this;
     }
 
+    Builder semanticGuards(boolean enabled) {
+      semanticGuards = enabled;
+      return this;
+    }
+
     EnginePathOptions build() {
       return new EnginePathOptions(
           literalFastPaths,
@@ -137,7 +144,8 @@ record EnginePathOptions(
           dfa,
           reverseDfa,
           bitState,
-          lazyCaptureExtraction);
+          lazyCaptureExtraction,
+          semanticGuards);
     }
   }
 }

--- a/safere/src/main/java/org/safere/EnginePathRole.java
+++ b/safere/src/main/java/org/safere/EnginePathRole.java
@@ -1,0 +1,14 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Declared semantic role for an engine path. */
+enum EnginePathRole {
+  AUTHORITATIVE_PRODUCER,
+  PARTIAL_PRODUCER,
+  FILTER,
+  GUARDED_OPTIMIZATION
+}

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -168,6 +168,10 @@ public final class Matcher implements MatchResult {
     return prog.requiresPikeNfaCaptureSemantics() && prog.numCaptures() > 1;
   }
 
+  private EnginePathOptions enginePathOptions() {
+    return parentPattern.enginePathOptions();
+  }
+
   /** Returns the Pattern's thread-local cached forward DFA, caching it for reuse. */
   private Dfa dfa() {
     Dfa d = cachedForwardDfa;
@@ -512,7 +516,9 @@ public final class Matcher implements MatchResult {
 
     // Literal fast path: for fully literal patterns with no user capture groups.
     String literal = parentPattern.literalMatch();
-    if (literal != null && parentPattern.numGroups() == 0) {
+    if (enginePathOptions().literalFastPaths()
+        && literal != null
+        && parentPattern.numGroups() == 0) {
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched = text.length() == literal.length()
@@ -531,7 +537,7 @@ public final class Matcher implements MatchResult {
 
     // Character-class fast path: for patterns like [a-zA-Z]+, \d+, \w*, etc.
     int[] ccRanges = parentPattern.charClassMatchRanges();
-    if (ccRanges != null) {
+    if (enginePathOptions().charClassMatchFastPaths() && ccRanges != null) {
       hasMatch = charClassMatchFastPath(ccRanges);
       return hasMatch;
     }
@@ -539,15 +545,17 @@ public final class Matcher implements MatchResult {
     Prog prog = parentPattern.prog();
 
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
-    OnePass onePass = parentPattern.onePass();
-    if (onePass != null && !requiresPikeNfaCaptureSemantics(prog)) {
+    EnginePathOptions options = enginePathOptions();
+    OnePass onePass = options.onePass() ? parentPattern.onePass() : null;
+    if (onePass != null
+        && !requiresPikeNfaCaptureSemantics(prog)) {
       groups = onePass.search(text, true, prog.numCaptures());
       hasMatch = (groups != null);
       return hasMatch;
     }
 
     // Medium path: use DFA to check if a full match exists.
-    {
+    if (enginePathOptions().dfa()) {
       Dfa.SearchResult dfaResult = dfa().doSearch(text, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
         hasMatch = false;
@@ -636,7 +644,9 @@ public final class Matcher implements MatchResult {
 
     // Literal fast path: for fully literal patterns with no user capture groups.
     String literal = parentPattern.literalMatch();
-    if (literal != null && parentPattern.numGroups() == 0) {
+    if (enginePathOptions().literalFastPaths()
+        && literal != null
+        && parentPattern.numGroups() == 0) {
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched = text.length() >= literal.length()
@@ -656,7 +666,9 @@ public final class Matcher implements MatchResult {
     Prog prog = parentPattern.prog();
 
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
-    if (parentPattern.canOnePassPrimary() && !requiresPikeNfaCaptureSemantics(prog)) {
+    if (enginePathOptions().onePass()
+        && parentPattern.canOnePassPrimary()
+        && !requiresPikeNfaCaptureSemantics(prog)) {
       OnePass onePass = parentPattern.onePass();
       groups = onePass.search(text, false, prog.numCaptures());
       hasMatch = (groups != null);
@@ -664,7 +676,7 @@ public final class Matcher implements MatchResult {
     }
 
     // Medium path: use DFA to check if an anchored match exists.
-    {
+    if (enginePathOptions().dfa()) {
       Dfa.SearchResult dfaResult = dfa().doSearch(text, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
         hasMatch = false;
@@ -878,7 +890,8 @@ public final class Matcher implements MatchResult {
     // Literal fast path: for fully literal patterns with no user capture groups,
     // use String.indexOf() directly.
     String literal = parentPattern.literalMatch();
-    if (literal != null && parentPattern.numGroups() == 0) {
+    EnginePathOptions options = enginePathOptions();
+    if (options.literalFastPaths() && literal != null && parentPattern.numGroups() == 0) {
       int idx;
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, literal, searchFrom);
@@ -897,7 +910,7 @@ public final class Matcher implements MatchResult {
     Prog prog = parentPattern.prog();
 
     Pattern.KeywordAlternation keywordAlternation = parentPattern.keywordAlternation();
-    if (!regionActive && keywordAlternation != null) {
+    if (options.keywordAlternationFastPath() && !regionActive && keywordAlternation != null) {
       return findKeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures());
     }
 
@@ -925,7 +938,9 @@ public final class Matcher implements MatchResult {
     // violating first-match alternation priority.
     //
     // The text size threshold (4096) matches C++ RE2. For larger texts, the DFA is more efficient.
-    if (prog.anchorStart() && parentPattern.canOnePassPrimary()
+    if (options.onePass()
+        && prog.anchorStart()
+        && parentPattern.canOnePassPrimary()
         && !parentPattern.hasNullableAlternation()
         && !requiresPikeNfaCaptureSemantics(prog)
         && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT) {
@@ -939,7 +954,7 @@ public final class Matcher implements MatchResult {
     // that prefix first appears instead of searching from the current position.
     int effectiveStart = searchFrom;
     String prefix = parentPattern.prefix();
-    if (prefix != null) {
+    if (options.startAcceleration() && prefix != null) {
       int idx;
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, prefix, searchFrom);
@@ -957,7 +972,7 @@ public final class Matcher implements MatchResult {
     // no literal prefix exists), scan for the first character that could begin a match. This
     // avoids running the full engine on text regions where no match can start.
     boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
-    if (ccPrefixAscii != null) {
+    if (options.startAcceleration() && ccPrefixAscii != null) {
       int idx = indexOfCharClass(text, ccPrefixAscii, searchFrom);
       if (idx < 0) {
         hasMatch = false;
@@ -967,7 +982,7 @@ public final class Matcher implements MatchResult {
     }
 
     Pattern.StartAcceleration startAcceleration = parentPattern.startAcceleration();
-    if (startAcceleration != null) {
+    if (options.startAcceleration() && startAcceleration != null) {
       int idx = nextAcceleratedStart(text, startAcceleration, effectiveStart, prog.unixLines());
       if (idx < 0) {
         hasMatch = false;
@@ -980,7 +995,9 @@ public final class Matcher implements MatchResult {
     // input, scan with OnePass directly. OnePass is faster than BitState — no visited bitmap
     // or job stack allocation, deterministic single-pass traversal per start position.
     // Skip for nullable alternation (see anchored path comment above).
-    if (parentPattern.canOnePassPrimary() && text.length() <= 256
+    if (options.onePass()
+        && parentPattern.canOnePassPrimary()
+        && text.length() <= 256
         && !requiresPikeNfaCaptureSemantics(prog)
         && !parentPattern.hasNullableAlternation()) {
       int[] result = parentPattern.onePass().searchUnanchored(
@@ -1007,7 +1024,11 @@ public final class Matcher implements MatchResult {
     //
     // A null result from the reverse DFA means the DFA budget was exceeded — in that case we
     // must fall through to the normal forward DFA path rather than returning false.
-    if (!regionActive && prog.anchorEnd() && !prog.anchorStart()
+    if (options.dfa()
+        && options.reverseDfa()
+        && !regionActive
+        && prog.anchorEnd()
+        && !prog.anchorStart()
         && text.length() >= MIN_REVERSE_FIRST_LEN
         && parentPattern.dfaStartReliable()) {
       Dfa revDfa = reverseDfa();
@@ -1091,6 +1112,7 @@ public final class Matcher implements MatchResult {
     boolean directFallback =
         !regionActive
             && !parentPattern.dfaStartReliable()
+            && options.startAcceleration()
             && (prefix != null || ccPrefixAscii != null)
             && text.length() <= DIRECT_FALLBACK_TEXT_LIMIT
             && BitState.maxTextSize(prog) >= text.length();
@@ -1101,7 +1123,7 @@ public final class Matcher implements MatchResult {
     // precheck cannot produce reusable bounds and would fall through to the complete fallback
     // search anyway.
     Dfa.SearchResult fwdResult;
-    if (directFallback) {
+    if (!options.dfa() || directFallback) {
       fwdResult = null;
     } else {
       fwdResult = dfa().doSearch(text, effectiveStart, false, false);
@@ -1138,7 +1160,8 @@ public final class Matcher implements MatchResult {
     // resolveCaptures() corrects the end position using the submatch engine.
     // Skip when a region is active — deferred capture resolution runs on the full text but the
     // DFA ran on the region substring, causing empty-width assertion mismatches at boundaries.
-    if (!regionActive
+    if (options.dfa()
+        && !regionActive
         && fwdResult != null
         && fwdResult.pos() > effectiveStart
         && parentPattern.dfaStartReliable()) {
@@ -1235,6 +1258,7 @@ public final class Matcher implements MatchResult {
     boolean lazyFallbackCaptures =
         !regionActive
             && !eagerFallbackCaptures
+            && options.lazyCaptureExtraction()
             && prog.numCaptures() <= MAX_LAZY_FALLBACK_SUBMATCHES;
     int nsubmatch = lazyFallbackCaptures ? 1 : prog.numCaptures();
     int[] result = searchWithBitStateOrNfa(
@@ -1399,7 +1423,8 @@ public final class Matcher implements MatchResult {
     // optimization; if capture-priority backtracking exceeds its work budget, fall back to the
     // Pike NFA below.
     int maxBitStateLen = BitState.maxTextSize(prog);
-    boolean canUseBitState = !prog.requiresPikeNfaCaptureSemantics() || nsubmatch <= 1;
+    boolean canUseBitState = enginePathOptions().bitState()
+        && (!prog.requiresPikeNfaCaptureSemantics() || nsubmatch <= 1);
     if (canUseBitState && maxBitStateLen >= 0 && text.length() <= maxBitStateLen) {
       boolean anchoredEffective = anchored || prog.anchorStart();
       boolean endMatchEffective = endMatch || prog.anchorEnd();
@@ -1689,7 +1714,9 @@ public final class Matcher implements MatchResult {
     // Character-class fast path: for patterns like \d+, [a-zA-Z]+, etc. with simple
     // replacement strings (no group references), scan the text in a single pass.
     int[] ccRanges = parentPattern.charClassMatchRanges();
-    if (ccRanges != null && !parentPattern.charClassMatchAllowEmpty()
+    if (enginePathOptions().charClassReplacementFastPath()
+        && ccRanges != null
+        && !parentPattern.charClassMatchAllowEmpty()
         && isSimpleReplacement(replacement)) {
       return charClassReplaceAll(ccRanges, replacement);
     }
@@ -2085,7 +2112,8 @@ public final class Matcher implements MatchResult {
     // alternation (e.g., GET|POST), all branches must consume characters so longest-match
     // and first-match are equivalent.
     int[] result;
-    if (parentPattern.canOnePassSubmatch()
+    if (enginePathOptions().onePass()
+        && parentPattern.canOnePassSubmatch()
         && !parentPattern.hasNullableAlternation()
         && !requiresPikeNfaCaptureSemantics(prog)) {
       result = parentPattern.onePass().search(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -45,7 +45,16 @@ public final class Matcher implements MatchResult {
   private record NoMatchResult() implements EngineResult {
   }
 
-  private record FullMatchResult(int[] groups) implements EngineResult {
+  private static final class FullMatchResult implements EngineResult {
+    private final int[] groups;
+
+    private FullMatchResult(int[] groups) {
+      this.groups = groups;
+    }
+
+    private int[] groups() {
+      return groups;
+    }
   }
 
   private record DeferredMatchResult(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -39,6 +39,20 @@ import java.util.stream.StreamSupport;
  * </ul>
  */
 public final class Matcher implements MatchResult {
+  private sealed interface EngineResult permits NoMatchResult, FullMatchResult, DeferredMatchResult {
+  }
+
+  private record NoMatchResult() implements EngineResult {
+  }
+
+  private record FullMatchResult(int[] groups) implements EngineResult {
+  }
+
+  private record DeferredMatchResult(
+      int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch)
+      implements EngineResult {
+  }
+
   private enum MatchOperation {
     MATCHES,
     LOOKING_AT,
@@ -168,8 +182,46 @@ public final class Matcher implements MatchResult {
     return prog.requiresPikeNfaCaptureSemantics() && prog.numCaptures() > 1;
   }
 
+  private boolean applyEngineResult(EngineResult result) {
+    switch (result) {
+      case NoMatchResult ignored -> {
+        groups = null;
+        hasMatch = false;
+        capturesResolved = true;
+        groupZeroResolved = true;
+      }
+      case FullMatchResult full -> {
+        groups = full.groups();
+        hasMatch = groups != null;
+        capturesResolved = true;
+        groupZeroResolved = true;
+      }
+      case DeferredMatchResult deferred -> {
+        groups = new int[2 * deferred.ncap()];
+        Arrays.fill(groups, -1);
+        groups[0] = deferred.start();
+        groups[1] = deferred.end();
+        deferredMatchStart = deferred.start();
+        deferredMatchEnd = deferred.end();
+        deferredEndMatch = deferred.endMatch();
+        groupZeroResolved = deferred.groupZeroResolved();
+        capturesResolved = deferred.groupZeroResolved() && deferred.ncap() <= 1;
+        hasMatch = true;
+      }
+    }
+    return hasMatch;
+  }
+
   private EnginePathOptions enginePathOptions() {
     return parentPattern.enginePathOptions();
+  }
+
+  private boolean semanticGuardsEnabled() {
+    return enginePathOptions().semanticGuards();
+  }
+
+  private boolean canUsePikeEquivalentCaptures(Prog prog) {
+    return !semanticGuardsEnabled() || !requiresPikeNfaCaptureSemantics(prog);
   }
 
   /** Returns the Pattern's thread-local cached forward DFA, caching it for reuse. */
@@ -478,9 +530,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        groups = null;
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       if (regionActive && transparentBounds) {
         return matchesTransparentRegion();
@@ -527,10 +577,9 @@ public final class Matcher implements MatchResult {
         matched = text.equals(literal);
       }
       if (matched) {
-        groups = new int[]{0, text.length()};
-        hasMatch = true;
+        applyEngineResult(new FullMatchResult(new int[]{0, text.length()}));
       } else {
-        hasMatch = false;
+        applyEngineResult(new NoMatchResult());
       }
       return hasMatch;
     }
@@ -548,43 +597,37 @@ public final class Matcher implements MatchResult {
     EnginePathOptions options = enginePathOptions();
     OnePass onePass = options.onePass() ? parentPattern.onePass() : null;
     if (onePass != null
-        && !requiresPikeNfaCaptureSemantics(prog)) {
-      groups = onePass.search(text, true, prog.numCaptures());
-      hasMatch = (groups != null);
-      return hasMatch;
+        && canUsePikeEquivalentCaptures(prog)) {
+      return applyEngineResult(new FullMatchResult(onePass.search(text, true, prog.numCaptures())));
     }
 
     // Medium path: use DFA to check if a full match exists.
     if (enginePathOptions().dfa()) {
       Dfa.SearchResult dfaResult = dfa().doSearch(text, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       if (dfaResult != null && dfaResult.pos() != text.length()) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       if (dfaResult != null && prog.numLoopRegs() == 0) {
-        setDeferredGroups(0, text.length(), prog.numCaptures(), true, true);
-        hasMatch = true;
-        return true;
+        return applyEngineResult(
+            new DeferredMatchResult(0, text.length(), prog.numCaptures(), true, true));
       }
     }
 
     // Slow path: try BitState (faster than NFA for small texts), then NFA.
-    groups = searchWithBitStateOrNfa(
+    int[] result = searchWithBitStateOrNfa(
         prog, text, 0, text.length(), text.length(), true, false, true, prog.numCaptures());
     // matches() requires the entire text to be consumed. With dollarAnchorEnd, the BitState
     // may accept a match ending before a trailing \n. In that case, fall back to the NFA
     // which uses longest-match mode for FULL_MATCH and finds the correct full-text match.
-    if (groups != null && groups[1] != text.length()) {
-      groups = Nfa.search(
+    if (result != null && result[1] != text.length()) {
+      result = Nfa.search(
           prog, text, 0, text.length(),
           Nfa.Anchor.ANCHORED, Nfa.MatchKind.FULL_MATCH, prog.numCaptures());
     }
-    hasMatch = (groups != null);
-    return hasMatch;
+    return applyEngineResult(new FullMatchResult(result));
   }
 
   /**
@@ -655,10 +698,9 @@ public final class Matcher implements MatchResult {
         matched = text.startsWith(literal);
       }
       if (matched) {
-        groups = new int[]{0, literal.length()};
-        hasMatch = true;
+        applyEngineResult(new FullMatchResult(new int[]{0, literal.length()}));
       } else {
-        hasMatch = false;
+        applyEngineResult(new NoMatchResult());
       }
       return hasMatch;
     }
@@ -668,27 +710,25 @@ public final class Matcher implements MatchResult {
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
     if (enginePathOptions().onePass()
         && parentPattern.canOnePassPrimary()
-        && !requiresPikeNfaCaptureSemantics(prog)) {
+        && canUsePikeEquivalentCaptures(prog)) {
       OnePass onePass = parentPattern.onePass();
-      groups = onePass.search(text, false, prog.numCaptures());
-      hasMatch = (groups != null);
-      return hasMatch;
+      return applyEngineResult(
+          new FullMatchResult(onePass.search(text, false, prog.numCaptures())));
     }
 
     // Medium path: use DFA to check if an anchored match exists.
     if (enginePathOptions().dfa()) {
       Dfa.SearchResult dfaResult = dfa().doSearch(text, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
     }
 
     // Slow path: try BitState (faster than NFA for small texts), then NFA.
-    groups = searchWithBitStateOrNfa(
-        prog, text, 0, text.length(), text.length(), true, false, false, prog.numCaptures());
-    hasMatch = (groups != null);
-    return hasMatch;
+    return applyEngineResult(
+        new FullMatchResult(searchWithBitStateOrNfa(
+            prog, text, 0, text.length(), text.length(), true, false, false,
+            prog.numCaptures())));
   }
 
   /**
@@ -839,37 +879,33 @@ public final class Matcher implements MatchResult {
     capturesResolved = true;
     groupZeroResolved = true;
     Prog prog = parentPattern.prog();
-    groups = searchWithBitStateOrNfa(
-        prog, text, regionStart, regionStart, regionEnd,
-        true, false, true, prog.numCaptures());
-    hasMatch = groups != null;
-    return hasMatch;
+    return applyEngineResult(
+        new FullMatchResult(searchWithBitStateOrNfa(
+            prog, text, regionStart, regionStart, regionEnd,
+            true, false, true, prog.numCaptures())));
   }
 
   private boolean lookingAtTransparentRegion() {
     capturesResolved = true;
     groupZeroResolved = true;
     Prog prog = parentPattern.prog();
-    groups = searchWithBitStateOrNfa(
-        prog, text, regionStart, regionStart, regionEnd,
-        true, false, false, prog.numCaptures());
-    hasMatch = groups != null;
-    return hasMatch;
+    return applyEngineResult(
+        new FullMatchResult(searchWithBitStateOrNfa(
+            prog, text, regionStart, regionStart, regionEnd,
+            true, false, false, prog.numCaptures())));
   }
 
   private boolean doFindTransparentRegion() {
     if (searchFrom > regionEnd) {
-      hasMatch = false;
-      return false;
+      return applyEngineResult(new NoMatchResult());
     }
     capturesResolved = true;
     groupZeroResolved = true;
     Prog prog = parentPattern.prog();
-    groups = searchWithBitStateOrNfa(
-        prog, text, searchFrom, regionEnd, regionEnd,
-        false, false, false, prog.numCaptures());
-    hasMatch = groups != null;
-    return hasMatch;
+    return applyEngineResult(
+        new FullMatchResult(searchWithBitStateOrNfa(
+            prog, text, searchFrom, regionEnd, regionEnd,
+            false, false, false, prog.numCaptures())));
   }
 
   /**
@@ -879,8 +915,7 @@ public final class Matcher implements MatchResult {
    */
   private boolean doFindCore(boolean regionActive) {
     if (searchFrom > text.length()) {
-      hasMatch = false;
-      return false;
+      return applyEngineResult(new NoMatchResult());
     }
 
     // Reset deferred-capture state; DFA sandwich path may set it to false.
@@ -899,12 +934,9 @@ public final class Matcher implements MatchResult {
         idx = text.indexOf(literal, searchFrom);
       }
       if (idx < 0) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
-      groups = new int[]{idx, idx + literal.length()};
-      hasMatch = true;
-      return true;
+      return applyEngineResult(new FullMatchResult(new int[]{idx, idx + literal.length()}));
     }
 
     Prog prog = parentPattern.prog();
@@ -919,8 +951,7 @@ public final class Matcher implements MatchResult {
     // when a region is active). Return false immediately to avoid the DFA matching at every
     // position because the compiler strips the anchor into prog.anchorStart().
     if (prog.anchorStart() && searchFrom > 0) {
-      hasMatch = false;
-      return false;
+      return applyEngineResult(new NoMatchResult());
     }
 
     // Anchored OnePass fast path: for anchored OnePass-eligible patterns on small text, use
@@ -940,14 +971,14 @@ public final class Matcher implements MatchResult {
     // The text size threshold (4096) matches C++ RE2. For larger texts, the DFA is more efficient.
     if (options.onePass()
         && prog.anchorStart()
-        && parentPattern.canOnePassPrimary()
-        && !parentPattern.hasNullableAlternation()
-        && !requiresPikeNfaCaptureSemantics(prog)
+        && (parentPattern.canOnePassPrimary()
+            || (!options.semanticGuards() && parentPattern.onePass() != null))
+        && (!options.semanticGuards() || !parentPattern.hasNullableAlternation())
+        && canUsePikeEquivalentCaptures(prog)
         && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT) {
-      groups = parentPattern.onePass().search(text, searchFrom, text.length(), false,
-          prog.numCaptures());
-      hasMatch = (groups != null);
-      return hasMatch;
+      return applyEngineResult(
+          new FullMatchResult(parentPattern.onePass().search(
+              text, searchFrom, text.length(), false, prog.numCaptures())));
     }
 
     // Prefix acceleration: if the pattern starts with a literal prefix, skip ahead to where
@@ -962,8 +993,7 @@ public final class Matcher implements MatchResult {
         idx = text.indexOf(prefix, searchFrom);
       }
       if (idx < 0) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       effectiveStart = idx;
     }
@@ -975,8 +1005,7 @@ public final class Matcher implements MatchResult {
     if (options.startAcceleration() && ccPrefixAscii != null) {
       int idx = indexOfCharClass(text, ccPrefixAscii, searchFrom);
       if (idx < 0) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       effectiveStart = idx;
     }
@@ -985,8 +1014,7 @@ public final class Matcher implements MatchResult {
     if (options.startAcceleration() && startAcceleration != null) {
       int idx = nextAcceleratedStart(text, startAcceleration, effectiveStart, prog.unixLines());
       if (idx < 0) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       effectiveStart = idx;
     }
@@ -996,19 +1024,17 @@ public final class Matcher implements MatchResult {
     // or job stack allocation, deterministic single-pass traversal per start position.
     // Skip for nullable alternation (see anchored path comment above).
     if (options.onePass()
-        && parentPattern.canOnePassPrimary()
+        && (parentPattern.canOnePassPrimary()
+            || (!options.semanticGuards() && parentPattern.onePass() != null))
         && text.length() <= 256
-        && !requiresPikeNfaCaptureSemantics(prog)
-        && !parentPattern.hasNullableAlternation()) {
+        && canUsePikeEquivalentCaptures(prog)
+        && (!options.semanticGuards() || !parentPattern.hasNullableAlternation())) {
       int[] result = parentPattern.onePass().searchUnanchored(
           text, effectiveStart, text.length(), prog.numCaptures());
       if (result != null) {
-        groups = result;
-        hasMatch = true;
-        return true;
+        return applyEngineResult(new FullMatchResult(result));
       }
-      hasMatch = false;
-      return false;
+      return applyEngineResult(new NoMatchResult());
     }
 
 
@@ -1030,7 +1056,7 @@ public final class Matcher implements MatchResult {
         && prog.anchorEnd()
         && !prog.anchorStart()
         && text.length() >= MIN_REVERSE_FIRST_LEN
-        && parentPattern.dfaStartReliable()) {
+        && (!options.semanticGuards() || parentPattern.dfaStartReliable())) {
       Dfa revDfa = reverseDfa();
       if (revDfa != null) {
         int textLen = text.length();
@@ -1086,8 +1112,7 @@ public final class Matcher implements MatchResult {
         if (!budgetExceeded) {
           if (matchStart < 0) {
             // No match possible at end of text — fail immediately without forward scan.
-            hasMatch = false;
-            return false;
+            return applyEngineResult(new NoMatchResult());
           }
 
           // Reverse DFA found a match start. Run forward DFA from there (anchored, longest)
@@ -1095,14 +1120,13 @@ public final class Matcher implements MatchResult {
           Dfa.SearchResult fwdAnchored = dfa().doSearch(text, matchStart, true, true);
           if (fwdAnchored != null && fwdAnchored.matched()) {
             int matchEnd = fwdAnchored.pos();
-            setDeferredGroups(
-                matchStart,
-                matchEnd,
-                prog.numCaptures(),
-                parentPattern.dfaGroupZeroReliable(),
-                false);
-            hasMatch = true;
-            return true;
+            return applyEngineResult(
+                new DeferredMatchResult(
+                    matchStart,
+                    matchEnd,
+                    prog.numCaptures(),
+                    !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
+                    false));
           }
         }
         // DFA budget exceeded or forward DFA disagreed — fall through to normal path.
@@ -1128,8 +1152,7 @@ public final class Matcher implements MatchResult {
     } else {
       fwdResult = dfa().doSearch(text, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
     }
 
@@ -1164,7 +1187,7 @@ public final class Matcher implements MatchResult {
         && !regionActive
         && fwdResult != null
         && fwdResult.pos() > effectiveStart
-        && parentPattern.dfaStartReliable()) {
+        && (!options.semanticGuards() || parentPattern.dfaStartReliable())) {
       int earlyEnd = fwdResult.pos();
 
       if (prog.anchorStart()) {
@@ -1173,14 +1196,13 @@ public final class Matcher implements MatchResult {
         Dfa.SearchResult fwdLongest = dfa().doSearch(text, effectiveStart, true, true);
         if (fwdLongest != null && fwdLongest.matched()) {
           int matchEnd = fwdLongest.pos();
-          setDeferredGroups(
-              effectiveStart,
-              matchEnd,
-              prog.numCaptures(),
-              parentPattern.dfaGroupZeroReliable(),
-              false);
-          hasMatch = true;
-          return true;
+          return applyEngineResult(
+              new DeferredMatchResult(
+                  effectiveStart,
+                  matchEnd,
+                  prog.numCaptures(),
+                  !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
+                  false));
         }
       } else {
         Dfa revDfa = reverseDfa();
@@ -1233,14 +1255,13 @@ public final class Matcher implements MatchResult {
             if (fwdLongest != null && fwdLongest.matched()) {
               int matchEnd = fwdLongest.pos();
               // Step 4: Store group(0) boundaries, defer inner captures until requested.
-              setDeferredGroups(
-                  matchStart,
-                  matchEnd,
-                  prog.numCaptures(),
-                  parentPattern.dfaGroupZeroReliable(),
-                  false);
-              hasMatch = true;
-              return true;
+              return applyEngineResult(
+                  new DeferredMatchResult(
+                      matchStart,
+                      matchEnd,
+                      prog.numCaptures(),
+                      !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
+                      false));
             }
             // If anchored forward DFA fails, fall through to full search.
           }
@@ -1264,16 +1285,14 @@ public final class Matcher implements MatchResult {
     int[] result = searchWithBitStateOrNfa(
         prog, text, effectiveStart, text.length(), text.length(), false, false, false, nsubmatch);
     if (result == null) {
-      hasMatch = false;
-      return false;
+      return applyEngineResult(new NoMatchResult());
     }
     if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
-      groups = result;
+      return applyEngineResult(new FullMatchResult(result));
     } else {
-      setDeferredGroups(result[0], result[1], prog.numCaptures(), true, false);
+      return applyEngineResult(
+          new DeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false));
     }
-    hasMatch = true;
-    return true;
   }
 
   private boolean findKeywordAlternation(
@@ -1287,25 +1306,23 @@ public final class Matcher implements MatchResult {
           if (end <= text.length()
               && text.regionMatches(true, i, keyword, 0, keyword.length())
               && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
-            groups = new int[2 * ncap];
-            Arrays.fill(groups, -1);
-            groups[0] = i;
-            groups[1] = end;
+            int[] keywordGroups = new int[2 * ncap];
+            Arrays.fill(keywordGroups, -1);
+            keywordGroups[0] = i;
+            keywordGroups[1] = end;
             if (keywordAlternation.captureGroup > 0) {
               int group = keywordAlternation.captureGroup;
-              groups[2 * group] = i;
-              groups[2 * group + 1] = end;
+              keywordGroups[2 * group] = i;
+              keywordGroups[2 * group + 1] = end;
             }
-            hasMatch = true;
-            return true;
+            return applyEngineResult(new FullMatchResult(keywordGroups));
           }
         }
       }
       int cp = text.codePointAt(i);
       i += Character.charCount(cp) - 1;
     }
-    hasMatch = false;
-    return false;
+    return applyEngineResult(new NoMatchResult());
   }
 
   private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {
@@ -1424,7 +1441,9 @@ public final class Matcher implements MatchResult {
     // Pike NFA below.
     int maxBitStateLen = BitState.maxTextSize(prog);
     boolean canUseBitState = enginePathOptions().bitState()
-        && (!prog.requiresPikeNfaCaptureSemantics() || nsubmatch <= 1);
+        && (!enginePathOptions().semanticGuards()
+            || !prog.requiresPikeNfaCaptureSemantics()
+            || nsubmatch <= 1);
     if (canUseBitState && maxBitStateLen >= 0 && text.length() <= maxBitStateLen) {
       boolean anchoredEffective = anchored || prog.anchorStart();
       boolean endMatchEffective = endMatch || prog.anchorEnd();
@@ -2114,8 +2133,8 @@ public final class Matcher implements MatchResult {
     int[] result;
     if (enginePathOptions().onePass()
         && parentPattern.canOnePassSubmatch()
-        && !parentPattern.hasNullableAlternation()
-        && !requiresPikeNfaCaptureSemantics(prog)) {
+        && (!enginePathOptions().semanticGuards() || !parentPattern.hasNullableAlternation())
+        && canUsePikeEquivalentCaptures(prog)) {
       result = parentPattern.onePass().search(
           text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures());
     } else {
@@ -2128,20 +2147,6 @@ public final class Matcher implements MatchResult {
     }
     capturesResolved = true;
     groupZeroResolved = true;
-  }
-
-  /** Stores DFA-determined group 0 and defers inner capture extraction until requested. */
-  private void setDeferredGroups(
-      int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch) {
-    groups = new int[2 * ncap];
-    Arrays.fill(groups, -1);
-    groups[0] = start;
-    groups[1] = end;
-    deferredMatchStart = start;
-    deferredMatchEnd = end;
-    deferredEndMatch = endMatch;
-    this.groupZeroResolved = groupZeroResolved;
-    capturesResolved = groupZeroResolved && ncap <= 1;
   }
 
   private void checkMatch() {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
@@ -110,6 +111,7 @@ public final class Pattern implements Serializable {
   private final transient boolean[] charClassPrefixAscii;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
+  private final transient EnginePathOptions enginePathOptions;
 
   /**
    * Precomputed character class data for the "repeated character class" fast path in
@@ -188,7 +190,7 @@ public final class Pattern implements Serializable {
       boolean[] charClassPrefixAscii, StartAcceleration startAcceleration,
       KeywordAlternation keywordAlternation,
       int[] charClassMatchRanges, long charClassMatchBitmap0, long charClassMatchBitmap1,
-      boolean charClassMatchAllowEmpty) {
+      boolean charClassMatchAllowEmpty, EnginePathOptions enginePathOptions) {
     this.pattern = pattern;
     this.flags = flags;
     this.prog = prog;
@@ -206,6 +208,7 @@ public final class Pattern implements Serializable {
     this.charClassPrefixAscii = charClassPrefixAscii;
     this.startAcceleration = startAcceleration;
     this.keywordAlternation = keywordAlternation;
+    this.enginePathOptions = enginePathOptions;
     this.charClassMatchRanges = charClassMatchRanges;
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
@@ -236,7 +239,12 @@ public final class Pattern implements Serializable {
    *     {@code CANON_EQ})
    */
   public static Pattern compile(String regex, int flags) {
+    return compile(regex, flags, EnginePathOptions.allEnabled());
+  }
+
+  static Pattern compile(String regex, int flags, EnginePathOptions enginePathOptions) {
     validateFlags(flags);
+    Objects.requireNonNull(enginePathOptions, "enginePathOptions");
     int effectiveFlags = effectiveFlags(flags);
     int parseFlags = toParseFlags(effectiveFlags);
     Regexp re = Parser.parse(regex, parseFlags);
@@ -275,7 +283,8 @@ public final class Pattern implements Serializable {
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
-        ccMatch != null && ccMatch.allowEmpty);
+        ccMatch != null && ccMatch.allowEmpty,
+        enginePathOptions);
   }
 
   /**
@@ -550,6 +559,10 @@ public final class Pattern implements Serializable {
   /** Returns the compiled program. */
   Prog prog() {
     return prog;
+  }
+
+  EnginePathOptions enginePathOptions() {
+    return enginePathOptions;
   }
 
   /** Returns the thread-local cached BitState, or null if none has been cached yet. */

--- a/safere/src/main/java/org/safere/ResultAuthority.java
+++ b/safere/src/main/java/org/safere/ResultAuthority.java
@@ -1,0 +1,17 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Public-result dimensions an engine path may claim to produce. */
+enum ResultAuthority {
+  NO_MATCH,
+  CANDIDATE_START,
+  GROUP_ZERO,
+  CAPTURES,
+  DEFERRED_CAPTURES,
+  SEARCH_CURSOR,
+  REPLACEMENT_RESULT
+}

--- a/safere/src/main/java/org/safere/SemanticGuard.java
+++ b/safere/src/main/java/org/safere/SemanticGuard.java
@@ -1,0 +1,20 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Semantic guard categories that justify a non-general engine path. */
+enum SemanticGuard {
+  BOUNDED_STATE,
+  CAPTURE_DEFERABLE,
+  CAPTURE_EQUIVALENT,
+  CONSERVATIVE_START_SET,
+  GROUP_ZERO_EQUIVALENT,
+  LEFTMOST_FIRST_EQUIVALENT,
+  NO_USER_CAPTURES,
+  NON_NULLABLE_PATTERN,
+  SIMPLE_REPLACEMENT,
+  WHOLE_PATTERN_SHAPE
+}

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -8,13 +8,50 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Forced-path equivalence coverage for package-private engine-path controls. */
 @DisabledForCrosscheck("uses package-private engine-path controls to compare SafeRE internals")
 class EnginePathEquivalenceTest {
+
+  @Test
+  @DisplayName("every forced engine path has a machine-readable contract")
+  void everyForcedEnginePathHasContract() {
+    Set<EnginePath> contracted = EnumSet.noneOf(EnginePath.class);
+    for (EnginePathContract contract : EnginePathContract.all()) {
+      contracted.add(contract.path());
+      assertThat(contract.authorities())
+          .as("authorities for %s", contract.path())
+          .isNotEmpty();
+      if (contract.role() != EnginePathRole.FILTER) {
+        assertThat(contract.guards())
+            .as("guards for %s", contract.path())
+            .isNotEmpty();
+      }
+    }
+
+    assertThat(contracted).containsExactlyInAnyOrderElementsOf(EnginePathOptions.accessors()
+        .keySet());
+    assertThat(EnginePathOptions.accessors().keySet()).containsExactlyInAnyOrderElementsOf(
+        EnumSet.allOf(EnginePath.class));
+  }
+
+  @Test
+  @DisplayName("engine path options disable only their declared path")
+  void enginePathOptionsDisableDeclaredPath() {
+    EnginePathOptions allEnabled = EnginePathOptions.allEnabled();
+    for (Map.Entry<EnginePath, EnginePathOptions.OptionAccessor> entry :
+        EnginePathOptions.accessors().entrySet()) {
+      assertThat(entry.getValue().enabled(allEnabled))
+          .as("default option for %s", entry.getKey())
+          .isTrue();
+    }
+  }
 
   @Test
   @DisplayName("literal fast paths match the canonical engine trace")

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -42,6 +42,27 @@ class EnginePathEquivalenceTest {
   }
 
   @Test
+  @DisplayName("engine path roles constrain declared result authority")
+  void enginePathRolesConstrainDeclaredResultAuthority() {
+    for (EnginePathContract contract : EnginePathContract.all()) {
+      if (contract.role() == EnginePathRole.FILTER) {
+        assertThat(contract.authorities())
+            .as("filter authorities for %s", contract.path())
+            .doesNotContain(
+                ResultAuthority.GROUP_ZERO,
+                ResultAuthority.CAPTURES,
+                ResultAuthority.DEFERRED_CAPTURES,
+                ResultAuthority.REPLACEMENT_RESULT);
+      }
+      if (contract.role() == EnginePathRole.PARTIAL_PRODUCER) {
+        assertThat(contract.authorities())
+            .as("partial producer authorities for %s", contract.path())
+            .doesNotContain(ResultAuthority.CAPTURES, ResultAuthority.REPLACEMENT_RESULT);
+      }
+    }
+  }
+
+  @Test
   @DisplayName("engine path options disable only their declared path")
   void enginePathOptionsDisableDeclaredPath() {
     EnginePathOptions allEnabled = EnginePathOptions.allEnabled();
@@ -51,6 +72,51 @@ class EnginePathEquivalenceTest {
           .as("default option for %s", entry.getKey())
           .isTrue();
     }
+  }
+
+  @Test
+  @DisplayName("OnePass nullable-alternation guard has semantic content")
+  void onePassNullableAlternationGuardHasSemanticContent() {
+    String regex = "(?:|a)";
+    String input = "a";
+    Pattern canonical = Pattern.compile(regex);
+    Pattern unguarded =
+        Pattern.compile(
+            regex,
+            0,
+            EnginePathOptions.builder()
+                .semanticGuards(false)
+                .dfa(false)
+                .bitState(false)
+                .build());
+
+    assertThat(canonical.hasNullableAlternation()).isTrue();
+    assertThat(canonical.onePass()).isNotNull();
+    assertThat(findTrace(unguarded.matcher(input)))
+        .as("unguarded OnePass should expose why the nullable-alternation guard exists")
+        .isNotEqualTo(findTrace(canonical.matcher(input)));
+  }
+
+  @Test
+  @DisplayName("DFA start-reliability guard has semantic content")
+  void dfaStartReliabilityGuardHasSemanticContent() {
+    String regex = "(bcd|abcde)";
+    String input = "abcde";
+    Pattern canonical = Pattern.compile(regex);
+    Pattern unguarded =
+        Pattern.compile(
+            regex,
+            0,
+            EnginePathOptions.builder()
+                .semanticGuards(false)
+                .onePass(false)
+                .bitState(false)
+                .build());
+
+    assertThat(canonical.dfaStartReliable()).isFalse();
+    assertThat(findTrace(unguarded.matcher(input)))
+        .as("unguarded DFA sandwich should expose why start reliability is guarded")
+        .isNotEqualTo(findTrace(canonical.matcher(input)));
   }
 
   @Test
@@ -148,6 +214,64 @@ class EnginePathEquivalenceTest {
     assertThat(defaultPattern.matcher(input).replaceFirst("<$0>"))
         .as("replaceFirst trace for /%s/ on %s", regex, input)
         .isEqualTo(forcedPattern.matcher(input).replaceFirst("<$0>"));
+    assertThat(defaultPattern.matcher(input).replaceAll(match -> "<" + match.group() + ">"))
+        .as("functional replaceAll trace for /%s/ on %s", regex, input)
+        .isEqualTo(forcedPattern.matcher(input).replaceAll(match -> "<" + match.group() + ">"));
+    assertThat(appendReplacementTrace(defaultPattern.matcher(input)))
+        .as("appendReplacement trace for /%s/ on %s", regex, input)
+        .isEqualTo(appendReplacementTrace(forcedPattern.matcher(input)));
+  }
+
+  @Test
+  @DisplayName("region traces are engine-path equivalent")
+  void regionTracesAreEnginePathEquivalent() {
+    EnginePathOptions forced =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .startAcceleration(false)
+            .onePass(false)
+            .dfa(false)
+            .bitState(false)
+            .lazyCaptureExtraction(false)
+            .build();
+    Pattern defaultPattern = Pattern.compile("^[a-z]+$");
+    Pattern forcedPattern = Pattern.compile("^[a-z]+$", 0, forced);
+    Matcher defaultMatcher = defaultPattern.matcher("00abc11").region(2, 5);
+    Matcher forcedMatcher = forcedPattern.matcher("00abc11").region(2, 5);
+
+    assertThat(operationTrace(defaultMatcher, Operation.MATCHES))
+        .isEqualTo(operationTrace(forcedMatcher, Operation.MATCHES));
+  }
+
+  @Test
+  @DisplayName("transparent and anchoring bounds traces are engine-path equivalent")
+  void boundsTracesAreEnginePathEquivalent() {
+    EnginePathOptions forced = EnginePathOptions.builder().dfa(false).bitState(false).build();
+    Pattern defaultPattern = Pattern.compile("^abc$");
+    Pattern forcedPattern = Pattern.compile("^abc$", 0, forced);
+    Matcher defaultMatcher =
+        defaultPattern.matcher("00abc11").region(2, 5).useAnchoringBounds(false);
+    Matcher forcedMatcher =
+        forcedPattern.matcher("00abc11").region(2, 5).useAnchoringBounds(false);
+
+    assertThat(operationTrace(defaultMatcher, Operation.MATCHES))
+        .isEqualTo(operationTrace(forcedMatcher, Operation.MATCHES));
+  }
+
+  @Test
+  @DisplayName("multiline CRLF anchor traces are engine-path equivalent")
+  void multilineCrLfAnchorTracesAreEnginePathEquivalent() {
+    assertEquivalent(
+        "(?m)^abc$",
+        "xx\r\nabc\r\nyy",
+        EnginePathOptions.builder()
+            .startAcceleration(false)
+            .onePass(false)
+            .dfa(false)
+            .reverseDfa(false)
+            .bitState(false)
+            .build());
   }
 
   private static MatchTrace operationTrace(Matcher matcher, Operation operation) {
@@ -166,6 +290,15 @@ class EnginePathEquivalenceTest {
     }
     traces.add(snapshot(matcher, false));
     return traces;
+  }
+
+  private static String appendReplacementTrace(Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    while (matcher.find()) {
+      matcher.appendReplacement(builder, "<$0>");
+    }
+    matcher.appendTail(builder);
+    return builder.toString();
   }
 
   private static MatchTrace snapshot(Matcher matcher, boolean matched) {

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -1,0 +1,157 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Forced-path equivalence coverage for package-private engine-path controls. */
+@DisabledForCrosscheck("uses package-private engine-path controls to compare SafeRE internals")
+class EnginePathEquivalenceTest {
+
+  @Test
+  @DisplayName("literal fast paths match the canonical engine trace")
+  void literalFastPathsMatchCanonicalTrace() {
+    assertEquivalent(
+        "abc",
+        "zzabcabc",
+        EnginePathOptions.builder().literalFastPaths(false).build());
+  }
+
+  @Test
+  @DisplayName("character-class replacement fast path matches canonical replacement")
+  void characterClassReplacementFastPathMatchesCanonicalReplacement() {
+    String regex = "\\d+";
+    String input = "a12b345c";
+    Pattern defaultPattern = Pattern.compile(regex);
+    Pattern canonicalPattern = Pattern.compile(
+        regex,
+        0,
+        EnginePathOptions.builder().charClassReplacementFastPath(false).build());
+
+    assertThat(defaultPattern.matcher(input).replaceAll("X"))
+        .isEqualTo(canonicalPattern.matcher(input).replaceAll("X"));
+    assertEquivalent(
+        regex,
+        input,
+        EnginePathOptions.builder()
+            .charClassMatchFastPaths(false)
+            .charClassReplacementFastPath(false)
+            .build());
+  }
+
+  @Test
+  @DisplayName("start accelerators match the canonical engine trace")
+  void startAcceleratorsMatchCanonicalTrace() {
+    assertEquivalent(
+        "foo[0-9]+",
+        "xxfoo123 yyfoo45",
+        EnginePathOptions.builder().startAcceleration(false).build());
+  }
+
+  @Test
+  @DisplayName("OnePass paths match the canonical engine trace")
+  void onePassPathsMatchCanonicalTrace() {
+    assertEquivalent(
+        "^([A-Z]+):(\\d+)$",
+        "ABC:123",
+        EnginePathOptions.builder().onePass(false).build());
+  }
+
+  @Test
+  @DisplayName("DFA paths match the canonical engine trace")
+  void dfaPathsMatchCanonicalTrace() {
+    assertEquivalent(
+        "([a-z]+)([0-9]+)",
+        "xxabc123yydef45",
+        EnginePathOptions.builder().dfa(false).reverseDfa(false).build());
+  }
+
+  @Test
+  @DisplayName("BitState paths match the Pike NFA trace")
+  void bitStatePathsMatchPikeNfaTrace() {
+    assertEquivalent(
+        "(a|aa)*b",
+        "aaaaab",
+        EnginePathOptions.builder().dfa(false).onePass(false).bitState(false).build());
+  }
+
+  @Test
+  @DisplayName("lazy capture extraction matches eager capture extraction")
+  void lazyCaptureExtractionMatchesEagerCaptureExtraction() {
+    assertEquivalent(
+        "([a-z]+)([0-9]+)",
+        "xxabc123yydef45",
+        EnginePathOptions.builder().lazyCaptureExtraction(false).build());
+  }
+
+  private static void assertEquivalent(String regex, String input, EnginePathOptions options) {
+    Pattern defaultPattern = Pattern.compile(regex);
+    Pattern forcedPattern = Pattern.compile(regex, 0, options);
+
+    assertThat(operationTrace(defaultPattern.matcher(input), Operation.MATCHES))
+        .as("matches trace for /%s/ on %s", regex, input)
+        .isEqualTo(operationTrace(forcedPattern.matcher(input), Operation.MATCHES));
+    assertThat(operationTrace(defaultPattern.matcher(input), Operation.LOOKING_AT))
+        .as("lookingAt trace for /%s/ on %s", regex, input)
+        .isEqualTo(operationTrace(forcedPattern.matcher(input), Operation.LOOKING_AT));
+    assertThat(findTrace(defaultPattern.matcher(input)))
+        .as("find trace for /%s/ on %s", regex, input)
+        .isEqualTo(findTrace(forcedPattern.matcher(input)));
+    assertThat(defaultPattern.matcher(input).replaceAll("<$0>"))
+        .as("replaceAll trace for /%s/ on %s", regex, input)
+        .isEqualTo(forcedPattern.matcher(input).replaceAll("<$0>"));
+    assertThat(defaultPattern.matcher(input).replaceFirst("<$0>"))
+        .as("replaceFirst trace for /%s/ on %s", regex, input)
+        .isEqualTo(forcedPattern.matcher(input).replaceFirst("<$0>"));
+  }
+
+  private static MatchTrace operationTrace(Matcher matcher, Operation operation) {
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+        };
+    return snapshot(matcher, matched);
+  }
+
+  private static List<MatchTrace> findTrace(Matcher matcher) {
+    List<MatchTrace> traces = new ArrayList<>();
+    while (matcher.find()) {
+      traces.add(snapshot(matcher, true));
+    }
+    traces.add(snapshot(matcher, false));
+    return traces;
+  }
+
+  private static MatchTrace snapshot(Matcher matcher, boolean matched) {
+    List<GroupTrace> groups = new ArrayList<>();
+    if (matched) {
+      for (int group = 0; group <= matcher.groupCount(); group++) {
+        groups.add(
+            new GroupTrace(
+                matcher.group(group),
+                matcher.start(group),
+                matcher.end(group)));
+      }
+    }
+    return new MatchTrace(matched, groups, matcher.hitEnd(), matcher.requireEnd());
+  }
+
+  private enum Operation {
+    MATCHES,
+    LOOKING_AT
+  }
+
+  private record MatchTrace(
+      boolean matched, List<GroupTrace> groups, boolean hitEnd, boolean requireEnd) {}
+
+  private record GroupTrace(String value, int start, int end) {}
+}


### PR DESCRIPTION
## Summary

- add package-private engine-path options to force or disable matcher fast paths in tests
- add machine-readable engine path contract metadata for roles, result authority, and semantic guards
- route core Matcher dispatch through typed engine results for no-match, full-match, and deferred-capture outcomes
- add forced-path equivalence tests across matching, captures, replacements, regions/bounds, CRLF anchors, end-state flags, and negative guard cases
- update design/ENGINE_PATH_EQUIVALENCE.md with the implemented approach, correctness evidence, and remaining work
- exclude the package-private engine-path test from generated crosscheck source compilation while keeping its DisabledForCrosscheck annotation in the original test

## Testing

- `mvn -pl safere -Dtest=EnginePathEquivalenceTest test -q`
- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere -Dtest=QuantifiedCaptureSemanticsTest test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere -DskipTests verify -q`
- `git diff --check`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
