### PR TITLE
Fix parser repeat count stack safety

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
@@ -19,13 +19,18 @@ final class ParserStackSafetyFuzzer {
       FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
+      FuzzSupport.assertFullMatchesJdk(nestedCountedRepeat(depth, "{0,2}"), 0, INPUTS);
     }
 
     int depth = data.consumeInt(0, 512);
-    switch (data.consumeInt(0, 2)) {
+    switch (data.consumeInt(0, 3)) {
       case 0 -> FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
       case 1 -> FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
-      default -> FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
+      case 2 -> FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
+      default -> {
+        String quantifier = data.pickValue(List.of("{0}", "{1}", "{0,2}", "{1,2}"));
+        FuzzSupport.assertFullMatchesJdk(nestedCountedRepeat(depth, quantifier), 0, INPUTS);
+      }
     }
   }
 
@@ -39,5 +44,9 @@ final class ParserStackSafetyFuzzer {
 
   private static String quantifiedNestedCaptures(int depth) {
     return "(".repeat(depth) + "a" + ")".repeat(depth) + "*";
+  }
+
+  private static String nestedCountedRepeat(int depth, String quantifier) {
+    return nestedGroups(depth) + quantifier;
   }
 }

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -64,6 +64,18 @@ class ParserTest {
     return pattern.toString();
   }
 
+  private static String nestedNonCapturingGroups(int depth, String atom) {
+    StringBuilder pattern = new StringBuilder(depth * 3 + atom.length() + depth);
+    for (int i = 0; i < depth; i++) {
+      pattern.append("(?:");
+    }
+    pattern.append(atom);
+    for (int i = 0; i < depth; i++) {
+      pattern.append(')');
+    }
+    return pattern.toString();
+  }
+
   private static Regexp simplify(String pattern) {
     return Simplifier.simplify(parse(pattern));
   }
@@ -718,6 +730,15 @@ class ParserTest {
       assertThat(re.op).isEqualTo(RegexpOp.REPEAT);
       assertThat(re.min).isEqualTo(0);
       assertThat(re.max).isEqualTo(5);
+    }
+
+    @Test
+    void countedRepeatAfterDeeplyNestedGroupedAtomIsStackSafe() {
+      Regexp re = parse(nestedNonCapturingGroups(5000, "a") + "{2}");
+
+      assertThat(re.op).isEqualTo(RegexpOp.REPEAT);
+      assertThat(re.min).isEqualTo(2);
+      assertThat(re.max).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add stack-safety regression coverage for counted repeats after deeply nested grouped atoms
- expand ParserStackSafetyFuzzer to cover nested counted-repeat shapes alongside the existing stack-safety cases

Fixes #293

## Verification

- `mvn -pl safere -Dtest=ParserTest test`
- `mvn -pl safere-fuzz -am -Dtest=ParserStackSafetyFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`

## Not Run

- Full SafeRE suite after rebasing the conflict resolution.
- Full public API crosscheck validation.
