### PR TITLE
Fix quantified empty quoted literals

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -24,9 +24,11 @@ final class ParserCompatibilityFuzzer {
       "\\p{Lower}",
       "\\P{Lower}",
       "\\Q\\E",
+      "\\Q\\E\\Q\\E",
       "\\Q*\\E",
       "^",
       "$",
+      "a\\Q\\E",
       "[a]",
       "[^a]",
       "[a-z]",
@@ -48,7 +50,7 @@ final class ParserCompatibilityFuzzer {
   private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "(?m)", "(?s)"};
   private static final String[] CONNECTORS =
       {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}",
-          "??{1,3}", "?{1,3}", "*{1,3}", "+{1,3}", "{1,3}{1,3}"};
+          "{1}", "??{1,3}", "?{1,3}", "*{1,3}", "+{1,3}", "{1,3}{1,3}"};
   private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
   private static final String[] COMMENT_TERMINATED_PREFIXES = {
       "a#\0",

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -320,6 +320,7 @@ final class Parser {
       if (next == 'Q') {
         // \Q ... \E: the ... is always literals
         pos += 2; // '\\', 'Q'
+        boolean sawLiteral = false;
         while (pos < pattern.length()) {
           if (pos + 1 < pattern.length()
               && pattern.charAt(pos) == '\\'
@@ -330,6 +331,10 @@ final class Parser {
           int r = pattern.codePointAt(pos);
           pos += Character.charCount(r);
           pushLiteral(r);
+          sawLiteral = true;
+        }
+        if (!sawLiteral) {
+          pushRegexp(Regexp.emptyMatch(flags));
         }
         return;
       }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -149,6 +149,7 @@ final class Parser {
 
     String lastunary = null;
     boolean lastTokenNonRepeatable = false;
+    boolean lastTokenWasEmptyQuotedLiteral = false;
     while (pos < pattern.length()) {
       // In comments mode, skip whitespace and #-comments before each token.
       if ((flags & ParseFlags.COMMENTS) != 0) {
@@ -217,6 +218,10 @@ final class Parser {
               nongreedy = true;
               pos++; // '?'
             }
+            if (lastunary != null && lastTokenWasEmptyQuotedLiteral && c != '*') {
+              isunary = lastunary;
+              break;
+            }
             if (lastunary != null && !canRepeatAfterUnary(op)) {
               throw new PatternSyntaxException(
                   "invalid nested repetition operator", pattern, opStart);
@@ -256,7 +261,14 @@ final class Parser {
           isunary = opstr;
         }
         case '\\' -> {
-          parseBackslash();
+          if (parseBackslash()) {
+            if (stacktop == null || isMarker(stacktop) || lastTokenNonRepeatable) {
+              lastunary = null;
+              lastTokenNonRepeatable = true;
+            }
+            lastTokenWasEmptyQuotedLiteral = true;
+            continue;
+          }
         }
         default -> {
           pos += Character.charCount(c);
@@ -265,13 +277,14 @@ final class Parser {
       }
       lastunary = isunary;
       lastTokenNonRepeatable = isNonRepeatable;
+      lastTokenWasEmptyQuotedLiteral = false;
     }
     return doFinish();
   }
 
   // ---- Backslash handling (top-level) ----
 
-  private void parseBackslash() {
+  private boolean parseBackslash() {
     // \b and \B: word boundary or not
     if ((flags & ParseFlags.PERL_B) != 0
         && pos + 1 < pattern.length()
@@ -285,11 +298,11 @@ final class Parser {
           && pattern.charAt(pos + 4) == '}') {
         pos += 5; // '\\', 'b', '{', 'g', '}'
         pushRegexp(Regexp.emptyMatch(flags));
-        return;
+        return false;
       }
       pushWordBoundary(pattern.charAt(pos + 1) == 'b');
       pos += 2; // '\\', 'b' or 'B'
-      return;
+      return false;
     }
 
     if ((flags & ParseFlags.PERL_X) != 0 && pos + 1 < pattern.length()) {
@@ -297,12 +310,12 @@ final class Parser {
       if (next == 'A') {
         pushSimpleOp(RegexpOp.BEGIN_TEXT);
         pos += 2;
-        return;
+        return false;
       }
       if (next == 'z') {
         pushSimpleOp(RegexpOp.END_TEXT);
         pos += 2;
-        return;
+        return false;
       }
       if (next == 'Z') {
         // \Z matches at end of input or before a final newline, same as $ in non-multiline mode.
@@ -311,7 +324,7 @@ final class Parser {
         pushSimpleOp(RegexpOp.END_TEXT);
         flags = oflags;
         pos += 2;
-        return;
+        return false;
       }
       if (next == 'G') {
         throw new PatternSyntaxException(
@@ -333,10 +346,7 @@ final class Parser {
           pushLiteral(r);
           sawLiteral = true;
         }
-        if (!sawLiteral) {
-          pushRegexp(Regexp.emptyMatch(flags));
-        }
-        return;
+        return !sawLiteral;
       }
     }
 
@@ -345,7 +355,7 @@ final class Parser {
     if (pos + 1 < pattern.length() && pattern.charAt(pos + 1) == 'R') {
       pos += 2; // '\\', 'R'
       pushRegexp(buildLinebreakRegexp());
-      return;
+      return false;
     }
 
     // \X: Extended grapheme cluster (simplified).
@@ -353,7 +363,7 @@ final class Parser {
     if (pos + 1 < pattern.length() && pattern.charAt(pos + 1) == 'X') {
       pos += 2; // '\\', 'X'
       pushRegexp(buildGraphemeClusterRegexp());
-      return;
+      return false;
     }
 
     // Unicode group \p{...} or \P{...}
@@ -365,10 +375,10 @@ final class Parser {
       if (result == PARSE_OK) {
         Regexp re = finishCharClassBuilder(ccb);
         pushRegexp(re);
-        return;
+        return false;
       } else if (result == PARSE_ERROR) {
         // error already thrown by parseUnicodeGroup
-        return;
+        return false;
       }
       // PARSE_NOTHING: fall through
       pos = saved;
@@ -381,17 +391,18 @@ final class Parser {
       if (ccb != null) {
         Regexp re = finishCharClassBuilder(ccb);
         pushRegexp(re);
-        return;
+        return false;
       }
       pos = saved;
     }
 
     // Regular escape
     if (maybePushNumericBackreferenceEscape()) {
-      return;
+      return false;
     }
     int r = parseEscape();
     pushLiteral(r);
+    return false;
   }
 
   private boolean maybePushNumericBackreferenceEscape() {

--- a/safere/src/test/java/org/safere/CommentsTest.java
+++ b/safere/src/test/java/org/safere/CommentsTest.java
@@ -22,6 +22,15 @@ import org.junit.jupiter.api.Test;
  */
 class CommentsTest {
 
+  private static void assertMatchesSameAsJdk(String regex, int flags, String input) {
+    boolean jdkMatches = java.util.regex.Pattern.compile(regex, flags).matcher(input).matches();
+    boolean safeMatches = Pattern.compile(regex, flags).matcher(input).matches();
+
+    assertThat(safeMatches)
+        .as("matches() for /%s/ (flags=%d) on \"%s\"", regex, flags, input)
+        .isEqualTo(jdkMatches);
+  }
+
   // ---------------------------------------------------------------------------
   // Pattern.COMMENTS compile flag
   // ---------------------------------------------------------------------------
@@ -317,6 +326,25 @@ class CommentsTest {
       Pattern p = Pattern.compile("\\Q a b \\E", Pattern.COMMENTS);
       assertThat(p.matcher(" a b ").matches()).isTrue();
       assertThat(p.matcher("ab").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("quantifiers after empty quoted literals bind to the empty literal")
+    void quantifiersAfterEmptyQuotedLiteralsBindToEmptyLiteral() {
+      String[] regexes = {
+          "a\\Q\\E+",
+          "a\\Q\\E*",
+          "a\\Q\\E?",
+          "a\\Q\\E{1,3}",
+          "^\\p{Lower}{1,3}\\Q\\E+"
+      };
+      String[] inputs = {"", "a", "aa", "aaa", "name"};
+
+      for (String regex : regexes) {
+        for (String input : inputs) {
+          assertMatchesSameAsJdk(regex, Pattern.COMMENTS, input);
+        }
+      }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Treat empty top-level `\Q\E` quoted literals as transparent parser syntax so following quantifiers bind according to JDK rules.
- Preserve JDK behavior for quantifiers after empty quoted literals under `Pattern.COMMENTS`, including already-quantified preceding atoms.
- Expand ParserCompatibilityFuzzer grammar inputs around adjacent empty quoted literals and exact-count repeats.

Fixes #324

## Verification

- `mvn -pl safere -Dtest=CommentsTest,JdkSyntaxCompatibilityTest,ParserTest test -q`
- Manual repro check: JDK and SafeRE both return `false` for `^\p{Lower}{1,3}\Q\E+` on `name` with `Pattern.COMMENTS`.
- Not run: full SafeRE plus public API crosscheck validation.
