### PR TITLE
Fix JDK-compatible repeated quantifier parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -25,6 +25,8 @@ final class ParserCompatibilityFuzzer {
       "\\P{Lower}",
       "\\Q\\E",
       "\\Q*\\E",
+      "^",
+      "$",
       "[a]",
       "[^a]",
       "[a-z]",
@@ -37,7 +39,8 @@ final class ParserCompatibilityFuzzer {
   };
   private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "(?m)", "(?s)"};
   private static final String[] CONNECTORS =
-      {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}"};
+      {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}",
+          "??{1,3}", "?{1,3}", "*{1,3}", "+{1,3}", "{1,3}{1,3}"};
   private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
   private static final List<String> INPUTS =
       List.of("", "a", "aa", "abc", "def", "0", " ", "\n", "*", "name");

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -205,7 +205,7 @@ final class Parser {
               nongreedy = true;
               pos++; // '?'
             }
-            if (lastunary != null) {
+            if (lastunary != null && !canRepeatAfterUnary(op)) {
               throw new PatternSyntaxException(
                   "invalid nested repetition operator", pattern, opStart);
             }
@@ -228,15 +228,16 @@ final class Parser {
               nongreedy = true;
               pos++; // '?'
             }
-            if (lastunary != null) {
-              throw new PatternSyntaxException(
-                  "invalid nested repetition operator", pattern, opStart);
-            }
           }
           String opstr = pattern.substring(opStart, pos);
           if (lastTokenNonRepeatable) {
             validateRepeatCount(lo, hi, opstr);
             isNonRepeatable = true;
+            break;
+          }
+          if (lastunary != null) {
+            validateRepeatCount(lo, hi, opstr);
+            isunary = opstr;
             break;
           }
           pushRepetition(lo, hi, opstr, nongreedy);
@@ -595,6 +596,38 @@ final class Parser {
       default -> throw new IllegalStateException("unexpected repeat op: " + op);
     };
     stacktop.re = re;
+  }
+
+  private boolean canRepeatAfterUnary(RegexpOp op) {
+    return op == RegexpOp.PLUS && stacktop != null && isQuantifiedZeroWidth(stacktop.re);
+  }
+
+  private boolean isQuantifiedZeroWidth(Regexp re) {
+    return switch (re.op) {
+      case STAR, PLUS, QUEST, REPEAT -> isZeroWidth(re.subs.getFirst());
+      default -> false;
+    };
+  }
+
+  private boolean isZeroWidth(Regexp re) {
+    ArrayDeque<Regexp> pending = new ArrayDeque<>();
+    pending.add(re);
+    while (!pending.isEmpty()) {
+      Regexp current = pending.removeLast();
+      switch (current.op) {
+        case EMPTY_MATCH, BEGIN_LINE, END_LINE, WORD_BOUNDARY, NO_WORD_BOUNDARY,
+            BEGIN_TEXT, END_TEXT -> {
+          // Zero-width by definition.
+        }
+        case CAPTURE, NON_CAPTURE, STAR, PLUS, QUEST, REPEAT ->
+            pending.add(current.subs.getFirst());
+        case CONCAT, ALTERNATE -> pending.addAll(current.subs);
+        default -> {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private void pushRepetition(int min, int max, String opstr, boolean nongreedy) {

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -2021,6 +2021,31 @@ class JdkSyntaxCompatibilityTest {
     void boundedRepeatOfConcatenatedBoundedRepeats() {
       assertMatchesSame("(?:a{0,63}b{0,99}){0,5}", "aaabbbb");
     }
+
+    @ParameterizedTest(name = "/{0}/ on \"{1}\"")
+    @MethodSource("boundedRepeatsOfQuantifiedAtoms")
+    @DisplayName("bounded repeats of quantified atoms")
+    void boundedRepeatsOfQuantifiedAtoms(String regex, String input) {
+      assertMatchesSame(regex, input);
+    }
+
+    static Stream<Arguments> boundedRepeatsOfQuantifiedAtoms() {
+      return Stream.of(
+          Arguments.of("\\S??{1,3}", ""),
+          Arguments.of("\\S??{1,3}", "a"),
+          Arguments.of("a?{1,3}", "a"),
+          Arguments.of("a*{1,3}", "aaa"),
+          Arguments.of("a+{1,3}", "aaa"),
+          Arguments.of("a{2}{3}", "aaaaaa"),
+          Arguments.of("a{2}?{3}", "aaaaaa"));
+    }
+
+    @Test
+    @DisplayName("quantified anchors separated by comments-mode whitespace")
+    void quantifiedAnchorsSeparatedByCommentsModeWhitespace() {
+      assertMatchesSameWithFlags("^+\n\n\n+^", java.util.regex.Pattern.COMMENTS, "");
+      assertMatchesSameWithFlags("^+\n\n\n+^", java.util.regex.Pattern.COMMENTS, "a");
+    }
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

- Accept JDK-compatible counted-repeat suffixes after already-quantified atoms by validating the suffix and preserving the original quantified atom semantics.
- Allow repeated zero-width assertions such as quantified anchors while continuing to reject possessive quantifiers on consuming atoms.
- Add parser compatibility regression coverage and expand the parser compatibility fuzzer grammar for repeated quantifier shapes and anchor atoms.

## Verification

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest,PatternTest,ParserTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=ParserCompatibilityFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl safere-fuzz -am -Dtest=UnicodeFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`

Skipped per request:

- Full verification: `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
- Full `mvn -pl safere test -q` was started but stopped during long exhaustive tests after focused checks had passed.

Fixes #320 
