### PR TITLE
Fix standalone flag quantifier parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -29,12 +29,15 @@ final class ParserCompatibilityFuzzer {
       "[^a]",
       "[a-z]",
       "[a-z&&[def]]",
+      "()",
+      "(?)",
       "(a)",
       "(?:a)",
       "(?<name>a)"
   };
   private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "(?m)", "(?s)"};
-  private static final String[] CONNECTORS = {"", "", "|", "?", "*", "+", "{0}", "{1,3}"};
+  private static final String[] CONNECTORS =
+      {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}"};
   private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
   private static final List<String> INPUTS =
       List.of("", "a", "aa", "abc", "def", "0", " ", "\n", "*", "name");

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -136,6 +136,7 @@ final class Parser {
     }
 
     String lastunary = null;
+    boolean lastTokenNonRepeatable = false;
     while (pos < pattern.length()) {
       // In comments mode, skip whitespace and #-comments before each token.
       if ((flags & ParseFlags.COMMENTS) != 0) {
@@ -145,6 +146,7 @@ final class Parser {
         }
       }
       String isunary = null;
+      boolean isNonRepeatable = false;
       int c = pattern.codePointAt(pos);
       switch (c) {
         case '(' -> {
@@ -152,7 +154,7 @@ final class Parser {
           if ((flags & ParseFlags.PERL_X) != 0
               && pos + 1 < pattern.length()
               && pattern.charAt(pos + 1) == '?') {
-            parsePerlFlags();
+            isNonRepeatable = parsePerlFlags();
             break;
           }
           if ((flags & ParseFlags.NEVER_CAPTURE) != 0) {
@@ -187,6 +189,10 @@ final class Parser {
           pushRegexp(re);
         }
         case '*', '+', '?' -> {
+          if (lastTokenNonRepeatable) {
+            throw new PatternSyntaxException(
+                "missing argument to repetition operator", pattern, pos);
+          }
           RegexpOp op =
               c == '*'
                   ? RegexpOp.STAR
@@ -228,6 +234,11 @@ final class Parser {
             }
           }
           String opstr = pattern.substring(opStart, pos);
+          if (lastTokenNonRepeatable) {
+            validateRepeatCount(lo, hi, opstr);
+            isNonRepeatable = true;
+            break;
+          }
           pushRepetition(lo, hi, opstr, nongreedy);
           isunary = opstr;
         }
@@ -240,6 +251,7 @@ final class Parser {
         }
       }
       lastunary = isunary;
+      lastTokenNonRepeatable = isNonRepeatable;
     }
     return doFinish();
   }
@@ -586,10 +598,7 @@ final class Parser {
   }
 
   private void pushRepetition(int min, int max, String opstr, boolean nongreedy) {
-    if ((max != -1 && max < min) || min > MAX_REPEAT || max > MAX_REPEAT) {
-      throw new PatternSyntaxException(
-          "invalid repeat count", pattern, pos - opstr.length());
-    }
+    validateRepeatCount(min, max, opstr);
     if (stacktop == null || isMarker(stacktop)) {
       throw new PatternSyntaxException(
           "missing argument to repetition operator", pattern, pos - opstr.length());
@@ -610,6 +619,13 @@ final class Parser {
         throw new PatternSyntaxException(
             "invalid repeat count", pattern, pos - opstr.length());
       }
+    }
+  }
+
+  private void validateRepeatCount(int min, int max, String opstr) {
+    if ((max != -1 && max < min) || min > MAX_REPEAT || max > MAX_REPEAT) {
+      throw new PatternSyntaxException(
+          "invalid repeat count", pattern, pos - opstr.length());
     }
   }
 
@@ -2586,7 +2602,7 @@ final class Parser {
 
   // ---- Perl flags parsing ----
 
-  private void parsePerlFlags() {
+  private boolean parsePerlFlags() {
     // Caller checked that pattern[pos] == '(' and pattern[pos+1] == '?'
     if ((flags & ParseFlags.PERL_X) == 0
         || pos + 1 >= pattern.length()
@@ -2629,7 +2645,7 @@ final class Parser {
         }
         doLeftParen(name);
         pos = end + 1; // skip past '>'
-        return;
+        return false;
       }
     }
 
@@ -2637,6 +2653,7 @@ final class Parser {
 
     boolean negated = false;
     boolean sawflags = false;
+    boolean standaloneFlags = false;
     int nflags = flags;
 
     boolean done = false;
@@ -2700,6 +2717,7 @@ final class Parser {
           done = true;
         }
         case ')' -> {
+          standaloneFlags = true;
           done = true;
         }
         default -> {
@@ -2713,6 +2731,7 @@ final class Parser {
     }
 
     flags = nflags;
+    return standaloneFlags;
   }
 
   // ---- Repetition parsing ----

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -196,6 +196,46 @@ class JdkSyntaxCompatibilityTest {
   @Nested
   @DisplayName("Syntax-family compatibility matrix")
   class SyntaxFamilyCompatibilityMatrix {
+    static Stream<Arguments> quantifiedBareQuestionGroups() {
+      return Stream.of(
+          Arguments.of("(?)?"),
+          Arguments.of("(?)*"),
+          Arguments.of("(?)+"),
+          Arguments.of("()??(?)?"),
+          Arguments.of("()?(?)?"),
+          Arguments.of("()*?(?)?"),
+          Arguments.of("()+?(?)?"),
+          Arguments.of("(a)??(?)?"),
+          Arguments.of("a??(?)?"),
+          Arguments.of("()??|(?)?"));
+    }
+
+    @ParameterizedTest(name = "/{0}/")
+    @MethodSource("quantifiedBareQuestionGroups")
+    @DisplayName("bare question groups reject following quantifiers like JDK")
+    void bareQuestionGroupsRejectFollowingQuantifiersLikeJdk(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
+    }
+
+    static Stream<Arguments> countedBareQuestionGroups() {
+      return Stream.of(
+          Arguments.of("(?){2}", "", true),
+          Arguments.of("a(?){2}", "a", true),
+          Arguments.of("a(?){2}", "aa", false),
+          Arguments.of("()??(?){2}", "", true),
+          Arguments.of("a(?){2}?", "a", true),
+          Arguments.of("(?){1}{1}", "", true));
+    }
+
+    @ParameterizedTest(name = "/{0}/ matches \"{1}\" = {2}")
+    @MethodSource("countedBareQuestionGroups")
+    @DisplayName("bare question groups accept counted repeats like JDK")
+    void bareQuestionGroupsAcceptCountedRepeatsLikeJdk(
+        String regex, String input, boolean expected) {
+      assertMatchesFull(regex, input);
+      assertThat(Pattern.compile(regex).matcher(input).matches()).isEqualTo(expected);
+    }
+
     static Stream<Arguments> acceptedSyntaxFamilies() {
       return Stream.of(
           Arguments.of(new SyntaxFamilyCase("literal characters", "abc", "abc", "ab")),


### PR DESCRIPTION
## Summary

- Reject `?`, `*`, and `+` after standalone embedded-flag constructs like `(?)`, matching JDK syntax behavior.
- Keep counted repeats after those constructs zero-width and non-AST, matching JDK behavior for forms like `(?){2}` and `a(?){2}`.
- Add JDK compatibility regression coverage and expand parser compatibility fuzz generation for nearby syntax shapes.

## Verification

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest,ParserTest,SimplifierTest test`
- `mvn -pl safere-fuzz -am -Dtest=ParserCompatibilityFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
