### PR TITLE
Fix character class intersection tail parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -103,7 +103,10 @@ final class CharacterClassExpressionFuzzer {
       "[&&[a]&-a]",
       "[&&[a]&-&&]",
       "[a\\d&&&\\Q\\E&]",
-      "[^[^b]&\\Q\\E&&\\Q\\E-&&]"
+      "[^[^b]&\\Q\\E&&\\Q\\E-&&]",
+      "(?x)[a\\d&& [0]&]",
+      "(?x)[a[b]&& [a]&]",
+      "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]"
   };
 
   @FuzzTest(maxDuration = "30s")

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1226,7 +1226,7 @@ final class Parser {
       expression = new CharClassBuilder().addCharClass(frame.accumulatedClass);
       expression.intersect(frame.intersectionRight);
       if (frame.hasPendingScalarItems) {
-        if (frame.pendingScalarItemsAfterCurrentOperand
+        if (!frame.pendingScalarItemsAfterCurrentOperand
             && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
           expression.addCharClass(frame.pendingScalarItems);
         } else {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1075,6 +1075,10 @@ class JdkSyntaxCompatibilityTest {
               "[[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]", inputs)),
           Arguments.of(new CharacterClassMembershipCase(
               "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("(?x)[a\\d&& [0]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("(?x)[a[b]&& [a]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[[a]Ā&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[\\d0-1&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[ [ab] && #x\n [bc] && ]",


### PR DESCRIPTION
## Summary

- Fix character-class parsing for nested intersection RHS tails followed by a literal ampersand.
- Add JDK compatibility regressions for comments-mode class expressions with pre-operand scalars.
- Add the reported syntax shape and nearby variants to the character-class expression fuzz seeds.

## Testing

- `mvn -pl safere -Dtest='JdkSyntaxCompatibilityTest$CharacterClasses#characterClassExpressionParserCasesMatchJdk' test`
- `mvn -pl safere-fuzz -am -Dtest=CharacterClassExpressionFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
