### PR TITLE
Fix grapheme boundary test performance regression

### DIFF
--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -424,7 +424,8 @@ final class BitState {
         }
 
         case InstOp.OP_EMPTY_WIDTH -> {
-          int curFlags = Nfa.emptyFlags(text, pos, prog.unixLines());
+          int curFlags =
+              Nfa.emptyFlags(text, pos, prog.unixLines(), prog.hasGraphemeClusterBoundary());
           if ((ip.arg & ~curFlags) == 0) {
             if (shouldVisit(ip.out, pos)) {
               push(ip.out, pos);

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -128,6 +128,10 @@ final class Dfa {
   private final Prog prog;
   private final int maxStates;
   private final boolean hasGraphemeClusterBoundary;
+  private final int stateEmptyFlagsMask;
+  private final int startCacheEmptyFlagsMask;
+  private final int anchoredCacheBit;
+  private final int reverseCacheBit;
 
   /** Sorted code point boundaries defining equivalence classes. */
   private final int[] boundaries;
@@ -174,7 +178,7 @@ final class Dfa {
    * character. This gives at most 2 × 2 × 1024 × 2 × 2 combinations. Caching avoids the expensive
    * {@link #expand} call and its {@code Arrays.copyOf} allocation on every DFA search.
    */
-  private final State[] startStateByContext = new State[16_384];
+  private final State[] startStateByContext;
 
   /** Shared empty instruction array to avoid repeated zero-length allocations. */
   private static final int[] EMPTY_INSTS = new int[0];
@@ -207,6 +211,15 @@ final class Dfa {
     this.prog = prog;
     this.maxStates = maxStates;
     this.hasGraphemeClusterBoundary = prog.hasGraphemeClusterBoundary();
+    this.stateEmptyFlagsMask =
+        hasGraphemeClusterBoundary
+            ? EmptyOp.ALL_FLAGS
+            : EmptyOp.ALL_FLAGS & ~EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
+    this.startCacheEmptyFlagsMask =
+        hasGraphemeClusterBoundary ? EmptyOp.ALL_FLAGS : 0x7F;
+    this.reverseCacheBit = (startCacheEmptyFlagsMask + 1) << 2;
+    this.anchoredCacheBit = reverseCacheBit << 1;
+    this.startStateByContext = new State[anchoredCacheBit << 1];
     this.boundaries = setup.boundaries;
     this.numClasses = setup.numClasses;
     this.asciiClassMap = setup.asciiClassMap;
@@ -501,7 +514,8 @@ final class Dfa {
     if (startInst == 0) {
       return deadState;
     }
-    int emptyFlags = Nfa.emptyFlags(text, pos, prog.unixLines());
+    int emptyFlags =
+        Nfa.emptyFlags(text, pos, prog.unixLines(), hasGraphemeClusterBoundary);
 
     // Determine word-character context for \b/\B support.
     boolean lastWord;
@@ -517,8 +531,8 @@ final class Dfa {
     // Check the start state cache. The start state depends only on (anchored, reverseContext,
     // emptyFlags, lastWord, lastUnicodeWord), so positions with identical context share the same
     // start state.
-    int cacheKey = (anchored ? 8192 : 0) | (reverseContext ? 4096 : 0)
-        | ((emptyFlags & EmptyOp.ALL_FLAGS) << 2) | (lastWord ? 2 : 0)
+    int cacheKey = (anchored ? anchoredCacheBit : 0) | (reverseContext ? reverseCacheBit : 0)
+        | ((emptyFlags & startCacheEmptyFlagsMask) << 2) | (lastWord ? 2 : 0)
         | (lastUnicodeWord ? 1 : 0);
     State cached = startStateByContext[cacheKey];
     if (cached != null) {
@@ -527,7 +541,7 @@ final class Dfa {
 
     computeBuf[0] = startInst;
     int[] insts = expand(computeBuf, 1, emptyFlags);
-    int flags = emptyFlags & EmptyOp.ALL_FLAGS;
+    int flags = emptyFlags & stateEmptyFlagsMask;
     if (hasMatch(insts)) {
       flags |= FLAG_MATCH;
     }
@@ -612,7 +626,8 @@ final class Dfa {
     // This allows empty-width assertions like $ and \b to fire.
     if (cp < 0) {
       // Compute empty flags for end-of-text, but override word boundary using state context.
-      int emptyFlags = Nfa.emptyFlags(text, nextPos, prog.unixLines());
+      int emptyFlags =
+          Nfa.emptyFlags(text, nextPos, prog.unixLines(), hasGraphemeClusterBoundary);
       // At end-of-text the "current" character is not a word char.
       boolean wasWord = (s.flags & FLAG_LAST_WORD) != 0;
       if (wasWord) {
@@ -643,7 +658,7 @@ final class Dfa {
       if (nextInsts.length == 0) {
         return deadState;
       }
-      int flags = emptyFlags & EmptyOp.ALL_FLAGS;
+      int flags = emptyFlags & stateEmptyFlagsMask;
       if (hasMatch(nextInsts)) {
         flags |= FLAG_MATCH;
       }
@@ -725,7 +740,7 @@ final class Dfa {
       // \b fires but expand() wouldn't satisfy the second \b because WORD_BOUNDARY
       // was stripped from the state's cached emptyFlags.
       int reExpandEmptyFlags =
-          (s.flags & EmptyOp.ALL_FLAGS) | wordBeforeFlags | unicodeWordBeforeFlags;
+          (s.flags & stateEmptyFlagsMask) | wordBeforeFlags | unicodeWordBeforeFlags;
       if (endLineHere) {
         reExpandEmptyFlags |= EmptyOp.END_LINE;
       }
@@ -782,7 +797,8 @@ final class Dfa {
     // word boundary (depends on the next character) and END_LINE (depends on what's at
     // nextPos, not deterministic for cache). Unsatisfied EMPTY_WIDTH instructions will
     // remain in the frontier for re-evaluation when the next character arrives.
-    int emptyFlags = Nfa.emptyFlags(text, nextPos, prog.unixLines());
+    int emptyFlags =
+        Nfa.emptyFlags(text, nextPos, prog.unixLines(), hasGraphemeClusterBoundary);
     emptyFlags &= ~(EmptyOp.WORD_BOUNDARY | EmptyOp.NON_WORD_BOUNDARY
         | EmptyOp.UNICODE_WORD_BOUNDARY | EmptyOp.UNICODE_NON_WORD_BOUNDARY
         | EmptyOp.END_LINE);
@@ -800,7 +816,7 @@ final class Dfa {
       return deadState;
     }
 
-    int flags = emptyFlags & EmptyOp.ALL_FLAGS;
+    int flags = emptyFlags & stateEmptyFlagsMask;
     if (hasMatchFromDeferred) {
       // A deferred assertion (\b, \B, or multiline $) fired before consuming the current
       // character and reached a MATCH instruction. This match is at position `pos` (before

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -416,7 +416,7 @@ final class Nfa {
         }
 
         case EMPTY_WIDTH -> {
-          int flags = emptyFlags(text, pos, prog.unixLines());
+          int flags = emptyFlags(text, pos, prog.unixLines(), prog.hasGraphemeClusterBoundary());
           if ((ip.arg & ~flags) == 0) {
             int nextTerminalEmptyFlags = terminalEmptyFlags;
             if (pos == endPos || isAtTrailingLineTerminator(text, pos, prog.unixLines())) {
@@ -610,6 +610,11 @@ final class Nfa {
    * @return a bitmask of {@link EmptyOp} flags
    */
   static int emptyFlags(String text, int pos, boolean unixLines) {
+    return emptyFlags(text, pos, unixLines, true);
+  }
+
+  static int emptyFlags(
+      String text, int pos, boolean unixLines, boolean includeGraphemeClusterBoundary) {
     int flags = 0;
 
     // ^ and \A
@@ -690,7 +695,7 @@ final class Nfa {
       flags |= EmptyOp.UNICODE_NON_WORD_BOUNDARY;
     }
 
-    if (isGraphemeClusterBoundary(text, pos)) {
+    if (includeGraphemeClusterBoundary && isGraphemeClusterBoundary(text, pos)) {
       flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
     }
 

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -105,6 +105,9 @@ final class OnePass {
   /** When true, only {@code '\n'} is recognized as a line terminator. */
   private final boolean unixLines;
 
+  /** Whether empty-width checks need the grapheme-cluster boundary flag. */
+  private final boolean hasGraphemeClusterBoundary;
+
   /**
    * Bitset indicating which states have match actions. Bit {@code s} is set if
    * {@code matchAction[s] != NO_ACTION}. Used to skip the {@code matchAction[]} array load for
@@ -114,7 +117,7 @@ final class OnePass {
   private final long matchStateBits;
 
   private OnePass(long[][] actions, long[] matchAction, int[] boundaries, boolean anchorEnd,
-      boolean dollarAnchorEnd, boolean unixLines) {
+      boolean dollarAnchorEnd, boolean unixLines, boolean hasGraphemeClusterBoundary) {
     int numStates = actions.length;
     int nc = (numStates > 0) ? actions[0].length : 0;
     this.numClasses = nc;
@@ -128,6 +131,7 @@ final class OnePass {
     this.anchorEnd = anchorEnd;
     this.dollarAnchorEnd = dollarAnchorEnd;
     this.unixLines = unixLines;
+    this.hasGraphemeClusterBoundary = hasGraphemeClusterBoundary;
 
     // Pre-compute match state bitset.
     long bits = 0;
@@ -320,7 +324,7 @@ final class OnePass {
     long[][] trimmedActions = Arrays.copyOf(actions, stateCount);
     long[] trimmedMatch = Arrays.copyOf(matchActions, stateCount);
     return new OnePass(trimmedActions, trimmedMatch, boundaries, prog.anchorEnd(),
-        prog.dollarAnchorEnd(), prog.unixLines());
+        prog.dollarAnchorEnd(), prog.unixLines(), prog.hasGraphemeClusterBoundary());
   }
 
   /** Builds sorted code point boundaries from all CHAR_RANGE and CHAR_CLASS instructions. */
@@ -405,7 +409,11 @@ final class OnePass {
       if ((msb & (1L << state)) != 0) {
         long matchAct = ma[state];
         int reqEmpty = (int) (matchAct & EMPTY_MASK);
-        if (reqEmpty == 0 || (reqEmpty & ~Nfa.emptyFlags(text, pos, unixLines)) == 0) {
+        if (reqEmpty == 0
+            || (reqEmpty
+                    & ~Nfa.emptyFlags(
+                        text, pos, unixLines, hasGraphemeClusterBoundary))
+                == 0) {
           int capMask = (int) ((matchAct >>> CAP_SHIFT) & CAP_REG_MASK);
           if (capMask != 0) {
             applyCaptures(capMask, pos, cap);
@@ -447,7 +455,8 @@ final class OnePass {
       if (conditions != 0) {
         int reqEmpty = (int) (conditions & EMPTY_MASK);
         if (reqEmpty != 0) {
-          int curEmpty = Nfa.emptyFlags(text, pos, unixLines);
+          int curEmpty =
+              Nfa.emptyFlags(text, pos, unixLines, hasGraphemeClusterBoundary);
           if ((reqEmpty & ~curEmpty) != 0) {
             break;
           }
@@ -465,7 +474,9 @@ final class OnePass {
     if (pos == endPos && (msb & (1L << state)) != 0) {
       long matchAct = ma[state];
       int reqEmpty = (int) (matchAct & EMPTY_MASK);
-      if (reqEmpty == 0 || (reqEmpty & ~Nfa.emptyFlags(text, pos, unixLines)) == 0) {
+      if (reqEmpty == 0
+          || (reqEmpty & ~Nfa.emptyFlags(text, pos, unixLines, hasGraphemeClusterBoundary))
+              == 0) {
         int capMask = (int) ((matchAct >>> CAP_SHIFT) & CAP_REG_MASK);
         if (capMask != 0) {
           applyCaptures(capMask, pos, cap);

--- a/safere/src/main/java/org/safere/Prog.java
+++ b/safere/src/main/java/org/safere/Prog.java
@@ -37,6 +37,7 @@ final class Prog {
   private boolean unixLines;
   private int numLoopRegs;
   private boolean requiresPikeNfaCaptureSemantics;
+  private boolean hasGraphemeClusterBoundary;
 
   /** Creates an empty program. */
   public Prog() {}
@@ -78,6 +79,7 @@ final class Prog {
    */
   public void freeze() {
     instArray = instructions.toArray(new Inst[0]);
+    hasGraphemeClusterBoundary = computeHasGraphemeClusterBoundary();
   }
 
   /** Returns the start instruction index for anchored matching. */
@@ -208,9 +210,13 @@ final class Prog {
 
   /** Returns true if this program contains a {@code \b{g}} assertion. */
   boolean hasGraphemeClusterBoundary() {
-    int n = size();
+    return hasGraphemeClusterBoundary;
+  }
+
+  private boolean computeHasGraphemeClusterBoundary() {
+    int n = instArray.length;
     for (int i = 0; i < n; i++) {
-      Inst ip = inst(i);
+      Inst ip = instArray[i];
       if (ip.op == InstOp.EMPTY_WIDTH
           && (ip.arg & EmptyOp.GRAPHEME_CLUSTER_BOUNDARY) != 0) {
         return true;


### PR DESCRIPTION
## Summary

- avoid computing grapheme cluster boundary empty flags for programs that do not contain `\b{g}`
- cache the compiled-program `\b{g}` property at freeze time instead of scanning in every DFA constructor
- keep the expanded DFA start-state cache only for grapheme-boundary programs, restoring the old cache size for ordinary patterns

## Timing

Hotspot command:

```bash
mvn test -pl safere -Dtest='CrossEngineExhaustiveTest$CaseInsensitiveDfa#caseInsensitiveBoundaries' -Dtest.parallelism=4 --batch-mode --no-transfer-progress
```

| Version | Surefire time | Wall time | Max RSS |
|---|---:|---:|---:|
| Before PR #337 (`e773189`) | `307.8 s` | `5:10.84` | `4.40 GB` |
| PR #337 unpatched (`a3df3b9`) | `659.0 s` | `11:15.88` | `4.40 GB` |
| This PR | `308.5 s` | `5:11.55` | `4.42 GB` |

## Verification

- `mvn test -pl safere -Dtest='DfaTest,BoundaryMatcherTest,LinebreakGraphemeTest' -Dtest.parallelism=4 --batch-mode --no-transfer-progress`
- hotspot timing command above
- `git diff --check`
