### PR TITLE
Implement matcher state-machine design

### DIFF
--- a/design/MATCHER_STATE_MACHINE.md
+++ b/design/MATCHER_STATE_MACHINE.md
@@ -1,0 +1,472 @@
+# Matcher State-Machine Design
+
+## Problem
+
+SafeRE's `Matcher` is not just a lightweight wrapper around a pattern and an
+input string.  It is a mutable public object whose state is observable through
+later calls.  A search operation updates the current match, the next search
+position, deferred capture state, append position, and end-state flags.  A
+later `group()`, `find()`, `appendReplacement()`, `reset()`, `region()`, or
+`usePattern()` call observes or mutates that state.
+
+That matters because SafeRE aims to be a drop-in replacement for
+`java.util.regex`.  Matching the JDK for a single isolated `find()` call is not
+enough.  The sequence of operations on one matcher must also behave like the
+JDK, while preserving SafeRE's linear-time guarantee.
+
+Recent bugs show the risk:
+
+- #225: after `usePattern`, SafeRE restarted `find()` from a different position
+  than `java.util.regex`.
+- #226: `hitEnd()` and `requireEnd()` diverged after `reset()` and `region()`
+  transitions following end-sensitive matches.
+
+The common failure mode is that local methods update the fields they need
+immediately, but the full public state transition is not represented as one
+contract.  That makes it easy to fix one method and leave a neighboring method
+with stale match bounds, stale end-state flags, stale deferred captures, or a
+wrong next-search cursor.
+
+## Current State
+
+`Matcher` currently carries several groups of state:
+
+- input and pattern state: `parentPattern`, `inputSequence`, and materialized
+  `text`;
+- region and bounds state: `regionStart`, `regionEnd`, `transparentBounds`,
+  and `anchoringBounds`;
+- current result state: `hasMatch`, `groups`, `capturesResolved`,
+  `groupZeroResolved`, `deferredMatchStart`, `deferredMatchEnd`, and
+  `deferredEndMatch`;
+- cursor state: `searchFrom`;
+- replacement state: `appendPos`;
+- end-state flags: `lastHitEnd` and `lastRequireEnd`;
+- cached engine state: cached DFA and BitState references;
+- stream and functional replacement mutation detection: `modCount`.
+
+The implementation already has useful centralization:
+
+- `find()` handles empty-match advancement before calling `doFind()`;
+- `doFind()` is the main search dispatcher;
+- `applyEngineResult()` centralizes most successful and failed match writes;
+- `resolveCaptures()` centralizes deferred capture materialization;
+- replacement APIs mostly consume the same `find()` sequence;
+- `reset()`, `region()`, and `usePattern()` explicitly invalidate several
+  match-result fields.
+
+The weak point is that these are conventions rather than a state-machine
+contract.  The code has no single place that says which state is valid after a
+failed search, after `usePattern`, after `region`, after an end-sensitive
+failed match, or after a functional replacement callback mutates the matcher.
+
+## Design Principle
+
+Every public method should be described as a transition from one matcher state
+to another.
+
+The state machine should make three facts explicit:
+
+- which fields are inputs to the transition;
+- which fields become valid, invalid, preserved, or reset;
+- which public observations are legal after the transition.
+
+The design should not add a second matcher implementation.  The goal is to
+name and enforce the existing public-state contract so future engine-path or
+capture work cannot accidentally leave matcher lifecycle behavior implicit.
+
+## State Model
+
+The matcher state can be modeled as these logical components.
+
+| Component | Meaning |
+| --- | --- |
+| Pattern | The current compiled pattern and all pattern-dependent engine caches. |
+| Input | The current input sequence and materialized text. |
+| Region | The active search interval plus transparent and anchoring bounds. |
+| Result status | Whether the matcher is reset/no-attempt, matched, or failed. |
+| Result data | Current group state when the result status is matched. |
+| Deferred captures | Whether group zero or inner captures still require resolution. |
+| Search cursor | The stored position used as the base for parameterless `find()`. |
+| Next-find derivation | The rule that derives the next `find()` start from the previous result. |
+| Replacement | The append position used by `appendReplacement`/`appendTail`. |
+| End state | `hitEnd()` and `requireEnd()` observations from the last match attempt. |
+| Structural mutation | Whether an operation invalidates active streams or replacement callbacks. |
+
+Those components should be represented in code either by small helper methods
+or by package-private state-transition helpers.  The important requirement is
+that a public method must not partially update one component without also
+declaring the effect on the others.
+
+## Transition Rules
+
+The following table is the target contract.  It is written in terms of logical
+state, not necessarily current field names.
+
+The result status should distinguish at least:
+
+- **reset/no-attempt:** no current match result is available because the matcher
+  has not attempted a match, or a lifecycle transition cleared the result;
+- **matched:** the last match attempt succeeded and group observations are
+  legal;
+- **failed:** the last match attempt failed, group observations are illegal,
+  and end-state flags describe that failed attempt.
+
+`reset`, `reset(input)`, `region`, and `usePattern` should move the matcher to
+reset/no-attempt for group-observation purposes without erasing the previous
+`hitEnd()` and `requireEnd()` values.
+
+| Operation | Result state | Deferred captures | Search cursor and next-find rule | Replacement state | End-state flags | Structural mutation | Caches |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| successful `matches()` | matched | resolved or deferred with full-match anchored bounds compatible with later `group()` and `toMatchResult()` | next `find()` derives from the full-region match result | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| failed `matches()` | failed | cleared | next-find state is set by the match-operation trace oracle for failed whole-region attempts | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| successful `lookingAt()` | matched | resolved or deferred with region-start anchored prefix bounds compatible with later `group()` and `toMatchResult()` | next `find()` derives from the prefix match result | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| failed `lookingAt()` | failed | cleared | next-find state is set by the match-operation trace oracle for failed anchored-prefix attempts | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| `find()` before first success | matched or failed | resolved, validly deferred, or cleared on failure | starts from stored search cursor | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| `find()` after non-empty success | matched or failed | resolves prior group zero if needed; new result may be resolved, validly deferred, or cleared | derives next start from previous end, then searches | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| `find()` after empty success | matched or failed | resolves prior group zero if needed; new result may be resolved, validly deferred, or cleared | derives next start from previous end plus one code unit unless at region end, then searches | preserved | updated from this attempt | invalidates active traversal/callback | preserved |
+| `find(start)` | matched or failed after reset/no-attempt | reset clears old deferred state; new result may be resolved, validly deferred, or cleared | resets region to full input per JDK behavior, sets stored cursor from `start`, then searches | append position reset by reset semantics | updated from this attempt | invalidates active traversal/callback | preserved |
+| `reset()` | reset/no-attempt | cleared | set to input start | set to 0 | preserved from the last match attempt until the next match attempt | invalidates active traversal/callback | engine caches may remain if pattern/input-compatible |
+| `reset(input)` | reset/no-attempt | cleared | set to new input start | set to 0 | preserved from the last match attempt until the next match attempt | invalidates active traversal/callback | input-dependent cached state invalidated if needed |
+| `region(start, end)` | reset/no-attempt | cleared | set to region start | set to 0 | preserved from the last match attempt until the next match attempt | invalidates active traversal/callback | pattern caches preserved; input/region assumptions invalidated |
+| `usePattern(newPattern)` | reset/no-attempt | cleared | preserves the JDK-compatible next-search position derived from the prior result | preserved unless JDK requires otherwise | preserved from the last match attempt until the next match attempt | invalidates active traversal/callback | old pattern caches invalidated |
+| `useTransparentBounds` | preserves result status and data | resolves unresolved captures under the pre-change bounds before clearing deferred markers unless a named predicate proves deferred resolution is bounds-independent | preserves cursor and next-find derivation | preserves append position | preserved | oracle-defined and recorded in the transition inventory | preserves caches unless bounds affect them |
+| `useAnchoringBounds` | preserves result status and data | resolves unresolved captures under the pre-change bounds before clearing deferred markers unless a named predicate proves deferred resolution is bounds-independent | preserves cursor and next-find derivation | preserves append position | preserved | oracle-defined and recorded in the transition inventory | preserves caches unless bounds affect them |
+| `appendReplacement` | requires matched result | resolves captures needed by replacement | preserves cursor and next-find derivation | advances append position to current match end | preserves last match end-state | oracle-defined and recorded in the transition inventory | preserved |
+| `appendTail` | preserves result status and data | preserves deferred state | preserves cursor and next-find derivation | preserves append position | preserves end-state | oracle-defined and recorded in the transition inventory | preserved |
+| `replaceFirst` | begins with reset/no-attempt, consumes at most one `find()` result | follows operations run | follows canonical `find()` | managed by append operations | final value follows the operations run | detects callback mutation | preserved |
+| `replaceAll` | begins with reset/no-attempt, consumes canonical `find()` sequence | follows operations run | follows canonical `find()` | managed by append operations | final value follows the operations run | detects callback mutation | preserved |
+| `results()` | lazily consumes canonical `find()` sequence | follows operations run | follows canonical `find()` | preserved | follows the last produced or failed match attempt | detects mutation between producing a result and returning from the action | preserved |
+| `toMatchResult()` | requires matched result, resolves captures, snapshots result | resolved before snapshot | preserves cursor and next-find derivation | preserves append position | preserves end-state | not a structural mutation | preserved |
+| `group()`/`start()`/`end()` | requires matched result, resolves captures as needed | resolved as needed | preserves cursor and next-find derivation | preserves append position | preserves end-state | not a structural mutation | preserved |
+| observer-only methods | preserve result status and data | preserve deferred state | preserve cursor and next-find derivation | preserve append position | preserve end-state | not structural mutations | preserve caches |
+
+This table intentionally separates "clears the match result" from "resets the
+next search cursor."  #225 happened because those two concepts were coupled
+incorrectly: losing group information after `usePattern` does not mean the next
+parameterless `find()` should restart from the beginning.
+
+It also separates the stored search cursor from the next-find derivation.  The
+JDK-compatible next `find()` start can depend on the previous result, especially
+for empty matches, and not only on a single stored integer.  SafeRE should make
+that derivation a named transition helper so state-clearing operations cannot
+accidentally erase the information needed to compute the next search start.
+
+For the difficult failed `matches()` and failed `lookingAt()` cases, the design
+does not rely on prose intuition.  The implementation should define a
+match-operation trace oracle: a generated crosscheck trace that records the next
+observable `find()` sequence after those operations for representative prior
+states.  The transition helper is correct only if it matches that oracle.
+
+## Observation Legality
+
+The transition inventory must also record which public observations are legal
+after each operation.  A state transition is incomplete if it updates fields but
+does not say what callers may observe next.
+
+The target legality rules are:
+
+- in reset/no-attempt state, observer-only methods such as `groupCount()`,
+  `hitEnd()`, and `requireEnd()` are legal, but `group()`, `start()`, `end()`,
+  `toMatchResult()`, and `appendReplacement()` must throw the JDK-compatible
+  exception;
+- after a successful match operation, observer-only methods are legal, and
+  match-result methods such as `group()`, `start()`, `end()`, `toMatchResult()`,
+  and `appendReplacement()` are also legal;
+- after a failed match operation, observer-only methods are legal, including
+  `hitEnd()` and `requireEnd()`, but `group()`, `start()`, `end()`,
+  `toMatchResult()`, and `appendReplacement()` must throw the JDK-compatible
+  exception;
+- after `reset`, `reset(input)`, `region`, and `usePattern`, previous match
+  groups and snapshots are invalid for the matcher, but `hitEnd()` and
+  `requireEnd()` still report the flags from the last match attempt until the
+  next match attempt updates them;
+- after `appendTail`, the previous match result remains the current result for
+  observation purposes;
+- after `toMatchResult`, the returned snapshot must remain valid even if later
+  matcher operations invalidate or mutate the matcher's current result;
+- during `results()` and functional replacement callbacks, matcher mutation
+  must be detected according to the JDK-compatible mutation-version contract.
+
+The mutation-detection contract should be pinned by differential tests for
+operations whose behavior is not obvious from the JDK documentation, including
+`useTransparentBounds`, `useAnchoringBounds`, `appendReplacement`, and
+`appendTail`.  The implementation should not infer their structural-mutation
+status from whether a field happens to change internally.
+
+Bounds changes have a separate deferred-capture rule: unresolved deferred
+captures must be resolved under the pre-change bounds before deferred markers
+are cleared, unless a named predicate proves that later capture resolution is
+independent of transparent and anchoring bounds.  This avoids resolving captures
+later under different empty-width assertion or region-bound semantics than the
+search that selected the match.
+
+Observer-only methods still need transition entries even though they should not
+mutate state.  The inventory should include at least `groupCount()`,
+`pattern()`, `regionStart()`, `regionEnd()`, `hasTransparentBounds()`,
+`hasAnchoringBounds()`, `namedGroups()`, and `toString()`.  Their contract is to
+report current matcher state without changing result status, next-search
+behavior, replacement position, end-state flags, or active traversal validity.
+
+## End-State Contract
+
+`hitEnd()` and `requireEnd()` are matcher state, not engine-local details.  A
+public match attempt must leave them in the JDK-compatible state for that
+attempt, whether the attempt succeeds or fails.
+
+The state-machine design should treat end-state flags as part of the completion
+step for `find()`, `matches()`, and `lookingAt()`.  Engine paths may provide
+facts that help compute the flags, but they should not leave those flags stale
+from an earlier operation.
+
+The contract should answer these cases explicitly:
+
+- successful match that reaches the region end;
+- failed search that scanned to the region end;
+- `reset()`, `reset(input)`, and `region()` after an end-sensitive prior match,
+  which should preserve the previous flags until the next match attempt;
+- `usePattern()` after an end-sensitive prior match, which should also preserve
+  the previous flags until the next match attempt;
+- region bounds with anchoring enabled and disabled;
+- transparent bounds, even though SafeRE rejects lookaround, because the flag
+  remains public matcher state.
+
+If SafeRE intentionally uses a conservative approximation for `requireEnd()`,
+that approximation must be documented as a stable product behavior and applied
+consistently after every relevant transition.
+
+## Deferred Capture Contract
+
+Deferred captures are an internal optimization, but their validity is tied to
+matcher state.  Any transition that invalidates the current result must also
+invalidate deferred capture state.  Any transition that changes pattern, input,
+region, matcher bounds, or group-zero bounds must make it impossible to resolve
+stale deferred captures later.
+
+The target rules are:
+
+- `group()`, `start()`, `end()`, `toMatchResult()`, and replacement
+  substitution may resolve captures, but must not change match identity;
+- `find()` may avoid resolving inner captures for the previous match when group
+  zero is already authoritative, but it must resolve group zero before using
+  previous bounds to advance;
+- `reset()`, `reset(input)`, `find(start)`, `region()`, and `usePattern()` must
+  clear deferred state because they reset the current result or replace the
+  state used to derive it;
+- `useTransparentBounds` and `useAnchoringBounds` must resolve unresolved
+  captures under the pre-change bounds before clearing deferred markers, unless
+  a named predicate proves that later capture resolution is independent of the
+  changed bounds;
+- snapshots must clone resolved state so later matcher transitions cannot
+  mutate an existing `MatchResult`.
+
+This ties the matcher-state design to the capture-semantics design without
+making matcher lifecycle responsible for computing capture semantics itself.
+
+## Replacement Contract
+
+Replacement APIs combine multiple state components and therefore need explicit
+rules.
+
+`appendReplacement` is a state transition over an existing successful match:
+
+- it requires a valid current match;
+- it resolves captures needed by the replacement;
+- it appends input from the previous append position to the current match
+  start;
+- it appends the replacement;
+- it advances append position to the current match end;
+- it does not change the next-search cursor.
+
+`replaceAll` and `replaceFirst` should be specified as canonical loops over
+`reset()`, `find()`, `appendReplacement`, and `appendTail`, except for fast
+paths that have an explicit engine-path equivalence contract.  The replacement
+contract must include empty matches, anchored matches, regions, and functional
+replacers that attempt to mutate the matcher while the replacement is in
+progress.
+
+## Cache Contract
+
+Engine caches are not public state, but stale caches can change public behavior
+if they are tied to the wrong pattern, input, region, or bounds.
+
+The cache rules should be:
+
+- pattern-dependent caches must be invalidated by `usePattern`;
+- input-dependent temporary state must not survive `reset(input)` unless it is
+  proven independent of input contents and length;
+- region and bounds changes must not reuse cached results that encode old
+  region assumptions;
+- returning borrowed engine objects to pattern-owned pools must be paired with
+  matcher lifecycle transitions that can no longer use them.
+
+The implementation should prefer helper methods with names such as
+`clearMatchResult`, `clearDeferredCaptures`, `invalidatePatternCaches`, and
+`resetSearchState` over open-coded field writes spread across public methods.
+
+## Proposed Work
+
+### 1. Add A Transition Inventory
+
+Create a package-private transition inventory for public matcher operations.
+This may begin as comments and focused tests, but the target should be
+machine-checkable metadata that names:
+
+- operation;
+- preconditions;
+- result effect;
+- cursor effect;
+- next-find derivation effect;
+- append-position effect;
+- deferred-capture effect;
+- end-state effect;
+- structural-mutation effect for active streams and callbacks;
+- cache effect;
+- legal and illegal public observations after the transition.
+
+This inventory should live close to `Matcher`, not only in design docs.
+
+### 2. Centralize State Mutations
+
+Refactor public methods toward named transition helpers.  The first useful
+helpers are likely:
+
+- clear current result and deferred capture state;
+- reset full matcher state for current input;
+- reset full matcher state for new input;
+- apply a successful match result;
+- apply a failed match result;
+- advance cursor after previous match;
+- invalidate pattern-dependent caches;
+- reset replacement append state.
+
+The goal is not abstraction for its own sake.  The goal is to make incomplete
+state transitions hard to write.
+
+### 3. Add Lifecycle Trace Tests
+
+Add generated or table-driven tests that compare SafeRE with `java.util.regex`
+for operation traces, not only single operations.  Traces should include:
+
+- `find`, `find`, `group`, `find` after empty and non-empty matches;
+- `find(start)` followed by parameterless `find`;
+- `matches` or `lookingAt` followed by `find`;
+- `usePattern` after success, failure, empty success, and deferred capture;
+- `reset`, `reset(input)`, and `region` after end-sensitive matches;
+- bounds changes before and after searches;
+- replacement APIs mixed with manual `find` and `appendReplacement`;
+- `results()` traversal and mutation detection;
+- `toMatchResult()` snapshots followed by matcher mutation.
+
+Generated public API crosscheck should be the primary oracle.  Package-private
+tests should supplement it where internal deferred-capture or engine-cache
+state needs to be forced.
+
+### 4. Make End-State Tests Systematic
+
+`hitEnd()` and `requireEnd()` need trace-based coverage.  The tests should
+compare the flags after every relevant transition, including failed operations,
+not only after successful matches.
+
+The matrix should include:
+
+- `$`, `\Z`, `\z`, word boundaries, multiline anchors, and CRLF-sensitive
+  cases;
+- full input and active regions;
+- anchoring bounds enabled and disabled;
+- reset and region calls after a prior end-sensitive result;
+- find loops where the final failed `find()` changes the flags.
+
+### 5. Define Public Divergences
+
+If SafeRE intentionally differs from the JDK for any matcher lifecycle behavior
+because linear-time matching cannot support the JDK behavior, document that
+case and add tests for the documented divergence.  Do not let lifecycle
+differences remain accidental.
+
+## Linear-Time Argument
+
+Making matcher transitions explicit should not add work proportional to the
+number of possible regex paths.  The transition helpers only move or clear
+bounded matcher fields.
+
+The linear-time constraints are:
+
+- no transition may resolve captures by enumerating candidate explanations;
+- no lifecycle operation may rerun an unbounded search except where the public
+  operation already requires a search, such as `find()` or replacement loops;
+- a lifecycle operation may materialize deferred captures for an existing match
+  only with the same bounded, anchored capture-resolution pass that `group()` or
+  `toMatchResult()` would have used, and must not enumerate candidate
+  explanations;
+- trace tests may compare SafeRE with the JDK or with forced internal paths,
+  but production code must not run multiple engines to vote on state;
+- cache invalidation must prefer recomputation by the next normal engine pass
+  over stale reuse or speculative multi-pass repair.
+
+The design is therefore compatible with the core linear-time guarantee: it
+clarifies when existing linear operations run and prevents stale state from
+creating hidden repair work later.
+
+## Machine-Checkable Contracts
+
+The practical enforcement target is similar to the engine-path design:
+
+- a transition inventory that tests can inspect;
+- a coverage check that compares that inventory with the actual public methods
+  declared by `Matcher`, so newly added methods require an explicit transition
+  contract;
+- named helpers for each common state mutation;
+- trace tests that execute the same public method sequence against SafeRE and
+  the JDK;
+- package-private assertions that invalidated deferred captures cannot be
+  resolved after a clearing transition;
+- tests that fail if a new public matcher method is not represented in the
+  transition inventory.
+
+This is not a formal proof of JDK lifecycle compatibility.  It is a way to make
+the lifecycle contract executable and hard to bypass.
+
+## Acceptance Criteria
+
+This design is complete when:
+
+- every public instance `Matcher` method has an explicit transition contract,
+  and public static utility methods such as `quoteReplacement` are explicitly
+  categorized as having no matcher-state transition;
+- `Matcher` uses named helpers for clearing result state, clearing deferred
+  capture state, applying search results, resetting replacement state, and
+  invalidating engine caches;
+- operation-trace crosscheck tests cover matcher lifecycle behavior, not only
+  isolated calls;
+- the result-status model distinguishes reset/no-attempt, matched, and failed
+  states in code or machine-checkable metadata;
+- the transition inventory includes deferred-capture effects for every public
+  instance method;
+- structural mutation behavior for streams and functional replacement callbacks
+  is defined by the transition inventory and pinned by differential tests;
+- observer-only methods have explicit no-mutation transition contracts;
+- failed `matches()` and `lookingAt()` next-find behavior is verified by
+  operation-trace oracles rather than left as prose;
+- `hitEnd()` and `requireEnd()` are verified after success, failure, reset,
+  region, bounds, and pattern-change transitions;
+- replacement append-position behavior is verified across manual and
+  convenience replacement APIs;
+- `usePattern` preserves the JDK-compatible next-search position while clearing
+  old match results and old pattern caches;
+- stale deferred captures cannot survive pattern, input, region, or group-zero
+  bounds changes;
+- unresolved deferred captures must be materialized under pre-change bounds
+  before bounds changes clear deferred markers, unless a named predicate proves
+  the deferred resolution is independent of the changed bounds;
+- any documented lifecycle divergence from the JDK has an explicit reason and
+  regression coverage.
+
+## Non-Goals
+
+- Do not replace the existing engine-path dispatch design.
+- Do not make matcher lifecycle responsible for general capture semantics.
+- Do not run extra production searches only to verify state.
+- Do not emulate unsupported JDK regex features such as backreferences or
+  lookaround.
+- Do not preserve stale caches for performance unless their validity is part of
+  an explicit transition contract.

--- a/design/SEMANTIC_INVARIANTS.md
+++ b/design/SEMANTIC_INVARIANTS.md
@@ -311,6 +311,8 @@ access, and end-state flags.
 
 ### Matcher State-Machine Design
 
+Focused design: [MATCHER_STATE_MACHINE.md](MATCHER_STATE_MACHINE.md).
+
 Scope: #225, #226, and related public API lifecycle behavior.
 
 This design should model `Matcher` as an explicit state machine.  It should

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -122,6 +122,8 @@
                         <exclude name="EnginePathEquivalenceTest.java"/>
                         <exclude name="InstOpTest.java"/>
                         <exclude name="InstTest.java"/>
+                        <exclude name="MatcherDeferredCaptureStateTest.java"/>
+                        <exclude name="MatcherTransitionInventoryTest.java"/>
                         <exclude name="NfaTest.java"/>
                         <exclude name="OnePassTest.java"/>
                         <exclude name="ParseFlagsTest.java"/>

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -68,6 +68,12 @@ public final class Matcher implements MatchResult {
     FIND
   }
 
+  private enum ResultStatus {
+    RESET_NO_ATTEMPT,
+    MATCHED,
+    FAILED
+  }
+
   /**
    * Minimum text length for the reverse-first optimization on end-anchored patterns. For shorter
    * texts, the forward DFA is trivially fast and the one-time cost of lazily compiling the reverse
@@ -104,6 +110,7 @@ public final class Matcher implements MatchResult {
   private String text;
   private int[] groups;
   private boolean hasMatch;
+  private ResultStatus resultStatus = ResultStatus.RESET_NO_ATTEMPT;
   private int searchFrom;
   private int appendPos;
   private boolean transparentBounds;
@@ -194,31 +201,113 @@ public final class Matcher implements MatchResult {
   private boolean applyEngineResult(EngineResult result) {
     switch (result) {
       case NoMatchResult ignored -> {
-        groups = null;
-        hasMatch = false;
-        capturesResolved = true;
-        groupZeroResolved = true;
+        applyFailedMatchResult();
       }
       case FullMatchResult full -> {
-        groups = full.groups();
-        hasMatch = groups != null;
-        capturesResolved = true;
-        groupZeroResolved = true;
+        applyFullMatchResult(full.groups());
       }
       case DeferredMatchResult deferred -> {
-        groups = new int[2 * deferred.ncap()];
-        Arrays.fill(groups, -1);
-        groups[0] = deferred.start();
-        groups[1] = deferred.end();
-        deferredMatchStart = deferred.start();
-        deferredMatchEnd = deferred.end();
-        deferredEndMatch = deferred.endMatch();
-        groupZeroResolved = deferred.groupZeroResolved();
-        capturesResolved = deferred.groupZeroResolved() && deferred.ncap() <= 1;
-        hasMatch = true;
+        applyDeferredMatchResult(deferred);
       }
     }
     return hasMatch;
+  }
+
+  private void applyFailedMatchResult() {
+    groups = null;
+    hasMatch = false;
+    resultStatus = ResultStatus.FAILED;
+    clearDeferredCaptureState();
+  }
+
+  private void applyFullMatchResult(int[] resultGroups) {
+    groups = resultGroups;
+    hasMatch = resultGroups != null;
+    resultStatus = hasMatch ? ResultStatus.MATCHED : ResultStatus.FAILED;
+    clearDeferredCaptureState();
+  }
+
+  private void applyDeferredMatchResult(DeferredMatchResult deferred) {
+    groups = new int[2 * deferred.ncap()];
+    Arrays.fill(groups, -1);
+    groups[0] = deferred.start();
+    groups[1] = deferred.end();
+    deferredMatchStart = deferred.start();
+    deferredMatchEnd = deferred.end();
+    deferredEndMatch = deferred.endMatch();
+    groupZeroResolved = deferred.groupZeroResolved();
+    capturesResolved = deferred.groupZeroResolved() && deferred.ncap() <= 1;
+    hasMatch = true;
+    resultStatus = ResultStatus.MATCHED;
+  }
+
+  private void clearCurrentResult() {
+    groups = null;
+    hasMatch = false;
+    resultStatus = ResultStatus.RESET_NO_ATTEMPT;
+    clearDeferredCaptureState();
+  }
+
+  private void clearDeferredCaptureState() {
+    capturesResolved = true;
+    groupZeroResolved = true;
+    deferredMatchStart = 0;
+    deferredMatchEnd = 0;
+    deferredEndMatch = false;
+  }
+
+  private void resetReplacementState() {
+    appendPos = 0;
+  }
+
+  private void resetSearchStateForInputStart() {
+    searchFrom = 0;
+  }
+
+  private void resetSearchStateForRegionStart() {
+    searchFrom = regionStart;
+  }
+
+  private void resetStateForCurrentInput() {
+    text = charSequenceToString(inputSequence);
+    regionStart = 0;
+    regionEnd = text.length();
+    resetSearchStateForInputStart();
+    resetReplacementState();
+    clearCurrentResult();
+    eagerFallbackCaptures = false;
+  }
+
+  private void resetStateForRegion(int start, int end) {
+    regionStart = start;
+    regionEnd = end;
+    resetSearchStateForRegionStart();
+    resetReplacementState();
+    clearCurrentResult();
+  }
+
+  private void invalidatePatternCaches() {
+    cachedForwardDfa = null;
+    cachedReverseDfa = null;
+    reverseDfaLookedUp = false;
+    if (bitStateBorrowed && cachedBitState != null) {
+      bitStateBorrowed = false;
+      cachedBitState = null;
+    }
+    bitStateResult = null;
+  }
+
+  private void invalidateInputDependentCaches() {
+    bitStateBorrowed = false;
+    cachedBitState = null;
+    bitStateResult = null;
+  }
+
+  private void preserveResultAcrossBoundsChange() {
+    if (hasMatch && !capturesResolved) {
+      resolveCaptures();
+    }
+    clearDeferredCaptureState();
   }
 
   private EnginePathOptions enginePathOptions() {
@@ -269,10 +358,9 @@ public final class Matcher implements MatchResult {
     int len = text.length();
     if (len == 0) {
       if (allowEmpty) {
-        groups = new int[]{0, 0};
-        return true;
+        return applyEngineResult(new FullMatchResult(new int[]{0, 0}));
       }
-      return false;
+      return applyEngineResult(new NoMatchResult());
     }
 
     // Scan every code point.
@@ -281,22 +369,21 @@ public final class Matcher implements MatchResult {
       int cp = text.codePointAt(i);
       if (cp < 64) {
         if ((b0 & (1L << cp)) == 0) {
-          return false;
+          return applyEngineResult(new NoMatchResult());
         }
       } else if (cp < 128) {
         if ((b1 & (1L << (cp - 64))) == 0) {
-          return false;
+          return applyEngineResult(new NoMatchResult());
         }
       } else {
         if (!binarySearchRanges(ranges, cp)) {
-          return false;
+          return applyEngineResult(new NoMatchResult());
         }
       }
       i += Character.charCount(cp);
     }
 
-    groups = new int[]{0, len};
-    return true;
+    return applyEngineResult(new FullMatchResult(new int[]{0, len}));
   }
 
   /** Binary search through sorted [lo, hi] ranges to check if {@code cp} is in any range. */
@@ -331,44 +418,6 @@ public final class Matcher implements MatchResult {
       }
     }
     return true;
-  }
-
-  /**
-   * Single-pass replaceAll for patterns that are a single character class under a {@code +}
-   * quantifier (e.g., {@code \d+}, {@code [a-zA-Z]+}). Scans the text once, identifying runs of
-   * matching characters and replacing each run with the replacement string. Completely bypasses
-   * all regex engines.
-   */
-  private String charClassReplaceAll(int[] ranges, String replacement) {
-    long b0 = parentPattern.charClassMatchBitmap0();
-    long b1 = parentPattern.charClassMatchBitmap1();
-    int len = text.length();
-
-    StringBuilder sb = new StringBuilder(len);
-    int copyFrom = 0;
-    int i = 0;
-
-    while (i < len) {
-      int cp = text.codePointAt(i);
-      if (charClassContains(b0, b1, ranges, cp)) {
-        // Found start of a match — append preceding non-match text.
-        sb.append(text, copyFrom, i);
-        // Skip past the entire run of matching characters.
-        do {
-          i += Character.charCount(cp);
-          if (i >= len) {
-            break;
-          }
-          cp = text.codePointAt(i);
-        } while (charClassContains(b0, b1, ranges, cp));
-        sb.append(replacement);
-        copyFrom = i;
-      } else {
-        i += Character.charCount(cp);
-      }
-    }
-    sb.append(text, copyFrom, len);
-    return sb.toString();
   }
 
   // ---------------------------------------------------------------------------
@@ -512,17 +561,6 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  /** Tests whether a code point belongs to a character class defined by bitmaps and ranges. */
-  private static boolean charClassContains(long b0, long b1, int[] ranges, int cp) {
-    if (cp < 64) {
-      return (b0 & (1L << cp)) != 0;
-    } else if (cp < 128) {
-      return (b1 & (1L << (cp - 64))) != 0;
-    } else {
-      return binarySearchRanges(ranges, cp);
-    }
-  }
-
   /**
    * Attempts to match the entire input sequence against the pattern.
    *
@@ -596,8 +634,7 @@ public final class Matcher implements MatchResult {
     // Character-class fast path: for patterns like [a-zA-Z]+, \d+, \w*, etc.
     int[] ccRanges = parentPattern.charClassMatchRanges();
     if (enginePathOptions().charClassMatchFastPaths() && ccRanges != null) {
-      hasMatch = charClassMatchFastPath(ccRanges);
-      return hasMatch;
+      return charClassMatchFastPath(ccRanges);
     }
 
     Prog prog = parentPattern.prog();
@@ -658,9 +695,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        groups = null;
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       if (regionActive && transparentBounds) {
         return lookingAtTransparentRegion();
@@ -761,7 +796,8 @@ public final class Matcher implements MatchResult {
       searchFrom = groups[1];
       if (groups[0] == groups[1]) { // empty match
         if (searchFrom >= regionEnd) {
-          hasMatch = false;
+          applyEngineResult(new NoMatchResult());
+          updateEndState(MatchOperation.FIND);
           return false;
         }
         searchFrom++;
@@ -831,9 +867,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        groups = null;
-        hasMatch = false;
-        return false;
+        return applyEngineResult(new NoMatchResult());
       }
       if (regionActive && transparentBounds) {
         return doFindTransparentRegion();
@@ -1739,16 +1773,6 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
-    // Character-class fast path: for patterns like \d+, [a-zA-Z]+, etc. with simple
-    // replacement strings (no group references), scan the text in a single pass.
-    int[] ccRanges = parentPattern.charClassMatchRanges();
-    if (enginePathOptions().charClassReplacementFastPath()
-        && ccRanges != null
-        && !parentPattern.charClassMatchAllowEmpty()
-        && isSimpleReplacement(replacement)) {
-      return charClassReplaceAll(ccRanges, replacement);
-    }
-
     // Pre-compile the replacement template once, avoiding per-match parseInt/substring overhead.
     ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
 
@@ -1804,6 +1828,7 @@ public final class Matcher implements MatchResult {
    *     operation failed
    */
   public Matcher appendReplacement(StringBuilder sb, String replacement) {
+    modCount++;
     checkMatch();
     sb.append(text, appendPos, start());
     appendReplacementBody(sb, replacement);
@@ -1834,6 +1859,7 @@ public final class Matcher implements MatchResult {
    *     operation failed
    */
   public Matcher appendReplacement(StringBuffer sb, String replacement) {
+    modCount++;
     checkMatch();
     // Build into a temporary StringBuilder, then transfer to the StringBuffer.
     StringBuilder tmp = new StringBuilder();
@@ -1868,16 +1894,7 @@ public final class Matcher implements MatchResult {
    */
   public Matcher reset() {
     modCount++;
-    this.text = charSequenceToString(inputSequence);
-    regionStart = 0;
-    regionEnd = text.length();
-    searchFrom = 0;
-    appendPos = 0;
-    hasMatch = false;
-    groups = null;
-    capturesResolved = true;
-    groupZeroResolved = true;
-    eagerFallbackCaptures = false;
+    resetStateForCurrentInput();
     return this;
   }
 
@@ -1889,6 +1906,7 @@ public final class Matcher implements MatchResult {
    */
   public Matcher reset(CharSequence input) {
     this.inputSequence = input;
+    invalidateInputDependentCaches();
     return reset();
   }
 
@@ -1916,15 +1934,8 @@ public final class Matcher implements MatchResult {
     if (start > end) {
       throw new IndexOutOfBoundsException("start=" + start + " > end=" + end);
     }
-    regionStart = start;
-    regionEnd = end;
     modCount++;
-    hasMatch = false;
-    searchFrom = start;
-    appendPos = 0;
-    groups = null;
-    capturesResolved = true;
-    groupZeroResolved = true;
+    resetStateForRegion(start, end);
     return this;
   }
 
@@ -2030,25 +2041,17 @@ public final class Matcher implements MatchResult {
     }
     modCount++;
     if (hasMatch && groups != null) {
+      if (!groupZeroResolved) {
+        resolveCaptures();
+      }
       searchFrom = groups[1];
       if (groups[0] == groups[1] && searchFrom < regionEnd) {
         searchFrom++;
       }
     }
     this.parentPattern = newPattern;
-    // Invalidate cached DFA references since they belong to the old pattern.
-    cachedForwardDfa = null;
-    cachedReverseDfa = null;
-    reverseDfaLookedUp = false;
-    // Return borrowed BitState to old pattern if needed.
-    if (bitStateBorrowed && cachedBitState != null) {
-      bitStateBorrowed = false;
-      cachedBitState = null;
-    }
-    hasMatch = false;
-    groups = null;
-    capturesResolved = true;
-    groupZeroResolved = true;
+    invalidatePatternCaches();
+    clearCurrentResult();
     eagerFallbackCaptures = false;
     return this;
   }
@@ -2062,6 +2065,7 @@ public final class Matcher implements MatchResult {
    * @return this matcher
    */
   public Matcher useTransparentBounds(boolean b) {
+    preserveResultAcrossBoundsChange();
     transparentBounds = b;
     return this;
   }
@@ -2084,6 +2088,7 @@ public final class Matcher implements MatchResult {
    * @return this matcher
    */
   public Matcher useAnchoringBounds(boolean b) {
+    preserveResultAcrossBoundsChange();
     anchoringBounds = b;
     return this;
   }
@@ -2159,7 +2164,7 @@ public final class Matcher implements MatchResult {
   }
 
   private void checkMatch() {
-    if (!hasMatch) {
+    if (resultStatus != ResultStatus.MATCHED) {
       throw new IllegalStateException("No match found");
     }
   }
@@ -2185,7 +2190,9 @@ public final class Matcher implements MatchResult {
     }
     boolean endedAtSensitiveEnd = matchEndsAtSensitiveEnd();
     lastRequireEnd = endedAtSensitiveEnd && parentPattern.hasEndConstraint();
-    lastHitEnd = lastRequireEnd || (endedAtSensitiveEnd && matchCanExtendAtEnd(operation));
+    lastHitEnd = lastRequireEnd
+        || (endedAtSensitiveEnd
+            && (parentPattern.hasHitEndConstraint() || matchCanExtendAtEnd(operation)));
   }
 
   private boolean matchEndsAtSensitiveEnd() {

--- a/safere/src/main/java/org/safere/MatcherTransitionInventory.java
+++ b/safere/src/main/java/org/safere/MatcherTransitionInventory.java
@@ -1,0 +1,375 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Package-private inventory of public {@link Matcher} lifecycle transitions.
+ *
+ * <p>The inventory is deliberately close to {@link Matcher} so tests can verify that every public
+ * Matcher method is assigned an explicit state-transition category when the API changes.
+ */
+final class MatcherTransitionInventory {
+  enum ResultEffect {
+    RESET_NO_ATTEMPT,
+    MATCH_ATTEMPT,
+    REQUIRES_MATCH,
+    PRESERVE,
+    STATIC_UTILITY
+  }
+
+  enum DeferredCaptureEffect {
+    CLEAR,
+    MAY_DEFER,
+    RESOLVE_AS_NEEDED,
+    RESOLVE_FOR_SNAPSHOT,
+    RESOLVE_FOR_REPLACEMENT,
+    RESOLVE_BEFORE_BOUNDS_CHANGE,
+    PRESERVE,
+    NONE
+  }
+
+  enum CursorEffect {
+    RESET_TO_INPUT_START,
+    RESET_TO_REGION_START,
+    SET_FROM_ARGUMENT_THEN_SEARCH,
+    DERIVE_FROM_PREVIOUS_RESULT_THEN_SEARCH,
+    PRESERVE,
+    NONE
+  }
+
+  enum ReplacementEffect {
+    RESET_APPEND_POSITION,
+    ADVANCE_APPEND_POSITION,
+    MANAGED_BY_APPEND_OPERATIONS,
+    PRESERVE,
+    NONE
+  }
+
+  enum EndStateEffect {
+    UPDATE_FROM_ATTEMPT,
+    PRESERVE,
+    FOLLOWS_OPERATIONS,
+    NONE
+  }
+
+  enum StructuralMutationEffect {
+    INVALIDATES_ACTIVE_TRAVERSAL,
+    DETECTS_CALLBACK_MUTATION,
+    ORACLE_DEFINED,
+    NOT_STRUCTURAL,
+    NONE
+  }
+
+  enum CacheEffect {
+    INVALIDATE_PATTERN_CACHES,
+    INVALIDATE_INPUT_CACHES,
+    INVALIDATE_REGION_ASSUMPTIONS,
+    PRESERVE,
+    NONE
+  }
+
+  record Signature(String name, List<Class<?>> parameterTypes, boolean isStatic) {
+    Signature(String name, boolean isStatic, Class<?>... parameterTypes) {
+      this(name, List.of(parameterTypes), isStatic);
+    }
+  }
+
+  record Transition(
+      Signature signature,
+      ResultEffect resultEffect,
+      DeferredCaptureEffect deferredCaptureEffect,
+      CursorEffect cursorEffect,
+      ReplacementEffect replacementEffect,
+      EndStateEffect endStateEffect,
+      StructuralMutationEffect structuralMutationEffect,
+      CacheEffect cacheEffect,
+      Set<String> legalObservationGroups) {}
+
+  private static final Set<String> OBSERVER_ONLY = Set.of("observer-only");
+  private static final Set<String> MATCH_RESULT = Set.of("observer-only", "match-result");
+  private static final Set<String> END_STATE_ONLY = Set.of("observer-only", "end-state");
+  private static final Set<String> REPLACEMENT = Set.of("observer-only", "replacement");
+  private static final Set<String> STATIC_UTILITY = Set.of("static-utility");
+
+  private static final List<Transition> TRANSITIONS = List.of(
+      transition(
+          signature("matches"),
+          ResultEffect.MATCH_ATTEMPT,
+          DeferredCaptureEffect.MAY_DEFER,
+          CursorEffect.RESET_TO_REGION_START,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.UPDATE_FROM_ATTEMPT,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.PRESERVE,
+          END_STATE_ONLY),
+      transition(
+          signature("lookingAt"),
+          ResultEffect.MATCH_ATTEMPT,
+          DeferredCaptureEffect.MAY_DEFER,
+          CursorEffect.RESET_TO_REGION_START,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.UPDATE_FROM_ATTEMPT,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.PRESERVE,
+          END_STATE_ONLY),
+      transition(
+          signature("find"),
+          ResultEffect.MATCH_ATTEMPT,
+          DeferredCaptureEffect.MAY_DEFER,
+          CursorEffect.DERIVE_FROM_PREVIOUS_RESULT_THEN_SEARCH,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.UPDATE_FROM_ATTEMPT,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.PRESERVE,
+          END_STATE_ONLY),
+      transition(
+          signature("find", int.class),
+          ResultEffect.MATCH_ATTEMPT,
+          DeferredCaptureEffect.CLEAR,
+          CursorEffect.SET_FROM_ARGUMENT_THEN_SEARCH,
+          ReplacementEffect.RESET_APPEND_POSITION,
+          EndStateEffect.UPDATE_FROM_ATTEMPT,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.PRESERVE,
+          END_STATE_ONLY),
+      transition(
+          signature("results"),
+          ResultEffect.MATCH_ATTEMPT,
+          DeferredCaptureEffect.RESOLVE_FOR_SNAPSHOT,
+          CursorEffect.DERIVE_FROM_PREVIOUS_RESULT_THEN_SEARCH,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.FOLLOWS_OPERATIONS,
+          StructuralMutationEffect.DETECTS_CALLBACK_MUTATION,
+          CacheEffect.PRESERVE,
+          MATCH_RESULT),
+      transition(
+          signature("groupCount"),
+          ResultEffect.PRESERVE,
+          DeferredCaptureEffect.PRESERVE,
+          CursorEffect.PRESERVE,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.PRESERVE,
+          StructuralMutationEffect.NOT_STRUCTURAL,
+          CacheEffect.PRESERVE,
+          OBSERVER_ONLY),
+      matchObserver(signature("group")),
+      matchObserver(signature("group", int.class)),
+      matchObserver(signature("group", String.class)),
+      matchObserver(signature("start")),
+      matchObserver(signature("start", int.class)),
+      matchObserver(signature("start", String.class)),
+      matchObserver(signature("end")),
+      matchObserver(signature("end", int.class)),
+      matchObserver(signature("end", String.class)),
+      transition(
+          staticSignature("quoteReplacement", String.class),
+          ResultEffect.STATIC_UTILITY,
+          DeferredCaptureEffect.NONE,
+          CursorEffect.NONE,
+          ReplacementEffect.NONE,
+          EndStateEffect.NONE,
+          StructuralMutationEffect.NONE,
+          CacheEffect.NONE,
+          STATIC_UTILITY),
+      replacementLoop(signature("replaceFirst", String.class)),
+      replacementLoop(signature("replaceFirst", Function.class)),
+      replacementLoop(signature("replaceAll", String.class)),
+      replacementLoop(signature("replaceAll", Function.class)),
+      appendReplacement(signature("appendReplacement", StringBuilder.class, String.class)),
+      appendTail(signature("appendTail", StringBuilder.class)),
+      appendReplacement(signature("appendReplacement", StringBuffer.class, String.class)),
+      appendTail(signature("appendTail", StringBuffer.class)),
+      transition(
+          signature("reset"),
+          ResultEffect.RESET_NO_ATTEMPT,
+          DeferredCaptureEffect.CLEAR,
+          CursorEffect.RESET_TO_INPUT_START,
+          ReplacementEffect.RESET_APPEND_POSITION,
+          EndStateEffect.PRESERVE,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.PRESERVE,
+          OBSERVER_ONLY),
+      transition(
+          signature("reset", CharSequence.class),
+          ResultEffect.RESET_NO_ATTEMPT,
+          DeferredCaptureEffect.CLEAR,
+          CursorEffect.RESET_TO_INPUT_START,
+          ReplacementEffect.RESET_APPEND_POSITION,
+          EndStateEffect.PRESERVE,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.INVALIDATE_INPUT_CACHES,
+          OBSERVER_ONLY),
+      transition(
+          signature("region", int.class, int.class),
+          ResultEffect.RESET_NO_ATTEMPT,
+          DeferredCaptureEffect.CLEAR,
+          CursorEffect.RESET_TO_REGION_START,
+          ReplacementEffect.RESET_APPEND_POSITION,
+          EndStateEffect.PRESERVE,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.INVALIDATE_REGION_ASSUMPTIONS,
+          OBSERVER_ONLY),
+      observer(signature("regionStart")),
+      observer(signature("regionEnd")),
+      observer(signature("hitEnd")),
+      observer(signature("requireEnd")),
+      observer(signature("namedGroups")),
+      observer(signature("pattern")),
+      observer(signature("toString")),
+      transition(
+          signature("usePattern", Pattern.class),
+          ResultEffect.RESET_NO_ATTEMPT,
+          DeferredCaptureEffect.CLEAR,
+          CursorEffect.DERIVE_FROM_PREVIOUS_RESULT_THEN_SEARCH,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.PRESERVE,
+          StructuralMutationEffect.INVALIDATES_ACTIVE_TRAVERSAL,
+          CacheEffect.INVALIDATE_PATTERN_CACHES,
+          OBSERVER_ONLY),
+      boundsChange(signature("useTransparentBounds", boolean.class)),
+      observer(signature("hasTransparentBounds")),
+      boundsChange(signature("useAnchoringBounds", boolean.class)),
+      observer(signature("hasAnchoringBounds")),
+      transition(
+          signature("toMatchResult"),
+          ResultEffect.REQUIRES_MATCH,
+          DeferredCaptureEffect.RESOLVE_FOR_SNAPSHOT,
+          CursorEffect.PRESERVE,
+          ReplacementEffect.PRESERVE,
+          EndStateEffect.PRESERVE,
+          StructuralMutationEffect.NOT_STRUCTURAL,
+          CacheEffect.PRESERVE,
+          MATCH_RESULT));
+
+  private static final Map<Signature, Transition> BY_SIGNATURE =
+      TRANSITIONS.stream()
+          .collect(java.util.stream.Collectors.toUnmodifiableMap(
+              Transition::signature, transition -> transition));
+
+  private MatcherTransitionInventory() {}
+
+  static List<Transition> transitions() {
+    return TRANSITIONS;
+  }
+
+  static Optional<Transition> transitionFor(Signature signature) {
+    return Optional.ofNullable(BY_SIGNATURE.get(signature));
+  }
+
+  private static Signature signature(String name, Class<?>... parameterTypes) {
+    return new Signature(name, false, parameterTypes);
+  }
+
+  private static Signature staticSignature(String name, Class<?>... parameterTypes) {
+    return new Signature(name, true, parameterTypes);
+  }
+
+  private static Transition observer(Signature signature) {
+    return transition(
+        signature,
+        ResultEffect.PRESERVE,
+        DeferredCaptureEffect.PRESERVE,
+        CursorEffect.PRESERVE,
+        ReplacementEffect.PRESERVE,
+        EndStateEffect.PRESERVE,
+        StructuralMutationEffect.NOT_STRUCTURAL,
+        CacheEffect.PRESERVE,
+        OBSERVER_ONLY);
+  }
+
+  private static Transition matchObserver(Signature signature) {
+    return transition(
+        signature,
+        ResultEffect.REQUIRES_MATCH,
+        DeferredCaptureEffect.RESOLVE_AS_NEEDED,
+        CursorEffect.PRESERVE,
+        ReplacementEffect.PRESERVE,
+        EndStateEffect.PRESERVE,
+        StructuralMutationEffect.NOT_STRUCTURAL,
+        CacheEffect.PRESERVE,
+        MATCH_RESULT);
+  }
+
+  private static Transition replacementLoop(Signature signature) {
+    return transition(
+        signature,
+        ResultEffect.RESET_NO_ATTEMPT,
+        DeferredCaptureEffect.MAY_DEFER,
+        CursorEffect.DERIVE_FROM_PREVIOUS_RESULT_THEN_SEARCH,
+        ReplacementEffect.MANAGED_BY_APPEND_OPERATIONS,
+        EndStateEffect.FOLLOWS_OPERATIONS,
+        StructuralMutationEffect.DETECTS_CALLBACK_MUTATION,
+        CacheEffect.PRESERVE,
+        REPLACEMENT);
+  }
+
+  private static Transition appendReplacement(Signature signature) {
+    return transition(
+        signature,
+        ResultEffect.REQUIRES_MATCH,
+        DeferredCaptureEffect.RESOLVE_FOR_REPLACEMENT,
+        CursorEffect.PRESERVE,
+        ReplacementEffect.ADVANCE_APPEND_POSITION,
+        EndStateEffect.PRESERVE,
+        StructuralMutationEffect.ORACLE_DEFINED,
+        CacheEffect.PRESERVE,
+        REPLACEMENT);
+  }
+
+  private static Transition appendTail(Signature signature) {
+    return transition(
+        signature,
+        ResultEffect.PRESERVE,
+        DeferredCaptureEffect.PRESERVE,
+        CursorEffect.PRESERVE,
+        ReplacementEffect.PRESERVE,
+        EndStateEffect.PRESERVE,
+        StructuralMutationEffect.ORACLE_DEFINED,
+        CacheEffect.PRESERVE,
+        REPLACEMENT);
+  }
+
+  private static Transition boundsChange(Signature signature) {
+    return transition(
+        signature,
+        ResultEffect.PRESERVE,
+        DeferredCaptureEffect.RESOLVE_BEFORE_BOUNDS_CHANGE,
+        CursorEffect.PRESERVE,
+        ReplacementEffect.PRESERVE,
+        EndStateEffect.PRESERVE,
+        StructuralMutationEffect.ORACLE_DEFINED,
+        CacheEffect.INVALIDATE_REGION_ASSUMPTIONS,
+        OBSERVER_ONLY);
+  }
+
+  private static Transition transition(
+      Signature signature,
+      ResultEffect resultEffect,
+      DeferredCaptureEffect deferredCaptureEffect,
+      CursorEffect cursorEffect,
+      ReplacementEffect replacementEffect,
+      EndStateEffect endStateEffect,
+      StructuralMutationEffect structuralMutationEffect,
+      CacheEffect cacheEffect,
+      Set<String> legalObservationGroups) {
+    return new Transition(
+        signature,
+        resultEffect,
+        deferredCaptureEffect,
+        cursorEffect,
+        replacementEffect,
+        endStateEffect,
+        structuralMutationEffect,
+        cacheEffect,
+        legalObservationGroups);
+  }
+}

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -108,6 +108,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasBoundedRepeat;
   private final transient boolean hasAnchorInQuant;
   private final transient boolean hasEndConstraint;
+  private final transient boolean hasHitEndConstraint;
   private final transient boolean[] charClassPrefixAscii;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
@@ -187,8 +188,8 @@ public final class Pattern implements Serializable {
       String literalMatch, boolean hasLazy, boolean hasAlternation,
       boolean hasNullableAlternation,
       boolean hasBoundedRepeat, boolean hasAnchorInQuant, boolean hasEndConstraint,
-      boolean[] charClassPrefixAscii, StartAcceleration startAcceleration,
-      KeywordAlternation keywordAlternation,
+      boolean hasHitEndConstraint, boolean[] charClassPrefixAscii,
+      StartAcceleration startAcceleration, KeywordAlternation keywordAlternation,
       int[] charClassMatchRanges, long charClassMatchBitmap0, long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty, EnginePathOptions enginePathOptions) {
     this.pattern = pattern;
@@ -205,6 +206,7 @@ public final class Pattern implements Serializable {
     this.hasBoundedRepeat = hasBoundedRepeat;
     this.hasAnchorInQuant = hasAnchorInQuant;
     this.hasEndConstraint = hasEndConstraint;
+    this.hasHitEndConstraint = hasHitEndConstraint;
     this.charClassPrefixAscii = charClassPrefixAscii;
     this.startAcceleration = startAcceleration;
     this.keywordAlternation = keywordAlternation;
@@ -268,6 +270,7 @@ public final class Pattern implements Serializable {
     boolean hasBounded = hasBoundedRepeat(re);
     boolean hasAnchorQuant = hasAnchorInQuantifier(re);
     boolean hasEndConst = hasEndConstraint(re);
+    boolean hasHitEndConst = hasHitEndConstraint(re);
     // Extract character-class prefix for acceleration when no literal prefix exists.
     boolean[] ccPrefixAscii = (prefix == null)
         ? extractCharClassPrefixAscii(metadataAst) : null;
@@ -279,7 +282,7 @@ public final class Pattern implements Serializable {
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(regex, effectiveFlags, compiled, re, named, prefix, prefixFoldCase,
         literalMatch, hasLazy, hasAlt, hasNullableAlt, hasBounded, hasAnchorQuant,
-        hasEndConst, ccPrefixAscii, startAcceleration, keywordAlternation,
+        hasEndConst, hasHitEndConst, ccPrefixAscii, startAcceleration, keywordAlternation,
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
@@ -889,6 +892,14 @@ public final class Pattern implements Serializable {
     return hasEndConstraint;
   }
 
+  /**
+   * Returns {@code true} if the pattern contains an assertion that observes the end of the input
+   * for {@link Matcher#hitEnd()} purposes.
+   */
+  boolean hasHitEndConstraint() {
+    return hasHitEndConstraint;
+  }
+
   // ---------------------------------------------------------------------------
   // Flag mapping
   // ---------------------------------------------------------------------------
@@ -1144,6 +1155,24 @@ public final class Pattern implements Serializable {
             return true;
           }
         }
+        default -> {}
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasHitEndConstraint(Regexp re) {
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      switch (node.op) {
+        case END_LINE, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY -> { return true; }
         default -> {}
       }
       if (node.subs != null) {

--- a/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
+++ b/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
@@ -1,0 +1,134 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests internal deferred-capture lifecycle invariants for {@link Matcher}. */
+@DisabledForCrosscheck("uses package-private reflection to assert SafeRE matcher internals")
+class MatcherDeferredCaptureStateTest {
+  private static final Pattern DEFERRED_CAPTURE_PATTERN =
+      Pattern.compile("(?m)(?:^|,)(?:\"([^\"]*)\"|([^,\r\n]+))");
+  private static final String CSV = "id,name\n42,\"Ada Lovelace\"";
+
+  @Test
+  @DisplayName("reset clears stale deferred captures")
+  void resetClearsStaleDeferredCaptures() throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    matcher.reset();
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("reset(input) clears stale deferred captures")
+  void resetInputClearsStaleDeferredCaptures() throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    matcher.reset("name");
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("region clears stale deferred captures")
+  void regionClearsStaleDeferredCaptures() throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    matcher.region(0, 2);
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("failed find(start) clears stale deferred captures")
+  void failedFindStartClearsStaleDeferredCaptures() throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    assertThat(matcher.find(CSV.length())).isFalse();
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("usePattern clears stale deferred captures")
+  void usePatternClearsStaleDeferredCaptures() throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    matcher.usePattern(Pattern.compile("name"));
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("anchoring bounds change resolves stale deferred captures before clearing markers")
+  void anchoringBoundsChangeResolvesStaleDeferredCapturesBeforeClearingMarkers()
+      throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    matcher.useAnchoringBounds(false);
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThat(matcher.group(1)).isNull();
+    assertThat(matcher.group(2)).isEqualTo("id");
+  }
+
+  @Test
+  @DisplayName("transparent bounds change resolves stale deferred captures before clearing markers")
+  void transparentBoundsChangeResolvesStaleDeferredCapturesBeforeClearingMarkers()
+      throws ReflectiveOperationException {
+    Matcher matcher = matcherWithDeferredCaptures();
+
+    matcher.useTransparentBounds(true);
+
+    assertDeferredCaptureStateClear(matcher);
+    assertThat(matcher.group(1)).isNull();
+    assertThat(matcher.group(2)).isEqualTo("id");
+  }
+
+  private static Matcher matcherWithDeferredCaptures() throws ReflectiveOperationException {
+    Matcher matcher = DEFERRED_CAPTURE_PATTERN.matcher(CSV);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group()).isEqualTo("id");
+    assertThat(booleanField(matcher, "capturesResolved")).isFalse();
+    return matcher;
+  }
+
+  private static void assertDeferredCaptureStateClear(Matcher matcher)
+      throws ReflectiveOperationException {
+    assertThat(booleanField(matcher, "capturesResolved")).isTrue();
+    assertThat(booleanField(matcher, "groupZeroResolved")).isTrue();
+    assertThat(intField(matcher, "deferredMatchStart")).isZero();
+    assertThat(intField(matcher, "deferredMatchEnd")).isZero();
+    assertThat(booleanField(matcher, "deferredEndMatch")).isFalse();
+  }
+
+  private static boolean booleanField(Matcher matcher, String name)
+      throws ReflectiveOperationException {
+    return (boolean) field(name).get(matcher);
+  }
+
+  private static int intField(Matcher matcher, String name) throws ReflectiveOperationException {
+    return (int) field(name).get(matcher);
+  }
+
+  private static Field field(String name) throws ReflectiveOperationException {
+    Field field = Matcher.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field;
+  }
+}

--- a/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
+++ b/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
@@ -1,0 +1,749 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Trace-based lifecycle tests for {@link Matcher}. */
+@DisabledForCrosscheck("this test is itself a SafeRE-vs-JDK lifecycle crosscheck")
+class MatcherStateMachineTraceTest {
+
+  @Test
+  @DisplayName("failed matches() leaves the next find() sequence JDK-compatible")
+  void failedMatchesLeavesNextFindSequenceJdkCompatible() {
+    assertTrace("a", "ba",
+        Step.matches(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.group(),
+        Step.start(),
+        Step.end(),
+        Step.find());
+  }
+
+  @Test
+  @DisplayName("failed lookingAt() leaves the next find() sequence JDK-compatible")
+  void failedLookingAtLeavesNextFindSequenceJdkCompatible() {
+    assertTrace("a", "ba",
+        Step.lookingAt(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.group(),
+        Step.start(),
+        Step.end(),
+        Step.find());
+  }
+
+  @Test
+  @DisplayName("empty matches advance the following find() sequence like the JDK")
+  void emptyMatchesAdvanceFollowingFindSequenceLikeJdk() {
+    assertTrace("a*", "ba",
+        Step.find(),
+        Step.group(),
+        Step.find(),
+        Step.group(),
+        Step.find(),
+        Step.group(),
+        Step.find());
+  }
+
+  @Test
+  @DisplayName("find(int) resets region and append position before searching")
+  void findStartResetsRegionAndAppendPositionBeforeSearching() {
+    assertTrace("\\d+", "xx11yy22",
+        Step.region(2, 4),
+        Step.find(),
+        Step.appendReplacement("[$0]"),
+        Step.findFrom(6),
+        Step.regionStart(),
+        Step.regionEnd(),
+        Step.appendReplacement("[$0]"),
+        Step.appendTail());
+  }
+
+  @Test
+  @DisplayName("usePattern preserves the JDK-compatible next search position")
+  void usePatternPreservesJdkCompatibleNextSearchPosition() {
+    assertTrace("a*", "ba",
+        Step.find(),
+        Step.group(),
+        Step.usePattern("."),
+        Step.find(),
+        Step.group(),
+        Step.find(),
+        Step.group());
+  }
+
+  @Test
+  @DisplayName("bounds changes preserve observable match data")
+  void boundsChangesPreserveObservableMatchData() {
+    assertTrace("(a+)", "xxaaaa",
+        Step.region(2, 6),
+        Step.find(),
+        Step.useAnchoringBounds(false),
+        Step.group(1),
+        Step.toMatchResult(),
+        Step.useTransparentBounds(true),
+        Step.start(1),
+        Step.end(1));
+  }
+
+  @Test
+  @DisplayName("reset and region preserve end-state flags until the next match attempt")
+  void resetAndRegionPreserveEndStateUntilNextAttempt() {
+    assertTrace("a+$", "aaa",
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.reset(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.region(0, 2),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd());
+  }
+
+  @Test
+  @DisplayName("end-state traces match the JDK across anchors, regions, and resets")
+  void endStateTracesMatchJdkAcrossAnchorsRegionsAndResets() {
+    assertEndStateTrace("a$", "a");
+    assertEndStateTrace("a\\Z", "a");
+    assertEndStateTrace("a\\z", "a");
+    assertEndStateTrace("a\\b", "a");
+    assertEndStateTrace("(?m)^b$", "a\r\nb");
+  }
+
+  @Test
+  @DisplayName("structural mutations during results() traversal match the JDK")
+  void structuralMutationsDuringResultsTraversalMatchJdk() {
+    for (Mutation mutation : structuralMutations()) {
+      String safere = runResultsMutationTrace(mutation, false);
+      String jdk = runResultsMutationTrace(mutation, true);
+
+      assertThat(safere).as(mutation.name()).isEqualTo(jdk);
+    }
+  }
+
+  @Test
+  @DisplayName("structural mutations during functional replacement match the JDK")
+  void structuralMutationsDuringFunctionalReplacementMatchJdk() {
+    for (Mutation mutation : structuralMutations()) {
+      String safereAll = runFunctionalReplacementMutationTrace(mutation, false, false);
+      String jdkAll = runFunctionalReplacementMutationTrace(mutation, true, false);
+      String safereFirst = runFunctionalReplacementMutationTrace(mutation, false, true);
+      String jdkFirst = runFunctionalReplacementMutationTrace(mutation, true, true);
+
+      assertThat(safereAll).as("replaceAll %s", mutation.name()).isEqualTo(jdkAll);
+      assertThat(safereFirst).as("replaceFirst %s", mutation.name()).isEqualTo(jdkFirst);
+    }
+  }
+
+  private static void assertEndStateTrace(String regex, String input) {
+    assertTrace(regex, input,
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.reset(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.region(0, input.length()),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.useAnchoringBounds(false),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd());
+  }
+
+  private static List<Mutation> structuralMutations() {
+    return List.of(
+        new Mutation(
+            "useTransparentBounds(true)",
+            subject -> subject.useTransparentBounds(true)),
+        new Mutation(
+            "useTransparentBounds(false)",
+            subject -> subject.useTransparentBounds(false)),
+        new Mutation(
+            "useAnchoringBounds(true)",
+            subject -> subject.useAnchoringBounds(true)),
+        new Mutation(
+            "useAnchoringBounds(false)",
+            subject -> subject.useAnchoringBounds(false)),
+        new Mutation(
+            "appendReplacement",
+            subject -> subject.appendReplacement(new StringBuilder(), "x")),
+        new Mutation(
+            "appendTail",
+            subject -> subject.appendTail(new StringBuilder())));
+  }
+
+  private static String runResultsMutationTrace(Mutation mutation, boolean jdk) {
+    TraceSubject subject = traceSubject("a", "aa", jdk);
+    try {
+      List<String> groups =
+          subject.resultsWithMutation(mutation).collect(Collectors.toList());
+      return "ok:" + groups;
+    } catch (RuntimeException e) {
+      return "throws " + e.getClass().getSimpleName();
+    }
+  }
+
+  private static String runFunctionalReplacementMutationTrace(
+      Mutation mutation, boolean jdk, boolean first) {
+    TraceSubject subject = traceSubject("a", "aa", jdk);
+    try {
+      String replaced = first
+          ? subject.replaceFirstWithMutation(mutation)
+          : subject.replaceAllWithMutation(mutation);
+      return "ok:" + replaced;
+    } catch (RuntimeException e) {
+      return "throws " + e.getClass().getSimpleName();
+    }
+  }
+
+  private static TraceSubject traceSubject(String regex, String input, boolean jdk) {
+    if (jdk) {
+      return new JdkSubject(java.util.regex.Pattern.compile(regex).matcher(input));
+    }
+    return new SafeReSubject(Pattern.compile(regex).matcher(input));
+  }
+
+  private static void assertTrace(String regex, String input, Step... steps) {
+    TraceSubject safere = new SafeReSubject(Pattern.compile(regex).matcher(input));
+    TraceSubject jdk =
+        new JdkSubject(java.util.regex.Pattern.compile(regex).matcher(input));
+
+    List<String> safereTrace = trace(safere, steps);
+    List<String> jdkTrace = trace(jdk, steps);
+
+    assertThat(safereTrace)
+        .as("trace for /%s/ on %s", regex, input)
+        .isEqualTo(jdkTrace);
+  }
+
+  private static List<String> trace(TraceSubject subject, Step... steps) {
+    List<String> events = new ArrayList<>();
+    for (Step step : steps) {
+      events.add(step.apply(subject));
+    }
+    return events;
+  }
+
+  private interface TraceSubject {
+    boolean matches();
+
+    boolean lookingAt();
+
+    boolean find();
+
+    boolean find(int start);
+
+    String group();
+
+    String group(int group);
+
+    int start();
+
+    int start(int group);
+
+    int end();
+
+    int end(int group);
+
+    boolean hitEnd();
+
+    boolean requireEnd();
+
+    void reset();
+
+    void region(int start, int end);
+
+    int regionStart();
+
+    int regionEnd();
+
+    void usePattern(String regex);
+
+    void useAnchoringBounds(boolean value);
+
+    void useTransparentBounds(boolean value);
+
+    MatchResult toMatchResult();
+
+    void appendReplacement(StringBuilder builder, String replacement);
+
+    void appendTail(StringBuilder builder);
+
+    java.util.stream.Stream<String> resultsWithMutation(Mutation mutation);
+
+    String replaceAllWithMutation(Mutation mutation);
+
+    String replaceFirstWithMutation(Mutation mutation);
+  }
+
+  private static final class SafeReSubject implements TraceSubject {
+    private Matcher matcher;
+
+    SafeReSubject(Matcher matcher) {
+      this.matcher = matcher;
+    }
+
+    @Override
+    public boolean matches() {
+      return matcher.matches();
+    }
+
+    @Override
+    public boolean lookingAt() {
+      return matcher.lookingAt();
+    }
+
+    @Override
+    public boolean find() {
+      return matcher.find();
+    }
+
+    @Override
+    public boolean find(int start) {
+      return matcher.find(start);
+    }
+
+    @Override
+    public String group() {
+      return matcher.group();
+    }
+
+    @Override
+    public String group(int group) {
+      return matcher.group(group);
+    }
+
+    @Override
+    public int start() {
+      return matcher.start();
+    }
+
+    @Override
+    public int start(int group) {
+      return matcher.start(group);
+    }
+
+    @Override
+    public int end() {
+      return matcher.end();
+    }
+
+    @Override
+    public int end(int group) {
+      return matcher.end(group);
+    }
+
+    @Override
+    public boolean hitEnd() {
+      return matcher.hitEnd();
+    }
+
+    @Override
+    public boolean requireEnd() {
+      return matcher.requireEnd();
+    }
+
+    @Override
+    public void reset() {
+      matcher.reset();
+    }
+
+    @Override
+    public void region(int start, int end) {
+      matcher.region(start, end);
+    }
+
+    @Override
+    public int regionStart() {
+      return matcher.regionStart();
+    }
+
+    @Override
+    public int regionEnd() {
+      return matcher.regionEnd();
+    }
+
+    @Override
+    public void usePattern(String regex) {
+      matcher.usePattern(Pattern.compile(regex));
+    }
+
+    @Override
+    public void useAnchoringBounds(boolean value) {
+      matcher.useAnchoringBounds(value);
+    }
+
+    @Override
+    public void useTransparentBounds(boolean value) {
+      matcher.useTransparentBounds(value);
+    }
+
+    @Override
+    public MatchResult toMatchResult() {
+      return matcher.toMatchResult();
+    }
+
+    @Override
+    public void appendReplacement(StringBuilder builder, String replacement) {
+      matcher.appendReplacement(builder, replacement);
+    }
+
+    @Override
+    public void appendTail(StringBuilder builder) {
+      matcher.appendTail(builder);
+    }
+
+    @Override
+    public java.util.stream.Stream<String> resultsWithMutation(Mutation mutation) {
+      return matcher.results()
+          .map(
+              result -> {
+                mutation.apply(this);
+                return result.group();
+              });
+    }
+
+    @Override
+    public String replaceAllWithMutation(Mutation mutation) {
+      return matcher.replaceAll(
+          result -> {
+            mutation.apply(this);
+            return "x";
+          });
+    }
+
+    @Override
+    public String replaceFirstWithMutation(Mutation mutation) {
+      return matcher.replaceFirst(
+          result -> {
+            mutation.apply(this);
+            return "x";
+          });
+    }
+  }
+
+  private static final class JdkSubject implements TraceSubject {
+    private java.util.regex.Matcher matcher;
+
+    JdkSubject(java.util.regex.Matcher matcher) {
+      this.matcher = matcher;
+    }
+
+    @Override
+    public boolean matches() {
+      return matcher.matches();
+    }
+
+    @Override
+    public boolean lookingAt() {
+      return matcher.lookingAt();
+    }
+
+    @Override
+    public boolean find() {
+      return matcher.find();
+    }
+
+    @Override
+    public boolean find(int start) {
+      return matcher.find(start);
+    }
+
+    @Override
+    public String group() {
+      return matcher.group();
+    }
+
+    @Override
+    public String group(int group) {
+      return matcher.group(group);
+    }
+
+    @Override
+    public int start() {
+      return matcher.start();
+    }
+
+    @Override
+    public int start(int group) {
+      return matcher.start(group);
+    }
+
+    @Override
+    public int end() {
+      return matcher.end();
+    }
+
+    @Override
+    public int end(int group) {
+      return matcher.end(group);
+    }
+
+    @Override
+    public boolean hitEnd() {
+      return matcher.hitEnd();
+    }
+
+    @Override
+    public boolean requireEnd() {
+      return matcher.requireEnd();
+    }
+
+    @Override
+    public void reset() {
+      matcher.reset();
+    }
+
+    @Override
+    public void region(int start, int end) {
+      matcher.region(start, end);
+    }
+
+    @Override
+    public int regionStart() {
+      return matcher.regionStart();
+    }
+
+    @Override
+    public int regionEnd() {
+      return matcher.regionEnd();
+    }
+
+    @Override
+    public void usePattern(String regex) {
+      matcher.usePattern(java.util.regex.Pattern.compile(regex));
+    }
+
+    @Override
+    public void useAnchoringBounds(boolean value) {
+      matcher.useAnchoringBounds(value);
+    }
+
+    @Override
+    public void useTransparentBounds(boolean value) {
+      matcher.useTransparentBounds(value);
+    }
+
+    @Override
+    public MatchResult toMatchResult() {
+      return matcher.toMatchResult();
+    }
+
+    @Override
+    public void appendReplacement(StringBuilder builder, String replacement) {
+      matcher.appendReplacement(builder, replacement);
+    }
+
+    @Override
+    public void appendTail(StringBuilder builder) {
+      matcher.appendTail(builder);
+    }
+
+    @Override
+    public java.util.stream.Stream<String> resultsWithMutation(Mutation mutation) {
+      return matcher.results()
+          .map(
+              result -> {
+                mutation.apply(this);
+                return result.group();
+              });
+    }
+
+    @Override
+    public String replaceAllWithMutation(Mutation mutation) {
+      return matcher.replaceAll(
+          result -> {
+            mutation.apply(this);
+            return "x";
+          });
+    }
+
+    @Override
+    public String replaceFirstWithMutation(Mutation mutation) {
+      return matcher.replaceFirst(
+          result -> {
+            mutation.apply(this);
+            return "x";
+          });
+    }
+  }
+
+  private record Mutation(String name, Effect effect) {
+    void apply(TraceSubject subject) {
+      effect.apply(subject);
+    }
+  }
+
+  private record Step(String name, Operation operation) {
+    static Step matches() {
+      return value("matches", subject -> subject.matches());
+    }
+
+    static Step lookingAt() {
+      return value("lookingAt", subject -> subject.lookingAt());
+    }
+
+    static Step find() {
+      return value("find", subject -> subject.find());
+    }
+
+    static Step findFrom(int start) {
+      return value("find(" + start + ")", subject -> subject.find(start));
+    }
+
+    static Step group() {
+      return value("group", subject -> subject.group());
+    }
+
+    static Step group(int group) {
+      return value("group(" + group + ")", subject -> subject.group(group));
+    }
+
+    static Step start() {
+      return value("start", subject -> subject.start());
+    }
+
+    static Step start(int group) {
+      return value("start(" + group + ")", subject -> subject.start(group));
+    }
+
+    static Step end() {
+      return value("end", subject -> subject.end());
+    }
+
+    static Step end(int group) {
+      return value("end(" + group + ")", subject -> subject.end(group));
+    }
+
+    static Step hitEnd() {
+      return value("hitEnd", subject -> subject.hitEnd());
+    }
+
+    static Step requireEnd() {
+      return value("requireEnd", subject -> subject.requireEnd());
+    }
+
+    static Step reset() {
+      return effect("reset", TraceSubject::reset);
+    }
+
+    static Step region(int start, int end) {
+      return effect("region(" + start + "," + end + ")", subject -> subject.region(start, end));
+    }
+
+    static Step regionStart() {
+      return value("regionStart", subject -> subject.regionStart());
+    }
+
+    static Step regionEnd() {
+      return value("regionEnd", subject -> subject.regionEnd());
+    }
+
+    static Step usePattern(String regex) {
+      return effect("usePattern(" + regex + ")", subject -> subject.usePattern(regex));
+    }
+
+    static Step useAnchoringBounds(boolean value) {
+      return effect(
+          "useAnchoringBounds(" + value + ")",
+          subject -> subject.useAnchoringBounds(value));
+    }
+
+    static Step useTransparentBounds(boolean value) {
+      return effect(
+          "useTransparentBounds(" + value + ")",
+          subject -> subject.useTransparentBounds(value));
+    }
+
+    static Step toMatchResult() {
+      return value("toMatchResult", subject -> snapshot(subject.toMatchResult()));
+    }
+
+    static Step appendReplacement(String replacement) {
+      return new Step(
+          "appendReplacement(" + replacement + ")",
+          subject -> {
+            StringBuilder builder = new StringBuilder();
+            subject.appendReplacement(builder, replacement);
+            return builder.toString();
+          });
+    }
+
+    static Step appendTail() {
+      return new Step(
+          "appendTail",
+          subject -> {
+            StringBuilder builder = new StringBuilder();
+            subject.appendTail(builder);
+            return builder.toString();
+          });
+    }
+
+    String apply(TraceSubject subject) {
+      try {
+        return name + "=" + operation.apply(subject);
+      } catch (RuntimeException e) {
+        return name + " throws " + e.getClass().getSimpleName();
+      }
+    }
+
+    private static Step value(String name, Operation operation) {
+      return new Step(name, operation);
+    }
+
+    private static Step effect(String name, Effect effect) {
+      return new Step(
+          name,
+          subject -> {
+            effect.apply(subject);
+            return "ok";
+          });
+    }
+
+    private static String snapshot(MatchResult result) {
+      List<String> groups = new ArrayList<>();
+      for (int group = 0; group <= result.groupCount(); group++) {
+        try {
+          groups.add(group + ":" + result.start(group) + "-" + result.end(group)
+              + "=" + result.group(group));
+        } catch (RuntimeException e) {
+          groups.add(group + ":throws " + e.getClass().getSimpleName());
+        }
+      }
+      return groups.toString();
+    }
+  }
+
+  private interface Operation {
+    Object apply(TraceSubject subject);
+  }
+
+  private interface Effect {
+    void apply(TraceSubject subject);
+  }
+}

--- a/safere/src/test/java/org/safere/MatcherTransitionInventoryTest.java
+++ b/safere/src/test/java/org/safere/MatcherTransitionInventoryTest.java
@@ -1,0 +1,99 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the package-private matcher transition inventory. */
+@DisabledForCrosscheck("package-private Matcher transition metadata is SafeRE-internal")
+class MatcherTransitionInventoryTest {
+
+  @Test
+  @DisplayName("transition inventory covers every public Matcher method")
+  void transitionInventoryCoversPublicMatcherMethods() {
+    Set<MatcherTransitionInventory.Signature> actualPublicMethods =
+        Arrays.stream(Matcher.class.getDeclaredMethods())
+            .filter(method -> Modifier.isPublic(method.getModifiers()))
+            .filter(method -> !method.isBridge())
+            .filter(method -> !method.isSynthetic())
+            .map(MatcherTransitionInventoryTest::signature)
+            .collect(Collectors.toSet());
+
+    Set<MatcherTransitionInventory.Signature> inventoriedMethods =
+        MatcherTransitionInventory.transitions().stream()
+            .map(MatcherTransitionInventory.Transition::signature)
+            .collect(Collectors.toSet());
+
+    assertThat(formatMissing(actualPublicMethods, inventoriedMethods))
+        .as("public Matcher methods missing transition metadata")
+        .isEmpty();
+    assertThat(formatMissing(inventoriedMethods, actualPublicMethods))
+        .as("transition metadata entries with no public Matcher method")
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("public instance transitions declare deferred capture behavior")
+  void publicInstanceTransitionsDeclareDeferredCaptureBehavior() {
+    assertThat(MatcherTransitionInventory.transitions())
+        .filteredOn(transition -> !transition.signature().isStatic())
+        .allSatisfy(transition ->
+            assertThat(transition.deferredCaptureEffect())
+                .as("%s", format(transition.signature()))
+                .isNotNull()
+                .isNotEqualTo(MatcherTransitionInventory.DeferredCaptureEffect.NONE));
+  }
+
+  @Test
+  @DisplayName("static utility transitions are explicitly non-stateful")
+  void staticUtilityTransitionsAreExplicitlyNonStateful() {
+    MatcherTransitionInventory.Transition quoteReplacement =
+        MatcherTransitionInventory.transitionFor(
+                new MatcherTransitionInventory.Signature(
+                    "quoteReplacement", List.of(String.class), true))
+            .orElseThrow();
+
+    assertThat(quoteReplacement.resultEffect())
+        .isEqualTo(MatcherTransitionInventory.ResultEffect.STATIC_UTILITY);
+    assertThat(quoteReplacement.deferredCaptureEffect())
+        .isEqualTo(MatcherTransitionInventory.DeferredCaptureEffect.NONE);
+  }
+
+  private static MatcherTransitionInventory.Signature signature(Method method) {
+    return new MatcherTransitionInventory.Signature(
+        method.getName(),
+        List.of(method.getParameterTypes()),
+        Modifier.isStatic(method.getModifiers()));
+  }
+
+  private static List<String> formatMissing(
+      Set<MatcherTransitionInventory.Signature> expected,
+      Set<MatcherTransitionInventory.Signature> actual) {
+    return expected.stream()
+        .filter(signature -> !actual.contains(signature))
+        .map(MatcherTransitionInventoryTest::format)
+        .sorted(Comparator.naturalOrder())
+        .toList();
+  }
+
+  private static String format(MatcherTransitionInventory.Signature signature) {
+    String params = signature.parameterTypes().stream()
+        .map(Class::getSimpleName)
+        .collect(Collectors.joining(", "));
+    String prefix = signature.isStatic() ? "static " : "";
+    return prefix + signature.name() + "(" + params + ")";
+  }
+}


### PR DESCRIPTION
## Summary

- add the matcher state-machine design doc and link it from the semantic invariants umbrella
- centralize Matcher lifecycle state transitions for results, deferred captures, search/reset state, replacement state, and cache invalidation
- add a package-private transition inventory covering public Matcher APIs
- add JDK trace tests for matcher lifecycle, structural mutation behavior, end-state flags, and stale deferred-capture cleanup
- align appendReplacement mutation detection and hitEnd behavior for end-sensitive assertions with java.util.regex

## Testing

- `mvn -pl safere -Dtest=MatcherStateMachineTraceTest,MatcherDeferredCaptureStateTest,MatcherTransitionInventoryTest test`
- `mvn -pl safere -DskipTests compile`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
- `git diff --check`
