### PR TITLE
Improve fuzz run reporting and triage

### DIFF
--- a/.agents/skills/fuzzer-run-triage/SKILL.md
+++ b/.agents/skills/fuzzer-run-triage/SKILL.md
@@ -99,11 +99,17 @@ inside the XML.
 When the user wants bugs verified or filed, replay candidates against the current working tree and
 current branch. Do not treat old console output as proof that a bug still exists.
 
-1. Compile the current test classes first if needed:
+1. Install the current SafeRE module and compile the current fuzz test classes first:
 
    ```bash
-   mvn -pl safere-fuzz -am -DskipTests test -q
+   mvn -pl safere -DskipTests install -q
+   mvn -pl safere-fuzz -DskipTests test-compile -q
    ```
+
+   Do not skip the `safere` install step before standalone `safere-fuzz` replays. A command such
+   as `mvn -pl safere-fuzz ... surefire:test` does not rebuild reactor dependencies, so it can
+   resolve an older `org.safere:safere` artifact from the local Maven repository and report bugs
+   that are already fixed on the current branch.
 
 2. Replay saved inputs one at a time by isolating the copied test resource directory under
    `target/test-classes`. This avoids stale build-output inputs and gives an exact

--- a/.agents/skills/fuzzer-run-triage/SKILL.md
+++ b/.agents/skills/fuzzer-run-triage/SKILL.md
@@ -9,8 +9,9 @@ description: "Triage SafeRE Jazzer fuzzer runs performed manually by the user: l
 
 When the user has run a SafeRE Jazzer fuzzer by hand, find what that run discovered and present
 the actionable bug findings. Do not assume `target/fuzz-reproducers` exists: Jazzer JUnit usually
-writes libFuzzer `crash-*` inputs to the fuzzer's input resource directory, while Maven/Surefire
-writes human-readable logs under `target/surefire-reports`.
+writes libFuzzer `crash-*` inputs to the fuzzer's input resource directory. Maven/Surefire writes
+XML summaries under `target/surefire-reports`, and SafeRE's helper script records raw
+stdout/stderr under `target/fuzz-logs`.
 
 ## First Checks
 
@@ -19,18 +20,30 @@ writes human-readable logs under `target/surefire-reports`.
 2. Inspect the latest matching Surefire files:
    - `safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml`
    - `safere-fuzz/target/surefire-reports/org.safere.fuzz.<Fuzzer>.txt`
-3. Check file mtimes before trusting artifacts:
+3. Inspect helper-script console logs if present. These are often the best source for
+   `artifact_prefix`, `Test unit written`, `Base64`, timeout, and crash path lines that Surefire
+   XML may omit:
+
+   ```bash
+   find safere-fuzz/target/fuzz-logs -path '*/<Fuzzer>.log' \
+     -printf '%TY-%Tm-%Td %TH:%TM:%TS %p\n' | sort
+   ```
+
+4. Check file mtimes before trusting artifacts:
 
    ```bash
    stat safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml
    stat safere-fuzz/target/surefire-reports/org.safere.fuzz.<Fuzzer>.txt
+   stat safere-fuzz/target/fuzz-logs/<run-id>/<Fuzzer>.log
    ```
 
-4. Extract findings from the XML:
+5. Extract findings from the XML and raw console log:
 
    ```bash
    rg -n '== Java Exception|AssertionError|CrosscheckException|PatternSyntaxException|divergence|DEDUP_TOKEN|libFuzzer crashing input|Test unit written|artifact_prefix|reproducer_path|Java reproducer written' \
      safere-fuzz/target/surefire-reports/TEST-org.safere.fuzz.<Fuzzer>.xml
+   rg -n '== Java Exception|AssertionError|CrosscheckException|PatternSyntaxException|divergence|DEDUP_TOKEN|libFuzzer: timeout|Test unit written|artifact_prefix|Base64:|reproducer_path|Java reproducer written' \
+     safere-fuzz/target/fuzz-logs/<run-id>/<Fuzzer>.log
    ```
 
 ## Where Artifacts Live
@@ -39,6 +52,14 @@ writes human-readable logs under `target/surefire-reports`.
   - Mixed by fuzzer class in one directory.
   - The same fuzzer's `.xml` and `.txt` files are overwritten by newer runs.
   - Other fuzzer reports may be older and unrelated.
+  - XML may omit raw libFuzzer lines such as `artifact_prefix`, `Test unit written`, and `Base64`.
+
+- **Raw helper-script console logs**: `safere-fuzz/target/fuzz-logs/<run-id>/<Fuzzer>.log`
+  - Created by `safere-fuzz/scripts/run-fuzz-test.sh`.
+  - Preserve the combined stdout/stderr stream while still showing output live in the terminal.
+  - Prefer these logs for mapping `== Java Exception` blocks to `crash-*`, `slow-unit-*`, and
+    `timeout-*` files.
+  - If a user provides a manually saved console log, inspect it the same way as these files.
 
 - **Generated corpus**: `safere-fuzz/.cifuzz-corpus/org.safere.fuzz.<Fuzzer>/<method>/`
   - Persistent coverage corpus, intentionally accumulated across runs.
@@ -73,6 +94,43 @@ If the user gives the approximate run time, compare crash mtimes to that time. I
 compare crash mtimes to the Surefire XML mtime and the `sun.java.command` or testcase elapsed time
 inside the XML.
 
+## Replaying Candidates on the Current Branch
+
+When the user wants bugs verified or filed, replay candidates against the current working tree and
+current branch. Do not treat old console output as proof that a bug still exists.
+
+1. Compile the current test classes first if needed:
+
+   ```bash
+   mvn -pl safere-fuzz -am -DskipTests test -q
+   ```
+
+2. Replay saved inputs one at a time by isolating the copied test resource directory under
+   `target/test-classes`. This avoids stale build-output inputs and gives an exact
+   `crash-*`-to-finding mapping:
+
+   ```bash
+   TARGET=safere-fuzz/target/test-classes/org/safere/fuzz/<Fuzzer>Inputs/<method>
+   SOURCE=safere-fuzz/src/test/resources/org/safere/fuzz/<Fuzzer>Inputs/<method>
+   rm -f "$TARGET"/*
+   cp "$SOURCE/<crash-or-timeout-file>" "$TARGET/"
+   mvn -pl safere-fuzz -Dtest=<Fuzzer> -Dsurefire.failIfNoSpecifiedTests=false surefire:test
+   ```
+
+3. Restore the copied test resources from source after isolated replay:
+
+   ```bash
+   rm -f "$TARGET"/*
+   cp "$SOURCE"/* "$TARGET"/
+   ```
+
+4. Record whether the candidate still reproduces, the current assertion output, and the exact
+   source input file. If it no longer reproduces on the current branch, say so and do not file a
+   bug for it.
+
+5. Deduplicate reproducible findings by semantic bug class before filing. Multiple `crash-*` files
+   may represent one parser rule, matcher invariant, or Unicode-boundary bug.
+
 ## Interpreting Results
 
 Use both logs and crash files:
@@ -81,8 +139,12 @@ Use both logs and crash files:
   result, stack trace, and dedup tokens.
 - `crash-*` files are the inputs Jazzer can replay through the fuzz target, but they may not be
   human-readable.
+- Raw console logs can contain crash paths and Base64 units even when Surefire XML has only
+  exception text, or when the fork exits on a libFuzzer timeout before a useful XML report is
+  written.
 - A `.txt` report with `Failures: 0, Errors: 0` does not prove no bugs were found when
-  `jazzer.keep_going` is in use. Always inspect the XML for `== Java Exception` and `DEDUP_TOKEN`.
+  `jazzer.keep_going` is in use. Always inspect the XML and raw console log for
+  `== Java Exception`, `DEDUP_TOKEN`, `Test unit written`, and `libFuzzer: timeout`.
 
 Classify findings before filing:
 
@@ -101,13 +163,17 @@ Summarize:
 
 - Which run files were inspected, with mtimes if recency matters.
 - Whether the Surefire report is a latest per-fuzzer report or mixed with older reports.
+- Whether a raw `target/fuzz-logs/<run-id>/<Fuzzer>.log` file, or a manually saved console log,
+  was inspected.
 - Each finding's regex/flags/input/operation and SafeRE vs JDK behavior.
 - The corresponding `crash-*` files, if identifiable.
+- Any `slow-unit-*`, `timeout-*`, or Base64 units for hangs/timeouts.
 - Whether `target/fuzz-reproducers` exists, and why absence may be normal.
 
 When asked to file issues:
 
 1. Search existing issues for exact repro substrings and the semantic class.
 2. Write the issue body to a temp file and use `gh issue create --body-file`.
-3. Include the command, Surefire XML path, crash input path, and concise observed behavior.
+3. Include the command, Surefire XML path, raw console log path, crash input path, and concise
+   observed behavior.
 4. Do not close existing issues unless all items are resolved.

--- a/.agents/skills/fuzzer-run-triage/SKILL.md
+++ b/.agents/skills/fuzzer-run-triage/SKILL.md
@@ -137,6 +137,10 @@ current branch. Do not treat old console output as proof that a bug still exists
 5. Deduplicate reproducible findings by semantic bug class before filing. Multiple `crash-*` files
    may represent one parser rule, matcher invariant, or Unicode-boundary bug.
 
+6. Preserve durable repro material before relying on it in an issue. Local `crash-*`, `slow-unit-*`,
+   `timeout-*`, console-log, and `/tmp` paths are useful provenance, but they are not durable bug
+   report content.
+
 ## Interpreting Results
 
 Use both logs and crash files:
@@ -180,6 +184,15 @@ When asked to file issues:
 
 1. Search existing issues for exact repro substrings and the semantic class.
 2. Write the issue body to a temp file and use `gh issue create --body-file`.
-3. Include the command, Surefire XML path, raw console log path, crash input path, and concise
-   observed behavior.
-4. Do not close existing issues unless all items are resolved.
+3. Make the issue self-contained. Do not rely on local or ephemeral paths such as
+   `target/surefire-reports`, `target/fuzz-logs`, `/tmp/...`, or local `crash-*` files being
+   available later.
+4. Include enough durable repro material to recreate the bug:
+   - minimized regex, flags, input, operation, and observed SafeRE/JDK behavior when available;
+   - for binary Jazzer inputs, include Base64 and/or hex bytes in the issue body, or attach/upload
+     the input artifact if GitHub supports it for the workflow being used;
+   - if the project owner wants persisted reproducers in-repo, add them deliberately as tracked
+     test resources or regression tests rather than depending on untracked local files.
+5. Local paths may be included only as provenance, clearly secondary to the self-contained repro
+   data.
+6. Do not close existing issues unless all items are resolved.

--- a/safere-fuzz/README.md
+++ b/safere-fuzz/README.md
@@ -76,9 +76,15 @@ The same settings are available through the helper script, which can run
 multiple fuzz targets sequentially:
 
 ```bash
+safere-fuzz/scripts/run-fuzz-test.sh
 safere-fuzz/scripts/run-fuzz-test.sh CharacterClassExpressionFuzzer MatchFuzzer
 safere-fuzz/scripts/run-fuzz-test.sh --max-duration 10m --keep-going 5 MatchFuzzer
 ```
+
+The helper script records each fuzzer's combined stdout/stderr stream under
+`safere-fuzz/target/fuzz-logs/<run-id>/<Fuzzer>.log`. Use these logs alongside
+Surefire XML reports when triaging `jazzer.keep_going` runs, since the XML does
+not always preserve every console detail needed to map findings to crash inputs.
 
 ## Findings
 

--- a/safere-fuzz/scripts/run-fuzz-test.sh
+++ b/safere-fuzz/scripts/run-fuzz-test.sh
@@ -5,6 +5,7 @@
 # Run one or more SafeRE Jazzer fuzz tests in coverage-guided mode.
 #
 # Usage:
+#   safere-fuzz/scripts/run-fuzz-test.sh
 #   safere-fuzz/scripts/run-fuzz-test.sh CharacterClassExpressionFuzzer
 #   safere-fuzz/scripts/run-fuzz-test.sh --max-duration 10m --keep-going 5 MatchFuzzer UnicodeFuzzer
 
@@ -12,13 +13,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FUZZ_TARGET_DIR="$REPO_ROOT/safere-fuzz/src/test/java/org/safere/fuzz"
 MAX_DURATION="30m"
 KEEP_GOING="10"
 TESTS=()
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_DIR="$REPO_ROOT/safere-fuzz/target/fuzz-logs/$RUN_ID"
 
 usage() {
   cat <<EOF
-Usage: $0 [--max-duration DURATION] [--keep-going COUNT] TEST [TEST...]
+Usage: $0 [--max-duration DURATION] [--keep-going COUNT] [TEST...]
 
 Options:
   --max-duration, --max_duration  Jazzer max duration per test (default: 30m)
@@ -26,9 +30,27 @@ Options:
   -h, --help                      Show this help
 
 Examples:
+  $0
   $0 CharacterClassExpressionFuzzer
   $0 --max-duration 10m --keep-going 5 MatchFuzzer UnicodeFuzzer
 EOF
+}
+
+valid_fuzz_targets() {
+  find "$FUZZ_TARGET_DIR" -maxdepth 1 -type f -name '*Fuzzer.java' -printf '%f\n' \
+    | sed 's/\.java$//' \
+    | sort
+}
+
+is_valid_fuzz_target() {
+  local test_name="$1"
+  local valid_name
+  while IFS= read -r valid_name; do
+    if [ "$test_name" = "$valid_name" ]; then
+      return 0
+    fi
+  done < <(valid_fuzz_targets)
+  return 1
 }
 
 while [ $# -gt 0 ]; do
@@ -73,18 +95,43 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "${#TESTS[@]}" -eq 0 ]; then
-  echo "error: at least one fuzz test is required" >&2
-  usage >&2
-  exit 2
+  while IFS= read -r test_name; do
+    TESTS+=("$test_name")
+  done < <(valid_fuzz_targets)
 fi
 
 for test_name in "${TESTS[@]}"; do
-  echo "=== Running $test_name (max_duration=$MAX_DURATION, keep_going=$KEEP_GOING) ==="
-  JAZZER_FUZZ=1 mvn -f "$REPO_ROOT/pom.xml" -pl safere-fuzz -am \
-    -Dtest="$test_name" \
-    -Dsurefire.failIfNoSpecifiedTests=false \
-    -Djazzer.max_duration="$MAX_DURATION" \
-    -Djazzer.keep_going="$KEEP_GOING" \
-    -Djazzer.reproducer_path=target/fuzz-reproducers \
-    test
+  if ! is_valid_fuzz_target "$test_name"; then
+    echo "error: unknown fuzz test: $test_name" >&2
+    echo >&2
+    echo "Valid fuzz tests:" >&2
+    valid_fuzz_targets | sed 's/^/  /' >&2
+    exit 2
+  fi
+done
+
+echo "=== Fuzz run configuration ==="
+echo "max_duration: $MAX_DURATION"
+echo "keep_going: $KEEP_GOING"
+echo "surefire_reports: safere-fuzz/target/surefire-reports"
+echo "reproducer_path: target/fuzz-reproducers"
+echo "fuzz_logs: safere-fuzz/target/fuzz-logs/$RUN_ID"
+echo "fuzz targets:"
+printf '  %s\n' "${TESTS[@]}"
+
+mkdir -p "$LOG_DIR"
+
+for test_name in "${TESTS[@]}"; do
+  log_file="$LOG_DIR/$test_name.log"
+  {
+    echo "=== Running $test_name (max_duration=$MAX_DURATION, keep_going=$KEEP_GOING) ==="
+    echo "log_file: $log_file"
+    JAZZER_FUZZ=1 mvn -f "$REPO_ROOT/pom.xml" -pl safere-fuzz -am \
+      -Dtest="$test_name" \
+      -Dsurefire.failIfNoSpecifiedTests=false \
+      -Djazzer.max_duration="$MAX_DURATION" \
+      -Djazzer.keep_going="$KEEP_GOING" \
+      -Djazzer.reproducer_path=target/fuzz-reproducers \
+      test
+  } 2>&1 | tee "$log_file"
 done

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -61,7 +61,9 @@ final class FuzzSupport {
     String jdk = jdkException == null
         ? "compiled successfully"
         : jdkException.getClass().getSimpleName() + ": " + jdkException.getMessage();
-    throw new AssertionError("compile divergence for /" + regex + "/ flags=" + flags
+    throw new AssertionError("compile divergence"
+        + "\nRegex: " + javaStringLiteral(regex)
+        + "\nFlags: " + flags
         + "\nSafeRE: " + safeRe + "\nJDK: " + jdk);
   }
 
@@ -113,12 +115,18 @@ final class FuzzSupport {
       java.util.regex.Pattern jdkPattern) {
 
     MatcherPair matcher(CharSequence input) {
-      return new MatcherPair(regex, flags, safeRePattern.matcher(input), jdkPattern.matcher(input));
+      return new MatcherPair(
+          regex,
+          flags,
+          input.toString(),
+          safeRePattern.matcher(input),
+          jdkPattern.matcher(input));
     }
 
     void split(CharSequence input) {
       assertArrayEquals(
           "split",
+          input.toString(),
           safeRePattern.split(input),
           jdkPattern.split(input));
     }
@@ -126,6 +134,7 @@ final class FuzzSupport {
     void split(CharSequence input, int limit) {
       assertArrayEquals(
           "split(" + limit + ")",
+          input.toString(),
           safeRePattern.split(input, limit),
           jdkPattern.split(input, limit));
     }
@@ -133,6 +142,7 @@ final class FuzzSupport {
     void splitWithDelimiters(CharSequence input) {
       assertArrayEquals(
           "splitWithDelimiters",
+          input.toString(),
           safeRePattern.splitWithDelimiters(input),
           jdkPattern.splitWithDelimiters(input, 0));
     }
@@ -140,24 +150,41 @@ final class FuzzSupport {
     void splitWithDelimiters(CharSequence input, int limit) {
       assertArrayEquals(
           "splitWithDelimiters(" + limit + ")",
+          input.toString(),
           safeRePattern.splitWithDelimiters(input, limit),
           jdkPattern.splitWithDelimiters(input, limit));
+    }
+
+    private void assertArrayEquals(
+        String operation, String input, String[] safeRe, String[] jdk) {
+      if (!Arrays.equals(safeRe, jdk)) {
+        throw new AssertionError(operation + " divergence"
+            + "\nRegex: " + javaStringLiteral(regex)
+            + "\nFlags: " + flags
+            + "\nInput: " + javaStringLiteral(input)
+            + "\nSafeRE: " + describeArray(safeRe)
+            + "\nJDK: " + describeArray(jdk));
+      }
     }
   }
 
   static final class MatcherPair {
     private final String regex;
     private final int flags;
+    private String input;
+    private String lastReplacement;
     private final org.safere.Matcher safeReMatcher;
     private final java.util.regex.Matcher jdkMatcher;
 
     MatcherPair(
         String regex,
         int flags,
+        String input,
         org.safere.Matcher safeReMatcher,
         java.util.regex.Matcher jdkMatcher) {
       this.regex = regex;
       this.flags = flags;
+      this.input = input;
       this.safeReMatcher = safeReMatcher;
       this.jdkMatcher = jdkMatcher;
     }
@@ -165,7 +192,7 @@ final class FuzzSupport {
     boolean matches() {
       boolean safeRe = safeReMatcher.matches();
       boolean jdk = jdkMatcher.matches();
-      assertEquals("matches", safeRe, jdk);
+      assertSame("matches", safeRe, jdk);
       if (safeRe) {
         assertMatchState("matches");
       }
@@ -175,7 +202,7 @@ final class FuzzSupport {
     boolean lookingAt() {
       boolean safeRe = safeReMatcher.lookingAt();
       boolean jdk = jdkMatcher.lookingAt();
-      assertEquals("lookingAt", safeRe, jdk);
+      assertSame("lookingAt", safeRe, jdk);
       if (safeRe) {
         assertMatchState("lookingAt");
       }
@@ -185,7 +212,7 @@ final class FuzzSupport {
     boolean find() {
       boolean safeRe = safeReMatcher.find();
       boolean jdk = jdkMatcher.find();
-      assertEquals("find", safeRe, jdk);
+      assertSame("find", safeRe, jdk);
       if (safeRe) {
         assertMatchState("find");
       }
@@ -195,7 +222,7 @@ final class FuzzSupport {
     boolean find(int start) {
       boolean safeRe = safeReMatcher.find(start);
       boolean jdk = jdkMatcher.find(start);
-      assertEquals("find(" + start + ")", safeRe, jdk);
+      assertSame("find(" + start + ")", safeRe, jdk);
       if (safeRe) {
         assertMatchState("find(" + start + ")");
       }
@@ -203,12 +230,15 @@ final class FuzzSupport {
     }
 
     MatcherPair reset() {
+      lastReplacement = null;
       safeReMatcher.reset();
       jdkMatcher.reset();
       return this;
     }
 
     MatcherPair reset(CharSequence input) {
+      this.input = input.toString();
+      this.lastReplacement = null;
       safeReMatcher.reset(input);
       jdkMatcher.reset(input);
       return this;
@@ -217,63 +247,63 @@ final class FuzzSupport {
     int groupCount() {
       int safeRe = safeReMatcher.groupCount();
       int jdk = jdkMatcher.groupCount();
-      assertEquals("groupCount", safeRe, jdk);
+      assertSame("groupCount", safeRe, jdk);
       return safeRe;
     }
 
     String group(int group) {
       String safeRe = safeReMatcher.group(group);
       String jdk = jdkMatcher.group(group);
-      assertEquals("group(" + group + ")", safeRe, jdk);
+      assertSame("group(" + group + ")", safeRe, jdk);
       return safeRe;
     }
 
     String group(String name) {
       String safeRe = safeReMatcher.group(name);
       String jdk = jdkMatcher.group(name);
-      assertEquals("group(" + name + ")", safeRe, jdk);
+      assertSame("group(" + name + ")", safeRe, jdk);
       return safeRe;
     }
 
     int start(int group) {
       int safeRe = safeReMatcher.start(group);
       int jdk = jdkMatcher.start(group);
-      assertEquals("start(" + group + ")", safeRe, jdk);
+      assertSame("start(" + group + ")", safeRe, jdk);
       return safeRe;
     }
 
     int start(String name) {
       int safeRe = safeReMatcher.start(name);
       int jdk = jdkMatcher.start(name);
-      assertEquals("start(" + name + ")", safeRe, jdk);
+      assertSame("start(" + name + ")", safeRe, jdk);
       return safeRe;
     }
 
     int end(int group) {
       int safeRe = safeReMatcher.end(group);
       int jdk = jdkMatcher.end(group);
-      assertEquals("end(" + group + ")", safeRe, jdk);
+      assertSame("end(" + group + ")", safeRe, jdk);
       return safeRe;
     }
 
     int end(String name) {
       int safeRe = safeReMatcher.end(name);
       int jdk = jdkMatcher.end(name);
-      assertEquals("end(" + name + ")", safeRe, jdk);
+      assertSame("end(" + name + ")", safeRe, jdk);
       return safeRe;
     }
 
     boolean hitEnd() {
       boolean safeRe = safeReMatcher.hitEnd();
       boolean jdk = jdkMatcher.hitEnd();
-      assertEquals("hitEnd", safeRe, jdk);
+      assertSame("hitEnd", safeRe, jdk);
       return safeRe;
     }
 
     boolean requireEnd() {
       boolean safeRe = safeReMatcher.requireEnd();
       boolean jdk = jdkMatcher.requireEnd();
-      assertEquals("requireEnd", safeRe, jdk);
+      assertSame("requireEnd", safeRe, jdk);
       return safeRe;
     }
 
@@ -286,14 +316,14 @@ final class FuzzSupport {
     int regionStart() {
       int safeRe = safeReMatcher.regionStart();
       int jdk = jdkMatcher.regionStart();
-      assertEquals("regionStart", safeRe, jdk);
+      assertSame("regionStart", safeRe, jdk);
       return safeRe;
     }
 
     int regionEnd() {
       int safeRe = safeReMatcher.regionEnd();
       int jdk = jdkMatcher.regionEnd();
-      assertEquals("regionEnd", safeRe, jdk);
+      assertSame("regionEnd", safeRe, jdk);
       return safeRe;
     }
 
@@ -312,20 +342,21 @@ final class FuzzSupport {
     boolean hasAnchoringBounds() {
       boolean safeRe = safeReMatcher.hasAnchoringBounds();
       boolean jdk = jdkMatcher.hasAnchoringBounds();
-      assertEquals("hasAnchoringBounds", safeRe, jdk);
+      assertSame("hasAnchoringBounds", safeRe, jdk);
       return safeRe;
     }
 
     boolean hasTransparentBounds() {
       boolean safeRe = safeReMatcher.hasTransparentBounds();
       boolean jdk = jdkMatcher.hasTransparentBounds();
-      assertEquals("hasTransparentBounds", safeRe, jdk);
+      assertSame("hasTransparentBounds", safeRe, jdk);
       return safeRe;
     }
 
     boolean replaceAll(String replacement) {
       return assertSameReplacementOutcome(
           "replaceAll",
+          replacement,
           () -> safeReMatcher.replaceAll(replacement),
           () -> jdkMatcher.replaceAll(replacement));
     }
@@ -333,6 +364,7 @@ final class FuzzSupport {
     boolean replaceAll(Function<MatchResult, String> replacer) {
       return assertSameReplacementOutcome(
           "replaceAll(function)",
+          null,
           () -> safeReMatcher.replaceAll(replacer),
           () -> jdkMatcher.replaceAll(replacer));
     }
@@ -340,6 +372,7 @@ final class FuzzSupport {
     boolean replaceFirst(String replacement) {
       return assertSameReplacementOutcome(
           "replaceFirst",
+          replacement,
           () -> safeReMatcher.replaceFirst(replacement),
           () -> jdkMatcher.replaceFirst(replacement));
     }
@@ -347,8 +380,10 @@ final class FuzzSupport {
     boolean appendReplacement(StringBuilder output, String replacement) {
       StringBuilder safeRe = new StringBuilder();
       StringBuilder jdk = new StringBuilder();
+      lastReplacement = replacement;
       boolean completed = assertSameReplacementOutcome(
           "appendReplacement",
+          replacement,
           () -> {
             safeReMatcher.appendReplacement(safeRe, replacement);
             return safeRe.toString();
@@ -366,8 +401,10 @@ final class FuzzSupport {
     boolean appendReplacement(StringBuffer output, String replacement) {
       StringBuffer safeRe = new StringBuffer();
       StringBuffer jdk = new StringBuffer();
+      lastReplacement = replacement;
       boolean completed = assertSameReplacementOutcome(
           "appendReplacement",
+          replacement,
           () -> {
             safeReMatcher.appendReplacement(safeRe, replacement);
             return safeRe.toString();
@@ -387,7 +424,7 @@ final class FuzzSupport {
       StringBuilder jdk = new StringBuilder();
       safeReMatcher.appendTail(safeRe);
       jdkMatcher.appendTail(jdk);
-      assertEquals("appendTail", safeRe.toString(), jdk.toString());
+      assertSame("appendTail", safeRe.toString(), jdk.toString());
       output.append(safeRe);
     }
 
@@ -396,7 +433,7 @@ final class FuzzSupport {
       StringBuffer jdk = new StringBuffer();
       safeReMatcher.appendTail(safeRe);
       jdkMatcher.appendTail(jdk);
-      assertEquals("appendTail", safeRe.toString(), jdk.toString());
+      assertSame("appendTail", safeRe.toString(), jdk.toString());
       output.append(safeRe);
     }
 
@@ -407,8 +444,8 @@ final class FuzzSupport {
     }
 
     private void assertMatchState(String operation) {
-      assertEquals(operation + ".start", safeReMatcher.start(), jdkMatcher.start());
-      assertEquals(operation + ".end", safeReMatcher.end(), jdkMatcher.end());
+      assertSame(operation + ".start", safeReMatcher.start(), jdkMatcher.start());
+      assertSame(operation + ".end", safeReMatcher.end(), jdkMatcher.end());
       int groupCount = groupCount();
       for (int i = 0; i <= groupCount; i++) {
         group(i);
@@ -418,23 +455,26 @@ final class FuzzSupport {
     }
 
     private void assertMatchResult(String operation, MatchResult safeRe, MatchResult jdk) {
-      assertEquals(operation + ".start", safeRe.start(), jdk.start());
-      assertEquals(operation + ".end", safeRe.end(), jdk.end());
+      assertSame(operation + ".start", safeRe.start(), jdk.start());
+      assertSame(operation + ".end", safeRe.end(), jdk.end());
       int groupCount = safeRe.groupCount();
-      assertEquals(operation + ".groupCount", groupCount, jdk.groupCount());
+      assertSame(operation + ".groupCount", groupCount, jdk.groupCount());
       for (int i = 0; i <= groupCount; i++) {
-        assertEquals(operation + ".group(" + i + ")", safeRe.group(i), jdk.group(i));
-        assertEquals(operation + ".start(" + i + ")", safeRe.start(i), jdk.start(i));
-        assertEquals(operation + ".end(" + i + ")", safeRe.end(i), jdk.end(i));
+        assertSame(operation + ".group(" + i + ")", safeRe.group(i), jdk.group(i));
+        assertSame(operation + ".start(" + i + ")", safeRe.start(i), jdk.start(i));
+        assertSame(operation + ".end(" + i + ")", safeRe.end(i), jdk.end(i));
       }
     }
 
     private boolean assertSameReplacementOutcome(
-        String operation, StringOperation safeReOperation, StringOperation jdkOperation) {
+        String operation,
+        String replacement,
+        StringOperation safeReOperation,
+        StringOperation jdkOperation) {
       OperationResult<String> safeRe = OperationResult.capture(safeReOperation);
       OperationResult<String> jdk = OperationResult.capture(jdkOperation);
       if (safeRe.throwable() == null && jdk.throwable() == null) {
-        assertEquals(operation, safeRe.value(), jdk.value());
+        assertSame(operation, replacement, safeRe.value(), jdk.value());
         return true;
       }
       if (safeRe.throwable() != null
@@ -443,12 +483,31 @@ final class FuzzSupport {
           && isExpectedReplacementException(safeRe.throwable())) {
         return false;
       }
-      throw divergence(operation, safeRe.describe(), jdk.describe());
+      throw divergence(operation, replacement, safeRe.describe(), jdk.describe());
     }
 
     private AssertionError divergence(String operation, Object safeRe, Object jdk) {
-      return new AssertionError(operation + " divergence for /" + regex + "/ flags=" + flags
+      return divergence(operation, lastReplacement, safeRe, jdk);
+    }
+
+    private AssertionError divergence(
+        String operation, String replacement, Object safeRe, Object jdk) {
+      return new AssertionError(operation + " divergence"
+          + "\nRegex: " + javaStringLiteral(regex)
+          + "\nFlags: " + flags
+          + "\nInput: " + javaStringLiteral(input)
+          + (replacement == null ? "" : "\nReplacement: " + javaStringLiteral(replacement))
           + "\nSafeRE: " + safeRe + "\nJDK: " + jdk);
+    }
+
+    private void assertSame(String operation, Object safeRe, Object jdk) {
+      assertSame(operation, lastReplacement, safeRe, jdk);
+    }
+
+    private void assertSame(String operation, String replacement, Object safeRe, Object jdk) {
+      if (!Objects.equals(safeRe, jdk)) {
+        throw divergence(operation, replacement, safeRe, jdk);
+      }
     }
   }
 
@@ -477,17 +536,37 @@ final class FuzzSupport {
         || exception instanceof IndexOutOfBoundsException;
   }
 
-  private static void assertArrayEquals(String operation, String[] safeRe, String[] jdk) {
-    if (!Arrays.equals(safeRe, jdk)) {
-      throw new AssertionError(operation + " divergence\nSafeRE: " + Arrays.toString(safeRe)
-          + "\nJDK: " + Arrays.toString(jdk));
-    }
+  private static String describeArray(String[] values) {
+    return Arrays.stream(values)
+        .map(FuzzSupport::javaStringLiteral)
+        .toList()
+        .toString();
   }
 
-  private static void assertEquals(String operation, Object safeRe, Object jdk) {
-    if (!Objects.equals(safeRe, jdk)) {
-      throw new AssertionError(operation + " divergence\nSafeRE: " + safeRe + "\nJDK: " + jdk);
+  private static String javaStringLiteral(String value) {
+    StringBuilder result = new StringBuilder(value.length() + 2);
+    result.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\' -> result.append("\\\\");
+        case '"' -> result.append("\\\"");
+        case '\b' -> result.append("\\b");
+        case '\f' -> result.append("\\f");
+        case '\n' -> result.append("\\n");
+        case '\r' -> result.append("\\r");
+        case '\t' -> result.append("\\t");
+        default -> {
+          if (c < 0x20 || Character.isSurrogate(c)) {
+            result.append(String.format("\\u%04x", (int) c));
+          } else {
+            result.append(c);
+          }
+        }
+      }
     }
+    result.append('"');
+    return result.toString();
   }
 
   private static boolean isIntentionallyUnsupported(String regex) {


### PR DESCRIPTION
## Summary

- record raw stdout/stderr from `run-fuzz-test.sh` under `safere-fuzz/target/fuzz-logs/<run-id>/<Fuzzer>.log`
- include regex, flags, input, and replacement context in fuzz assertion failures
- document raw fuzz logs and update the fuzzer triage skill with current-branch replay workflow

## Testing

Not run; requested no verification.
