### PR TITLE
Reject malformed character-class ampersand runs

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -104,6 +104,9 @@ final class CharacterClassExpressionFuzzer {
       "[&&[a]&-&&]",
       "[a\\d&&&\\Q\\E&]",
       "[^[^b]&\\Q\\E&&\\Q\\E-&&]",
+      "(?x)[0&\\Q\\E\\Q\\E&&& #x\n-&&]",
+      "(?x)[0&\\Q\\E\\Q\\E&&&& #x\n-&&]",
+      "(?x)[0&\\Q\\E\\Q\\E&&&&&& #x\n-&&]",
       "(?x)[a\\d&& [0]&]",
       "(?x)[a[b]&& [a]&]",
       "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]"

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1297,6 +1297,8 @@ final class Parser {
         }
         if (!tail.skippedCommentsTrivia()) {
           rejectInvalidRangeTailAfterOddAmpersandRun();
+        } else if (pattern.charAt(pos) == '-' && hasRangeEndpointAfterHyphen()) {
+          throw new PatternSyntaxException("bad class syntax", pattern, pos);
         }
         if (tail.skippedCommentsTrivia() && pattern.charAt(pos) == '[') {
           frame.accumulatedClass = new CharClassBuilder();

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1175,6 +1175,16 @@ class JdkSyntaxCompatibilityTest {
           Arguments.of(new CharacterClassMembershipCase("(?x)[^[a]& &&]", inputs)));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "(?x)[0&\\Q\\E\\Q\\E&&&& #x\n-&&]",
+        "(?x)[0&\\Q\\E\\Q\\E&&&&&& #x\n-&&]"
+    })
+    @DisplayName("character-class ampersand runs with empty quotes reject malformed syntax")
+    void characterClassAmpersandRunsWithEmptyQuotesRejectMalformedSyntax(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("deferredCharacterClassExpressionParserCases")
     @DisplayName("character-class expression parser cases match JDK")


### PR DESCRIPTION
## Summary

- Reject malformed comments-mode character-class ampersand runs with empty quoted literals before a range tail.
- Add JDK compatibility regression coverage for the #299 reproducer shape.
- Add matching grammar-biased fuzz regression seeds.

Fixes #299

## Testing

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test`
- `mvn -pl safere-fuzz -am -Dtest=CharacterClassExpressionFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
