### PR TITLE
Include surrogates in negated character classes

### DIFF
--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -120,6 +120,13 @@ class CrosscheckTest {
     }
 
     @Test
+    @DisplayName("crosscheck for [^a-z].. with surrogate pair")
+    void crosscheckWithSurrogatePair() {
+      Matcher m = Pattern.compile("[^a-z]..").matcher("\ud801\ud800\udc00xyz");
+      m.find();
+    }
+
+    @Test
     @DisplayName("find() iterates all matches")
     void findAll() {
       Matcher m = Pattern.compile("\\d+").matcher("a1b23c456");

--- a/safere/src/main/java/org/safere/CharClassBuilder.java
+++ b/safere/src/main/java/org/safere/CharClassBuilder.java
@@ -148,14 +148,14 @@ final class CharClassBuilder {
       int hi = r.hi;
 
       if (next < lo) {
-        // Add gap [next, lo-1], but skip surrogates.
-        addGapSkippingSurrogates(negated, next, lo - 1);
+        // Add gap [next, lo-1].
+        addGap(negated, next, lo - 1);
       }
       next = hi + 1;
     }
 
     if (next <= Utils.MAX_RUNE) {
-      addGapSkippingSurrogates(negated, next, Utils.MAX_RUNE);
+      addGap(negated, next, Utils.MAX_RUNE);
     }
 
     ranges.clear();
@@ -169,21 +169,11 @@ final class CharClassBuilder {
     return this;
   }
 
-  private static void addGapSkippingSurrogates(NavigableSet<Range> dest, int lo, int hi) {
+  private static void addGap(NavigableSet<Range> dest, int lo, int hi) {
     if (lo > hi) {
       return;
     }
-    // Split around surrogate range [0xD800, 0xDFFF].
-    if (hi < Utils.MIN_SURROGATE || lo > Utils.MAX_SURROGATE) {
-      dest.add(new Range(lo, hi));
-    } else {
-      if (lo < Utils.MIN_SURROGATE) {
-        dest.add(new Range(lo, Utils.MIN_SURROGATE - 1));
-      }
-      if (hi > Utils.MAX_SURROGATE) {
-        dest.add(new Range(Utils.MAX_SURROGATE + 1, hi));
-      }
-    }
+    dest.add(new Range(lo, hi));
   }
 
   /**


### PR DESCRIPTION
SafeRE's CharClassBuilder.negate() was explicitly excluding surrogate code points when negating a character class. This caused a divergence from java.util.regex, which treats isolated surrogates as normal characters that can match a negated class.

https://github.com/eaftan/safere/issues/361