### PR TITLE
Defer toMatchResult no-match failures

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2143,14 +2143,15 @@ public final class Matcher implements MatchResult {
    * of this matcher; subsequent operations on this matcher will not affect the returned result.
    *
    * @return a {@link MatchResult} with the state of this matcher
-   * @throws IllegalStateException if no match has yet been attempted, or if the previous match
-   *     operation failed
    */
   public MatchResult toMatchResult() {
-    checkMatch();
-    eagerFallbackCaptures = true;
-    resolveCaptures();
-    return new SnapshotMatchResult(groups.clone(), text, groupCount(), parentPattern.namedGroups());
+    if (resultStatus == ResultStatus.MATCHED) {
+      eagerFallbackCaptures = true;
+      resolveCaptures();
+    }
+    int[] snapshotGroups = groups == null ? null : groups.clone();
+    return new SnapshotMatchResult(
+        snapshotGroups, text, groupCount(), parentPattern.namedGroups());
   }
 
   // ---------------------------------------------------------------------------
@@ -2519,6 +2520,7 @@ public final class Matcher implements MatchResult {
 
     @Override
     public int start(int group) {
+      checkMatch();
       validateGroup(group);
       return groups[2 * group];
     }
@@ -2535,6 +2537,7 @@ public final class Matcher implements MatchResult {
 
     @Override
     public int end(int group) {
+      checkMatch();
       validateGroup(group);
       return groups[2 * group + 1];
     }
@@ -2587,6 +2590,12 @@ public final class Matcher implements MatchResult {
       if (group < 0 || group > groupCount) {
         throw new IndexOutOfBoundsException(
             "No group " + group + " (groupCount=" + groupCount + ")");
+      }
+    }
+
+    private void checkMatch() {
+      if (groups == null) {
+        throw new IllegalStateException("No match found");
       }
     }
   }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1356,12 +1356,35 @@ class MatcherTest {
     }
 
     @Test
-    @DisplayName("toMatchResult() throws when no match")
-    void toMatchResultNoMatch() {
+    @DisplayName("toMatchResult() before a match defers failures to result access")
+    void toMatchResultBeforeMatchDefersFailuresToResultAccess() {
+      Pattern p = Pattern.compile("(?<letter>x)(y)?");
+      Matcher m = p.matcher("abc");
+
+      MatchResult result = m.toMatchResult();
+
+      assertThat(result.groupCount()).isEqualTo(2);
+      assertThat(result.namedGroups()).containsEntry("letter", 1);
+      assertThatThrownBy(result::start).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(result::end).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(result::group).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> result.start(1)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> result.start(99)).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(() -> result.group("letter")).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("toMatchResult() after a failed match defers failures to result access")
+    void toMatchResultAfterFailedMatchDefersFailuresToResultAccess() {
       Pattern p = Pattern.compile("x");
       Matcher m = p.matcher("abc");
-      assertThatThrownBy(m::toMatchResult)
-          .isInstanceOf(IllegalStateException.class);
+      assertThat(m.find()).isFalse();
+
+      MatchResult result = m.toMatchResult();
+
+      assertThat(result.groupCount()).isZero();
+      assertThatThrownBy(result::start).isInstanceOf(IllegalStateException.class);
+      assertThatThrownBy(result::group).isInstanceOf(IllegalStateException.class);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Allow `Matcher.toMatchResult()` to create an immutable result even when no match has been found.
- Keep `IllegalStateException` deferred until callers access match-dependent snapshot methods.
- Add regression coverage for snapshots before any match and after a failed match attempt.

Fixes #356

## Verification

Ran:
- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere test -q`

Not run:
- Benchmarks, because this is a matcher API semantics fix rather than a performance change.
