### PR TITLE
Fix quoted class intersection parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -135,6 +135,7 @@ final class CharacterClassExpressionFuzzer {
       "(?x)[a[b]&& [a]&]",
       "(?x)[a& &&&& -z]",
       "(?x)[\\Qab\\E& &&&&&& \\Q\\E\\Q\\E-\\D]",
+      "(?x)[\\Qab\\E\\d &&\\Q\\E &-&]",
       "[0-1ab&&[a]&]",
       "[^0-1ab&&[a]&]",
       "(?x)[^0-1\\Qab\\E\\Q\\E\\Q\\E&& [a]&]",

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -1137,6 +1137,13 @@ final class Parser {
                 && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
               throw new PatternSyntaxException("bad class syntax", pattern, pos);
             }
+            if (frame.currentIntersectionOperand != null
+                && frame.hasPendingScalarItems
+                && !frame.pendingScalarItemsAfterCurrentOperand
+                && frame.pendingScalarRole == ClassAtomRole.ORDINARY_SCALAR) {
+              frame.pendingScalarItems = new CharClassBuilder();
+              frame.hasPendingScalarItems = false;
+            }
             if (frame.currentIntersectionOperand != null && !frame.hasPendingScalarItems) {
               frame.accumulatedClass =
                   new CharClassBuilder().addCharClass(frame.currentIntersectionOperand);

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -1223,6 +1223,8 @@ class JdkSyntaxCompatibilityTest {
           Arguments.of(new CharacterClassMembershipCase("(?x)[a& &&&& -z]", inputs)),
           Arguments.of(new CharacterClassMembershipCase(
               "(?x)[\\Qab\\E& &&&&&& \\Q\\E\\Q\\E-\\D]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "(?x)[\\Qab\\E\\d &&\\Q\\E &-&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[a\\d&& [0]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[a[b]&& [a]&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[0-1ab&&[a]&]", inputs)),
@@ -1299,6 +1301,8 @@ class JdkSyntaxCompatibilityTest {
               List.of("", "a", "&", "-", "z", "0", "A", " "))),
           Arguments.of(new CharacterClassMembershipCase(
               "(?x)[\\Qab\\E& &&&&&& \\Q\\E\\Q\\E-\\D]", inputs)),
+          Arguments.of(new CharacterClassMembershipCase(
+              "(?x)[\\Qab\\E\\d &&\\Q\\E &-&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("[^[a]a-b&&]", inputs)),
           Arguments.of(new CharacterClassMembershipCase("(?x)[^[a]& &&]", inputs)));
     }


### PR DESCRIPTION
## Summary

- Preserve JDK-compatible class-expression state when an empty quoted literal appears after `&&` before a raw ampersand tail.
- Add the issue reproducer to the JDK compatibility matrix and character-class fuzz regression corpus.

Fixes #369

## Verification

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest$CharacterClasses test`
- `mvn -pl safere-fuzz -am -Dtest=CharacterClassExpressionFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
