### PR TITLE
Add escaped non-ASCII parser regressions

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
@@ -32,6 +32,8 @@ final class EscapeSyntaxFuzzer {
       "\\©",
       "\\Ā",
       "\\é",
+      "\\☃",
+      "\\😀",
       "\\Q\\E",
       "\\Q&\\E",
       "\\Q-\\E",
@@ -39,12 +41,31 @@ final class EscapeSyntaxFuzzer {
   };
   private static final String[] SUFFIXES = {"", "$", "]", "a", "-", "-z", "&&[a]"};
   private static final List<String> INPUTS =
-      List.of("", "a", "A", "0", "7", "@", "\u001b", "&", "-", "©", "Ā", "é", "\u0000");
+      List.of(
+          "",
+          "a",
+          "A",
+          "0",
+          "7",
+          "@",
+          "\u001b",
+          "&",
+          "-",
+          "©",
+          "Ā",
+          "é",
+          "☃",
+          "😀",
+          "\u0000");
   private static final String[] REGRESSION_REGEXES = {
       "^\\©",
       "[\\©]",
       "\\Ā",
       "[\\Ā]",
+      "\\☃",
+      "[\\☃]",
+      "\\😀",
+      "[\\😀]",
       "\\0",
       "\\08",
       "\\400",

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -2439,6 +2439,23 @@ class JdkSyntaxCompatibilityTest {
     void escapedMetacharacter(String regex) {
       assertCompiles(regex);
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\\©", "\\é", "\\Ā", "\\☃", "\\😀"})
+    @DisplayName("escaped non-ASCII character is literal")
+    void escapedNonAsciiCharacter(String regex) {
+      String literal = regex.substring(1);
+      assertMatchesFull(regex, literal);
+      assertMatchesFull("^" + regex + "$", literal);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[\\©]", "[\\é]", "[\\Ā]", "[\\☃]", "[\\😀]"})
+    @DisplayName("escaped non-ASCII character in class is literal")
+    void escapedNonAsciiCharacterInClass(String regex) {
+      String literal = regex.substring(2, regex.length() - 1);
+      assertMatchesFull(regex, literal);
+    }
   }
 
   // ===========================================================================

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -179,6 +179,14 @@ class ParserTest {
       assertThat(re.rune).isEqualTo('_');
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"\\©", "\\é", "\\Ā", "\\☃", "\\😀"})
+    void escapedNonAsciiLiteral(String regex) {
+      Regexp re = parse(regex);
+      assertThat(re.op).isEqualTo(RegexpOp.LITERAL);
+      assertThat(re.rune).isEqualTo(regex.codePointAt(1));
+    }
+
     @Test
     void multipleEscapedPunctuation() {
       Regexp re = parse("\\.\\^\\$\\\\");
@@ -507,6 +515,19 @@ class ParserTest {
       assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
       assertThat(re.charClass.contains('\n')).isTrue();
       assertThat(re.charClass.contains('\t')).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[\\©]", "[\\é]", "[\\Ā]", "[\\☃]", "[\\😀]"})
+    void escapedNonAsciiLiteralInClass(String regex) {
+      int codePoint = regex.codePointAt(2);
+      Regexp re = parse(regex);
+      if (re.op == RegexpOp.LITERAL) {
+        assertThat(re.rune).isEqualTo(codePoint);
+      } else {
+        assertThat(re.op).isEqualTo(RegexpOp.CHAR_CLASS);
+        assertThat(re.charClass.contains(codePoint)).isTrue();
+      }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add parser regression coverage for escaped non-ASCII literals outside and inside character classes.
- Add public JDK syntax compatibility coverage for the same BMP and supplementary code point cases.
- Expand `EscapeSyntaxFuzzer` seeds and inputs to keep nearby non-ASCII escaped literal forms covered.

## Notes

The underlying parser behavior was already fixed by #284 (`695d478`). I validated the exact issue repro against the parent and fix commit:

- `695d478^` (`df6e6be`): `org.safere.Pattern.compile("^\\©")` throws `PatternSyntaxException`.
- `695d478`: `org.safere.Pattern.compile("^\\©")` compiles.

Fixes #303

## Validation

- `mvn -pl safere -Dtest=ParserTest test -q`
- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=EscapeSyntaxFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl safere test -q`

Skipped public API crosscheck verification at maintainer request because this is low-risk regression coverage.
