### PR TITLE
Fix raw ampersand class range tail parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -40,7 +40,7 @@ final class CharacterClassExpressionFuzzer {
   };
   private static final String[] AMPERSAND_PIECES = {"&", "\\&", "\\Q&\\E"};
   private static final String[] TRAILING_PIECES = {
-      "", "&", "\\&", "\\Q&\\E", "-\\D", "-a", "-&&", "\\Q\\E-\\D"
+      "", "&", "\\&", "\\Q&\\E", "-\\D", "-a", "-&", "-&a", "-&&", "\\Q\\E-\\D"
   };
   private static final Separator[] SEPARATORS = {
       new Separator("", false),
@@ -107,6 +107,11 @@ final class CharacterClassExpressionFuzzer {
       "(?x)[0&\\Q\\E\\Q\\E&&& #x\n-&&]",
       "(?x)[0&\\Q\\E\\Q\\E&&&& #x\n-&&]",
       "(?x)[0&\\Q\\E\\Q\\E&&&&&& #x\n-&&]",
+      "[0&\\Q\\E\\Q\\E&&&&&&-&&]",
+      "[0&\\Q\\E\\Q\\E&&&&&&-&]",
+      "[0&\\Q\\E\\Q\\E&&&&&&-&a]",
+      "[0&\\Q\\E\\Q\\E&&&&&&\\Q\\E-&&]",
+      "(?x)[0&\\Q\\E\\Q\\E&&&&&&-&&]",
       "(?x)[a\\d&& [0]&]",
       "(?x)[a[b]&& [a]&]",
       "[0-1ab&&[a]&]",

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1439,6 +1439,15 @@ final class Parser {
       }
       if (!tail.skippedNormalizedSyntax()) {
         rejectInvalidRangeTailAfterOddAmpersandRun();
+        CharClassBuilder expression = snapshotPendingExpression(frame);
+        if (addRawAmpersandRangeTailIfPresent(expression)) {
+          frame.accumulatedClass = new CharClassBuilder().addCharClass(expression);
+          frame.currentIntersectionOperand = frame.accumulatedClass;
+          frame.pendingScalarItems = new CharClassBuilder();
+          frame.hasPendingScalarItems = false;
+          frame.pendingScalarItemsAfterCurrentOperand = false;
+          frame.pendingScalarRole = ClassAtomRole.ORDINARY_SCALAR;
+        }
       }
       frame.rawAmpersandSeparatorActive = false;
       frame.rawAmpersandLeftExpression = null;

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1168,6 +1168,16 @@ class JdkSyntaxCompatibilityTest {
           Arguments.of(new CharacterClassMembershipCase("[^0-1ab&&[a]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase(
               "(?x)[^0-1\\Qab\\E\\Q\\E\\Q\\E&& [a]&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "[0&\\Q\\E\\Q\\E&&&&&&-&&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "[0&\\Q\\E\\Q\\E&&&&&&-&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "[0&\\Q\\E\\Q\\E&&&&&&-&a]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "[0&\\Q\\E\\Q\\E&&&&&&\\Q\\E-&&]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "(?x)[0&\\Q\\E\\Q\\E&&&&&&-&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[[a]Ā&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[\\d0-1&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[ [ab] && #x\n [bc] && ]",


### PR DESCRIPTION
## Summary

- Fix raw ampersand separator parsing so a following valid `-&...` tail binds as an ampersand range tail instead of making `-` an unrelated literal.
- Add JDK compatibility regressions for empty quoted literals plus long ampersand runs.
- Extend the character-class expression fuzzer seeds and generated trailing pieces for nearby `-&` shapes.

Fixes #348

## Verification

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test`
- `mvn -pl safere-fuzz -am -Dtest=CharacterClassExpressionFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`

## Not Run

- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
