### PR TITLE
Fix hitEnd after final zero-width find

### DIFF
--- a/.agents/skills/parser-bug-fix/SKILL.md
+++ b/.agents/skills/parser-bug-fix/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: parser-bug-fix
-description: "Fix SafeRE parser bugs using the project bug-fixing discipline: test-driven diagnosis, mandatory regression tests, principled class-level fixes instead of point patches, invariant-based verification, and required grammar-biased fuzz generator updates. Use when a SafeRE bug involves regex syntax parsing, parse-time acceptance or rejection, JDK syntax compatibility, parser stack safety, character-class parsing, escape parsing, unsupported regex feature rejection, or crashes/errors from Parser or Pattern.compile."
+description: "Fix SafeRE parser, capture, and matcher lifecycle bugs using the project bug-fixing discipline: test-driven diagnosis, mandatory regression tests, principled class-level fixes instead of point patches, invariant-based verification, and required fuzz seed/generator coverage. Use when a SafeRE bug involves regex syntax parsing, parse-time acceptance or rejection, JDK syntax compatibility, parser stack safety, character classes, escapes, unsupported regex feature rejection, capture semantics, quantified captures, group boundaries, find() sequences, hitEnd()/requireEnd(), matcher state transitions, or crashes/errors from Parser, Pattern.compile, Pattern, or Matcher."
 ---
 
-# Parser Bug Fix
+# SafeRE Parser, Capture, and Matcher Bug Fix
 
 ## Goal
 
-Fix parser bugs in a way that preserves SafeRE's semantics and linear-time guarantee. The fix must
-be test-driven, include regression coverage, address the semantic class of the bug rather than the
-single reproducer, and add grammar-biased fuzz coverage for the bug's syntax shape.
+Fix parser, capture, and matcher lifecycle bugs in a way that preserves SafeRE's semantics,
+JDK-compatible public API behavior, and linear-time guarantee. The fix must be test-driven, include
+regression coverage, address the semantic class of the bug rather than the single reproducer, and
+add fuzz seed or generator coverage for the bug's behavioral shape.
 
 ## Workflow
 
@@ -19,13 +20,15 @@ single reproducer, and add grammar-biased fuzz coverage for the bug's syntax sha
    - Do not use `Fixes #N` unless the change fully resolves every item in the issue; use
      `Refs #N` or `Part of #N` otherwise.
 
-2. Start with tests, before reading parser internals.
-   - Ask why the existing tests missed this class of syntax.
+2. Start with tests, before reading parser, capture, or matcher internals.
+   - Ask why the existing tests missed this class of syntax or behavior.
    - Add systematic JUnit coverage in `safere/src/test/java/org/safere`, usually
-     `ParserTest.java` or `JdkSyntaxCompatibilityTest.java`.
-   - Cover representative variants: accepted/rejected forms, inside and outside character
-     classes, relevant flags, nesting, separators, Unicode/code point boundaries, and JDK
-     compatibility behavior when applicable.
+     `ParserTest.java`, `JdkSyntaxCompatibilityTest.java`, `MatcherTest.java`,
+     `MatcherStateMachineTraceTest.java`, or `QuantifiedCaptureSemanticsTest.java`.
+   - Cover representative variants for the bug class: accepted/rejected forms, inside and outside
+     character classes, flags, nesting, separators, Unicode/code point boundaries, capture groups,
+     nullable/quantified captures, repeated `find()` sequences, regions/bounds, end-state flags,
+     and JDK compatibility behavior when applicable.
    - Name tests for behavior, not issue numbers. Keep issue IDs only in comments or display-name
      suffixes if useful.
 
@@ -35,7 +38,7 @@ single reproducer, and add grammar-biased fuzz coverage for the bug's syntax sha
    - For public API compatibility behavior, include the matching crosscheck or compatibility test
      path when practical.
 
-4. Root-cause the parser behavior and make a principled fix.
+4. Root-cause the parser, capture, or matcher behavior and make a principled fix.
    - Read parser internals only after the failing coverage exists.
    - Fix the semantic class of the bug, not a pattern string or fuzzer seed.
    - Do not add point guards unless they directly encode a documented regex/API rule.
@@ -54,7 +57,7 @@ single reproducer, and add grammar-biased fuzz coverage for the bug's syntax sha
    - When SafeRE intentionally diverges from JDK behavior for linear-time guarantees, document the
      reason in tests or code comments where relevant.
 
-6. Add the syntax shape to the relevant fuzz generator axis.
+6. Add the behavioral shape to the relevant fuzz generator axis or seed corpus.
    - Character-class expressions: `safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java`
    - Escapes and escaped literals: `safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java`
    - Dialect boundaries, unsupported constructs, property spelling variants:
@@ -63,8 +66,13 @@ single reproducer, and add grammar-biased fuzz coverage for the bug's syntax sha
      `safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java`
    - Deep nesting or parser stack safety:
      `safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java`
-   - If none fits, extend the closest axis or add a new focused parser fuzzer. Do not rely only on
-     a one-off regression string.
+   - Captures, quantified captures, group boundaries:
+     `safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java` or a focused capture fuzzer.
+   - Stateful matcher APIs, repeated `find()`, regions/bounds, `hitEnd()`/`requireEnd()`:
+     `safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java` or
+     `safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java`.
+   - If none fits, extend the closest axis or add a new focused fuzzer. Do not rely only on a
+     one-off regression string.
 
 7. Verify the fix.
    - Run the focused JUnit tests again.

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -22,6 +22,17 @@ final class FindSequenceFuzzer {
       return;
     }
 
+    Matcher findWalker = pattern.matcher(input);
+    int maxFinds = Math.min(input.length() + 2, 64);
+    for (int i = 0; i < maxFinds; i++) {
+      boolean found = findWalker.find();
+      findWalker.hitEnd();
+      findWalker.requireEnd();
+      if (!found) {
+        break;
+      }
+    }
+
     Matcher matcher = pattern.matcher(input);
     boolean hasMatch = false;
     int steps = data.consumeInt(1, 32);

--- a/safere-fuzz/src/test/resources/org/safere/fuzz/FindSequenceFuzzerInputs/sequence/final-nullable-hit-end
+++ b/safere-fuzz/src/test/resources/org/safere/fuzz/FindSequenceFuzzerInputs/sequence/final-nullable-hit-end
@@ -1,0 +1,2 @@
+(?:(a)?)??c?
+cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -119,6 +119,7 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean lastHitEnd;
   private boolean lastRequireEnd;
+  private boolean findExhaustedAfterTerminalEmptyMatch;
   private int modCount;
 
   /**
@@ -221,6 +222,7 @@ public final class Matcher implements MatchResult {
   }
 
   private void applyFullMatchResult(int[] resultGroups) {
+    findExhaustedAfterTerminalEmptyMatch = false;
     groups = resultGroups;
     hasMatch = resultGroups != null;
     resultStatus = hasMatch ? ResultStatus.MATCHED : ResultStatus.FAILED;
@@ -228,6 +230,7 @@ public final class Matcher implements MatchResult {
   }
 
   private void applyDeferredMatchResult(DeferredMatchResult deferred) {
+    findExhaustedAfterTerminalEmptyMatch = false;
     groups = new int[2 * deferred.ncap()];
     Arrays.fill(groups, -1);
     groups[0] = deferred.start();
@@ -242,6 +245,7 @@ public final class Matcher implements MatchResult {
   }
 
   private void clearCurrentResult() {
+    findExhaustedAfterTerminalEmptyMatch = false;
     groups = null;
     hasMatch = false;
     resultStatus = ResultStatus.RESET_NO_ATTEMPT;
@@ -568,6 +572,7 @@ public final class Matcher implements MatchResult {
    */
   public boolean matches() {
     modCount++;
+    findExhaustedAfterTerminalEmptyMatch = false;
     searchFrom = regionStart;
 
     // --- Region setup ---
@@ -686,6 +691,7 @@ public final class Matcher implements MatchResult {
    */
   public boolean lookingAt() {
     modCount++;
+    findExhaustedAfterTerminalEmptyMatch = false;
     searchFrom = regionStart;
 
     // --- Region setup ---
@@ -786,6 +792,10 @@ public final class Matcher implements MatchResult {
    */
   public boolean find() {
     modCount++;
+    if (findExhaustedAfterTerminalEmptyMatch) {
+      applyEngineResult(new NoMatchResult());
+      return false;
+    }
     if (hasMatch) {
       // Only resolve deferred captures before advancing when group 0 itself is not authoritative.
       // If group 0 is already exact, find-all loops that never read inner captures should not pay
@@ -797,7 +807,8 @@ public final class Matcher implements MatchResult {
       if (groups[0] == groups[1]) { // empty match
         if (searchFrom >= regionEnd) {
           applyEngineResult(new NoMatchResult());
-          updateEndState(MatchOperation.FIND);
+          findExhaustedAfterTerminalEmptyMatch = true;
+          searchFrom = regionEnd + 1;
           return false;
         }
         searchFrom++;
@@ -2206,7 +2217,7 @@ public final class Matcher implements MatchResult {
 
   private boolean matchCanExtendAtEnd(MatchOperation operation) {
     java.util.List<String> samples = new java.util.ArrayList<>();
-    collectTerminalRepeatSamples(parentPattern.ast(), samples);
+    collectTerminalExtensionSamples(parentPattern.ast(), samples);
     if (samples.isEmpty()) {
       return false;
     }
@@ -2234,19 +2245,19 @@ public final class Matcher implements MatchResult {
     return false;
   }
 
-  private static void collectTerminalRepeatSamples(Regexp re, java.util.List<String> samples) {
+  private static void collectTerminalExtensionSamples(Regexp re, java.util.List<String> samples) {
     switch (re.op) {
-      case STAR, PLUS -> addSample(re.subs.get(0), samples);
+      case STAR, PLUS, QUEST -> addSample(re.subs.get(0), samples);
       case REPEAT -> {
-        if (re.max < 0) {
+        if (re.max < 0 || re.max > re.min) {
           addSample(re.subs.get(0), samples);
         }
       }
-      case NON_CAPTURE, CAPTURE -> collectTerminalRepeatSamples(re.subs.get(0), samples);
+      case NON_CAPTURE, CAPTURE -> collectTerminalExtensionSamples(re.subs.get(0), samples);
       case CONCAT -> {
         for (int i = re.subs.size() - 1; i >= 0; i--) {
           Regexp sub = re.subs.get(i);
-          collectTerminalRepeatSamples(sub, samples);
+          collectTerminalExtensionSamples(sub, samples);
           if (!Pattern.canMatchEmpty(sub)) {
             break;
           }
@@ -2254,7 +2265,7 @@ public final class Matcher implements MatchResult {
       }
       case ALTERNATE -> {
         for (Regexp sub : re.subs) {
-          collectTerminalRepeatSamples(sub, samples);
+          collectTerminalExtensionSamples(sub, samples);
         }
       }
       default -> {}

--- a/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
+++ b/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
@@ -60,6 +60,54 @@ class MatcherStateMachineTraceTest {
   }
 
   @Test
+  @DisplayName("final nullable find at input end preserves JDK-compatible hitEnd")
+  void finalNullableFindAtInputEndPreservesJdkCompatibleHitEnd() {
+    assertTrace("(?:(a)?)??c?", "c" + "b".repeat(3),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd());
+  }
+
+  @Test
+  @DisplayName("find failure after terminal empty-pattern match preserves JDK-compatible hitEnd")
+  void findFailureAfterTerminalEmptyPatternMatchPreservesJdkCompatibleHitEnd() {
+    assertTrace("", "abc",
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd(),
+        Step.find(),
+        Step.hitEnd(),
+        Step.requireEnd());
+  }
+
+  @Test
   @DisplayName("find(int) resets region and append position before searching")
   void findStartResetsRegionAndAppendPositionBeforeSearching() {
     assertTrace("\\d+", "xx11yy22",


### PR DESCRIPTION
## Summary

- Fix JDK-compatible `hitEnd()` state after terminal zero-width `find()` sequences.
- Preserve terminal-empty `find()` exhaustion state across repeated `find()` calls until reset.
- Add matcher lifecycle regressions and FindSequenceFuzzer end-state coverage with a seed for issue #302.
- Generalize the local parser bug-fix skill to cover capture and matcher lifecycle bugs.

## Validation

Skipped per request.

Fixes #302
