### PR TITLE
Fix escaped non-ASCII literal parsing

### DIFF
--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -38,6 +38,13 @@ class CrosscheckTest {
     }
 
     @Test
+    @DisplayName("compiles escaped non-ASCII literals on both engines")
+    void escapedNonAsciiLiteral() {
+      Pattern p = Pattern.compile("^\\©");
+      assertThat(p.matcher("©").matches()).isTrue();
+    }
+
+    @Test
     @DisplayName("throws UnsupportedPatternException for backreference")
     void backreference() {
       assertThatThrownBy(() -> Pattern.compile("(a)\\1"))

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1994,8 +1994,8 @@ final class Parser {
         throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 1);
       }
       default -> {
-        // Escaped non-word characters are always themselves.
-        if (c < 0x80 && !Utils.isAlnum(c)) {
+        // JDK reserves backslash before ASCII alphabetic characters for escaped constructs.
+        if (!Utils.isAlpha(c)) {
           return c;
         }
         throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -152,6 +152,7 @@ class JdkSyntaxCompatibilityTest {
       return Stream.of(
           Arguments.of(new SyntaxFamilyCase("literal characters", "abc", "abc", "ab")),
           Arguments.of(new SyntaxFamilyCase("quoting", "\\Q.+*\\E", ".+*", "abc")),
+          Arguments.of(new SyntaxFamilyCase("escaped non-ASCII literals", "\\©", "©", "c")),
           Arguments.of(new SyntaxFamilyCase("control escapes", "\\t", "\t", "t")),
           Arguments.of(new SyntaxFamilyCase("octal escapes", "\\041", "!", "1")),
           Arguments.of(new SyntaxFamilyCase("hex escapes", "\\x41", "A", "x41")),
@@ -420,6 +421,24 @@ class JdkSyntaxCompatibilityTest {
     @DisplayName("escaped backslash: \\\\")
     void escapedBackslash() {
       assertMatchesSame("\\\\", "a\\b");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\©", "\\о", "\\\uD83D\uDE00"})
+    @DisplayName("escaped non-ASCII character is literal")
+    void escapedNonAsciiCharacterIsLiteral(String regex) {
+      String literal = regex.substring(1);
+      assertMatchesFull(regex, literal);
+      assertMatchesFull(regex, "x");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[\\©]", "[\\о]", "[\\\uD83D\uDE00]"})
+    @DisplayName("escaped non-ASCII character in class is literal")
+    void escapedNonAsciiCharacterInClassIsLiteral(String regex) {
+      String literal = regex.substring(2, regex.length() - 1);
+      assertMatchesFull(regex, literal);
+      assertMatchesFull(regex, "x");
     }
 
     // -- Octal escapes --
@@ -1094,6 +1113,7 @@ class JdkSyntaxCompatibilityTest {
           new CharacterClassMatrixPiece("quoteAB", "\\Qab\\E"),
           new CharacterClassMatrixPiece("quoteEmpty", "\\Q\\E"),
           new CharacterClassMatrixPiece("nonInline", "Ā"),
+          new CharacterClassMatrixPiece("escapedNonAscii", "\\Ā"),
           new CharacterClassMatrixPiece("nestedA", "[a]"),
           new CharacterClassMatrixPiece("nestedB", "[b]"),
           new CharacterClassMatrixPiece("nestedAB", "[ab]"),
@@ -1139,6 +1159,7 @@ class JdkSyntaxCompatibilityTest {
           new CharacterClassMatrixPiece("quoteA", "\\Qa\\E"),
           new CharacterClassMatrixPiece("quoteEmpty", "\\Q\\E"),
           new CharacterClassMatrixPiece("nonInline", "Ā"),
+          new CharacterClassMatrixPiece("escapedNonAscii", "\\Ā"),
           new CharacterClassMatrixPiece("nestedA", "[a]"),
           new CharacterClassMatrixPiece("nestedB", "[b]"),
           new CharacterClassMatrixPiece("nestedAB", "[ab]"),


### PR DESCRIPTION
## Summary

- Accept escaped non-ASCII code points as literal characters, matching java.util.regex reserved-escape behavior.
- Add focused JDK syntax compatibility coverage outside and inside character classes.
- Add a crosscheck facade regression and add escaped non-ASCII content to the disabled generated character-class matrix without re-enabling it.

Fixes #271

## Validation

- mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test -q
- mvn -pl safere test -q
- mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q
