### PR TITLE
Fix COMMENTS whitespace compatibility

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -33,14 +33,41 @@ final class ParserCompatibilityFuzzer {
       "(?)",
       "(a)",
       "(?:a)",
-      "(?<name>a)"
+      "(?<name>a)",
+      "a\u001C\\^]",
+      "a\u001D\\^]",
+      "a\u001E\\^]",
+      "a\u001F\\^]",
+      "[a\u001Cb]",
+      "[a\u001Db]",
+      "[a\u001Eb]",
+      "[a\u001Fb]"
   };
   private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "(?m)", "(?s)"};
   private static final String[] CONNECTORS =
       {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}"};
   private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
   private static final List<String> INPUTS =
-      List.of("", "a", "aa", "abc", "def", "0", " ", "\n", "*", "name");
+      List.of(
+          "",
+          "a",
+          "aa",
+          "abc",
+          "def",
+          "0",
+          " ",
+          "\n",
+          "*",
+          "name",
+          "a\u001C^]",
+          "a\u001D^]",
+          "a\u001E^]",
+          "a\u001F^]",
+          "a^]",
+          "\u001C",
+          "\u001D",
+          "\u001E",
+          "\u001F");
 
   @FuzzTest(maxDuration = "30s")
   void parserCompatibility(FuzzedDataProvider data) {

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -77,6 +77,10 @@ final class Parser {
     this.runeMax = Utils.MAX_RUNE;
   }
 
+  private static boolean isCommentsWhitespace(int cp) {
+    return cp == ' ' || ('\t' <= cp && cp <= '\r');
+  }
+
   /**
    * Parses a regular expression pattern into a {@link Regexp} AST.
    *
@@ -113,7 +117,7 @@ final class Parser {
         if (pos < pattern.length()) {
           pos++;
         }
-      } else if (Character.isWhitespace(c)) {
+      } else if (isCommentsWhitespace(c)) {
         pos += Character.charCount(c);
       } else {
         break;
@@ -1738,7 +1742,7 @@ final class Parser {
   private int skipCommentsAndWhitespaceAt(int index) {
     while (index < pattern.length()) {
       int cp = pattern.codePointAt(index);
-      if (Character.isWhitespace(cp)) {
+      if (isCommentsWhitespace(cp)) {
         index += Character.charCount(cp);
         continue;
       }

--- a/safere/src/test/java/org/safere/CommentsTest.java
+++ b/safere/src/test/java/org/safere/CommentsTest.java
@@ -46,6 +46,30 @@ class CommentsTest {
     }
 
     @Test
+    @DisplayName("COMMENTS whitespace set matches JDK parser")
+    void commentsWhitespaceSetMatchesJdkParser() {
+      int[] ignoredByJdkComments = {'\t', '\n', 0x0B, '\f', '\r', ' '};
+      for (int cp : ignoredByJdkComments) {
+        String pattern = "a" + new String(Character.toChars(cp)) + "b";
+        assertThat(Pattern.compile(pattern, Pattern.COMMENTS).matcher("ab").matches())
+            .as("U+%04X should be ignored in COMMENTS mode", cp)
+            .isTrue();
+      }
+
+      int[] literalInJdkComments = {0x1C, 0x1D, 0x1E, 0x1F, 0x85, 0x1680, 0x2028, 0x2029};
+      for (int cp : literalInJdkComments) {
+        String ch = new String(Character.toChars(cp));
+        Pattern p = Pattern.compile("a" + ch + "\\^]", Pattern.COMMENTS | Pattern.MULTILINE);
+        assertThat(p.matcher("a" + ch + "^]").matches())
+            .as("U+%04X should remain literal in COMMENTS mode", cp)
+            .isTrue();
+        assertThat(p.matcher("a^]").matches())
+            .as("U+%04X should not be ignored in COMMENTS mode", cp)
+            .isFalse();
+      }
+    }
+
+    @Test
     @DisplayName("# starts a comment to end of line")
     void hashComment() {
       Pattern p = Pattern.compile("a # match 'a'\nb", Pattern.COMMENTS);
@@ -145,6 +169,30 @@ class CommentsTest {
       Pattern p = Pattern.compile("[\\ ]", Pattern.COMMENTS);
       assertThat(p.matcher(" ").matches()).isTrue();
       assertThat(p.matcher("a").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("COMMENTS character-class whitespace set matches JDK parser")
+    void commentsCharacterClassWhitespaceSetMatchesJdkParser() {
+      int[] ignoredByJdkComments = {'\t', '\n', 0x0B, '\f', '\r', ' '};
+      for (int cp : ignoredByJdkComments) {
+        String pattern = "[a" + new String(Character.toChars(cp)) + "b]";
+        Pattern p = Pattern.compile(pattern, Pattern.COMMENTS);
+        assertThat(p.matcher("a").matches()).isTrue();
+        assertThat(p.matcher("b").matches()).isTrue();
+        assertThat(p.matcher(new String(Character.toChars(cp))).matches())
+            .as("U+%04X should be ignored inside COMMENTS character classes", cp)
+            .isFalse();
+      }
+
+      int[] literalInJdkComments = {0x1C, 0x1D, 0x1E, 0x1F, 0x85, 0x1680, 0x2028, 0x2029};
+      for (int cp : literalInJdkComments) {
+        String ch = new String(Character.toChars(cp));
+        Pattern p = Pattern.compile("[a" + ch + "b]", Pattern.COMMENTS);
+        assertThat(p.matcher(ch).matches())
+            .as("U+%04X should remain literal inside COMMENTS character classes", cp)
+            .isTrue();
+      }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Match JDK COMMENTS-mode parser whitespace exactly: ASCII space and U+0009 through U+000D only.
- Add regression coverage for C0 controls and Unicode separators that `Character.isWhitespace`
  treats as whitespace but the JDK regex parser keeps literal.
- Expand parser compatibility fuzzing with the reopened issue shape around escaped literals and
  character classes.

Fixes #125

## Verification

- `mvn -pl safere -Dtest=CommentsTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=ParserCompatibilityFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl safere-fuzz -am -Dtest=UnicodeFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`

Full crosscheck verification intentionally skipped per request.
