### PR TITLE
Fix character-class ampersand range parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -40,7 +40,7 @@ final class CharacterClassExpressionFuzzer {
   };
   private static final String[] AMPERSAND_PIECES = {"&", "\\&", "\\Q&\\E"};
   private static final String[] TRAILING_PIECES = {
-      "", "&", "\\&", "\\Q&\\E", "-\\D", "\\Q\\E-\\D"
+      "", "&", "\\&", "\\Q&\\E", "-\\D", "-a", "-&&", "\\Q\\E-\\D"
   };
   private static final Separator[] SEPARATORS = {
       new Separator("", false),
@@ -77,7 +77,8 @@ final class CharacterClassExpressionFuzzer {
       "\\p{javaLowerCase}"
   };
   private static final List<String> INPUTS =
-      List.of("", "a", "b", "c", "&", "-", "0", "1", "x", "_", " ", "\t", "Ā", "é", "\n");
+      List.of("", "a", "b", "c", "&", "-", "0", "1", "9", "A", "Z", "_", "`", "x", " ",
+          "\t", "Ā", "é", "\n");
   private static final String[] REGRESSION_REGEXES = {
       "[\\d&&&-\\D]",
       "[\\d&&&\\Q\\E-\\D]",
@@ -98,7 +99,11 @@ final class CharacterClassExpressionFuzzer {
       "[[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&\\&]",
       "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&\\&]",
       "[[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]",
-      "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]"
+      "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]",
+      "[&&[a]&-a]",
+      "[&&[a]&-&&]",
+      "[a\\d&&&\\Q\\E&]",
+      "[^[^b]&\\Q\\E&&\\Q\\E-&&]"
   };
 
   @FuzzTest(maxDuration = "30s")

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -978,7 +978,10 @@ final class Parser {
                 && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
               throw new PatternSyntaxException("bad class syntax", pattern, pos);
             }
-            addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+            pos++;
+            if (!addRawAmpersandRangeTailIfPresent(expression)) {
+              addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+            }
             frame.accumulatedClass = expression;
             frame.currentIntersectionOperand = expression;
             frame.pendingScalarItems = new CharClassBuilder();
@@ -987,7 +990,6 @@ final class Parser {
             frame.pendingScalarRole = ClassAtomRole.ORDINARY_SCALAR;
             frame.parsingIntersectionRight = false;
             frame.intersectionRightStartedAfterCommentsTrivia = false;
-            pos++;
             continue;
           }
           if (c == '&') {
@@ -996,7 +998,8 @@ final class Parser {
             }
             if (countAmpersandsAt(pos) == 1
                 && frame.intersectionRightHasExpression
-                && frame.intersectionRightOnlyNestedClasses) {
+                && frame.intersectionRightOnlyNestedClasses
+                && !rawAmpersandStartsRangeAt(pos)) {
               finishNestedRightBeforeTrailingAmpersand(frame);
               pos++;
               continue;
@@ -1020,7 +1023,10 @@ final class Parser {
                   && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
                 throw new PatternSyntaxException("bad class syntax", pattern, pos);
               }
-              addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+              pos = tail.pos() + 1;
+              if (!addRawAmpersandRangeTailIfPresent(expression)) {
+                addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+              }
               frame.accumulatedClass = expression;
               frame.currentIntersectionOperand = expression;
               frame.pendingScalarItems = new CharClassBuilder();
@@ -1029,7 +1035,6 @@ final class Parser {
               frame.pendingScalarRole = ClassAtomRole.ORDINARY_SCALAR;
               frame.parsingIntersectionRight = false;
               frame.intersectionRightStartedAfterCommentsTrivia = false;
-              pos = tail.pos() + 1;
               continue;
             }
           }
@@ -1326,6 +1331,7 @@ final class Parser {
             includeSeparatorLiteral
                 ? snapshotPendingExpression(frame)
                 : frame.rawAmpersandLeftExpression;
+        addRawAmpersandRangeTailIfPresent(expression);
         frame.accumulatedClass = new CharClassBuilder().addCharClass(expression);
         frame.currentIntersectionOperand = frame.accumulatedClass;
         frame.pendingScalarItems = new CharClassBuilder();
@@ -1381,7 +1387,9 @@ final class Parser {
     OddAmpersandRunTail tail = inspectOddAmpersandRunTail(pos);
     if (!tail.skippedNormalizedSyntax()) {
       rejectInvalidRangeTailAfterOddAmpersandRun();
-      addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+      if (!addRawAmpersandRangeTailIfPresent(expression)) {
+        addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+      }
     } else {
       pos = tail.pos();
       if (!tail.skippedCommentsTrivia()) {
@@ -1398,12 +1406,18 @@ final class Parser {
         if (tail.skippedCommentsTrivia()) {
           throw new PatternSyntaxException("bad class syntax", pattern, pos);
         }
-        addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+        if (!addRawAmpersandRangeTailIfPresent(expression)) {
+          addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+        }
       }
       if (pattern.charAt(pos) == '&') {
         int tailAmpersands = countAmpersandsAt(pos);
         if (tailAmpersands == 1) {
-          startIntersectionRightAfterOddRunDelimiter(frame, expression, tail);
+          CharClassBuilder intersectionLeft = expression;
+          if (frame.currentIntersectionOperand != null) {
+            intersectionLeft = new CharClassBuilder().addCharClass(frame.currentIntersectionOperand);
+          }
+          startIntersectionRightAfterOddRunDelimiter(frame, intersectionLeft, tail);
           return;
         } else if (tailAmpersands % 2 == 0) {
           addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
@@ -1428,7 +1442,9 @@ final class Parser {
         frame.suppressNegation = true;
         return;
       } else if (!tail.skippedCommentsTrivia()) {
-        addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+        if (!addRawAmpersandRangeTailIfPresent(expression)) {
+          addRangeFlags(expression, '&', '&', flags | ParseFlags.CLASS_NL);
+        }
       }
     }
     frame.accumulatedClass = expression;
@@ -1493,6 +1509,40 @@ final class Parser {
       return false;
     }
     return startsPredefinedClassAt(tail.pos() + 1) || startsPropertyClassAt(tail.pos() + 1);
+  }
+
+  private boolean rawAmpersandStartsRangeAt(int ampersandIndex) {
+    if (ampersandIndex + 1 >= pattern.length() || pattern.charAt(ampersandIndex + 1) != '-') {
+      return false;
+    }
+    int saved = pos;
+    pos = ampersandIndex + 1;
+    boolean hasEndpoint = hasRangeEndpointAfterHyphen();
+    pos = saved;
+    return hasEndpoint;
+  }
+
+  private boolean addRawAmpersandRangeTailIfPresent(CharClassBuilder ccb) {
+    if (pos >= pattern.length() || pattern.charAt(pos) != '-' || !hasRangeEndpointAfterHyphen()) {
+      return false;
+    }
+    pos++;
+    if ((flags & ParseFlags.COMMENTS) != 0) {
+      skipCommentsAndWhitespace();
+    }
+    RangeEndpoint endpoint = parseCCRangeEndpoint();
+    if (endpoint.first < '&') {
+      throw new PatternSyntaxException("invalid character class range", pattern, pos);
+    }
+    addRangeFlags(ccb, '&', endpoint.first, flags | ParseFlags.CLASS_NL);
+    for (int r : endpoint.trailingLiterals) {
+      addRangeFlags(ccb, r, r, flags | ParseFlags.CLASS_NL);
+    }
+    if (pos < pattern.length() && pattern.charAt(pos) == '&' && countAmpersandsAt(pos) == 1) {
+      addRangeFlags(ccb, '&', '&', flags | ParseFlags.CLASS_NL);
+      pos++;
+    }
+    return true;
   }
 
   private CharClassBuilder snapshotOddAmpersandUnionExpression(ClassExpressionFrame frame) {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1082,8 +1082,8 @@ class JdkSyntaxCompatibilityTest {
     }
 
     static Stream<Arguments> characterClassExpressionOracleMatrixCases() {
-      List<String> inputs = List.of("", "a", "b", "c", "&", "-", "0", "1", "x", " ", "\t",
-          "Ā", "é");
+      List<String> inputs = List.of("", "a", "b", "c", "&", "-", "0", "1", "9", "A", "Z", "_",
+          "`", "x", " ", "\t", "Ā", "é");
       return Stream.of(
           Arguments.of(new CharacterClassMembershipCase("[ab&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[a-b&&]", inputs)),
@@ -1117,9 +1117,12 @@ class JdkSyntaxCompatibilityTest {
           Arguments.of(new CharacterClassMembershipCase("[\\d&\\Q\\E&&&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[\\w&\\Q\\E&& &&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[a&&&\\Q\\E&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[a\\d&&&\\Q\\E&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[a&&&\\Q\\E&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[a&\\Q\\E&&\\Q\\E&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[a&\\Q\\E&&\\Q\\E&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[&&[a]&-a]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[&&[a]&-&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[&&abc]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[ &&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[ &&&a]", inputs)),
@@ -1234,6 +1237,8 @@ class JdkSyntaxCompatibilityTest {
           new CharacterClassMatrixPiece("escapedAmp", "\\&"),
           new CharacterClassMatrixPiece("quoteAmp", "\\Q&\\E"),
           new CharacterClassMatrixPiece("rangeToNonDigit", "-\\D"),
+          new CharacterClassMatrixPiece("rangeToA", "-a"),
+          new CharacterClassMatrixPiece("rangeToIntersection", "-&&"),
           new CharacterClassMatrixPiece("zeroWidthRangeToNonDigit", "\\Q\\E-\\D"));
       List<CharacterClassMatrixSeparator> separators = List.of(
           new CharacterClassMatrixSeparator("none", "", false),


### PR DESCRIPTION
## Summary
- preserve raw ampersands as range starts when followed by valid range tails in character-class intersections
- use the current intersection operand for normalized odd-ampersand RHS transitions
- add focused JDK oracle coverage plus fuzz generator coverage for #287 shapes

Fixes #287

## Testing
- `mvn -pl safere -Dtest='JdkSyntaxCompatibilityTest$CharacterClasses#characterClassExpressionOracleMatrixMatchesJdk' test -q`
- `mvn -pl safere -Dtest='JdkSyntaxCompatibilityTest$CharacterClasses' test -q`
- first 50k generated matrix with `-Dsafere.longSyntaxMatrix=true -Dsafere.syntaxMatrix.limit=50000`
- all 8 bounded generated-matrix shards, 50k each
- `mvn -pl safere test -q`
- `mvn -pl safere-fuzz -am -Dtest=CharacterClassExpressionFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
