### PR TITLE
Fix grapheme cluster boundary matching

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
@@ -32,17 +32,37 @@ final class DialectSyntaxFuzzer {
       "[=a=]",
       "\\C",
       "\\R",
+      "\\X",
+      "\\b{g}",
       "\\K"
   };
   private static final String[] CONTEXT_SUFFIXES = {"", "$", ")", "b", "]", "&&[a]]"};
   private static final List<String> INPUTS =
-      List.of("", "a", "b", "Braille", "Latin", ":", "[", "]", "l", "o", "w", "e", "r");
+      List.of(
+          "",
+          "a",
+          "b",
+          "a\u0300",
+          "\r\n",
+          "Braille",
+          "Latin",
+          ":",
+          "[",
+          "]",
+          "l",
+          "o",
+          "w",
+          "e",
+          "r");
   private static final String[] REGRESSION_REGEXES = {
       "(?P<name>a)",
       "\\p{Braille}",
       "\\p{Latin}",
       "[[:lower:]]",
       "[[:^space:]]",
+      "a\\b{g}\\u0300",
+      "\\r\\b{g}\\n",
+      "\\b{g}a\\u0300\\b{g}",
       "\\Q{?\\E",
       "{?",
       "a{,2}",

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -921,7 +921,7 @@ final class Compiler extends Walker<Compiler.Frag> {
       Regexp node = stack.pop();
       switch (node.op) {
         case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
-             NO_WORD_BOUNDARY -> {}
+             NO_WORD_BOUNDARY, GRAPHEME_CLUSTER_BOUNDARY -> {}
         case NON_CAPTURE, CAPTURE -> stack.push(node.sub());
         case CONCAT -> {
           if (node.subs != null) {
@@ -1069,6 +1069,8 @@ final class Compiler extends Walker<Compiler.Frag> {
         }
         yield emptyWidth(EmptyOp.NON_WORD_BOUNDARY);
       }
+
+      case GRAPHEME_CLUSTER_BOUNDARY -> emptyWidth(EmptyOp.GRAPHEME_CLUSTER_BOUNDARY);
 
       default -> {
         failed = true;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -43,17 +43,17 @@ final class Dfa {
   record ManyMatchResult(boolean matched, int[] matchIds) {}
 
   /** Flag bit: this state contains a MATCH instruction. */
-  private static final int FLAG_MATCH = 1 << 9;
+  private static final int FLAG_MATCH = 1 << 10;
 
   /** Flag bit: last consumed character was a word character (for {@code \b}/\B}). */
-  private static final int FLAG_LAST_WORD = 1 << 10;
+  private static final int FLAG_LAST_WORD = 1 << 11;
 
   /**
    * Flag bit: match was triggered by a word-boundary assertion BEFORE consuming the transition
    * character. The match position should be recorded at the current position, not after the
    * character.
    */
-  private static final int FLAG_MATCH_BEFORE = 1 << 11;
+  private static final int FLAG_MATCH_BEFORE = 1 << 12;
 
   /**
    * Flag bit: when {@link #FLAG_MATCH_BEFORE} is set, indicates that an after-consume match ALSO
@@ -61,12 +61,12 @@ final class Dfa {
    * before-consume match first (earlier position) and fall back to the after-consume match if the
    * before-consume match is rejected (e.g., by {@code needEndMatch} requiring end-of-text).
    */
-  private static final int FLAG_MATCH_AFTER_DEFERRED = 1 << 12;
+  private static final int FLAG_MATCH_AFTER_DEFERRED = 1 << 13;
 
   /**
    * Flag bit: last consumed character was a Unicode word character (for Unicode {@code \b}/\B}).
    */
-  private static final int FLAG_LAST_UNICODE_WORD = 1 << 13;
+  private static final int FLAG_LAST_UNICODE_WORD = 1 << 14;
 
   /** Maximum number of DFA states before bailing out to NFA. */
   private static final int DEFAULT_MAX_STATES = 10_000;
@@ -127,6 +127,7 @@ final class Dfa {
 
   private final Prog prog;
   private final int maxStates;
+  private final boolean hasGraphemeClusterBoundary;
 
   /** Sorted code point boundaries defining equivalence classes. */
   private final int[] boundaries;
@@ -169,11 +170,11 @@ final class Dfa {
   /**
    * Cache of DFA start states indexed by position context. The start state depends on four factors:
    * whether the search is anchored, whether it's a reverse context, the empty-width flags at the
-   * position (6 bits for BOL/EOL/BOT/EOT/WB/NWB), and whether the previous character was a word
-   * character. This gives at most 2 × 2 × 64 × 2 = 512 combinations. Caching avoids the expensive
+   * position, and whether the previous character was a word
+   * character. This gives at most 2 × 2 × 1024 × 2 × 2 combinations. Caching avoids the expensive
    * {@link #expand} call and its {@code Arrays.copyOf} allocation on every DFA search.
    */
-  private final State[] startStateByContext = new State[2048];
+  private final State[] startStateByContext = new State[16_384];
 
   /** Shared empty instruction array to avoid repeated zero-length allocations. */
   private static final int[] EMPTY_INSTS = new int[0];
@@ -205,6 +206,7 @@ final class Dfa {
   Dfa(Prog prog, int maxStates, Setup setup) {
     this.prog = prog;
     this.maxStates = maxStates;
+    this.hasGraphemeClusterBoundary = prog.hasGraphemeClusterBoundary();
     this.boundaries = setup.boundaries;
     this.numClasses = setup.numClasses;
     this.asciiClassMap = setup.asciiClassMap;
@@ -515,8 +517,9 @@ final class Dfa {
     // Check the start state cache. The start state depends only on (anchored, reverseContext,
     // emptyFlags, lastWord, lastUnicodeWord), so positions with identical context share the same
     // start state.
-    int cacheKey = (anchored ? 1024 : 0) | (reverseContext ? 512 : 0)
-        | ((emptyFlags & 0x7F) << 2) | (lastWord ? 2 : 0) | (lastUnicodeWord ? 1 : 0);
+    int cacheKey = (anchored ? 8192 : 0) | (reverseContext ? 4096 : 0)
+        | ((emptyFlags & EmptyOp.ALL_FLAGS) << 2) | (lastWord ? 2 : 0)
+        | (lastUnicodeWord ? 1 : 0);
     State cached = startStateByContext[cacheKey];
     if (cached != null) {
       return cached;
@@ -524,7 +527,7 @@ final class Dfa {
 
     computeBuf[0] = startInst;
     int[] insts = expand(computeBuf, 1, emptyFlags);
-    int flags = emptyFlags & 0x1FF;
+    int flags = emptyFlags & EmptyOp.ALL_FLAGS;
     if (hasMatch(insts)) {
       flags |= FLAG_MATCH;
     }
@@ -559,6 +562,9 @@ final class Dfa {
    * is always safe to cache because it always represents "at text end".
    */
   private int positionDependentThreshold(String text) {
+    if (hasGraphemeClusterBoundary) {
+      return 0;
+    }
     int len = text.length();
     if (prog.unixLines()) {
       return (len > 0 && text.charAt(len - 1) == '\n') ? len - 1 : len;
@@ -637,7 +643,7 @@ final class Dfa {
       if (nextInsts.length == 0) {
         return deadState;
       }
-      int flags = emptyFlags & 0x1FF;
+      int flags = emptyFlags & EmptyOp.ALL_FLAGS;
       if (hasMatch(nextInsts)) {
         flags |= FLAG_MATCH;
       }
@@ -718,7 +724,8 @@ final class Dfa {
       // kind (e.g., \b\b or $$) can fire during expansion. Without this, the first
       // \b fires but expand() wouldn't satisfy the second \b because WORD_BOUNDARY
       // was stripped from the state's cached emptyFlags.
-      int reExpandEmptyFlags = (s.flags & 0x1FF) | wordBeforeFlags | unicodeWordBeforeFlags;
+      int reExpandEmptyFlags =
+          (s.flags & EmptyOp.ALL_FLAGS) | wordBeforeFlags | unicodeWordBeforeFlags;
       if (endLineHere) {
         reExpandEmptyFlags |= EmptyOp.END_LINE;
       }
@@ -793,7 +800,7 @@ final class Dfa {
       return deadState;
     }
 
-    int flags = emptyFlags & 0x1FF;
+    int flags = emptyFlags & EmptyOp.ALL_FLAGS;
     if (hasMatchFromDeferred) {
       // A deferred assertion (\b, \B, or multiline $) fired before consuming the current
       // character and reached a MATCH instruction. This match is at position `pos` (before

--- a/safere/src/main/java/org/safere/EmptyOp.java
+++ b/safere/src/main/java/org/safere/EmptyOp.java
@@ -45,8 +45,11 @@ final class EmptyOp {
   /** {@code \B} — Unicode not a word boundary (when UNICODE_CHARACTER_CLASS is set). */
   public static final int UNICODE_NON_WORD_BOUNDARY = 1 << 8;
 
+  /** {@code \b{g}} — Unicode extended grapheme cluster boundary. */
+  public static final int GRAPHEME_CLUSTER_BOUNDARY = 1 << 9;
+
   /** All flags combined. */
-  public static final int ALL_FLAGS = (1 << 9) - 1;
+  public static final int ALL_FLAGS = (1 << 10) - 1;
 
   private EmptyOp() {} // Non-instantiable.
 }

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -690,7 +690,41 @@ final class Nfa {
       flags |= EmptyOp.UNICODE_NON_WORD_BOUNDARY;
     }
 
+    if (isGraphemeClusterBoundary(text, pos)) {
+      flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
+    }
+
     return flags;
+  }
+
+  /**
+   * Returns true if {@code pos} is a grapheme cluster boundary for SafeRE's supported
+   * approximation of JDK {@code \X}: CRLF is atomic, and combining marks extend the preceding
+   * cluster.
+   */
+  static boolean isGraphemeClusterBoundary(String text, int pos) {
+    if (pos < 0 || pos > text.length()) {
+      return false;
+    }
+    if (pos == 0 || pos == text.length()) {
+      return true;
+    }
+    char prevChar = text.charAt(pos - 1);
+    char nextChar = text.charAt(pos);
+    if (Character.isHighSurrogate(prevChar) && Character.isLowSurrogate(nextChar)) {
+      return false;
+    }
+    if (prevChar == '\r' && nextChar == '\n') {
+      return false;
+    }
+    return !isCombiningMark(text.codePointAt(pos));
+  }
+
+  private static boolean isCombiningMark(int c) {
+    int type = Character.getType(c);
+    return type == Character.NON_SPACING_MARK
+        || type == Character.ENCLOSING_MARK
+        || type == Character.COMBINING_SPACING_MARK;
   }
 
   /** Returns true if the code point is a word character ({@code [A-Za-z0-9_]}). */

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -44,14 +44,14 @@ final class OnePass {
   // -------------------------------------------------------------------------
   // Action encoding: each action is packed into a single long.
   //
-  //   bits  0-7 : empty-width flags required for this transition
-  //   bits  8-27: capture mask (which capture registers to set)
-  //   bits 28-63: next state index
+  //   bits  0-9 : empty-width flags required for this transition
+  //   bits 10-29: capture mask (which capture registers to set)
+  //   bits 30-63: next state index
   //
   // Special value: NO_ACTION (-1L) means no valid transition.
   // -------------------------------------------------------------------------
 
-  private static final int EMPTY_BITS = 9;
+  private static final int EMPTY_BITS = 10;
   private static final int CAP_SHIFT = EMPTY_BITS;
   private static final int INDEX_SHIFT = CAP_SHIFT + MAX_CAP_REGS;
   private static final long EMPTY_MASK = (1L << EMPTY_BITS) - 1;

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -289,16 +289,15 @@ final class Parser {
     if ((flags & ParseFlags.PERL_B) != 0
         && pos + 1 < pattern.length()
         && (pattern.charAt(pos + 1) == 'b' || pattern.charAt(pos + 1) == 'B')) {
-      // \b{g}: grapheme cluster boundary — accepted for JDK compatibility.
-      // Approximated as an empty match (matches at every position).
+      // \b{g}: grapheme cluster boundary.
       if (pattern.charAt(pos + 1) == 'b'
           && pos + 4 < pattern.length()
           && pattern.charAt(pos + 2) == '{'
           && pattern.charAt(pos + 3) == 'g'
           && pattern.charAt(pos + 4) == '}') {
         pos += 5; // '\\', 'b', '{', 'g', '}'
-        pushRegexp(Regexp.emptyMatch(flags));
-        return false;
+        pushSimpleOp(RegexpOp.GRAPHEME_CLUSTER_BOUNDARY);
+        return true;
       }
       pushWordBoundary(pattern.charAt(pos + 1) == 'b');
       pos += 2; // '\\', 'b' or 'B'
@@ -584,6 +583,7 @@ final class Parser {
       case ANY_CHAR -> Regexp.anyChar(flags);
       case WORD_BOUNDARY -> Regexp.wordBoundary(flags);
       case NO_WORD_BOUNDARY -> Regexp.noWordBoundary(flags);
+      case GRAPHEME_CLUSTER_BOUNDARY -> Regexp.graphemeClusterBoundary(flags);
       default -> Regexp.emptyMatch(flags);
     };
     pushRegexp(re);
@@ -644,7 +644,7 @@ final class Parser {
       Regexp current = pending.removeLast();
       switch (current.op) {
         case EMPTY_MATCH, BEGIN_LINE, END_LINE, WORD_BOUNDARY, NO_WORD_BOUNDARY,
-            BEGIN_TEXT, END_TEXT -> {
+            GRAPHEME_CLUSTER_BOUNDARY, BEGIN_TEXT, END_TEXT -> {
           // Zero-width by definition.
         }
         case CAPTURE, NON_CAPTURE, STAR, PLUS, QUEST, REPEAT ->

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1087,7 +1087,7 @@ public final class Pattern implements Serializable {
         Regexp re, Boolean parentArg, Boolean preArg, List<Boolean> childArgs) {
       return switch (re.op) {
         case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
-             NO_WORD_BOUNDARY -> true;
+             NO_WORD_BOUNDARY, GRAPHEME_CLUSTER_BOUNDARY -> true;
         case STAR, QUEST -> true;
         case REPEAT -> re.min == 0;
         case PLUS, NON_CAPTURE, CAPTURE -> !childArgs.isEmpty() && childArgs.getFirst();
@@ -1152,7 +1152,9 @@ public final class Pattern implements Serializable {
     while (!stack.isEmpty()) {
       Regexp node = stack.pop();
       switch (node.op) {
-        case END_LINE, WORD_BOUNDARY, NO_WORD_BOUNDARY -> { return true; }
+        case END_LINE, WORD_BOUNDARY, NO_WORD_BOUNDARY, GRAPHEME_CLUSTER_BOUNDARY -> {
+          return true;
+        }
         case END_TEXT -> {
           if ((node.flags & ParseFlags.WAS_DOLLAR) != 0) {
             return true;
@@ -1175,7 +1177,9 @@ public final class Pattern implements Serializable {
     while (!stack.isEmpty()) {
       Regexp node = stack.pop();
       switch (node.op) {
-        case END_LINE, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY -> { return true; }
+        case END_LINE, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY, GRAPHEME_CLUSTER_BOUNDARY -> {
+          return true;
+        }
         default -> {}
       }
       if (node.subs != null) {
@@ -1205,8 +1209,8 @@ public final class Pattern implements Serializable {
       boolean insideQuant = entry.insideQuant();
       if (insideQuant) {
         switch (node.op) {
-          case BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY ->
-              { return true; }
+          case BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY,
+               GRAPHEME_CLUSTER_BOUNDARY -> { return true; }
           default -> {}
         }
       }

--- a/safere/src/main/java/org/safere/Prog.java
+++ b/safere/src/main/java/org/safere/Prog.java
@@ -206,6 +206,19 @@ final class Prog {
     return false;
   }
 
+  /** Returns true if this program contains a {@code \b{g}} assertion. */
+  boolean hasGraphemeClusterBoundary() {
+    int n = size();
+    for (int i = 0; i < n; i++) {
+      Inst ip = inst(i);
+      if (ip.op == InstOp.EMPTY_WIDTH
+          && (ip.arg & EmptyOp.GRAPHEME_CLUSTER_BOUNDARY) != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Returns a human-readable dump of the program, useful for debugging.
    *

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -227,6 +227,11 @@ final class Regexp {
     return new Regexp(RegexpOp.NO_WORD_BOUNDARY, flags);
   }
 
+  /** Creates a GRAPHEME_CLUSTER_BOUNDARY node. */
+  public static Regexp graphemeClusterBoundary(int flags) {
+    return new Regexp(RegexpOp.GRAPHEME_CLUSTER_BOUNDARY, flags);
+  }
+
   /** Creates a BEGIN_TEXT node. */
   public static Regexp beginText(int flags) {
     return new Regexp(RegexpOp.BEGIN_TEXT, flags);
@@ -316,8 +321,8 @@ final class Regexp {
 
       nprec = switch (re.op) {
         case NO_MATCH, EMPTY_MATCH, LITERAL, ANY_CHAR, ANY_BYTE, BEGIN_LINE, END_LINE,
-             BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY, CHAR_CLASS, HAVE_MATCH ->
-            PREC_ATOM;
+             BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY, GRAPHEME_CLUSTER_BOUNDARY,
+             CHAR_CLASS, HAVE_MATCH -> PREC_ATOM;
         case CONCAT, LITERAL_STRING -> {
           if (prec < PREC_CONCAT) {
             sb.append("(?:");
@@ -445,6 +450,7 @@ final class Regexp {
         }
         case WORD_BOUNDARY -> sb.append("\\b");
         case NO_WORD_BOUNDARY -> sb.append("\\B");
+        case GRAPHEME_CLUSTER_BOUNDARY -> sb.append("\\b{g}");
         case CHAR_CLASS -> appendCharClass(sb, re.charClass);
         case NON_CAPTURE -> sb.append(')');
         case CAPTURE -> sb.append(')');

--- a/safere/src/main/java/org/safere/RegexpOp.java
+++ b/safere/src/main/java/org/safere/RegexpOp.java
@@ -71,6 +71,9 @@ enum RegexpOp {
   /** Matches not-a-word boundary ({@code \B}). */
   NO_WORD_BOUNDARY,
 
+  /** Matches a Unicode extended grapheme cluster boundary ({@code \b{g}}). */
+  GRAPHEME_CLUSTER_BOUNDARY,
+
   /** Matches empty string at beginning of text ({@code \A}). */
   BEGIN_TEXT,
 

--- a/safere/src/main/java/org/safere/Simplifier.java
+++ b/safere/src/main/java/org/safere/Simplifier.java
@@ -141,6 +141,7 @@ final class Simplifier {
       case END_LINE:
       case WORD_BOUNDARY:
       case NO_WORD_BOUNDARY:
+      case GRAPHEME_CLUSTER_BOUNDARY:
       case BEGIN_TEXT:
         return true;
 
@@ -475,6 +476,7 @@ final class Simplifier {
         case BEGIN_TEXT:
         case WORD_BOUNDARY:
         case NO_WORD_BOUNDARY:
+        case GRAPHEME_CLUSTER_BOUNDARY:
         case END_TEXT:
         case ANY_CHAR:
         case ANY_BYTE:
@@ -553,6 +555,7 @@ final class Simplifier {
         || re.op == RegexpOp.END_LINE
         || re.op == RegexpOp.WORD_BOUNDARY
         || re.op == RegexpOp.NO_WORD_BOUNDARY
+        || re.op == RegexpOp.GRAPHEME_CLUSTER_BOUNDARY
         || re.op == RegexpOp.BEGIN_TEXT
         || re.op == RegexpOp.END_TEXT;
   }
@@ -564,7 +567,7 @@ final class Simplifier {
       Regexp node = stack.pop();
       switch (node.op) {
         case EMPTY_MATCH, BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY,
-             NO_WORD_BOUNDARY -> {}
+             NO_WORD_BOUNDARY, GRAPHEME_CLUSTER_BOUNDARY -> {}
         case NON_CAPTURE, CAPTURE -> stack.push(node.sub());
         case CONCAT -> {
           for (Regexp sub : node.subs) {
@@ -613,6 +616,7 @@ final class Simplifier {
       case BEGIN_TEXT:
       case WORD_BOUNDARY:
       case NO_WORD_BOUNDARY:
+      case GRAPHEME_CLUSTER_BOUNDARY:
       case END_TEXT:
       case ANY_CHAR:
       case ANY_BYTE:

--- a/safere/src/test/java/org/safere/BoundaryMatcherTest.java
+++ b/safere/src/test/java/org/safere/BoundaryMatcherTest.java
@@ -206,6 +206,25 @@ class BoundaryMatcherTest {
   @DisplayName("\\b{g} (grapheme cluster boundary)")
   class GraphemeClusterBoundary {
 
+    private void assertFindSameAsJdk(String regex, String input) {
+      java.util.regex.Matcher jdkMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+      Matcher safeMatcher = Pattern.compile(regex).matcher(input);
+
+      List<int[]> jdkMatches = new ArrayList<>();
+      while (jdkMatcher.find()) {
+        jdkMatches.add(new int[] {jdkMatcher.start(), jdkMatcher.end()});
+      }
+
+      List<int[]> safeMatches = new ArrayList<>();
+      while (safeMatcher.find()) {
+        safeMatches.add(new int[] {safeMatcher.start(), safeMatcher.end()});
+      }
+
+      assertThat(safeMatches)
+          .as("find() positions for /%s/ on %s", regex, input)
+          .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
     @Test
     @DisplayName("\\b{g} compiles without error")
     void compiles() {
@@ -216,6 +235,30 @@ class BoundaryMatcherTest {
     @DisplayName("\\b{g} in a larger pattern compiles without error")
     void compilesInLargerPattern() {
       assertThatNoException().isThrownBy(() -> Pattern.compile("foo\\b{g}bar"));
+    }
+
+    @Test
+    @DisplayName("\\b{g} does not match inside a base-plus-combining-mark cluster")
+    void doesNotMatchInsideBaseCombiningCluster() {
+      assertFindSameAsJdk("a\\b{g}\\u0300", "a\u0300");
+    }
+
+    @Test
+    @DisplayName("\\b{g} matches at the edges of base-plus-combining-mark clusters")
+    void matchesBaseCombiningClusterEdges() {
+      assertFindSameAsJdk("\\b{g}a\\u0300\\b{g}", "a\u0300");
+    }
+
+    @Test
+    @DisplayName("\\b{g} find() reports cluster boundaries, not every UTF-16 position")
+    void findReportsOnlyClusterBoundaries() {
+      assertFindSameAsJdk("\\b{g}", "a\u0300b");
+    }
+
+    @Test
+    @DisplayName("\\b{g} does not split CRLF")
+    void doesNotSplitCrLf() {
+      assertFindSameAsJdk("\\r\\b{g}\\n", "\r\n");
     }
 
     @Test

--- a/safere/src/test/java/org/safere/EmptyOpTest.java
+++ b/safere/src/test/java/org/safere/EmptyOpTest.java
@@ -24,6 +24,7 @@ class EmptyOpTest {
     assertThat(EmptyOp.DOLLAR_END).isEqualTo(64);
     assertThat(EmptyOp.UNICODE_WORD_BOUNDARY).isEqualTo(128);
     assertThat(EmptyOp.UNICODE_NON_WORD_BOUNDARY).isEqualTo(256);
+    assertThat(EmptyOp.GRAPHEME_CLUSTER_BOUNDARY).isEqualTo(512);
   }
 
   @Test
@@ -37,9 +38,10 @@ class EmptyOpTest {
             | EmptyOp.NON_WORD_BOUNDARY
             | EmptyOp.DOLLAR_END
             | EmptyOp.UNICODE_WORD_BOUNDARY
-            | EmptyOp.UNICODE_NON_WORD_BOUNDARY;
+            | EmptyOp.UNICODE_NON_WORD_BOUNDARY
+            | EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
     assertThat(EmptyOp.ALL_FLAGS).isEqualTo(combined);
-    assertThat(EmptyOp.ALL_FLAGS).isEqualTo(511);
+    assertThat(EmptyOp.ALL_FLAGS).isEqualTo(1023);
   }
 
   @Test
@@ -54,7 +56,8 @@ class EmptyOpTest {
       EmptyOp.NON_WORD_BOUNDARY,
       EmptyOp.DOLLAR_END,
       EmptyOp.UNICODE_WORD_BOUNDARY,
-      EmptyOp.UNICODE_NON_WORD_BOUNDARY
+      EmptyOp.UNICODE_NON_WORD_BOUNDARY,
+      EmptyOp.GRAPHEME_CLUSTER_BOUNDARY
     };
     for (int i = 0; i < flags.length; i++) {
       for (int j = i + 1; j < flags.length; j++) {


### PR DESCRIPTION
## Summary

- Implement `\b{g}` as a real zero-width grapheme cluster boundary assertion instead of lowering it to an empty match.
- Evaluate the boundary through shared empty-width flags across parser, compiler, NFA/BitState/OnePass/DFA paths.
- Add JDK comparison regressions for combining-mark clusters and CRLF, plus fuzz syntax coverage.

## Verification

- `mvn -pl safere -Dtest=BoundaryMatcherTest test`
- `mvn -pl safere-fuzz -am -Dtest=DialectSyntaxFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere -Dtest=EmptyOpTest,BoundaryMatcherTest test`
- `git diff --check`
- `mvn -pl safere test -q`

Not run: `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`.

Fixes #316
