### PR TITLE
Make crosscheck Pattern serializable

### DIFF
--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
@@ -3,6 +3,8 @@
 
 package org.safere.crosscheck;
 
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +32,9 @@ import java.util.stream.Stream;
  * rejects a pattern that the JDK accepts (e.g., backreferences), an
  * {@link UnsupportedPatternException} is thrown.
  */
-public final class Pattern {
+public final class Pattern implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   // Flag constants — identical to java.util.regex.Pattern and org.safere.Pattern.
   public static final int UNIX_LINES = java.util.regex.Pattern.UNIX_LINES;
@@ -243,6 +247,10 @@ public final class Pattern {
     return saferePattern.toString();
   }
 
+  private Object writeReplace() throws ObjectStreamException {
+    return new SerializedForm(pattern(), flags());
+  }
+
   /** Returns the underlying SafeRE pattern (package-private, used by Matcher). */
   org.safere.Pattern saferePattern() {
     return saferePattern;
@@ -255,5 +263,14 @@ public final class Pattern {
 
   private static String quote(CharSequence s) {
     return "\"" + s + "\"";
+  }
+
+  private record SerializedForm(String regex, int flags) implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Object readResolve() throws ObjectStreamException {
+      return Pattern.compile(regex, flags);
+    }
   }
 }

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -6,6 +6,11 @@ package org.safere.crosscheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -35,6 +40,22 @@ class CrosscheckTest {
     void compileWithFlags() {
       Pattern p = Pattern.compile("abc", Pattern.CASE_INSENSITIVE);
       assertThat(p.flags()).isEqualTo(Pattern.CASE_INSENSITIVE);
+    }
+
+    @Test
+    @DisplayName("serialized pattern round-trips through regex and flags")
+    void serializedPatternRoundTripsThroughRegexAndFlags() throws Exception {
+      Pattern p = Pattern.compile("(?<word>[a-z]+)-(\\d+)", Pattern.CASE_INSENSITIVE);
+
+      Pattern restored = roundTrip(p);
+
+      assertThat(restored).isInstanceOf(Serializable.class);
+      assertThat(restored.pattern()).isEqualTo("(?<word>[a-z]+)-(\\d+)");
+      assertThat(restored.flags()).isEqualTo(Pattern.CASE_INSENSITIVE);
+      Matcher m = restored.matcher("Abc-123");
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group("word")).isEqualTo("Abc");
+      assertThat(m.group(2)).isEqualTo("123");
     }
 
     @Test
@@ -541,6 +562,17 @@ class CrosscheckTest {
       m.matches();
       // Both engines should agree on hitEnd
       m.hitEnd();
+    }
+  }
+
+  private static Pattern roundTrip(Pattern pattern) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(pattern);
+    }
+    try (ObjectInputStream in = new ObjectInputStream(
+        new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (Pattern) in.readObject();
     }
   }
 }


### PR DESCRIPTION
## Summary

- Make org.safere.crosscheck.Pattern implement Serializable.
- Serialize crosscheck patterns through a regex/flags proxy and rebuild both SafeRE and JDK delegates during deserialization.
- Add regression coverage for round-tripping a flagged pattern and matching named/numbered captures after deserialization.

Fixes #362

## Verification

- mvn -pl safere-crosscheck test -q
