### PR TITLE
Fix leading counted repetition parsing

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -52,6 +52,17 @@ final class ParserCompatibilityFuzzer {
       {"", "", "|", "?", "??", "*", "*?", "+", "+?", "{0}", "{1,3}",
           "{1}", "??{1,3}", "?{1,3}", "*{1,3}", "+{1,3}", "{1,3}{1,3}"};
   private static final String[] SUFFIXES = {"", "$", "?", "*", "+", "{2}", "{1,3}"};
+  private static final String[] LEADING_COUNTED_REPEATS = {
+      "{0}",
+      "{1}",
+      "{1,3}",
+      "{1,}",
+      "{1,3}?",
+      "{1,3}$",
+      "^{1,3}",
+      "a|{1,3}",
+      "({1,3})"
+  };
   private static final String[] COMMENT_TERMINATED_PREFIXES = {
       "a#\0",
       "a#\n",
@@ -91,6 +102,8 @@ final class ParserCompatibilityFuzzer {
       flags |= org.safere.Pattern.COMMENTS;
       regex = data.pickValue(COMMENT_TERMINATED_PREFIXES)
           + data.pickValue(MALFORMED_GROUP_SUFFIXES);
+    } else if (data.consumeBoolean()) {
+      regex = data.pickValue(PREFIXES) + data.pickValue(LEADING_COUNTED_REPEATS);
     } else {
       regex = data.pickValue(PREFIXES)
           + data.pickValue(ATOMS)

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -718,8 +718,7 @@ final class Parser {
   private void pushRepetition(int min, int max, String opstr, boolean nongreedy) {
     validateRepeatCount(min, max, opstr);
     if (stacktop == null || isMarker(stacktop)) {
-      throw new PatternSyntaxException(
-          "missing argument to repetition operator", pattern, pos - opstr.length());
+      pushRegexp(Regexp.emptyMatch(flags));
     }
 
     int fl = flags;

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -246,6 +246,35 @@ class JdkSyntaxCompatibilityTest {
       assertThat(Pattern.compile(regex).matcher(input).matches()).isEqualTo(expected);
     }
 
+    static Stream<Arguments> leadingCountedRepeats() {
+      return Stream.of(
+          Arguments.of("{1}", 0, ""),
+          Arguments.of("{1,3}", 0, ""),
+          Arguments.of("{1,}$", Pattern.CASE_INSENSITIVE | Pattern.COMMENTS
+              | Pattern.UNICODE_CASE | Pattern.UNICODE_CHARACTER_CLASS, "abc"),
+          Arguments.of("{1,3}$", Pattern.CASE_INSENSITIVE | Pattern.COMMENTS
+              | Pattern.UNICODE_CASE | Pattern.UNICODE_CHARACTER_CLASS, "abc"),
+          Arguments.of("a|{1,3}", 0, ""),
+          Arguments.of("({1,3})", 0, ""),
+          Arguments.of("^{1,3}", 0, ""));
+    }
+
+    @ParameterizedTest(name = "/{0}/ flags={1} matches \"{2}\"")
+    @MethodSource("leadingCountedRepeats")
+    @DisplayName("leading counted repeats apply to the empty expression like JDK")
+    void leadingCountedRepeatsApplyToEmptyExpressionLikeJdk(
+        String regex, int flags, String input) {
+      java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(regex, flags);
+      Pattern safeRePattern = Pattern.compile(regex, flags);
+
+      assertThat(safeRePattern.matcher(input).find())
+          .as("SafeRE find() result for /%s/ flags=%d on \"%s\"", regex, flags, input)
+          .isEqualTo(jdkPattern.matcher(input).find());
+      assertThat(safeRePattern.matcher(input).matches())
+          .as("SafeRE matches() result for /%s/ flags=%d on \"%s\"", regex, flags, input)
+          .isEqualTo(jdkPattern.matcher(input).matches());
+    }
+
     static Stream<Arguments> acceptedSyntaxFamilies() {
       return Stream.of(
           Arguments.of(new SyntaxFamilyCase("literal characters", "abc", "abc", "ab")),


### PR DESCRIPTION
## Summary

- Accept leading counted repetitions by applying them to an explicit empty expression, matching JDK behavior.
- Add JDK compatibility coverage for start-of-pattern, start-of-alternative, grouped, anchored, and flagged leading counted repeats.
- Expand parser compatibility fuzz generation to include leading counted-repeat shapes.

Fixes #370

## Verification

- `mvn -pl safere -Dtest=JdkSyntaxCompatibilityTest test`
- `mvn -pl safere-fuzz -am -Dtest=ParserCompatibilityFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
