### PR TITLE
Optimize char class range removal

### DIFF
--- a/safere/src/main/java/org/safere/CharClassBuilder.java
+++ b/safere/src/main/java/org/safere/CharClassBuilder.java
@@ -196,32 +196,28 @@ final class CharClassBuilder {
       return this;
     }
 
-    Iterator<Range> it = ranges.iterator();
-    TreeSet<Range> toAdd = new TreeSet<>();
+    Range r = ranges.floor(new Range(lo, Integer.MAX_VALUE));
+    if (r == null || r.hi < lo) {
+      r = ranges.ceiling(new Range(lo, Integer.MIN_VALUE));
+    }
 
-    while (it.hasNext()) {
-      Range r = it.next();
-      if (r.hi < lo) {
-        continue; // entirely before
-      }
-      if (r.lo > hi) {
-        break; // entirely after
-      }
+    while (r != null && r.lo <= hi) {
+      Range next = ranges.higher(r);
       // r overlaps [lo, hi] — remove it and possibly add back the non-overlapping parts.
-      it.remove();
+      ranges.remove(r);
       nrunes -= (r.hi - r.lo + 1);
 
       if (r.lo < lo) {
-        toAdd.add(new Range(r.lo, lo - 1));
+        ranges.add(new Range(r.lo, lo - 1));
         nrunes += (lo - 1 - r.lo + 1);
       }
       if (r.hi > hi) {
-        toAdd.add(new Range(hi + 1, r.hi));
+        ranges.add(new Range(hi + 1, r.hi));
         nrunes += (r.hi - hi - 1 + 1);
       }
+      r = next;
     }
 
-    ranges.addAll(toAdd);
     return this;
   }
 

--- a/safere/src/test/java/org/safere/CharClassTest.java
+++ b/safere/src/test/java/org/safere/CharClassTest.java
@@ -273,11 +273,114 @@ class CharClassTest {
   }
 
   @Test
+  void removeRangeBeforeAllRanges() {
+    CharClass cc =
+        new CharClassBuilder()
+            .addRange(100, 110)
+            .addRange(200, 210)
+            .removeRange(10, 20)
+            .build();
+
+    assertRanges(cc, 100, 110, 200, 210);
+  }
+
+  @Test
+  void removeRangeAfterAllRanges() {
+    CharClass cc =
+        new CharClassBuilder()
+            .addRange(10, 20)
+            .addRange(100, 110)
+            .removeRange(200, 210)
+            .build();
+
+    assertRanges(cc, 10, 20, 100, 110);
+  }
+
+  @Test
+  void removeRangeTrimsLeftSide() {
+    CharClass cc =
+        new CharClassBuilder()
+            .addRange(10, 20)
+            .addRange(100, 110)
+            .removeRange(5, 12)
+            .build();
+
+    assertRanges(cc, 13, 20, 100, 110);
+  }
+
+  @Test
+  void removeRangeTrimsRightSide() {
+    CharClass cc =
+        new CharClassBuilder()
+            .addRange(10, 20)
+            .addRange(100, 110)
+            .removeRange(18, 30)
+            .build();
+
+    assertRanges(cc, 10, 17, 100, 110);
+  }
+
+  @Test
+  void removeRangeRemovesAcrossMultipleRanges() {
+    CharClass cc =
+        new CharClassBuilder()
+            .addRange(10, 20)
+            .addRange(30, 40)
+            .addRange(50, 60)
+            .removeRange(15, 55)
+            .build();
+
+    assertRanges(cc, 10, 14, 56, 60);
+  }
+
+  @Test
+  void removeRangeHandlesEmptyAndBoundaryRanges() {
+    CharClass cc =
+        new CharClassBuilder()
+            .addRange(0, 20)
+            .addRange(Utils.MAX_RUNE - 20, Utils.MAX_RUNE)
+            .removeRange(20, 10)
+            .removeRange(0, 0)
+            .removeRange(Utils.MAX_RUNE, Utils.MAX_RUNE)
+            .build();
+
+    assertRanges(cc, 1, 20, Utils.MAX_RUNE - 20, Utils.MAX_RUNE - 1);
+  }
+
+  @Test
   void removeEntireRange() {
     CharClassBuilder builder = new CharClassBuilder();
     builder.addRange('a', 'c');
     builder.removeRange('a', 'c');
     assertThat(builder.isEmpty()).isTrue();
+  }
+
+  @Test
+  void randomizedAddAndRemoveRangeMatchesBitSetReferenceModel() {
+    int domainSize = 4096;
+    Random random = new Random(0x5AFE_290L);
+
+    for (int trial = 0; trial < 200; trial++) {
+      CharClassBuilder builder = new CharClassBuilder();
+      BitSet expected = new BitSet(domainSize);
+
+      for (int step = 0; step < 300; step++) {
+        int a = random.nextInt(domainSize);
+        int b = random.nextInt(domainSize);
+        int lo = Math.min(a, b);
+        int hi = Math.max(a, b);
+
+        if (random.nextBoolean()) {
+          builder.addRange(lo, hi);
+          expected.set(lo, hi + 1);
+        } else {
+          builder.removeRange(lo, hi);
+          expected.clear(lo, hi + 1);
+        }
+      }
+
+      assertMatchesReferenceModel(builder.build(), expected, domainSize);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Optimize `CharClassBuilder.removeRange` to start traversal near the first possible overlapping range instead of scanning from the beginning of the `TreeSet`.
- Add deterministic coverage for disjoint, trimming, multi-range, empty, and boundary removal cases.
- Add randomized add/remove reference-model coverage against a bounded-domain `BitSet` model.

## Runtime impact

`removeRange` is not currently on the `JdkSyntaxCompatibilityTest` parser path, so this change is not expected to materially improve that test runtime. It removes the same algorithmic risk for direct or future `removeRange` callers.

## Verification

- `mvn -pl safere -Dtest=CharClassTest test -q`
- `mvn -pl safere test -q`
- `git diff --check`

Not run:

- Crosscheck public API validation.
- Benchmarks.

Fixes #289
