### PR TITLE
Add fuzzer run triage skill

### DIFF
--- a/.agents/skills/fuzzer-run-triage/SKILL.md
+++ b/.agents/skills/fuzzer-run-triage/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: fuzzer-run-triage
+description: "Triage SafeRE Jazzer fuzzer runs performed manually by the user: locate Surefire/Jazzer logs, distinguish latest run artifacts from persistent corpus and older crashes, extract bugs/findings, identify crash inputs, summarize repro details, and prepare GitHub issue material without rerunning fuzzing."
+---
+
+# Fuzzer Run Triage
+
+## Goal
+
+When the user has run a SafeRE Jazzer fuzzer by hand, find what that run discovered and present
+the actionable bug findings. Do not assume `target/fuzz-reproducers` exists: Jazzer JUnit usually
+writes libFuzzer `crash-*` inputs to the fuzzer's input resource directory, while Maven/Surefire
+writes human-readable logs under `target/surefire-reports`.
+
+## First Checks
+
+1. Identify the fuzzer class from the user's command or question, for example
+   `CharacterClassExpressionFuzzer`.
+2. Inspect the latest matching Surefire files:
+   - `safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml`
+   - `safere-fuzz/target/surefire-reports/org.safere.fuzz.<Fuzzer>.txt`
+3. Check file mtimes before trusting artifacts:
+
+   ```bash
+   stat safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml
+   stat safere-fuzz/target/surefire-reports/org.safere.fuzz.<Fuzzer>.txt
+   ```
+
+4. Extract findings from the XML:
+
+   ```bash
+   rg -n '== Java Exception|AssertionError|CrosscheckException|PatternSyntaxException|divergence|DEDUP_TOKEN|libFuzzer crashing input|Test unit written|artifact_prefix|reproducer_path|Java reproducer written' \
+     safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml
+   ```
+
+## Where Artifacts Live
+
+- **Surefire logs**: `safere-fuzz/target/surefire-reports/`
+  - Mixed by fuzzer class in one directory.
+  - The same fuzzer's `.xml` and `.txt` files are overwritten by newer runs.
+  - Other fuzzer reports may be older and unrelated.
+
+- **Generated corpus**: `safere-fuzz/.cifuzz-corpus/org.safere.fuzz.<Fuzzer>/<method>/`
+  - Persistent coverage corpus, intentionally accumulated across runs.
+  - Not a clean list of current-run bugs.
+
+- **Jazzer JUnit crash inputs**:
+  `safere-fuzz/src/test/resources/org/safere/fuzz/<Fuzzer>Inputs/<method>/crash-*`
+  - Usually the important reproducer files for JUnit fuzz findings.
+  - These are persistent checked-in seed locations, so use mtimes and the Surefire log to tell
+    new crashes from old ones.
+
+- **Compiled test resource copies**:
+  `safere-fuzz/target/test-classes/org/safere/fuzz/<Fuzzer>Inputs/<method>/`
+  - Build output copies. Do not treat these as source-of-truth new findings.
+
+- **Standalone Java reproducers**: path from `-Djazzer.reproducer_path=...`
+  - In Jazzer JUnit mode these often do not exist, even when bugs were found.
+  - If present, inspect them, but absence is not evidence that no bugs were found.
+
+## Finding New Crash Inputs
+
+Find the fuzzer method and input resource directory. For most SafeRE fuzzers the method name is
+visible in the Surefire testcase name and in the resource path:
+
+```bash
+rg -n '<testcase name=' safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml
+find safere-fuzz/src/test/resources/org/safere/fuzz/<Fuzzer>Inputs -type f -name 'crash-*' \
+  -printf '%TY-%Tm-%Td %TH:%TM:%TS %p\n' | sort
+```
+
+If the user gives the approximate run time, compare crash mtimes to that time. If they do not,
+compare crash mtimes to the Surefire XML mtime and the `sun.java.command` or testcase elapsed time
+inside the XML.
+
+## Interpreting Results
+
+Use both logs and crash files:
+
+- The XML usually contains the readable exception text: regex, flags, input, SafeRE result, JDK
+  result, stack trace, and dedup tokens.
+- `crash-*` files are the inputs Jazzer can replay through the fuzz target, but they may not be
+  human-readable.
+- A `.txt` report with `Failures: 0, Errors: 0` does not prove no bugs were found when
+  `jazzer.keep_going` is in use. Always inspect the XML for `== Java Exception` and `DEDUP_TOKEN`.
+
+Classify findings before filing:
+
+- **compile divergence**: SafeRE accepts/rejects a pattern differently from JDK.
+- **match divergence**: SafeRE and JDK compile but produce different match results.
+- **API sequence divergence**: matcher/split/replace/stateful operation differs.
+- **crash/hang/stack overflow**: SafeRE throws unexpectedly, times out, or exceeds stack limits.
+
+Deduplicate by semantic class, not only exact string. If two findings are variants of the same
+parser rule or matcher invariant, discuss whether to file one broader issue or multiple focused
+issues.
+
+## Reporting to the User
+
+Summarize:
+
+- Which run files were inspected, with mtimes if recency matters.
+- Whether the Surefire report is a latest per-fuzzer report or mixed with older reports.
+- Each finding's regex/flags/input/operation and SafeRE vs JDK behavior.
+- The corresponding `crash-*` files, if identifiable.
+- Whether `target/fuzz-reproducers` exists, and why absence may be normal.
+
+When asked to file issues:
+
+1. Search existing issues for exact repro substrings and the semantic class.
+2. Write the issue body to a temp file and use `gh issue create --body-file`.
+3. Include the command, Surefire XML path, crash input path, and concise observed behavior.
+4. Do not close existing issues unless all items are resolved.

--- a/.agents/skills/fuzzer-run-triage/agents/openai.yaml
+++ b/.agents/skills/fuzzer-run-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fuzzer Run Triage"
+  short_description: "Find bugs from SafeRE Jazzer run artifacts"
+  default_prompt: "Use $fuzzer-run-triage after a manual SafeRE Jazzer run to locate logs, crash inputs, and actionable bug findings."

--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -103,7 +103,10 @@ final class CharacterClassExpressionFuzzer {
       "[&&[a]&-a]",
       "[&&[a]&-&&]",
       "[a\\d&&&\\Q\\E&]",
-      "[^[^b]&\\Q\\E&&\\Q\\E-&&]"
+      "[^[^b]&\\Q\\E&&\\Q\\E-&&]",
+      "(?x)[a\\d&& [0]&]",
+      "(?x)[a[b]&& [a]&]",
+      "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]"
   };
 
   @FuzzTest(maxDuration = "30s")

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1226,7 +1226,7 @@ final class Parser {
       expression = new CharClassBuilder().addCharClass(frame.accumulatedClass);
       expression.intersect(frame.intersectionRight);
       if (frame.hasPendingScalarItems) {
-        if (frame.pendingScalarItemsAfterCurrentOperand
+        if (!frame.pendingScalarItemsAfterCurrentOperand
             && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
           expression.addCharClass(frame.pendingScalarItems);
         } else {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1075,6 +1075,10 @@ class JdkSyntaxCompatibilityTest {
               "[[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]", inputs)),
           Arguments.of(new CharacterClassMembershipCase(
               "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("(?x)[a\\d&& [0]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("(?x)[a[b]&& [a]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[[a]Ā&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[\\d0-1&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[ [ab] && #x\n [bc] && ]",


### PR DESCRIPTION
## Summary

- Add a repo-local `fuzzer-run-triage` skill for interpreting manual Jazzer runs.
- Document where to find Surefire XML logs, persistent corpora, JUnit `crash-*` inputs, and optional Java reproducers.
- Capture the workflow for extracting findings and preparing issue material.

## Validation

- Not run, per request.
