### PR TITLE
Fix comments-mode parser comment termination

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -39,16 +39,33 @@ final class ParserCompatibilityFuzzer {
   private static final String[] CONNECTORS =
       {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}"};
   private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
+  private static final String[] COMMENT_TERMINATED_PREFIXES = {
+      "a#\0",
+      "a#\n",
+      "a#\r",
+      "a#\u0085",
+      "a#\u2028",
+      "a#\u2029"
+  };
+  private static final String[] MALFORMED_GROUP_SUFFIXES = {"(", "|(", "b|(", "(?:b)|("};
   private static final List<String> INPUTS =
       List.of("", "a", "aa", "abc", "def", "0", " ", "\n", "*", "name");
 
   @FuzzTest(maxDuration = "30s")
   void parserCompatibility(FuzzedDataProvider data) {
-    String regex = data.pickValue(PREFIXES)
-        + data.pickValue(ATOMS)
-        + data.pickValue(CONNECTORS)
-        + data.pickValue(ATOMS)
-        + data.pickValue(SUFFIXES);
-    FuzzSupport.assertFullMatchesJdk(regex, FuzzSupport.consumeParserFlags(data), INPUTS);
+    int flags = FuzzSupport.consumeParserFlags(data);
+    String regex;
+    if (data.consumeBoolean()) {
+      flags |= org.safere.Pattern.COMMENTS;
+      regex = data.pickValue(COMMENT_TERMINATED_PREFIXES)
+          + data.pickValue(MALFORMED_GROUP_SUFFIXES);
+    } else {
+      regex = data.pickValue(PREFIXES)
+          + data.pickValue(ATOMS)
+          + data.pickValue(CONNECTORS)
+          + data.pickValue(ATOMS)
+          + data.pickValue(SUFFIXES);
+    }
+    FuzzSupport.assertFullMatchesJdk(regex, flags, INPUTS);
   }
 }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -106,12 +106,13 @@ final class Parser {
       int c = pattern.codePointAt(pos);
       if (c == '#') {
         // Skip from '#' to end of line (or end of pattern).
-        while (pos < pattern.length() && pattern.charAt(pos) != '\n') {
-          pos++;
-        }
-        // Skip the newline itself if present.
-        if (pos < pattern.length()) {
-          pos++;
+        pos++;
+        while (pos < pattern.length()) {
+          int commentChar = pattern.codePointAt(pos);
+          if (isCommentTerminator(commentChar)) {
+            break;
+          }
+          pos += Character.charCount(commentChar);
         }
       } else if (Character.isWhitespace(c)) {
         pos += Character.charCount(c);
@@ -119,6 +120,13 @@ final class Parser {
         break;
       }
     }
+  }
+
+  private boolean isCommentTerminator(int c) {
+    if (c == '\0' || c == '\n') {
+      return true;
+    }
+    return (flags & ParseFlags.UNIX_LINES) == 0 && Nfa.isLineTerminator(c);
   }
 
   // ---- Main parse method ----

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -66,6 +66,16 @@ class JdkSyntaxCompatibilityTest {
         .isInstanceOf(PatternSyntaxException.class);
   }
 
+  /** Asserts JDK and SafeRE both reject the pattern with the given flags. */
+  private static void assertRejectedByJdkAndSafeRe(String regex, int flags) {
+    assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex, flags))
+        .as("JDK should reject: %s flags=%d", regex, flags)
+        .isInstanceOf(PatternSyntaxException.class);
+    assertThatThrownBy(() -> Pattern.compile(regex, flags))
+        .as("SafeRE should reject: %s flags=%d", regex, flags)
+        .isInstanceOf(PatternSyntaxException.class);
+  }
+
   /** Asserts SafeRE compiles and matches identically to JDK on the given input. */
   private static void assertMatchesSame(String regex, String input) {
     // Sanity: JDK must accept it.
@@ -387,6 +397,11 @@ class JdkSyntaxCompatibilityTest {
           Arguments.of(new DialectRejection("unmatched close group", "a)")),
           Arguments.of(new DialectRejection("unterminated group", "(a")),
           Arguments.of(new DialectRejection("dangling alternation group opener", "(|")),
+          Arguments.of(new DialectRejection("unterminated group after alternation", "a|(")),
+          Arguments.of(new DialectRejection("unterminated group after empty alternation",
+              "|(")),
+          Arguments.of(new DialectRejection("unterminated group after nested alternation",
+              "(a|b)|(")),
           Arguments.of(new DialectRejection("nothing to repeat star", "*a")),
           Arguments.of(new DialectRejection("malformed bounded quantifier", "a{2,1}")),
           Arguments.of(new DialectRejection("bare leading class intersection", "[&&]")),
@@ -478,6 +493,27 @@ class JdkSyntaxCompatibilityTest {
     @DisplayName("malformed JDK syntax is rejected")
     void malformedJdkSyntaxIsRejected(DialectRejection rejection) {
       assertRejectedByJdkAndSafeRe(rejection.regex());
+    }
+
+    static Stream<Arguments> commentTerminatorCases() {
+      return Stream.of(
+          Arguments.of("a#\0|(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("#\0(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\0b|(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\0(?:b)|(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\r(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\u0085(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\u2028(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\u2029(", java.util.regex.Pattern.COMMENTS),
+          Arguments.of("a#\0|(", java.util.regex.Pattern.COMMENTS
+              | java.util.regex.Pattern.UNIX_LINES));
+    }
+
+    @ParameterizedTest(name = "/{0}/ flags={1}")
+    @MethodSource("commentTerminatorCases")
+    @DisplayName("comments-mode comment terminators expose malformed group syntax")
+    void commentsModeCommentTerminatorsExposeMalformedGroupSyntax(String regex, int flags) {
+      assertRejectedByJdkAndSafeRe(regex, flags);
     }
 
     static Stream<Arguments> unsupportedNonRegularJdkSyntax() {

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1497,6 +1497,37 @@ class ParserTest {
           .isInstanceOf(PatternSyntaxException.class);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"a|(", "|(", "(a|b)|(", "a|b|(", "a|(?:b)|("})
+    void unclosedGroup_afterAlternationBoundary(String pattern) {
+      assertThatThrownBy(() -> parse(pattern))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "a#\0|(",
+        "#\0(",
+        "a#\0b|(",
+        "a#\0(?:b)|(",
+        "a#\r(",
+        "a#\u0085(",
+        "a#\u2028(",
+        "a#\u2029("
+    })
+    void unclosedGroup_afterCommentsModeTerminatedComment(String pattern) {
+      assertThatThrownBy(() -> parse(pattern, PERL | ParseFlags.COMMENTS))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a#\0|(", "#\0("})
+    void unclosedGroup_afterUnixLinesCommentsModeNulTerminatedComment(String pattern) {
+      assertThatThrownBy(() -> parse(
+          pattern, PERL | ParseFlags.COMMENTS | ParseFlags.UNIX_LINES))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
+
     @Test
     void unclosedGroup_partial() {
       assertThatThrownBy(() -> parse("(a|b"))


### PR DESCRIPTION
## Summary

- Fix comments-mode `#` skipping so comments stop at JDK line terminators, respect `UNIX_LINES`, and stop at NUL.
- Add parser and JDK compatibility regressions for malformed group syntax after comment terminators and alternation boundaries.
- Extend parser compatibility fuzz generation for comment-terminated malformed group tails.

## Verification

- `mvn -pl safere -Dtest=ParserTest,JdkSyntaxCompatibilityTest test`
- `mvn -pl safere-fuzz -am -Dtest=ParserCompatibilityFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`

Full public API crosscheck verification was skipped per request.

Fixes #321
