### PR TITLE
Fix quoted class intersection compatibility

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -106,6 +106,9 @@ final class CharacterClassExpressionFuzzer {
       "[^[^b]&\\Q\\E&&\\Q\\E-&&]",
       "(?x)[a\\d&& [0]&]",
       "(?x)[a[b]&& [a]&]",
+      "[0-1ab&&[a]&]",
+      "[^0-1ab&&[a]&]",
+      "(?x)[^0-1\\Qab\\E\\Q\\E\\Q\\E&& [a]&]",
       "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]"
   };
 

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1238,6 +1238,10 @@ final class Parser {
     } else if (frame.currentIntersectionOperandRole == ClassAtomRole.ORDINARY_SCALAR
         && !frame.hasPendingScalarItems) {
       expression = new CharClassBuilder().addCharClass(frame.accumulatedClass);
+    } else if (frame.hasPendingScalarItems
+        && frame.pendingScalarItemsAfterCurrentOperand
+        && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
+      expression = new CharClassBuilder().addCharClass(frame.pendingScalarItems);
     } else {
       expression = new CharClassBuilder().addCharClass(frame.accumulatedClass);
       expression.intersect(frame.intersectionRight);

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1117,8 +1117,12 @@ class JdkSyntaxCompatibilityTest {
               "[^[^b]&\\Q\\E\\Q\\E&&&&\\Q\\E&-\\D]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[a\\d&& [0]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[a[b]&& [a]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[0-1ab&&[a]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase(
               "(?x)[^ab\\p{javaLowerCase}&&\\Q\\E [a]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase("[^0-1ab&&[a]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "(?x)[^0-1\\Qab\\E\\Q\\E\\Q\\E&& [a]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[[a]Ā&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[\\d0-1&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[ [ab] && #x\n [bc] && ]",


### PR DESCRIPTION
## Summary

- Fix character-class intersection parsing when ordinary scalar tail items before `&&` are followed by a nested class RHS and trailing raw `&`.
- Add JDK compatibility regressions for the original `(?x)` quoted-literal repro and reduced negated/non-negated forms.
- Add the same syntax shapes to `CharacterClassExpressionFuzzer` regression seeds.

Fixes #300

## Validation

Skipped new validation per request. Previously completed locally before this PR:

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test`
- `mvn -pl safere-fuzz -am -Dtest=CharacterClassExpressionFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
