### PR TITLE
Fix Unicode dot and anchor bounds

### DIFF
--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -943,14 +943,9 @@ final class Compiler extends Walker<Compiler.Frag> {
     return charRange(rune, rune, foldCase);
   }
 
-  /**
-   * Compiles an "any code point" fragment — matches all valid Unicode code points except
-   * surrogates. This produces [0-0xD7FF] | [0xE000-0x10FFFF].
-   */
+  /** Compiles an "any code point" fragment. */
   private Frag anyCodePoint() {
-    Frag lo = charRange(0, Utils.MIN_SURROGATE - 1, false);
-    Frag hi = charRange(Utils.MAX_SURROGATE + 1, Utils.MAX_RUNE, false);
-    return alt(lo, hi);
+    return charRange(0, Utils.MAX_RUNE, false);
   }
 
   /**

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -961,7 +961,8 @@ final class Dfa {
           cp = ch;
           nextPos = pos + 1;
           cls = asciiClassMap[ch];
-        } else if (Character.isHighSurrogate(ch) && pos + 1 < textLen) {
+        } else if (Character.isHighSurrogate(ch) && pos + 1 < textLen
+            && Character.isLowSurrogate(text.charAt(pos + 1))) {
           cp = Character.toCodePoint(ch, text.charAt(pos + 1));
           nextPos = pos + 2;
           cls = classOf(cp);
@@ -1249,7 +1250,8 @@ final class Dfa {
             cp = ch;
             nextPos = pos + 1;
             cls = asciiClassMap[ch];
-          } else if (Character.isHighSurrogate(ch) && pos + 1 < textLen) {
+          } else if (Character.isHighSurrogate(ch) && pos + 1 < textLen
+              && Character.isLowSurrogate(text.charAt(pos + 1))) {
             cp = Character.toCodePoint(ch, text.charAt(pos + 1));
             nextPos = pos + 2;
             cls = classOf(cp);

--- a/safere/src/test/java/org/safere/UnicodeMatchBoundsTest.java
+++ b/safere/src/test/java/org/safere/UnicodeMatchBoundsTest.java
@@ -1,0 +1,89 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("Unicode match bounds")
+class UnicodeMatchBoundsTest {
+
+  record Case(String label, String regex, int flags, String input) {
+    @Override
+    public String toString() {
+      return label;
+    }
+  }
+
+  record Outcome(boolean matched, int start, int end) {}
+
+  static Stream<Case> dotAndAnchorBoundsMatchJdk() {
+    return Stream.of(
+        new Case("dot-empty-alternative", ".|", 352, "\ud85c"),
+        new Case("dollar-anchor", "$", 332, "\udb7f\udb7f\ud85c\r\r"),
+        new Case("dot-plus-surrogate", ".+", 358, "\ud828"),
+        new Case(
+            "dot-plus-anchor",
+            ".+^",
+            300,
+            "\u0301\r\u2028\u0301\u0301\u2028\u0301\u0301\ud85c\u2028a"),
+        new Case("dot-unpaired-high-surrogate", ".", Pattern.DOTALL, "\ud83d"),
+        new Case("dot-unpaired-low-surrogate", ".", Pattern.DOTALL, "\ude00"),
+        new Case("dot-valid-surrogate-pair", ".", Pattern.DOTALL, "\ud83d\ude00"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  @DisplayName("dot and anchor bounds match java.util.regex")
+  void dotAndAnchorBoundsMatchJdk(Case c) {
+    Pattern safePattern = Pattern.compile(c.regex(), c.flags());
+    java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(c.regex(), c.flags());
+
+    assertThat(findOutcome(safePattern.matcher(c.input())))
+        .as("%s find", c.label())
+        .isEqualTo(findOutcome(jdkPattern.matcher(c.input())));
+    assertThat(lookingAtOutcome(safePattern.matcher(c.input())))
+        .as("%s lookingAt", c.label())
+        .isEqualTo(lookingAtOutcome(jdkPattern.matcher(c.input())));
+    assertThat(matchesOutcome(safePattern.matcher(c.input())))
+        .as("%s matches", c.label())
+        .isEqualTo(matchesOutcome(jdkPattern.matcher(c.input())));
+  }
+
+  private static Outcome findOutcome(Matcher matcher) {
+    boolean matched = matcher.find();
+    return new Outcome(matched, matched ? matcher.start() : -1, matched ? matcher.end() : -1);
+  }
+
+  private static Outcome findOutcome(java.util.regex.Matcher matcher) {
+    boolean matched = matcher.find();
+    return new Outcome(matched, matched ? matcher.start() : -1, matched ? matcher.end() : -1);
+  }
+
+  private static Outcome lookingAtOutcome(Matcher matcher) {
+    boolean matched = matcher.lookingAt();
+    return new Outcome(matched, matched ? matcher.start() : -1, matched ? matcher.end() : -1);
+  }
+
+  private static Outcome lookingAtOutcome(java.util.regex.Matcher matcher) {
+    boolean matched = matcher.lookingAt();
+    return new Outcome(matched, matched ? matcher.start() : -1, matched ? matcher.end() : -1);
+  }
+
+  private static Outcome matchesOutcome(Matcher matcher) {
+    boolean matched = matcher.matches();
+    return new Outcome(matched, matched ? matcher.start() : -1, matched ? matcher.end() : -1);
+  }
+
+  private static Outcome matchesOutcome(java.util.regex.Matcher matcher) {
+    boolean matched = matcher.matches();
+    return new Outcome(matched, matched ? matcher.start() : -1, matched ? matcher.end() : -1);
+  }
+}


### PR DESCRIPTION
## Summary

- Match unpaired surrogate code units with dot the same way java.util.regex does.
- Keep valid surrogate pairs as single code points while treating unpaired surrogates as single input units in DFA scans.
- Add JDK comparison regressions for the issue #323 dot, surrogate, line terminator, and anchor-bound cases.

Fixes #323

## Verification

- `mvn -pl safere -Dtest=UnicodeMatchBoundsTest test -q`
- `mvn -pl safere -Dtest=UnicodeMatchBoundsTest,CrossEngineTest,DfaTest,NfaTest,BitStateTest,OnePassTest test -q`

Full verification was skipped per request.
