### PR TITLE
Define parser dialect compatibility policy

### DIFF
--- a/design/PARSER_DIALECT_COMPATIBILITY.md
+++ b/design/PARSER_DIALECT_COMPATIBILITY.md
@@ -1,0 +1,252 @@
+# Parser Dialect Compatibility Design
+
+## Problem
+
+SafeRE aims to be a drop-in replacement for `java.util.regex.Pattern`, while
+using a parser lineage that came from RE2.  That creates a recurring risk:
+source syntax can be parsed according to the wrong dialect before any matching
+engine runs.
+
+This matters because parser mistakes are silent semantic bugs.  A pattern can
+compile successfully, but mean something different from the JDK.  Users then
+observe wrong matches even though the matching engines are behaving correctly
+for the AST they were given.
+
+Recent bugs show the class:
+
+- #216: POSIX bracket spellings such as `[[:lower:]]` were interpreted with
+  RE2/POSIX semantics instead of JDK character-class text semantics.
+- #217: `(?P<name>...)` was accepted even though the JDK named-capture spelling
+  is `(?<name>...)`.
+- #220: empty left-side character-class intersections such as `[&&abc]` and
+  `[a&&&&b]` diverged from the JDK.
+- #224: octal escape acceptance and interpretation drifted from
+  `java.util.regex`.
+
+The common problem is not any one syntax feature.  It is the absence of an
+explicit dialect policy that every parser feature must pass through.
+
+This design does not claim that SafeRE can prove complete equivalence with the
+JDK parser.  The JDK parser is not exposed as a formal grammar or structured
+oracle, and some edge behavior is only observable by compiling and matching
+examples.  The achievable contract is an engineering one: every known syntax
+family has an explicit policy, and that policy is backed by compile/error and
+membership tests against `java.util.regex`.
+
+## Design Principle
+
+SafeRE should not have regex syntax extensions in `Pattern.compile`.
+
+SafeRE-only public APIs such as `PatternSet` are fine.  The regex language
+accepted by `Pattern.compile` should follow one of two policies:
+
+- **JDK-compatible:** SafeRE accepts the syntax and gives it the same
+  membership, capture, flag, and compile/reject behavior as `java.util.regex`,
+  subject to documented linear-time rejections.
+- **Rejected:** SafeRE rejects the syntax because the JDK rejects it, or because
+  supporting it would violate SafeRE's linear-time guarantee.
+
+There should not be a third implicit category of "accepted because RE2 accepts
+it" or "accepted because it was easy to parse."  RE2 source compatibility is a
+source of implementation ideas, not a product dialect.
+
+## Current State
+
+SafeRE already has significant JDK syntax coverage:
+
+- `JdkSyntaxCompatibilityTest` is organized around JDK `Pattern` syntax
+  families.
+- Generated public API crosscheck exercises many compiled patterns through
+  both SafeRE and the JDK.
+- Unicode property tests compare SafeRE's property spellings and membership
+  against the running JDK.
+- Unsupported non-regular features such as backreferences and lookaround are
+  rejected rather than emulated.
+- The recent bugs in this design's scope are closed with focused regression
+  coverage.
+
+The weak point is that the policy is still mostly encoded in tests and parser
+branches.  There is no central compatibility matrix that tells a future parser
+change which dialect owns a spelling, which spellings are deliberately
+rejected, and which membership tests must be run before a change is safe.
+
+## Dialect Policy
+
+The parser should classify every syntax feature into one explicit category.
+
+| Category | Meaning | Examples |
+| --- | --- | --- |
+| Accepted JDK syntax | JDK accepts the spelling and SafeRE implements the same syntax and semantics. | literals, character classes, quantifiers, `(?<name>...)`, `\p{Lu}`, `\Q...\E`, `\R`, `\X`, JDK flags |
+| JDK-compatible with linear implementation | JDK accepts the spelling, and SafeRE implements the same observable behavior with a linear engine rather than backtracking. | alternation priority, captures in supported regular syntax, anchors, regions |
+| Rejected non-regular JDK syntax | JDK accepts the spelling, but supporting it would violate SafeRE's linear-time guarantee or architecture. | backreferences, lookahead, lookbehind, possessive quantifiers |
+| Rejected non-JDK syntax | Another regex dialect accepts the spelling, but JDK does not. | `(?P<name>...)`, RE2/Python-only or POSIX-only spellings |
+| JDK accepted literal text | A spelling resembles another dialect's metasyntax but is ordinary text in the JDK. | POSIX bracket fragments inside Java character classes such as `[[:lower:]]` |
+| JDK rejected malformed syntax | Both JDK and SafeRE should throw `PatternSyntaxException`. | malformed octal escapes such as `\0`, bad property names, invalid group syntax |
+| Documented divergence | SafeRE intentionally differs for a stated reason and has regression coverage. | unsupported non-regular features, known capture behavior that would require non-linear backtracking state |
+
+The implementation does not need a giant runtime table.  The design target is a
+source-level matrix near parser tests, plus helper APIs that make every family
+testable against the JDK oracle.
+
+The matrix is not a one-time proof that no undiscovered parser divergence
+exists.  It is the place where future parser divergences must be classified.
+When a new dialect bug appears, the fix should add or refine a matrix row and
+its tests, rather than introducing local parser behavior without naming the
+syntax policy.
+
+## Compatibility Matrix
+
+The focused compatibility matrix should cover at least these syntax families.
+
+| Family | Policy | Oracle |
+| --- | --- | --- |
+| Literal characters and quoting | JDK-compatible | compile and membership tests, including `LITERAL` flag and `\Q...\E` |
+| Escaped literals and control escapes | JDK-compatible or JDK-rejected | compile/error tests and representative membership |
+| Octal, numeric, hex, Unicode, and named-character escapes | JDK-compatible for accepted forms; reject JDK-rejected forms | compile/error tests plus membership for boundary values |
+| Predefined character classes | JDK-compatible | membership against representative ASCII, Unicode, and line-terminator inputs |
+| Java character classes | JDK-compatible | membership against `java.lang.Character` behavior |
+| POSIX property escapes `\p{Lower}` etc. | JDK-compatible | membership against JDK |
+| POSIX bracket fragments `[[:lower:]]` | ordinary JDK character-class text, not POSIX metasyntax | membership tests proving characters like `l`, `o`, `w`, `e`, `r`, `:`, `[`, and `]` behave like JDK |
+| Unicode scripts, blocks, categories, and binary properties | JDK-compatible, tied to the running JDK where possible | property lookup and membership crosschecks |
+| Character-class union, range, intersection, subtraction, and negation | JDK-compatible | generated membership tests for edge shapes, including empty operands |
+| Group syntax | JDK-compatible accepted forms; reject non-JDK forms | compile/error tests for capturing, non-capturing, flags, named groups, and rejected dialect spellings |
+| Quantifier syntax | JDK-compatible where regular; reject unsupported non-regular forms | compile/error tests plus membership for greedy/lazy and bounded forms |
+| Boundary matchers and line terminators | JDK-compatible where supported | membership and `hitEnd`/`requireEnd` tests where observable |
+| Comments and embedded flags | JDK-compatible | compile and membership tests for whitespace, comments, scoped flags, and flag restoration |
+| Unsupported non-regular constructs | rejected with clear errors | compile-error tests against known feature spellings |
+
+This matrix should live in the focused test suite or a small package-private
+test helper rather than only in prose.  The doc should describe the policy; the
+tests should make the policy executable.
+
+## Parser Architecture
+
+The parser should retain its stack-based shape.  This design is not a request
+to replace the parser.
+
+The desired changes are structural:
+
+- Parse branches should name the JDK syntax family they implement.
+- Dialect spellings from RE2, POSIX, Python, or PCRE should be accepted only
+  when they are also JDK-compatible.
+- Character-class parsing should have explicit handling for JDK intersection
+  and subtraction edge cases, not a generic POSIX class interpretation.
+- Escape parsing should separate "numeric backreference-like syntax,"
+  "JDK octal syntax," and "invalid numeric escape" instead of treating them as
+  one fallback.
+- Error paths should throw `PatternSyntaxException` with stable enough messages
+  for debugging, but tests should generally assert the exception type and
+  index-sensitive behavior only when the public contract needs it.
+- Unsupported-feature detection should be early and explicit so users get a
+  clear rejection instead of a later malformed-AST failure.
+
+The parser should not use the original source text after compilation to repair
+syntax semantics.  Once parsed, the AST must represent the JDK-compatible
+meaning or the pattern must have been rejected.
+
+This also means SafeRE should not delegate parsing to the JDK as the primary
+implementation strategy.  Delegation would not produce the SafeRE AST, would
+not cleanly encode SafeRE's linear-time rejections, and would still leave the
+compiler and engines responsible for the accepted semantics.  The JDK is the
+test oracle, not the parser implementation.
+
+## Test Strategy
+
+Parser compatibility needs two kinds of tests.
+
+### Compile/Error Tests
+
+For every syntax family, tests should say whether JDK and SafeRE both accept
+or reject a spelling.  Rejected non-regular JDK syntax is the main exception:
+JDK may accept it, while SafeRE rejects it for the documented linear-time
+reason.
+
+Compile/error tests should include:
+
+- representative ordinary forms;
+- malformed forms adjacent to valid ones;
+- dialect spellings that are tempting because RE2 or another regex engine
+  accepts them;
+- flag-sensitive forms;
+- forms inside and outside character classes.
+
+### Membership Tests
+
+Accepted syntax must also be tested for meaning.  Compile parity alone would
+not have caught #216 or #220.
+
+Membership tests should:
+
+- compare SafeRE and JDK on representative positive and negative inputs;
+- include edge characters for class syntax, such as `&`, `[`, `]`, `:`, `^`,
+  and range endpoints;
+- test nested and combined character-class operations;
+- include escape boundary values such as octal overflow points;
+- use generated small-alphabet membership checks for character-class grammar
+  where hand-written examples are likely to miss cases.
+
+Generated public API crosscheck remains useful, but parser dialect tests should
+not rely on accidental future fuzzing to discover the matrix.  The suite should
+intentionally cover each syntax family.
+
+This is intentionally a test-backed compatibility contract, not a formal proof.
+The success criterion is that known syntax families and newly discovered
+divergences are machine-checked against the JDK oracle.  The design should
+avoid language that implies the parser can be proven equivalent to all current
+and future JDK behavior.
+
+## Linear-Time Argument
+
+Parser dialect compatibility does not weaken the matching-time guarantee.
+
+The design either:
+
+- parses a JDK-compatible regular construct into the existing linear execution
+  model; or
+- rejects constructs that would require non-linear matching semantics.
+
+Adding membership tests for accepted syntax does not imply that SafeRE must
+support every JDK feature.  The acceptance decision remains constrained by the
+core linear-time contract.  When JDK accepts a non-regular feature, SafeRE's
+compatible behavior is a clear `PatternSyntaxException`, not backtracking
+emulation.
+
+Parser work must still preserve stack safety.  Any new source or AST walk used
+for syntax classification should be iterative or bounded by local token
+structure, not recursive over user-controlled nesting.
+
+## Acceptance Criteria
+
+This design track is complete when:
+
+- the parser dialect policy is documented as "JDK-compatible or rejected";
+- the design explicitly states that this is not a formal proof of complete JDK
+  parser equivalence;
+- `JdkSyntaxCompatibilityTest` or an equivalent focused suite contains a
+  syntax-family matrix matching the table above;
+- every known RE2/POSIX/Python-only spelling that SafeRE might accidentally
+  accept has an explicit accept/reject test;
+- POSIX bracket fragments inside Java character classes are tested as ordinary
+  JDK character-class text;
+- named-capture tests prove `(?<name>...)` is accepted and `(?P<name>...)` is
+  rejected;
+- character-class intersection and subtraction tests include empty operand and
+  repeated-operator edge cases;
+- octal and numeric escape tests cover accepted JDK forms, rejected malformed
+  forms, and boundary values;
+- unsupported non-regular JDK features are rejected by clear tests tied to the
+  linear-time rationale;
+- generated public API crosscheck can run parser-compatible public tests unless
+  a test documents why it is not comparable;
+- any future parser bug can be classified by adding a row or case to the matrix,
+  not by inventing a new dialect policy.
+
+## Non-Goals
+
+- Do not add SafeRE regex syntax extensions.
+- Do not emulate backreferences, lookaround, or other non-regular JDK features.
+- Do not make error message text the main compatibility target unless users
+  observe it through a documented API guarantee.
+- Do not preserve RE2/POSIX source compatibility when it conflicts with
+  `java.util.regex`.
+- Do not replace the parser as part of this design.

--- a/design/SEMANTIC_INVARIANTS.md
+++ b/design/SEMANTIC_INVARIANTS.md
@@ -322,6 +322,8 @@ then map each transition to JDK-compatible behavior.
 
 ### Parser Dialect Compatibility Design
 
+Focused design: [PARSER_DIALECT_COMPATIBILITY.md](PARSER_DIALECT_COMPATIBILITY.md).
+
 Scope: #216, #217, #220, #224, and future syntax compatibility issues.
 
 This design should define the dialect policy for every syntax family: accepted

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -15,12 +15,13 @@ import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * Parser for RE2 regular expression syntax. Converts a pattern string into a {@link Regexp} AST.
+ * Parser for SafeRE's {@link Pattern} syntax. Converts a JDK-compatible regular expression string
+ * into a {@link Regexp} AST, rejecting unsupported non-regular constructs rather than accepting
+ * another regex dialect as an extension.
  *
- * <p>This is a stack-based operator-precedence parser ported from RE2's {@code parse.cc}. It
- * supports POSIX extended regular expressions (excluding backreferences, collating elements, and
- * collating classes), Perl extensions (when enabled via flags), Unicode character properties, and
- * named captures.
+ * <p>This is a stack-based operator-precedence parser derived from RE2's {@code parse.cc}. The
+ * parser's accepted language is governed by {@code java.util.regex.Pattern} compatibility and the
+ * linear-time execution contract, not by RE2 source syntax compatibility.
  */
 final class Parser {
 
@@ -938,11 +939,15 @@ final class Parser {
         }
       }
 
-      // Character class intersection: &&
-      if (!first
-          && pos + 1 < pattern.length()
-          && pattern.charAt(pos) == '&'
-          && pattern.charAt(pos + 1) == '&') {
+      // Character class intersection: &&. At the start of a class, the JDK treats the marker as
+      // syntax, not as two literal ampersands, and then continues with following class items.
+      if (first && isClassIntersectionOperator()) {
+        pos += 2;
+        requireLeadingClassIntersectionOperandStart();
+        first = false;
+        continue;
+      }
+      if (!first && isClassIntersectionOperator()) {
         pos += 2; // skip '&&'
         if (pos < pattern.length() && pattern.charAt(pos) == ']') {
           break;
@@ -1039,6 +1044,25 @@ final class Parser {
     }
 
     return Regexp.charClass(ccb.build(), flags & ~ParseFlags.FOLD_CASE);
+  }
+
+  private boolean isClassIntersectionOperator() {
+    return pos + 1 < pattern.length()
+        && pattern.charAt(pos) == '&'
+        && pattern.charAt(pos + 1) == '&';
+  }
+
+  private void requireLeadingClassIntersectionOperandStart() {
+    if ((flags & ParseFlags.COMMENTS) != 0) {
+      skipCommentsAndWhitespace();
+    }
+    if (pos >= pattern.length()) {
+      throw new PatternSyntaxException("missing closing ]", pattern, pos);
+    }
+    char c = pattern.charAt(pos);
+    if (c == ']' || c == '&') {
+      throw new PatternSyntaxException("bad class syntax", pattern, pos);
+    }
   }
 
   private int[] parseCCRange() {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -95,6 +95,13 @@ class JdkSyntaxCompatibilityTest {
         .isEqualTo(jdkMatches);
   }
 
+  /** Asserts SafeRE full-match behavior agrees with the JDK for every input. */
+  private static void assertFullMatchesSameForAll(String regex, List<String> inputs) {
+    for (String input : inputs) {
+      assertMatchesFull(regex, input);
+    }
+  }
+
   /**
    * Asserts SafeRE compiles with the given flags and matches identically to JDK on the given
    * input.
@@ -116,6 +123,131 @@ class JdkSyntaxCompatibilityTest {
       assertThat(safeM.group())
           .as("group() for /%s/ (flags=%d) on \"%s\"", regex, jdkFlags, input)
           .isEqualTo(jdkM.group());
+    }
+  }
+
+  private record SyntaxFamilyCase(
+      String family, String acceptedRegex, String matchingInput, String nonMatchingInput) {}
+
+  private record DialectRejection(String family, String regex) {}
+
+  private record CharacterClassMembershipCase(String regex, List<String> inputs) {}
+
+  @Nested
+  @DisplayName("Syntax-family compatibility matrix")
+  class SyntaxFamilyCompatibilityMatrix {
+    static Stream<Arguments> acceptedSyntaxFamilies() {
+      return Stream.of(
+          Arguments.of(new SyntaxFamilyCase("literal characters", "abc", "abc", "ab")),
+          Arguments.of(new SyntaxFamilyCase("quoting", "\\Q.+*\\E", ".+*", "abc")),
+          Arguments.of(new SyntaxFamilyCase("control escapes", "\\t", "\t", "t")),
+          Arguments.of(new SyntaxFamilyCase("octal escapes", "\\041", "!", "1")),
+          Arguments.of(new SyntaxFamilyCase("hex escapes", "\\x41", "A", "x41")),
+          Arguments.of(new SyntaxFamilyCase("Unicode escapes", "\\u0041", "A", "u0041")),
+          Arguments.of(new SyntaxFamilyCase("named characters", "\\N{LATIN SMALL LETTER A}",
+              "a", "A")),
+          Arguments.of(new SyntaxFamilyCase("predefined classes", "\\d", "7", "a")),
+          Arguments.of(new SyntaxFamilyCase("Java character classes", "\\p{javaLowerCase}",
+              "a", "A")),
+          Arguments.of(new SyntaxFamilyCase("POSIX property escapes", "\\p{Lower}", "a", "A")),
+          Arguments.of(new SyntaxFamilyCase("POSIX bracket fragments", "[[:lower:]]",
+              "l", "a")),
+          Arguments.of(new SyntaxFamilyCase("Unicode scripts", "\\p{IsLatin}", "A", "1")),
+          Arguments.of(new SyntaxFamilyCase("Unicode blocks", "\\p{InGreek}", "\u0391", "A")),
+          Arguments.of(new SyntaxFamilyCase("Unicode categories", "\\p{Lu}", "A", "a")),
+          Arguments.of(new SyntaxFamilyCase("Unicode binary properties", "\\p{IsAlphabetic}",
+              "a", "1")),
+          Arguments.of(new SyntaxFamilyCase("class union", "[a-d[m-p]]", "m", "z")),
+          Arguments.of(new SyntaxFamilyCase("class intersection", "[a-z&&[def]]", "d", "a")),
+          Arguments.of(new SyntaxFamilyCase("class subtraction", "[a-z&&[^bc]]", "a", "b")),
+          Arguments.of(new SyntaxFamilyCase("capturing groups", "(ab)+", "abab", "aba")),
+          Arguments.of(new SyntaxFamilyCase("named groups", "(?<word>\\w+)", "abc", "!")),
+          Arguments.of(new SyntaxFamilyCase("non-capturing groups", "(?:ab)+", "abab", "aba")),
+          Arguments.of(new SyntaxFamilyCase("greedy quantifiers", "ab*c", "abbc", "abdc")),
+          Arguments.of(new SyntaxFamilyCase("lazy quantifiers", "a.*?c", "abc", "ab")),
+          Arguments.of(new SyntaxFamilyCase("bounded quantifiers", "a{2,4}", "aaa", "a")),
+          Arguments.of(new SyntaxFamilyCase("boundary matchers", "\\bword\\b", "word", "sword")),
+          Arguments.of(new SyntaxFamilyCase("linebreak matcher", "\\R", "\r\n", "a")),
+          Arguments.of(new SyntaxFamilyCase("comments flag", "(?x)a b c # comment", "abc", "ab")),
+          Arguments.of(new SyntaxFamilyCase("embedded flags", "(?i:abc)def", "ABCdef",
+              "ABCDEF")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("acceptedSyntaxFamilies")
+    @DisplayName("accepted syntax families compile and match like JDK")
+    void acceptedSyntaxFamiliesCompileAndMatchLikeJdk(SyntaxFamilyCase syntaxCase) {
+      assertMatchesFull(syntaxCase.acceptedRegex(), syntaxCase.matchingInput());
+      assertMatchesFull(syntaxCase.acceptedRegex(), syntaxCase.nonMatchingInput());
+    }
+
+    static Stream<Arguments> nonJdkDialectSpellings() {
+      return Stream.of(
+          Arguments.of(new DialectRejection("Python named capture", "(?P<word>a)")),
+          Arguments.of(new DialectRejection("bare script property", "\\p{Latin}")),
+          Arguments.of(new DialectRejection("bare binary property", "\\p{Alphabetic}")),
+          Arguments.of(new DialectRejection("lowercase category", "\\p{lu}")),
+          Arguments.of(new DialectRejection("invalid numeric class escape", "[\\123]")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nonJdkDialectSpellings")
+    @DisplayName("non-JDK dialect spellings are rejected")
+    void nonJdkDialectSpellingsAreRejected(DialectRejection rejection) {
+      assertRejectedByJdkAndSafeRe(rejection.regex());
+    }
+
+    static Stream<Arguments> malformedJdkSyntax() {
+      return Stream.of(
+          Arguments.of(new DialectRejection("bare leading class intersection", "[&&]")),
+          Arguments.of(new DialectRejection("bare negated leading class intersection", "[^&&]")),
+          Arguments.of(new DialectRejection("solitary ampersand after leading class intersection",
+              "[&&&b]")),
+          Arguments.of(new DialectRejection(
+              "solitary ampersand after negated leading class intersection", "[^&&&b]")),
+          Arguments.of(new DialectRejection("repeated leading class intersection", "[&&&&b]")),
+          Arguments.of(new DialectRejection("repeated negated leading class intersection",
+              "[^&&&&b]")),
+          Arguments.of(new DialectRejection("comments-mode spaced bare leading class intersection",
+              "(?x)[&&  ]")),
+          Arguments.of(new DialectRejection("comments-mode commented bare leading class intersection",
+              "(?x)[&& #x\n ]")),
+          Arguments.of(new DialectRejection(
+              "comments-mode spaced solitary ampersand after leading class intersection",
+              "(?x)[&&  &b]")),
+          Arguments.of(new DialectRejection(
+              "comments-mode spaced repeated leading class intersection", "(?x)[&&  &&b]")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("malformedJdkSyntax")
+    @DisplayName("malformed JDK syntax is rejected")
+    void malformedJdkSyntaxIsRejected(DialectRejection rejection) {
+      assertRejectedByJdkAndSafeRe(rejection.regex());
+    }
+
+    static Stream<Arguments> unsupportedNonRegularJdkSyntax() {
+      return Stream.of(
+          Arguments.of(new DialectRejection("backreference", "(a)\\1")),
+          Arguments.of(new DialectRejection("named backreference", "(?<name>a)\\k<name>")),
+          Arguments.of(new DialectRejection("positive lookahead", "a(?=b)")),
+          Arguments.of(new DialectRejection("negative lookahead", "a(?!b)")),
+          Arguments.of(new DialectRejection("positive lookbehind", "(?<=a)b")),
+          Arguments.of(new DialectRejection("negative lookbehind", "(?<!a)b")),
+          Arguments.of(new DialectRejection("possessive quantifier", "a++")),
+          Arguments.of(new DialectRejection("atomic group", "(?>a+)")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedNonRegularJdkSyntax")
+    @DisplayName("JDK syntax outside SafeRE's linear-time subset is rejected")
+    void unsupportedNonRegularJdkSyntaxIsRejected(DialectRejection rejection) {
+      assertThatNoException()
+          .as("JDK should accept: %s", rejection.regex())
+          .isThrownBy(() -> java.util.regex.Pattern.compile(rejection.regex()));
+      assertThatThrownBy(() -> Pattern.compile(rejection.regex()))
+          .as("SafeRE should reject unsupported syntax: %s", rejection.regex())
+          .isInstanceOf(PatternSyntaxException.class);
     }
   }
 
@@ -487,6 +619,28 @@ class JdkSyntaxCompatibilityTest {
       assertMatchesSame(regex, "a");
       assertMatchesSame(regex, "`");
       assertMatchesSame(regex, "˫");
+    }
+
+    static Stream<Arguments> generatedCharacterClassMembershipCases() {
+      List<String> inputs = List.of("", "&", "[", "]", ":", "^", "-", "a", "b", "c",
+          "d", "e", "f", "m", "p", "z", "`", "+");
+      return Stream.of(
+          Arguments.of(new CharacterClassMembershipCase("[&&abc]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[a&&&&b]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[a-z&&[def]]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[a-z&&[^bc]]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[a-d[m-p]]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[[:lower:]]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[^[:lower:]]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[[:^space:]]", inputs)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("generatedCharacterClassMembershipCases")
+    @DisplayName("character-class edge syntax matches JDK over generated inputs")
+    void characterClassEdgeSyntaxMatchesJdkOverGeneratedInputs(
+        CharacterClassMembershipCase membershipCase) {
+      assertFullMatchesSameForAll(membershipCase.regex(), membershipCase.inputs());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add the focused parser dialect compatibility design doc and link it from the umbrella semantic invariants doc
- make `Parser` document the JDK-compatible-or-rejected dialect policy instead of RE2 source compatibility
- add an executable syntax-family compatibility matrix and generated character-class membership checks against `java.util.regex`
- fix leading `&&` character-class parsing so malformed leading-intersection operands are rejected like the JDK, including comments-mode whitespace/comment cases

## Verification

```bash
mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests
```

Passed locally after rebasing onto `origin/main`.
