### PR TITLE
Add parser-focused fuzz targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,10 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   README.md, TESTING.md, or other documentation.
 - **Regression tests for bugs**: Any time a bug is found, a regression test
   must be added that fails without the fix and passes with it.
+- **Parser bug fuzz coverage**: Any time a parser bug is found, also add the
+  bug's syntax shape to the relevant grammar-biased fuzz generator axis (for
+  example character-class expressions, escapes, dialect spellings, or nested
+  parser structure), not just to a one-off regression test.
 
 ## Benchmarking
 

--- a/safere-fuzz/README.md
+++ b/safere-fuzz/README.md
@@ -7,6 +7,11 @@ This module contains Jazzer fuzz targets for SafeRE. The targets use
 ## Targets
 
 - `CompileFuzzer` fuzzes compile/reject behavior.
+- `ParserCompatibilityFuzzer` fuzzes grammar-biased compile and membership compatibility.
+- `CharacterClassExpressionFuzzer` fuzzes JDK character-class expression syntax.
+- `EscapeSyntaxFuzzer` fuzzes escape syntax and escaped literal compatibility.
+- `DialectSyntaxFuzzer` fuzzes non-JDK-looking syntax and dialect boundary cases.
+- `ParserStackSafetyFuzzer` fuzzes parser nesting depth and stack safety.
 - `MatchFuzzer` fuzzes `matches()`, `lookingAt()`, `find()`, and `find(int)`.
 - `FindSequenceFuzzer` fuzzes stateful matcher API call sequences.
 - `ReplacementFuzzer` fuzzes replacement APIs.
@@ -21,13 +26,13 @@ over the empty input and the checked-in seed corpus. Seed inputs live under
 `src/test/resources/org/safere/fuzz/<FuzzerClass>Inputs/<methodName>/`.
 
 ```bash
-mvn -pl safere-fuzz test
+mvn -pl safere-fuzz -am test
 ```
 
 Run one target:
 
 ```bash
-mvn -pl safere-fuzz -Dtest=MatchFuzzer test
+mvn -pl safere-fuzz -am -Dtest=MatchFuzzer -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
 ## Fuzzing Mode
@@ -41,14 +46,15 @@ SafeRE and `java.util.regex`; sanitizer findings on the JDK oracle are noise for
 this crosscheck workflow.
 
 ```bash
-JAZZER_FUZZ=1 mvn -pl safere-fuzz -Dtest=MatchFuzzer test
+JAZZER_FUZZ=1 mvn -pl safere-fuzz -am -Dtest=MatchFuzzer \
+  -Dsurefire.failIfNoSpecifiedTests=false test
 ```
 
 Limit a local run with Jazzer options:
 
 ```bash
-JAZZER_FUZZ=1 mvn -pl safere-fuzz -Dtest=MatchFuzzer \
-  -Djazzer.max_duration=2m test
+JAZZER_FUZZ=1 mvn -pl safere-fuzz -am -Dtest=MatchFuzzer \
+  -Dsurefire.failIfNoSpecifiedTests=false -Djazzer.max_duration=2m test
 ```
 
 ## Findings

--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -1,0 +1,154 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
+
+final class CharacterClassExpressionFuzzer {
+
+  private static final String[] BASE_PIECES = {
+      "",
+      "a",
+      "ab",
+      "a-b",
+      "0",
+      "0-1",
+      "&",
+      "\\&",
+      "\\Q&\\E",
+      "\\Qa\\E",
+      "\\Qab\\E",
+      "\\Q\\E",
+      "Ā",
+      "\\Ā",
+      "[a]",
+      "[b]",
+      "[ab]",
+      "[^b]",
+      "\\d",
+      "\\D",
+      "\\w",
+      "\\W",
+      "\\p{Lower}",
+      "\\P{Lower}",
+      "\\p{javaLowerCase}"
+  };
+  private static final String[] AMPERSAND_PIECES = {"&", "\\&", "\\Q&\\E"};
+  private static final String[] TRAILING_PIECES = {
+      "", "&", "\\&", "\\Q&\\E", "-\\D", "\\Q\\E-\\D"
+  };
+  private static final Separator[] SEPARATORS = {
+      new Separator("", false),
+      new Separator("\\Q\\E", false),
+      new Separator("\\Q\\E\\Q\\E", false),
+      new Separator(" ", true),
+      new Separator(" #x\n", true),
+      new Separator("\\Q\\E ", true),
+      new Separator(" \\Q\\E", true)
+  };
+  private static final String[] OPERATORS = {"&&", "&&&", "&&&&", "&&&&&", "&&&&&&"};
+  private static final String[] RIGHT_PIECES = {
+      "",
+      "a",
+      "b",
+      "a-b",
+      "0",
+      "0-1",
+      "&",
+      "\\&",
+      "\\Q&\\E",
+      "\\Qa\\E",
+      "\\Q\\E",
+      "Ā",
+      "\\Ā",
+      "[a]",
+      "[b]",
+      "[ab]",
+      "\\d",
+      "\\D",
+      "\\w",
+      "\\p{Lower}",
+      "\\P{Lower}",
+      "\\p{javaLowerCase}"
+  };
+  private static final List<String> INPUTS =
+      List.of("", "a", "b", "c", "&", "-", "0", "1", "x", "_", " ", "\t", "Ā", "é", "\n");
+  private static final String[] REGRESSION_REGEXES = {
+      "[\\d&&&-\\D]",
+      "[\\d&&&\\Q\\E-\\D]",
+      "(?x)[a&&& -\\D]",
+      "(?x)[a&&& #x\n -\\D]",
+      "[&\\Q\\E &&\\d]",
+      "[b&&[a]&]",
+      "[^b&&[a]&]",
+      "[&&abc]",
+      "[a&&&&b]",
+      "[ [a]&&]",
+      "[ &&&]",
+      "[&&[x]-&&a]",
+      "[ab\\Q\\E\\Q\\E&&&&&\\Q\\E&\\&]",
+      "[a\\Q\\E&&\\Q\\E\\Q\\E&-\\D]",
+      "[\\&\\Q\\E&&&&&\\Q\\E\\Q\\E&-\\D]",
+      "[\\Q&\\E&&\\Q\\E&-\\D]",
+      "[[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&\\&]",
+      "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&\\&]",
+      "[[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]",
+      "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]"
+  };
+
+  @FuzzTest(maxDuration = "30s")
+  void characterClassExpressions(FuzzedDataProvider data) {
+    for (String regex : REGRESSION_REGEXES) {
+      FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
+    }
+
+    boolean comments = data.consumeBoolean();
+    boolean negated = data.consumeBoolean();
+    String prefix = (comments ? "(?x)" : "") + "[" + (negated ? "^" : "");
+    String regex = switch (data.consumeInt(0, 2)) {
+      case 0 -> prefix
+          + data.pickValue(BASE_PIECES)
+          + data.pickValue(BASE_PIECES)
+          + pickSeparator(data, comments)
+          + data.pickValue(OPERATORS)
+          + pickSeparator(data, comments)
+          + data.pickValue(RIGHT_PIECES)
+          + data.pickValue(TRAILING_PIECES)
+          + "]";
+      case 1 -> prefix
+          + data.pickValue(BASE_PIECES)
+          + data.pickValue(AMPERSAND_PIECES)
+          + pickSeparator(data, comments)
+          + data.pickValue(OPERATORS)
+          + pickSeparator(data, comments)
+          + data.pickValue(RIGHT_PIECES)
+          + data.pickValue(TRAILING_PIECES)
+          + "]";
+      case 2 -> prefix
+          + pickSeparator(data, comments)
+          + data.pickValue(OPERATORS)
+          + pickSeparator(data, comments)
+          + data.pickValue(RIGHT_PIECES)
+          + data.pickValue(TRAILING_PIECES)
+          + "]";
+      default -> throw new AssertionError();
+    };
+
+    FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
+  }
+
+  private static String pickSeparator(FuzzedDataProvider data, boolean comments) {
+    Separator separator;
+    do {
+      separator = data.pickValue(SEPARATORS);
+    } while (separator.commentsModeOnly() && !comments);
+    return separator.text();
+  }
+
+  private record Separator(String text, boolean commentsModeOnly) {}
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/CompileFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CompileFuzzer.java
@@ -7,8 +7,6 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
-import java.util.regex.PatternSyntaxException;
-import org.safere.crosscheck.Pattern;
 
 final class CompileFuzzer {
 
@@ -16,10 +14,6 @@ final class CompileFuzzer {
   void compile(FuzzedDataProvider data) {
     int flags = FuzzSupport.consumeFlags(data);
     String regex = data.consumeRemainingAsString();
-    try {
-      Pattern.compile(regex, flags);
-    } catch (PatternSyntaxException expected) {
-      // Invalid or intentionally unsupported patterns are valid fuzzer inputs.
-    }
+    FuzzSupport.compileCompatibleOrSkip(regex, flags);
   }
 }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
@@ -1,0 +1,73 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
+
+final class DialectSyntaxFuzzer {
+
+  private static final String[] CONTEXT_PREFIXES = {"", "^", "(?:", "a|", "[", "[^"};
+  private static final String[] DIALECT_FRAGMENTS = {
+      "(?P<name>a)",
+      "(?P=name)",
+      "(?'name'a)",
+      "\\g{name}",
+      "\\g1",
+      "\\p{Braille}",
+      "\\P{Braille}",
+      "\\p{Latin}",
+      "\\p{^Braille}",
+      "\\p{InBraille}",
+      "\\p{IsLatin}",
+      "[:lower:]",
+      "[:alpha:]",
+      "[:digit:]",
+      "[:^space:]",
+      "[.ch.]",
+      "[=a=]",
+      "\\C",
+      "\\R",
+      "\\K"
+  };
+  private static final String[] CONTEXT_SUFFIXES = {"", "$", ")", "b", "]", "&&[a]]"};
+  private static final List<String> INPUTS =
+      List.of("", "a", "b", "Braille", "Latin", ":", "[", "]", "l", "o", "w", "e", "r");
+  private static final String[] REGRESSION_REGEXES = {
+      "(?P<name>a)",
+      "\\p{Braille}",
+      "\\p{Latin}",
+      "[[:lower:]]",
+      "[[:^space:]]",
+      "\\Q{?\\E",
+      "{?",
+      "a{,2}",
+      "a{2,1}"
+  };
+
+  @FuzzTest(maxDuration = "30s")
+  void dialectSyntax(FuzzedDataProvider data) {
+    for (String regex : REGRESSION_REGEXES) {
+      FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
+    }
+
+    String prefix = data.pickValue(CONTEXT_PREFIXES);
+    String suffix = data.pickValue(CONTEXT_SUFFIXES);
+    if (prefix.startsWith("[") && !suffix.contains("]")) {
+      suffix = suffix + "]";
+    }
+    if (!prefix.startsWith("[") && suffix.startsWith("]")) {
+      suffix = "";
+    }
+    if (prefix.equals("(?:") && !suffix.startsWith(")")) {
+      suffix = ")" + suffix;
+    }
+
+    String regex = prefix + data.pickValue(DIALECT_FRAGMENTS) + suffix;
+    FuzzSupport.assertFullMatchesJdk(regex, FuzzSupport.consumeParserFlags(data), INPUTS);
+  }
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
@@ -1,0 +1,74 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
+
+final class EscapeSyntaxFuzzer {
+
+  private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "[", "[^"};
+  private static final String[] ESCAPES = {
+      "\\0",
+      "\\00",
+      "\\07",
+      "\\08",
+      "\\077",
+      "\\078",
+      "\\123",
+      "\\400",
+      "\\777",
+      "\\u0041",
+      "\\u{41}",
+      "\\x41",
+      "\\x{41}",
+      "\\e",
+      "\\cA",
+      "\\ca",
+      "\\©",
+      "\\Ā",
+      "\\é",
+      "\\Q\\E",
+      "\\Q&\\E",
+      "\\Q-\\E",
+      "\\Qab\\E"
+  };
+  private static final String[] SUFFIXES = {"", "$", "]", "a", "-", "-z", "&&[a]"};
+  private static final List<String> INPUTS =
+      List.of("", "a", "A", "0", "7", "@", "\u001b", "&", "-", "©", "Ā", "é", "\u0000");
+  private static final String[] REGRESSION_REGEXES = {
+      "^\\©",
+      "[\\©]",
+      "\\Ā",
+      "[\\Ā]",
+      "\\0",
+      "\\08",
+      "\\400",
+      "\\777",
+      "\\123",
+      "(a)\\12"
+  };
+
+  @FuzzTest(maxDuration = "30s")
+  void escapeSyntax(FuzzedDataProvider data) {
+    for (String regex : REGRESSION_REGEXES) {
+      FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
+    }
+
+    String prefix = data.pickValue(PREFIXES);
+    String suffix = data.pickValue(SUFFIXES);
+    if (prefix.startsWith("[") && !suffix.contains("]")) {
+      suffix = suffix + "]";
+    }
+    if (!prefix.startsWith("[") && suffix.equals("]")) {
+      suffix = "";
+    }
+
+    String regex = prefix + data.pickValue(ESCAPES) + suffix;
+    FuzzSupport.assertFullMatchesJdk(regex, FuzzSupport.consumeParserFlags(data), INPUTS);
+  }
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -6,6 +6,7 @@
 package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.util.List;
 import java.util.regex.PatternSyntaxException;
 import org.safere.crosscheck.Pattern;
 
@@ -24,6 +25,59 @@ final class FuzzSupport {
 
   private FuzzSupport() {}
 
+  static org.safere.Pattern compileCompatibleOrSkip(String regex, int flags) {
+    org.safere.Pattern safeRePattern = null;
+    java.util.regex.Pattern jdkPattern = null;
+    PatternSyntaxException safeReException = null;
+    PatternSyntaxException jdkException = null;
+
+    try {
+      safeRePattern = org.safere.Pattern.compile(regex, flags);
+    } catch (PatternSyntaxException e) {
+      safeReException = e;
+    }
+    try {
+      jdkPattern = java.util.regex.Pattern.compile(regex, flags);
+    } catch (PatternSyntaxException e) {
+      jdkException = e;
+    }
+
+    if (safeRePattern != null && jdkPattern != null) {
+      return safeRePattern;
+    }
+    if (safeReException != null && jdkException != null) {
+      return null;
+    }
+    if (safeReException != null && isIntentionallyUnsupported(regex)) {
+      return null;
+    }
+
+    String safeRe = safeReException == null
+        ? "compiled successfully"
+        : safeReException.getClass().getSimpleName() + ": " + safeReException.getMessage();
+    String jdk = jdkException == null
+        ? "compiled successfully"
+        : jdkException.getClass().getSimpleName() + ": " + jdkException.getMessage();
+    throw new AssertionError("compile divergence for /" + regex + "/ flags=" + flags
+        + "\nSafeRE: " + safeRe + "\nJDK: " + jdk);
+  }
+
+  static void assertFullMatchesJdk(String regex, int flags, List<String> inputs) {
+    org.safere.Pattern safeRePattern = compileCompatibleOrSkip(regex, flags);
+    if (safeRePattern == null) {
+      return;
+    }
+    java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(regex, flags);
+    for (String input : inputs) {
+      boolean safeReMatches = safeRePattern.matcher(input).matches();
+      boolean jdkMatches = jdkPattern.matcher(input).matches();
+      if (safeReMatches != jdkMatches) {
+        throw new AssertionError("matches() divergence for /" + regex + "/ flags=" + flags
+            + " input=\"" + input + "\"\nSafeRE: " + safeReMatches + "\nJDK: " + jdkMatches);
+      }
+    }
+  }
+
   static Pattern compileOrSkip(String regex, int flags) {
     try {
       return Pattern.compile(regex, flags);
@@ -40,6 +94,54 @@ final class FuzzSupport {
       }
     }
     return flags;
+  }
+
+  static int consumeParserFlags(FuzzedDataProvider data) {
+    int flags = 0;
+    if (data.consumeBoolean()) {
+      flags |= Pattern.COMMENTS;
+    }
+    if (data.consumeBoolean()) {
+      flags |= Pattern.CASE_INSENSITIVE;
+    }
+    if (data.consumeBoolean()) {
+      flags |= Pattern.UNICODE_CASE;
+    }
+    if (data.consumeBoolean()) {
+      flags |= Pattern.UNICODE_CHARACTER_CLASS;
+    }
+    return flags;
+  }
+
+  private static boolean isIntentionallyUnsupported(String regex) {
+    return hasLookaround(regex) || hasBackreference(regex) || hasPossessiveQuantifier(regex);
+  }
+
+  private static boolean hasLookaround(String regex) {
+    return regex.contains("(?=")
+        || regex.contains("(?!")
+        || regex.contains("(?<=")
+        || regex.contains("(?<!");
+  }
+
+  private static boolean hasBackreference(String regex) {
+    return regex.matches(".*\\\\[1-9].*")
+        || regex.contains("\\k<")
+        || regex.contains("\\g{")
+        || regex.contains("\\g");
+  }
+
+  private static boolean hasPossessiveQuantifier(String regex) {
+    for (int i = 1; i < regex.length(); i++) {
+      if (regex.charAt(i) == '+' && isPossessiveQuantifierPrefix(regex.charAt(i - 1))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isPossessiveQuantifierPrefix(char c) {
+    return c == '?' || c == '*' || c == '+' || c == '}';
   }
 
   static int consumeIndex(FuzzedDataProvider data, String input) {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -1,0 +1,51 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
+
+final class ParserCompatibilityFuzzer {
+
+  private static final String[] ATOMS = {
+      "",
+      "a",
+      ".",
+      "\\d",
+      "\\D",
+      "\\w",
+      "\\W",
+      "\\s",
+      "\\S",
+      "\\p{Lower}",
+      "\\P{Lower}",
+      "\\Q\\E",
+      "\\Q*\\E",
+      "[a]",
+      "[^a]",
+      "[a-z]",
+      "[a-z&&[def]]",
+      "(a)",
+      "(?:a)",
+      "(?<name>a)"
+  };
+  private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "(?m)", "(?s)"};
+  private static final String[] CONNECTORS = {"", "", "|", "?", "*", "+", "{0}", "{1,3}"};
+  private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
+  private static final List<String> INPUTS =
+      List.of("", "a", "aa", "abc", "def", "0", " ", "\n", "*", "name");
+
+  @FuzzTest(maxDuration = "30s")
+  void parserCompatibility(FuzzedDataProvider data) {
+    String regex = data.pickValue(PREFIXES)
+        + data.pickValue(ATOMS)
+        + data.pickValue(CONNECTORS)
+        + data.pickValue(ATOMS)
+        + data.pickValue(SUFFIXES);
+    FuzzSupport.assertFullMatchesJdk(regex, FuzzSupport.consumeParserFlags(data), INPUTS);
+  }
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
@@ -1,0 +1,38 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
+
+final class ParserStackSafetyFuzzer {
+
+  private static final List<String> INPUTS = List.of("", "a", "b");
+
+  @FuzzTest(maxDuration = "30s")
+  void parserStackSafety(FuzzedDataProvider data) {
+    for (int depth : List.of(1, 8, 64, 512)) {
+      FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
+      FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
+    }
+
+    int depth = data.consumeInt(0, 512);
+    if (data.consumeBoolean()) {
+      FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
+    } else {
+      FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
+    }
+  }
+
+  private static String nestedCharacterClass(int depth) {
+    return "[".repeat(depth + 1) + "a" + "]".repeat(depth + 1);
+  }
+
+  private static String nestedGroups(int depth) {
+    return "(?:".repeat(depth) + "a" + ")".repeat(depth);
+  }
+}


### PR DESCRIPTION
## Summary
- add strict SafeRE-vs-JDK parser compile/membership fuzz oracles that do not hide parser divergences behind crosscheck unsupported-pattern handling
- add grammar-biased parser fuzz targets for character-class expressions, escapes, dialect-boundary syntax, broad parser compatibility, and parser stack safety
- document parser fuzz targets and require parser bug shapes to be added to the relevant fuzz generator axis

Fixes #281

## Testing
- `mvn -pl safere-fuzz -am -Dtest=CompileFuzzer,ParserCompatibilityFuzzer,CharacterClassExpressionFuzzer,EscapeSyntaxFuzzer,DialectSyntaxFuzzer,ParserStackSafetyFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

Full `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests` was started but intentionally stopped before completion at maintainer request.
