### PR TITLE
Fix terminal repeat sampling stack safety

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -12,9 +12,20 @@ final class FindSequenceFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void sequence(FuzzedDataProvider data) {
-    String regex = data.consumeString(256);
-    int flags = FuzzSupport.consumeFlags(data);
-    String input = data.consumeString(2048);
+    assertTerminalRepeatEndStateSamplingStackSafe();
+
+    String regex;
+    int flags;
+    String input;
+    if (data.consumeBoolean()) {
+      regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
+      flags = 0;
+      input = data.consumeBoolean() ? "a" : "a!";
+    } else {
+      regex = data.consumeString(256);
+      flags = FuzzSupport.consumeFlags(data);
+      input = data.consumeString(2048);
+    }
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, flags);
     if (pattern == null) {
       return;
@@ -72,5 +83,28 @@ final class FindSequenceFuzzer {
         default -> throw new AssertionError();
       }
     }
+  }
+
+  private static void assertTerminalRepeatEndStateSamplingStackSafe() {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(nestedCapturingGroups(512) + "*");
+
+    org.safere.Matcher matches = pattern.matcher("a");
+    if (!matches.matches() || !matches.hitEnd() || matches.requireEnd()) {
+      throw new AssertionError("deep terminal repeat matches() end-state divergence");
+    }
+
+    org.safere.Matcher lookingAt = pattern.matcher("a!");
+    if (!lookingAt.lookingAt() || lookingAt.hitEnd()) {
+      throw new AssertionError("deep terminal repeat lookingAt() end-state divergence");
+    }
+
+    org.safere.Matcher find = pattern.matcher("a");
+    if (!find.find() || !find.hitEnd() || find.requireEnd()) {
+      throw new AssertionError("deep terminal repeat find() end-state divergence");
+    }
+  }
+
+  private static String nestedCapturingGroups(int depth) {
+    return "(".repeat(depth) + "a" + ")".repeat(depth);
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -72,6 +73,18 @@ public final class Matcher implements MatchResult {
     RESET_NO_ATTEMPT,
     MATCHED,
     FAILED
+  }
+
+  private static final class SampleFrame {
+    private Regexp re;
+    private int nextSub;
+    private StringBuilder builder;
+    private String chosen;
+    private boolean failed;
+
+    private SampleFrame(Regexp re) {
+      this.re = re;
+    }
   }
 
   /**
@@ -2278,29 +2291,34 @@ public final class Matcher implements MatchResult {
   }
 
   private static void collectTerminalExtensionSamples(Regexp re, java.util.List<String> samples) {
-    switch (re.op) {
-      case STAR, PLUS, QUEST -> addSample(re.subs.get(0), samples);
-      case REPEAT -> {
-        if (re.max < 0 || re.max > re.min) {
-          addSample(re.subs.get(0), samples);
-        }
-      }
-      case NON_CAPTURE, CAPTURE -> collectTerminalExtensionSamples(re.subs.get(0), samples);
-      case CONCAT -> {
-        for (int i = re.subs.size() - 1; i >= 0; i--) {
-          Regexp sub = re.subs.get(i);
-          collectTerminalExtensionSamples(sub, samples);
-          if (!Pattern.canMatchEmpty(sub)) {
-            break;
+    ArrayDeque<Regexp> work = new ArrayDeque<>();
+    work.addFirst(re);
+    while (!work.isEmpty()) {
+      Regexp current = work.removeFirst();
+      switch (current.op) {
+        case STAR, PLUS, QUEST -> addSample(current.subs.get(0), samples);
+        case REPEAT -> {
+          if (current.max < 0 || current.max > current.min) {
+            addSample(current.subs.get(0), samples);
           }
         }
-      }
-      case ALTERNATE -> {
-        for (Regexp sub : re.subs) {
-          collectTerminalExtensionSamples(sub, samples);
+        case NON_CAPTURE, CAPTURE -> work.addFirst(current.subs.get(0));
+        case CONCAT -> {
+          int firstTerminal = current.subs.size() - 1;
+          while (firstTerminal > 0 && Pattern.canMatchEmpty(current.subs.get(firstTerminal))) {
+            firstTerminal--;
+          }
+          for (int i = firstTerminal; i < current.subs.size(); i++) {
+            work.addFirst(current.subs.get(i));
+          }
         }
+        case ALTERNATE -> {
+          for (int i = current.subs.size() - 1; i >= 0; i--) {
+            work.addFirst(current.subs.get(i));
+          }
+        }
+        default -> {}
       }
-      default -> {}
     }
   }
 
@@ -2312,37 +2330,109 @@ public final class Matcher implements MatchResult {
   }
 
   private static String sampleString(Regexp re) {
-    return switch (re.op) {
-      case LITERAL -> new String(Character.toChars(re.rune));
-      case LITERAL_STRING -> new String(re.runes, 0, re.runes.length);
-      case CHAR_CLASS -> re.charClass.isEmpty()
-          ? null
-          : new String(Character.toChars(re.charClass.lo(0)));
-      case ANY_CHAR -> "a";
-      case NON_CAPTURE, CAPTURE -> sampleString(re.subs.get(0));
-      case CONCAT -> {
-        StringBuilder sb = new StringBuilder();
-        for (Regexp sub : re.subs) {
-          String sample = sampleString(sub);
-          if (sample == null) {
-            yield null;
+    ArrayDeque<SampleFrame> stack = new ArrayDeque<>();
+    stack.addFirst(new SampleFrame(re));
+    while (!stack.isEmpty()) {
+      SampleFrame frame = stack.peekFirst();
+      Regexp current = frame.re;
+      switch (current.op) {
+        case LITERAL -> {
+          String sample = new String(Character.toChars(current.rune));
+          stack.removeFirst();
+          if (stack.isEmpty()) {
+            return sample;
           }
-          sb.append(sample);
+          acceptSample(stack.peekFirst(), sample);
         }
-        yield sb.toString();
+        case LITERAL_STRING -> {
+          String sample = new String(current.runes, 0, current.runes.length);
+          stack.removeFirst();
+          if (stack.isEmpty()) {
+            return sample;
+          }
+          acceptSample(stack.peekFirst(), sample);
+        }
+        case CHAR_CLASS -> {
+          String sample = current.charClass.isEmpty()
+              ? null
+              : new String(Character.toChars(current.charClass.lo(0)));
+          stack.removeFirst();
+          if (stack.isEmpty()) {
+            return sample;
+          }
+          acceptSample(stack.peekFirst(), sample);
+        }
+        case ANY_CHAR -> {
+          stack.removeFirst();
+          if (stack.isEmpty()) {
+            return "a";
+          }
+          acceptSample(stack.peekFirst(), "a");
+        }
+        case NON_CAPTURE, CAPTURE -> frame.re = current.subs.get(0);
+        case CONCAT -> {
+          if (frame.failed) {
+            stack.removeFirst();
+            if (stack.isEmpty()) {
+              return null;
+            }
+            acceptSample(stack.peekFirst(), null);
+          } else if (frame.nextSub == current.subs.size()) {
+            String sample = frame.builder == null ? "" : frame.builder.toString();
+            stack.removeFirst();
+            if (stack.isEmpty()) {
+              return sample;
+            }
+            acceptSample(stack.peekFirst(), sample);
+          } else {
+            if (frame.builder == null) {
+              frame.builder = new StringBuilder();
+            }
+            stack.addFirst(new SampleFrame(current.subs.get(frame.nextSub)));
+            frame.nextSub++;
+          }
+        }
+        case ALTERNATE -> {
+          if (frame.chosen != null || frame.nextSub == current.subs.size()) {
+            String sample = frame.chosen;
+            stack.removeFirst();
+            if (stack.isEmpty()) {
+              return sample;
+            }
+            acceptSample(stack.peekFirst(), sample);
+          } else {
+            stack.addFirst(new SampleFrame(current.subs.get(frame.nextSub)));
+            frame.nextSub++;
+          }
+        }
+        default -> {
+          stack.removeFirst();
+          if (stack.isEmpty()) {
+            return null;
+          }
+          acceptSample(stack.peekFirst(), null);
+        }
+      }
+    }
+    return null;
+  }
+
+  private static void acceptSample(SampleFrame frame, String sample) {
+    switch (frame.re.op) {
+      case CONCAT -> {
+        if (sample == null) {
+          frame.failed = true;
+        } else {
+          frame.builder.append(sample);
+        }
       }
       case ALTERNATE -> {
-        String sample = null;
-        for (Regexp sub : re.subs) {
-          sample = sampleString(sub);
-          if (sample != null) {
-            break;
-          }
+        if (sample != null) {
+          frame.chosen = sample;
         }
-        yield sample;
       }
-      default -> null;
-    };
+      default -> throw new AssertionError("unexpected sample parent: " + frame.re.op);
+    }
   }
 
   /**

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -176,6 +176,30 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("JDK stack overflows on this SafeRE stack-safety stress case")
+    @DisplayName("terminal repeat end-state sampling stays stack-safe for deep groups")
+    void terminalRepeatEndStateSamplingStaysStackSafeForDeepGroups() {
+      Pattern p = Pattern.compile(nestedCapturingGroups(10_000) + "*");
+
+      assertCompletesWithinPerformanceTimeout(
+          () -> {
+            Matcher matches = p.matcher("a");
+            assertThat(matches.matches()).isTrue();
+            assertThat(matches.hitEnd()).isTrue();
+            assertThat(matches.requireEnd()).isFalse();
+
+            Matcher lookingAt = p.matcher("a!");
+            assertThat(lookingAt.lookingAt()).isTrue();
+            assertThat(lookingAt.hitEnd()).isFalse();
+
+            Matcher find = p.matcher("a");
+            assertThat(find.find()).isTrue();
+            assertThat(find.hitEnd()).isTrue();
+            assertThat(find.requireEnd()).isFalse();
+          });
+    }
+
+    @Test
     @DisplayName("group access after lookingAt() works correctly")
     void lookingAtUpdatesGroupInfo() {
       Pattern p = Pattern.compile("(\\d+)(\\w+)");
@@ -2599,6 +2623,10 @@ class MatcherTest {
     return Pattern.compile(
         ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  }
+
+  private static String nestedCapturingGroups(int depth) {
+    return "(".repeat(depth) + "a" + ")".repeat(depth);
   }
 
   private static void assertNoPerformanceCliff(String api, IntConsumer scenario) {


### PR DESCRIPTION
## Summary

- Replace recursive matcher terminal-repeat sample collection with iterative traversal.
- Replace recursive sample-string construction with an explicit frame stack.
- Add deep nested-group regression coverage and FindSequence fuzzer coverage for terminal-repeat end-state handling.

Fixes #292

## Verification

Run:

- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl safere test -q`
- `git diff --check`

Not run:

- Full crosscheck public API validation.

## Notes

While adding fuzz coverage, a separate compile-time stack-safety issue in `Simplifier.computeSimple()` was found and filed as #338.
