### PR TITLE
Fix Unicode flag handling for horizontal whitespace escapes

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
@@ -26,6 +26,10 @@ final class EscapeSyntaxFuzzer {
       "\\u{41}",
       "\\x41",
       "\\x{41}",
+      "\\h",
+      "\\H",
+      "\\v",
+      "\\V",
       "\\e",
       "\\cA",
       "\\ca",
@@ -71,7 +75,11 @@ final class EscapeSyntaxFuzzer {
       "\\400",
       "\\777",
       "\\123",
-      "(a)\\12"
+      "(a)\\12",
+      "\\h",
+      "\\H",
+      "\\v",
+      "\\V"
   };
 
   @FuzzTest(maxDuration = "30s")

--- a/safere/src/main/java/org/safere/UnicodeTables.java
+++ b/safere/src/main/java/org/safere/UnicodeTables.java
@@ -794,8 +794,8 @@ final class UnicodeTables {
   // ---------------------------------------------------------------------------
   //
   // These define Unicode-aware \d, \s, \w for use when the UNICODE_CHARACTER_CLASS
-  // flag is enabled. They parallel PERL_GROUPS but use Unicode properties instead
-  // of ASCII-only ranges.
+  // flag is enabled. \h and \v are fixed JDK-defined sets, so they remain the same
+  // as in PERL_GROUPS.
 
   /**
    * Unicode {@code \d}: Unicode category Nd (Number, Decimal Digit). JDK maps {@code \d} under
@@ -860,7 +860,12 @@ final class UnicodeTables {
             JOIN_CONTROL);
 
     static final Map<String, int[][]> UNICODE_PERL_GROUPS =
-        Map.of("\\d", unicodeDigit(), "\\s", unicodeSpace(), "\\w", UNICODE_WORD);
+        Map.of(
+            "\\d", unicodeDigit(),
+            "\\s", unicodeSpace(),
+            "\\w", UNICODE_WORD,
+            "\\h", HORIZ_SPACE,
+            "\\v", VERT_SPACE);
   }
 
   /**

--- a/safere/src/test/java/org/safere/PredefinedCharClassTest.java
+++ b/safere/src/test/java/org/safere/PredefinedCharClassTest.java
@@ -471,6 +471,31 @@ class PredefinedCharClassTest {
       Pattern p = Pattern.compile("\\h+", Pattern.DOTALL);
       assertThat(p.matcher("\t ").matches()).isTrue();
     }
+
+    @Test
+    @DisplayName("\\h and \\H compile under Unicode character class flags")
+    void horizontalWhitespaceCompilesWithUnicodeCharacterClassFlags() {
+      Pattern h = Pattern.compile("\\h", Pattern.UNIX_LINES | Pattern.UNICODE_CHARACTER_CLASS);
+      Pattern bigH =
+          Pattern.compile("\\H", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+
+      assertThat(h.matcher("\t").matches()).isTrue();
+      assertThat(h.matcher("\n").matches()).isFalse();
+      assertThat(bigH.matcher("a").matches()).isTrue();
+      assertThat(bigH.matcher(" ").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("\\v and \\V compile under Unicode character class flags")
+    void verticalWhitespaceCompilesWithUnicodeCharacterClassFlags() {
+      Pattern v = Pattern.compile("\\v", Pattern.UNICODE_CHARACTER_CLASS);
+      Pattern bigV = Pattern.compile("\\V", Pattern.UNICODE_CHARACTER_CLASS);
+
+      assertThat(v.matcher("\n").matches()).isTrue();
+      assertThat(v.matcher(" ").matches()).isFalse();
+      assertThat(bigV.matcher("a").matches()).isTrue();
+      assertThat(bigV.matcher("\r").matches()).isFalse();
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

- Keep JDK-defined `\h` and `\v` entries available when `UNICODE_CHARACTER_CLASS` selects the Unicode shorthand table.
- Add regression coverage for `\h`, `\H`, `\v`, and `\V` with `UNICODE_CHARACTER_CLASS` flag combinations.
- Add the horizontal/vertical whitespace escapes to the escape syntax fuzzer axis and regression cases.

Fixes #368

## Verification

- `mvn -pl safere -Dtest=PredefinedCharClassTest test`
- JShell repro check: `Pattern.compile("\\h", 321)` and `Pattern.compile("\\H", 290)` compile successfully
- `mvn -pl safere-fuzz -am -Dtest=EscapeSyntaxFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
