### PR TITLE
Keep fuzz runner going after target failures

### DIFF
--- a/safere-fuzz/README.md
+++ b/safere-fuzz/README.md
@@ -85,6 +85,8 @@ The helper script records each fuzzer's combined stdout/stderr stream under
 `safere-fuzz/target/fuzz-logs/<run-id>/<Fuzzer>.log`. Use these logs alongside
 Surefire XML reports when triaging `jazzer.keep_going` runs, since the XML does
 not always preserve every console detail needed to map findings to crash inputs.
+When one fuzzer exits with findings, the helper still runs the remaining
+requested fuzzers and reports the failed targets at the end.
 
 ## Findings
 

--- a/safere-fuzz/scripts/run-fuzz-test.sh
+++ b/safere-fuzz/scripts/run-fuzz-test.sh
@@ -121,8 +121,11 @@ printf '  %s\n' "${TESTS[@]}"
 
 mkdir -p "$LOG_DIR"
 
+FAILED_TESTS=()
+
 for test_name in "${TESTS[@]}"; do
   log_file="$LOG_DIR/$test_name.log"
+  set +e
   {
     echo "=== Running $test_name (max_duration=$MAX_DURATION, keep_going=$KEEP_GOING) ==="
     echo "log_file: $log_file"
@@ -134,4 +137,22 @@ for test_name in "${TESTS[@]}"; do
       -Djazzer.reproducer_path=target/fuzz-reproducers \
       test
   } 2>&1 | tee "$log_file"
+  test_status="${PIPESTATUS[0]}"
+  set -e
+  if [ "$test_status" -eq 0 ]; then
+    echo "=== Completed $test_name: PASS ===" | tee -a "$log_file"
+  else
+    echo "=== Completed $test_name: FAIL (exit $test_status) ===" | tee -a "$log_file"
+    FAILED_TESTS+=("$test_name:$test_status")
+  fi
 done
+
+if [ "${#FAILED_TESTS[@]}" -gt 0 ]; then
+  echo
+  echo "=== Fuzz run completed with failures ==="
+  printf '  %s\n' "${FAILED_TESTS[@]}"
+  exit 1
+fi
+
+echo
+echo "=== Fuzz run completed successfully ==="


### PR DESCRIPTION
## Summary

- Keep `safere-fuzz/scripts/run-fuzz-test.sh` running remaining requested fuzzers after one target exits with findings.
- Record a per-fuzzer PASS/FAIL footer in each raw fuzz log.
- Summarize failed fuzz targets at the end and preserve a nonzero script exit code when any target fails.
- Document the helper script's cross-target keep-going behavior.

## Verification

Not run. Script/docs-only change per maintainer direction.
