### PR TITLE
Fix word boundaries to handle non-spacing marks with base characters

### DIFF
--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -521,10 +521,11 @@ final class Dfa {
     boolean lastWord;
     boolean lastUnicodeWord;
     if (reverseContext) {
-      lastWord = pos < text.length() && Nfa.isWordChar(text.codePointAt(pos));
+      lastWord = pos < text.length() && Nfa.isWordChar(text.codePointAt(pos), text, pos);
       lastUnicodeWord = pos < text.length() && Nfa.isUnicodeWordChar(text.codePointAt(pos));
     } else {
-      lastWord = pos > 0 && Nfa.isWordChar(text.codePointBefore(pos));
+      int prevCp = pos > 0 ? text.codePointBefore(pos) : -1;
+      lastWord = pos > 0 && Nfa.isWordChar(prevCp, text, pos - Character.charCount(prevCp));
       lastUnicodeWord = pos > 0 && Nfa.isUnicodeWordChar(text.codePointBefore(pos));
     }
 
@@ -680,7 +681,7 @@ final class Dfa {
     //
     // Both are re-expanded before consuming the character so that MATCH instructions
     // reached through these assertions are detected at the correct position.
-    boolean isWord = Nfa.isWordChar(cp);
+    boolean isWord = Nfa.isWordChar(cp, text, nextPos - 1);
     boolean wasWord = (s.flags & FLAG_LAST_WORD) != 0;
     int wordBeforeFlags = (isWord != wasWord) ? EmptyOp.WORD_BOUNDARY
         : EmptyOp.NON_WORD_BOUNDARY;
@@ -1007,7 +1008,7 @@ final class Dfa {
       // is always safe to cache because it always means "at text end".
       int effectiveNextPos = Math.min(nextPos, textLen);
       State ns;
-      if (cp >= 0 && effectiveNextPos >= posDepThreshold) {
+      if (cp >= 0 && (effectiveNextPos >= posDepThreshold || Character.getType(cp) == Character.NON_SPACING_MARK)) {
         ns = computeNext(s, cp, text, effectiveNextPos);
         if (ns == null) {
           return null; // budget exceeded
@@ -1161,7 +1162,7 @@ final class Dfa {
       // Bypass cache for position-dependent transitions (same invariant as doSearch).
       int effectivePrevPos = Math.max(prevPos, startLimit);
       State ns;
-      if (cp >= 0 && effectivePrevPos >= posDepThreshold) {
+      if (cp >= 0 && (effectivePrevPos >= posDepThreshold || Character.getType(cp) == Character.NON_SPACING_MARK)) {
         ns = computeNext(s, cp, text, effectivePrevPos);
         if (ns == null) {
           return null; // budget exceeded
@@ -1292,7 +1293,7 @@ final class Dfa {
         // Bypass cache for position-dependent transitions (same invariant as doSearch).
         int effectiveNextPos = Math.min(nextPos, textLen);
         State ns;
-        if (cp >= 0 && effectiveNextPos >= posDepThreshold) {
+        if (cp >= 0 && (effectiveNextPos >= posDepThreshold || Character.getType(cp) == Character.NON_SPACING_MARK)) {
           ns = computeNext(s, cp, text, effectiveNextPos);
           if (ns == null) {
             return null; // budget exceeded

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1405,15 +1405,18 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {
+    int prevCp = pos > 0 ? text.codePointBefore(pos) : -1;
     boolean prevWord =
-        pos > 0 && isBoundaryWordChar(text.codePointBefore(pos), unicodeWordBoundary);
+        pos > 0 && isBoundaryWordChar(prevCp, text, pos - Character.charCount(prevCp), unicodeWordBoundary);
+
+    int nextCp = pos < text.length() ? text.codePointAt(pos) : -1;
     boolean nextWord =
-        pos < text.length() && isBoundaryWordChar(text.codePointAt(pos), unicodeWordBoundary);
+        pos < text.length() && isBoundaryWordChar(nextCp, text, pos, unicodeWordBoundary);
     return prevWord != nextWord;
   }
 
-  private static boolean isBoundaryWordChar(int cp, boolean unicodeWordBoundary) {
-    return unicodeWordBoundary ? Nfa.isUnicodeWordChar(cp) : Nfa.isWordChar(cp);
+  private static boolean isBoundaryWordChar(int cp, String text, int pos, boolean unicodeWordBoundary) {
+    return unicodeWordBoundary ? Nfa.isUnicodeWordChar(cp) : Nfa.isWordChar(cp, text, pos);
   }
 
   private static int asciiLower(int ch) {

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -678,8 +678,11 @@ final class Nfa {
     }
 
     // \b and \B
-    boolean prevWord = pos > 0 && isWordChar(text.codePointBefore(pos));
-    boolean nextWord = pos < text.length() && isWordChar(text.codePointAt(pos));
+    int prevCp = pos > 0 ? text.codePointBefore(pos) : -1;
+    boolean prevWord = pos > 0 && isWordChar(prevCp, text, pos - 1);
+
+    int nextCp = pos < text.length() ? text.codePointAt(pos) : -1;
+    boolean nextWord = pos < text.length() && isWordChar(nextCp, text, pos);
     if (prevWord != nextWord) {
       flags |= EmptyOp.WORD_BOUNDARY;
     } else {
@@ -733,9 +736,14 @@ final class Nfa {
   }
 
   /** Returns true if the code point is a word character ({@code [A-Za-z0-9_]}). */
-  static boolean isWordChar(int c) {
-    return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
-        || ('0' <= c && c <= '9') || c == '_';
+  static boolean isWordChar(int c, String text, int pos) {
+    if (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_') {
+      return true;
+    }
+    if (Character.getType(c) == Character.NON_SPACING_MARK) {
+      return hasBaseCharacter(text, pos);
+    }
+    return false;
   }
 
   /** Returns true if the code point is a Unicode word character (matching {@code \w} under UCC). */
@@ -748,6 +756,22 @@ final class Nfa {
         || Character.getType(c) == Character.CONNECTOR_PUNCTUATION
         || c == 0x200C  // ZWNJ
         || c == 0x200D; // ZWJ
+  }
+
+  // Iterate over Java characters, not code points, for bug compatibility.
+  // See https://bugs.openjdk.org/browse/JDK-8384082
+  private static boolean hasBaseCharacter(String seq, int i) {
+    for (int x = i; x >= 0; x--) {
+      int cp = seq.codePointAt(x);
+      if (Character.isLetterOrDigit(cp)) {
+        return true;
+      }
+      if (Character.getType(cp) == Character.NON_SPACING_MARK) {
+        continue;
+      }
+      return false;
+    }
+    return false;
   }
 
   private Nfa() {

--- a/safere/src/test/java/org/safere/BoundaryMatcherTest.java
+++ b/safere/src/test/java/org/safere/BoundaryMatcherTest.java
@@ -404,4 +404,61 @@ class BoundaryMatcherTest {
       assertThat(p.matcher("word ").find()).isTrue();
     }
   }
+
+  @Nested
+  @DisplayName("Unicode word boundaries")
+  class UnicodeWordBoundary {
+
+    @Test
+    @DisplayName("\\B matches inside CJK base + mark cluster at specific positions")
+    void matchesInsideCjkBaseMarkCluster() {
+      Pattern p = Pattern.compile("\\B");
+      Matcher m = p.matcher("\u8fe3\u030c\u030c");
+
+      List<Integer> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(m.start());
+      }
+      assertThat(matches).containsExactly(0, 2);
+    }
+
+    @Test
+    @DisplayName("\\B matches everywhere in symbol + mark cluster")
+    void matchesEverywhereInSymbolMarkCluster() {
+      Pattern p = Pattern.compile("\\B");
+      Matcher m = p.matcher("|\u030c\u030c");
+
+      List<Integer> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(m.start());
+      }
+      assertThat(matches).containsExactly(0, 1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("\\B matches everywhere with standalone marks")
+    void matchesEverywhereWithStandaloneMarks() {
+      Pattern p = Pattern.compile("\\B");
+      Matcher m = p.matcher("\u030c\u030c");
+
+      List<Integer> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(m.start());
+      }
+      assertThat(matches).containsExactly(0, 1, 2);
+    }
+
+    @Test
+    @DisplayName("\\B matches everywhere with supplementary base (JDK bug compatibility)")
+    void matchesEverywhereWithSupplementaryBase() {
+      Pattern p = Pattern.compile("\\B");
+      Matcher m = p.matcher("\uD835\uDC00\u030c");
+
+      List<Integer> matches = new ArrayList<>();
+      while (m.find()) {
+        matches.add(m.start());
+      }
+      assertThat(matches).containsExactly(0, 1, 2, 3);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #345, see discussion in https://github.com/eaftan/safere/issues/345#issuecomment-4395871566

From https://bugs.openjdk.org/browse/JDK-6452709, the JDK defines a "word boundary"  as

> a transition from [A-Za-z0-9_] (or a non-spacing mark with a base character) to not such a character.

This updates SafeRE to treat non-spacing marks with base characters as word for the purposes of determining word boundaries.

That logic is position-dependent (we have to search back from a non-spacing mark to see if it has a base character). That affects the position-independent caching in the DFA, so this change disables DFA caching for non-spacing marks.

Another option would be to compute the base character for non-spacing marks and include that in the DFA cache key. I can do that instead, I don't have a good sense of what the performance tradeoffs are for doing that additional work up-front and having more state in the cache key. In general I suspect this case doesn't come up that often and may not be worth optimizing.