### PR TITLE
Make simplification stack-safe for deep groups

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
@@ -18,13 +18,14 @@ final class ParserStackSafetyFuzzer {
     for (int depth : List.of(1, 8, 64, 512)) {
       FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
+      FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
     }
 
     int depth = data.consumeInt(0, 512);
-    if (data.consumeBoolean()) {
-      FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
-    } else {
-      FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
+    switch (data.consumeInt(0, 2)) {
+      case 0 -> FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
+      case 1 -> FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
+      default -> FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
     }
   }
 
@@ -34,5 +35,9 @@ final class ParserStackSafetyFuzzer {
 
   private static String nestedGroups(int depth) {
     return "(?:".repeat(depth) + "a" + ")".repeat(depth);
+  }
+
+  private static String quantifiedNestedCaptures(int depth) {
+    return "(".repeat(depth) + "a" + ")".repeat(depth) + "*";
   }
 }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -59,6 +59,62 @@ final class Parser {
     }
   }
 
+  private static final class RepeatCountFrame {
+    final Regexp re;
+    final int multiplier;
+    int nextSub;
+    int cost;
+    boolean hasRepeat;
+
+    RepeatCountFrame(Regexp re) {
+      this.re = re;
+      if (re.op == RegexpOp.REPEAT) {
+        int repeatMultiplier = re.max;
+        if (repeatMultiplier < 0) {
+          repeatMultiplier = re.min;
+        }
+        if (repeatMultiplier <= 0) {
+          repeatMultiplier = 1;
+        }
+        multiplier = repeatMultiplier;
+      } else {
+        multiplier = 1;
+      }
+      cost = re.op == RegexpOp.CONCAT ? 0 : 1;
+    }
+
+    void addChild(RepeatCount child, int limit) {
+      switch (re.op) {
+        case ALTERNATE -> {
+          cost = Math.max(cost, child.cost);
+          hasRepeat |= child.hasRepeat;
+        }
+        case CONCAT -> {
+          if (child.hasRepeat) {
+            cost = addSaturated(cost, child.cost, limit);
+            hasRepeat = true;
+          }
+        }
+        default -> {
+          if (child.cost > cost) {
+            cost = child.cost;
+            hasRepeat = child.hasRepeat;
+          }
+        }
+      }
+    }
+
+    RepeatCount finish(int limit) {
+      int subCost = cost;
+      boolean subHasRepeat = hasRepeat;
+      if (re.op == RegexpOp.CONCAT && !subHasRepeat) {
+        subCost = 1;
+      }
+      int totalCost = multiplySaturated(multiplier, subCost, limit);
+      return new RepeatCount(totalCost, re.op == RegexpOp.REPEAT || subHasRepeat);
+    }
+  }
+
   // Parse state
   private int flags;
   private final String pattern;
@@ -700,66 +756,25 @@ final class Parser {
   }
 
   private static RepeatCount repeatCount(Regexp re, int limit) {
-    int multiplier = 1;
-    if (re.op == RegexpOp.REPEAT) {
-      multiplier = re.max;
-      if (multiplier < 0) {
-        multiplier = re.min;
+    ArrayDeque<RepeatCountFrame> stack = new ArrayDeque<>();
+    stack.push(new RepeatCountFrame(re));
+    RepeatCount result = null;
+    while (!stack.isEmpty()) {
+      RepeatCountFrame frame = stack.peek();
+      int nsub = frame.re.subs == null ? 0 : frame.re.subs.size();
+      if (frame.nextSub < nsub) {
+        stack.push(new RepeatCountFrame(frame.re.subs.get(frame.nextSub)));
+        frame.nextSub++;
+        continue;
       }
-      if (multiplier <= 0) {
-        multiplier = 1;
-      }
-    }
 
-    RepeatCount subCount = switch (re.op) {
-      case ALTERNATE -> alternateRepeatCount(re, limit);
-      case CONCAT -> concatRepeatCount(re, limit);
-      default -> unaryRepeatCount(re, limit);
-    };
-
-    int cost = multiplySaturated(multiplier, subCount.cost, limit);
-    return new RepeatCount(cost, re.op == RegexpOp.REPEAT || subCount.hasRepeat);
-  }
-
-  private static RepeatCount unaryRepeatCount(Regexp re, int limit) {
-    if (re.subs == null || re.subs.isEmpty()) {
-      return new RepeatCount(1, false);
-    }
-    RepeatCount maxCount = new RepeatCount(1, false);
-    for (Regexp sub : re.subs) {
-      RepeatCount subCount = repeatCount(sub, limit);
-      if (subCount.cost > maxCount.cost) {
-        maxCount = subCount;
+      result = frame.finish(limit);
+      stack.pop();
+      if (!stack.isEmpty()) {
+        stack.peek().addChild(result, limit);
       }
     }
-    return maxCount;
-  }
-
-  private static RepeatCount alternateRepeatCount(Regexp re, int limit) {
-    int cost = 1;
-    boolean hasRepeat = false;
-    for (Regexp sub : re.subs) {
-      RepeatCount subCount = repeatCount(sub, limit);
-      cost = Math.max(cost, subCount.cost);
-      hasRepeat |= subCount.hasRepeat;
-    }
-    return new RepeatCount(cost, hasRepeat);
-  }
-
-  private static RepeatCount concatRepeatCount(Regexp re, int limit) {
-    int cost = 0;
-    boolean hasRepeat = false;
-    for (Regexp sub : re.subs) {
-      RepeatCount subCount = repeatCount(sub, limit);
-      if (subCount.hasRepeat) {
-        cost = addSaturated(cost, subCount.cost, limit);
-        hasRepeat = true;
-      }
-    }
-    if (!hasRepeat) {
-      return new RepeatCount(1, false);
-    }
-    return new RepeatCount(cost, true);
+    return result;
   }
 
   private static int multiplySaturated(int a, int b, int limit) {

--- a/safere/src/main/java/org/safere/Simplifier.java
+++ b/safere/src/main/java/org/safere/Simplifier.java
@@ -603,56 +603,62 @@ final class Simplifier {
    * Determines whether a Regexp is already "simple" (no REPEAT, no empty/full char classes, no
    * nested quantifiers on quantifiers).
    */
-  // Switch mirrors the C++ RE2 structure and is clearer as a statement switch.
-  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   private static boolean computeSimple(Regexp re) {
-    switch (re.op) {
-      case NO_MATCH:
-      case EMPTY_MATCH:
-      case LITERAL:
-      case LITERAL_STRING:
-      case BEGIN_LINE:
-      case END_LINE:
-      case BEGIN_TEXT:
-      case WORD_BOUNDARY:
-      case NO_WORD_BOUNDARY:
-      case GRAPHEME_CLUSTER_BOUNDARY:
-      case END_TEXT:
-      case ANY_CHAR:
-      case ANY_BYTE:
-      case HAVE_MATCH:
-        return true;
-      case CONCAT:
-      case ALTERNATE:
-        for (Regexp sub : re.subs) {
-          if (!computeSimple(sub)) {
+    ArrayDeque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      switch (node.op) {
+        case NO_MATCH:
+        case EMPTY_MATCH:
+        case LITERAL:
+        case LITERAL_STRING:
+        case BEGIN_LINE:
+        case END_LINE:
+        case BEGIN_TEXT:
+        case WORD_BOUNDARY:
+        case NO_WORD_BOUNDARY:
+        case GRAPHEME_CLUSTER_BOUNDARY:
+        case END_TEXT:
+        case ANY_CHAR:
+        case ANY_BYTE:
+        case HAVE_MATCH:
+          break;
+        case CONCAT:
+        case ALTERNATE:
+          for (Regexp sub : node.subs) {
+            stack.push(sub);
+          }
+          break;
+        case CHAR_CLASS:
+          if (node.charClass.isEmpty() || isFull(node.charClass)) {
             return false;
           }
-        }
-        return true;
-      case CHAR_CLASS:
-        return !re.charClass.isEmpty() && !isFull(re.charClass);
-      case NON_CAPTURE:
-        return false;
-      case CAPTURE:
-        return computeSimple(re.subs.getFirst());
-      case STAR:
-      case PLUS:
-      case QUEST:
-        if (!computeSimple(re.subs.getFirst())) {
+          break;
+        case CAPTURE:
+          stack.push(node.subs.getFirst());
+          break;
+        case STAR:
+        case PLUS:
+        case QUEST:
+          Regexp sub = node.subs.getFirst();
+          RegexpOp subOp = sub.op;
+          if (subOp == RegexpOp.STAR
+              || subOp == RegexpOp.PLUS
+              || subOp == RegexpOp.QUEST
+              || subOp == RegexpOp.EMPTY_MATCH
+              || subOp == RegexpOp.NO_MATCH) {
+            return false;
+          }
+          stack.push(sub);
+          break;
+        case NON_CAPTURE:
+        case REPEAT:
+        default:
           return false;
-        }
-        RegexpOp subOp = re.subs.getFirst().op;
-        return subOp != RegexpOp.STAR
-            && subOp != RegexpOp.PLUS
-            && subOp != RegexpOp.QUEST
-            && subOp != RegexpOp.EMPTY_MATCH
-            && subOp != RegexpOp.NO_MATCH;
-      case REPEAT:
-        return false;
-      default:
-        return false;
+      }
     }
+    return true;
   }
 
   /**

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -2458,6 +2458,7 @@ class MatcherTest {
 
     @Test
     @DisplayName("terminal extension sampling is stack-safe through deep groups")
+    @DisabledForCrosscheck("JDK java.util.regex can overflow on this intentionally deep pattern")
     void terminalExtensionSamplingIsStackSafeThroughDeepGroups() {
       String regex = "(".repeat(10_000) + "a" + ")".repeat(10_000) + "*$";
 

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -8,6 +8,7 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
@@ -2453,6 +2454,19 @@ class MatcherTest {
       assertEndStateAfterFindMatchesJdk("abc$", "abc");
       assertEndStateAfterFindMatchesJdk("abc\\Z", "abc");
       assertEndStateAfterFindMatchesJdk("abc\\z", "abc");
+    }
+
+    @Test
+    @DisplayName("terminal extension sampling is stack-safe through deep groups")
+    void terminalExtensionSamplingIsStackSafeThroughDeepGroups() {
+      String regex = "(".repeat(10_000) + "a" + ")".repeat(10_000) + "*$";
+
+      assertThatNoException()
+          .isThrownBy(() -> {
+            Matcher matcher = Pattern.compile(regex).matcher("a");
+            assertThat(matcher.find()).isTrue();
+            assertThat(matcher.hitEnd()).isTrue();
+          });
     }
   }
 

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -8,6 +8,7 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.regex.PatternSyntaxException;
@@ -1722,6 +1723,13 @@ class ParserTest {
       assertThat(re.op).isEqualTo(RegexpOp.REPEAT);
       assertThat(re.min).isEqualTo(1000);
       assertThat(re.max).isEqualTo(1000);
+    }
+
+    @Test
+    void countedRepeatLimitCheckIsStackSafeThroughDeepGroups() {
+      String pattern = "(".repeat(10_000) + "a{2}" + ")".repeat(10_000) + "{2}";
+
+      assertThatNoException().isThrownBy(() -> parse(pattern));
     }
 
     @Test

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -8,6 +8,7 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -274,6 +275,20 @@ class SimplifierTest {
     Regexp sre = Simplifier.simplify(re);
     // Already-simple regexps should return the same object.
     assertThat(sre).isSameAs(re);
+  }
+
+  @Test
+  void deeplyNestedCapturesRemainStackSafeDuringCompileSimplification() {
+    String regex = "(".repeat(10_000) + "a" + ")".repeat(10_000) + "*";
+
+    assertThatNoException().isThrownBy(() -> Pattern.compile(regex));
+  }
+
+  @Test
+  void deeplyNestedSimpleGroupsRemainStackSafeDuringSimplification() {
+    Regexp re = Parser.parse("(?:".repeat(10_000) + "a" + ")".repeat(10_000), FLAGS);
+
+    assertThat(Simplifier.simplify(re).toString()).isEqualTo("a");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Make Simplifier.computeSimple stack-safe for deeply nested capture/group ASTs.
- Make parser counted-repeat cost checks and matcher terminal-extension sampling use explicit traversal instead of recursive AST walks.
- Add regression tests and extend parser stack-safety fuzz coverage for quantified nested captures.

Fixes #338

## Verification

- `mvn -pl safere -Dtest=ParserTest,SimplifierTest test`
- `mvn -pl safere -Dtest=MatcherTest test`
- `mvn -pl safere-fuzz -am -Dtest=ParserStackSafetyFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`

## Not Run

- Crosscheck public API profile was not run.
