### PR TITLE
Optimize Java character class single-find

### DIFF
--- a/safere-benchmarks/src/main/java/org/safere/benchmark/JavaCharacterClassBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/JavaCharacterClassBenchmark.java
@@ -1,0 +1,69 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Benchmarks for JDK-compatible {@code \p{java...}} character classes. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class JavaCharacterClassBenchmark {
+  private static final String JAVA_LETTER = "\\p{javaLetter}";
+  private static final int INPUT_COUNT = 4096;
+
+  private String[] inputs;
+  private int index;
+  private org.safere.Pattern saferePattern;
+  private java.util.regex.Pattern jdkPattern;
+
+  @Setup
+  public void setup() {
+    inputs = new String[INPUT_COUNT];
+    Random random = new Random(0x5AFE355L);
+    for (int i = 0; i < inputs.length; i++) {
+      inputs[i] = new String(new char[] {(char) random.nextInt()});
+    }
+    saferePattern = org.safere.Pattern.compile(JAVA_LETTER);
+    jdkPattern = java.util.regex.Pattern.compile(JAVA_LETTER);
+  }
+
+  @Benchmark
+  public boolean compileAndFindJavaLetter_safere() {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(JAVA_LETTER);
+    return pattern.matcher(nextInput()).find();
+  }
+
+  @Benchmark
+  public boolean compileAndFindJavaLetter_jdk() {
+    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(JAVA_LETTER);
+    return pattern.matcher(nextInput()).find();
+  }
+
+  @Benchmark
+  public boolean findJavaLetter_safere() {
+    return saferePattern.matcher(nextInput()).find();
+  }
+
+  @Benchmark
+  public boolean findJavaLetter_jdk() {
+    return jdkPattern.matcher(nextInput()).find();
+  }
+
+  private String nextInput() {
+    String input = inputs[index];
+    index = (index + 1) & (INPUT_COUNT - 1);
+    return input;
+  }
+}

--- a/safere/src/main/java/org/safere/CharClassBuilder.java
+++ b/safere/src/main/java/org/safere/CharClassBuilder.java
@@ -126,10 +126,28 @@ final class CharClassBuilder {
    * @return this builder, for chaining
    */
   public CharClassBuilder addTable(int[][] table) {
+    if (ranges.isEmpty() && canAppendTableDirectly(table)) {
+      for (int[] row : table) {
+        ranges.add(new Range(row[0], row[1]));
+        nrunes += row[1] - row[0] + 1;
+      }
+      return this;
+    }
     for (int[] row : table) {
       addRange(row[0], row[1]);
     }
     return this;
+  }
+
+  private static boolean canAppendTableDirectly(int[][] table) {
+    int previousHi = -2;
+    for (int[] row : table) {
+      if (row.length != 2 || row[0] > row[1] || row[0] <= (long) previousHi + 1) {
+        return false;
+      }
+      previousHi = row[1];
+    }
+    return true;
   }
 
   /**

--- a/safere/src/main/java/org/safere/JavaCharacterClasses.java
+++ b/safere/src/main/java/org/safere/JavaCharacterClasses.java
@@ -8,6 +8,7 @@ package org.safere;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.IntPredicate;
 
 /**
@@ -22,34 +23,65 @@ import java.util.function.IntPredicate;
 final class JavaCharacterClasses {
   private JavaCharacterClasses() {}
 
-  // Lazy holder pattern — tables are computed on first access, then cached.
-  private static final class Holder {
-    static final Map<String, int[][]> JAVA_GROUPS = buildAll();
+  private record JavaClass(String name, IntPredicate predicate) {
+    JavaClass {
+      Objects.requireNonNull(name);
+      Objects.requireNonNull(predicate);
+    }
+  }
 
-    private static Map<String, int[][]> buildAll() {
-      return Map.ofEntries(
-          entry("javaLowerCase", Character::isLowerCase),
-          entry("javaUpperCase", Character::isUpperCase),
-          entry("javaWhitespace", Character::isWhitespace),
-          entry("javaMirrored", Character::isMirrored),
-          entry("javaAlphabetic", Character::isAlphabetic),
-          entry("javaIdeographic", Character::isIdeographic),
-          entry("javaTitleCase", Character::isTitleCase),
-          entry("javaDigit", Character::isDigit),
-          entry("javaDefined", Character::isDefined),
-          entry("javaLetter", Character::isLetter),
-          entry("javaLetterOrDigit", Character::isLetterOrDigit),
-          entry("javaSpaceChar", Character::isSpaceChar),
-          entry("javaISOControl", Character::isISOControl),
-          entry("javaIdentifierIgnorable", Character::isIdentifierIgnorable),
-          entry("javaUnicodeIdentifierStart", Character::isUnicodeIdentifierStart),
-          entry("javaUnicodeIdentifierPart", Character::isUnicodeIdentifierPart),
-          entry("javaJavaIdentifierStart", cp -> Character.isJavaIdentifierStart(cp)),
-          entry("javaJavaIdentifierPart", cp -> Character.isJavaIdentifierPart(cp)));
+  private static final class LazyTable {
+    private final IntPredicate predicate;
+    private volatile int[][] ranges;
+
+    LazyTable(IntPredicate predicate) {
+      this.predicate = predicate;
     }
 
-    private static Map.Entry<String, int[][]> entry(String name, IntPredicate predicate) {
-      return Map.entry(name, buildRanges(predicate));
+    int[][] ranges() {
+      int[][] result = ranges;
+      if (result == null) {
+        synchronized (this) {
+          result = ranges;
+          if (result == null) {
+            result = buildRanges(predicate);
+            ranges = result;
+          }
+        }
+      }
+      return result;
+    }
+  }
+
+  // Lazy holder pattern — the name index is computed on first access, and each range table is
+  // computed only when that specific java character class is requested.
+  private static final class Holder {
+    static final Map<String, LazyTable> JAVA_GROUPS = buildIndex();
+
+    private static Map<String, LazyTable> buildIndex() {
+      return Map.ofEntries(
+          entry(new JavaClass("javaLowerCase", Character::isLowerCase)),
+          entry(new JavaClass("javaUpperCase", Character::isUpperCase)),
+          entry(new JavaClass("javaWhitespace", Character::isWhitespace)),
+          entry(new JavaClass("javaMirrored", Character::isMirrored)),
+          entry(new JavaClass("javaAlphabetic", Character::isAlphabetic)),
+          entry(new JavaClass("javaIdeographic", Character::isIdeographic)),
+          entry(new JavaClass("javaTitleCase", Character::isTitleCase)),
+          entry(new JavaClass("javaDigit", Character::isDigit)),
+          entry(new JavaClass("javaDefined", Character::isDefined)),
+          entry(new JavaClass("javaLetter", Character::isLetter)),
+          entry(new JavaClass("javaLetterOrDigit", Character::isLetterOrDigit)),
+          entry(new JavaClass("javaSpaceChar", Character::isSpaceChar)),
+          entry(new JavaClass("javaISOControl", Character::isISOControl)),
+          entry(new JavaClass("javaIdentifierIgnorable", Character::isIdentifierIgnorable)),
+          entry(new JavaClass("javaUnicodeIdentifierStart", Character::isUnicodeIdentifierStart)),
+          entry(new JavaClass("javaUnicodeIdentifierPart", Character::isUnicodeIdentifierPart)),
+          entry(new JavaClass("javaJavaIdentifierStart", Character::isJavaIdentifierStart)),
+          entry(new JavaClass("javaJavaIdentifierPart", Character::isJavaIdentifierPart)));
+    }
+
+    private static Map.Entry<String, LazyTable> entry(JavaClass javaClass) {
+      return Map.entry(javaClass.name(), new LazyTable(javaClass.predicate()));
     }
   }
 
@@ -61,7 +93,8 @@ final class JavaCharacterClasses {
     if (!name.startsWith("java")) {
       return null;
     }
-    return Holder.JAVA_GROUPS.get(name);
+    LazyTable table = Holder.JAVA_GROUPS.get(name);
+    return table == null ? null : table.ranges();
   }
 
   /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -415,6 +415,36 @@ public final class Matcher implements MatchResult {
     return applyEngineResult(new FullMatchResult(new int[] {0, len}));
   }
 
+  /**
+   * Fast path for {@code find()} when the pattern is exactly one character class. Scans code points
+   * directly and returns the first matching code point as group 0.
+   */
+  private boolean singleCharClassFindFastPath(int[] ranges, int fromIndex) {
+    long b0 = parentPattern.singleCharClassBitmap0();
+    long b1 = parentPattern.singleCharClassBitmap1();
+
+    int i = fromIndex;
+    int len = text.length();
+    while (i < len) {
+      int cp = text.codePointAt(i);
+      if (charClassContains(ranges, b0, b1, cp)) {
+        return applyEngineResult(new FullMatchResult(new int[] {i, i + Character.charCount(cp)}));
+      }
+      i += Character.charCount(cp);
+    }
+    return applyEngineResult(new NoMatchResult());
+  }
+
+  private static boolean charClassContains(int[] ranges, long b0, long b1, int cp) {
+    if (cp < 64) {
+      return (b0 & (1L << cp)) != 0;
+    }
+    if (cp < 128) {
+      return (b1 & (1L << (cp - 64))) != 0;
+    }
+    return binarySearchRanges(ranges, cp);
+  }
+
   /** Binary search through sorted [lo, hi] ranges to check if {@code cp} is in any range. */
   private static boolean binarySearchRanges(int[] ranges, int cp) {
     int lo = 0;
@@ -1051,6 +1081,11 @@ public final class Matcher implements MatchResult {
         return applyEngineResult(new NoMatchResult());
       }
       return applyEngineResult(new FullMatchResult(new int[] {idx, idx + literal.length()}));
+    }
+
+    int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
+    if (options.charClassMatchFastPaths() && singleCharClassRanges != null) {
+      return singleCharClassFindFastPath(singleCharClassRanges, searchFrom);
     }
 
     Prog prog = parentPattern.prog();

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -2787,6 +2787,12 @@ final class Parser {
   // ---- Group add helpers ----
 
   private void addGroupPositive(CharClassBuilder ccb, int[][] table) {
+    if ((flags & ParseFlags.FOLD_CASE) == 0
+        && (flags & ParseFlags.CLASS_NL) != 0
+        && (flags & ParseFlags.NEVER_NL) == 0) {
+      ccb.addTable(table);
+      return;
+    }
     for (int[] row : table) {
       addRangeFlags(ccb, row[0], row[1], flags);
     }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -131,6 +131,16 @@ public final class Pattern implements Serializable {
   private final transient boolean charClassMatchAllowEmpty;
 
   /**
+   * Precomputed character class data for a pattern that is exactly one character class, such as
+   * {@code \p{javaLetter}}. Non-null when {@code find()} can scan directly for one matching code
+   * point and produce group 0 without invoking the engine cascade.
+   */
+  private final transient int[] singleCharClassRanges;
+
+  private final transient long singleCharClassBitmap0;
+  private final transient long singleCharClassBitmap1;
+
+  /**
    * Lazily computed OnePass analysis results. Holds the OnePass automaton (if eligible) and derived
    * flags ({@code canOnePassFind}, {@code canOnePassSubmatch}). Computed on first access to avoid
    * paying the OnePass BFS cost at compile time.
@@ -208,6 +218,9 @@ public final class Pattern implements Serializable {
       long charClassMatchBitmap0,
       long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty,
+      int[] singleCharClassRanges,
+      long singleCharClassBitmap0,
+      long singleCharClassBitmap1,
       EnginePathOptions enginePathOptions) {
     this.pattern = pattern;
     this.flags = flags;
@@ -232,6 +245,9 @@ public final class Pattern implements Serializable {
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
     this.charClassMatchAllowEmpty = charClassMatchAllowEmpty;
+    this.singleCharClassRanges = singleCharClassRanges;
+    this.singleCharClassBitmap0 = singleCharClassBitmap0;
+    this.singleCharClassBitmap1 = singleCharClassBitmap1;
   }
 
   /**
@@ -297,6 +313,7 @@ public final class Pattern implements Serializable {
     KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
+    CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -321,6 +338,9 @@ public final class Pattern implements Serializable {
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
         ccMatch != null && ccMatch.allowEmpty,
+        singleCharClass != null ? singleCharClass.ranges : null,
+        singleCharClass != null ? singleCharClass.bitmap0 : 0,
+        singleCharClass != null ? singleCharClass.bitmap1 : 0,
         enginePathOptions);
   }
 
@@ -840,6 +860,23 @@ public final class Pattern implements Serializable {
    */
   boolean charClassMatchAllowEmpty() {
     return charClassMatchAllowEmpty;
+  }
+
+  /**
+   * Returns precomputed ranges when the pattern is exactly one character class, or {@code null}.
+   */
+  int[] singleCharClassRanges() {
+    return singleCharClassRanges;
+  }
+
+  /** ASCII bitmap (code points 0–63) for the single-character-class fast path. */
+  long singleCharClassBitmap0() {
+    return singleCharClassBitmap0;
+  }
+
+  /** ASCII bitmap (code points 64–127) for the single-character-class fast path. */
+  long singleCharClassBitmap1() {
+    return singleCharClassBitmap1;
   }
 
   /**
@@ -1695,6 +1732,19 @@ public final class Pattern implements Serializable {
   @SuppressWarnings("ArrayRecordComponent")
   private record CharClassMatchInfo(int[] ranges, long bitmap0, long bitmap1, boolean allowEmpty) {}
 
+  /** Holds precomputed data for scanning one character class. */
+  private static final class CharClassScanInfo {
+    final int[] ranges;
+    final long bitmap0;
+    final long bitmap1;
+
+    CharClassScanInfo(int[] ranges, long bitmap0, long bitmap1) {
+      this.ranges = ranges;
+      this.bitmap0 = bitmap0;
+      this.bitmap1 = bitmap1;
+    }
+  }
+
   /**
    * Detects patterns that are structurally a single character class under a quantifier covering the
    * entire string — e.g., {@code [a-zA-Z]+}, {@code \d*}, {@code \w{1,}}, {@code [0-9]+}. When
@@ -1770,6 +1820,49 @@ public final class Pattern implements Serializable {
       }
     }
     return new CharClassMatchInfo(ranges, b0, b1, allowEmpty);
+  }
+
+  /**
+   * Detects patterns that are exactly one character class, such as {@code [a-z]} or {@code
+   * \p{javaLetter}}. The fast path only produces group 0, so patterns with user capture groups are
+   * excluded.
+   */
+  private static CharClassScanInfo extractSingleCharClass(Regexp re) {
+    Regexp node = re;
+    if (node.op == RegexpOp.CAPTURE && node.cap == 0) {
+      node = node.sub();
+    }
+    if (node.op != RegexpOp.CHAR_CLASS || node.charClass == null || hasUserCaptures(re)) {
+      return null;
+    }
+    CharClass cc = node.charClass;
+    if (cc.isEmpty()) {
+      return null;
+    }
+    return buildCharClassScanInfo(cc);
+  }
+
+  private static CharClassScanInfo buildCharClassScanInfo(CharClass cc) {
+    int numRanges = cc.numRanges();
+    int[] ranges = new int[numRanges * 2];
+    long b0 = 0;
+    long b1 = 0;
+    for (int i = 0; i < numRanges; i++) {
+      int lo = cc.lo(i);
+      int hi = cc.hi(i);
+      ranges[i * 2] = lo;
+      ranges[i * 2 + 1] = hi;
+      int start = Math.max(lo, 0);
+      int end = Math.min(hi, 127);
+      for (int cp = start; cp <= end; cp++) {
+        if (cp < 64) {
+          b0 |= 1L << cp;
+        } else {
+          b1 |= 1L << (cp - 64);
+        }
+      }
+    }
+    return new CharClassScanInfo(ranges, b0, b1);
   }
 
   /**

--- a/safere/src/test/java/org/safere/JavaCharacterClassesTest.java
+++ b/safere/src/test/java/org/safere/JavaCharacterClassesTest.java
@@ -179,6 +179,29 @@ class JavaCharacterClassesTest {
   }
 
   @Test
+  @DisplayName("Single java character class find matches one code point at a time")
+  void singleJavaCharacterClassFindMatchesOneCodePoint() {
+    var safe = Pattern.compile("\\p{javaLetter}");
+    var jdk = java.util.regex.Pattern.compile("\\p{javaLetter}");
+    String text = "1a\uD835\uDD18_";
+
+    Matcher safeMatcher = safe.matcher(text);
+    java.util.regex.Matcher jdkMatcher = jdk.matcher(text);
+
+    assertThat(safeMatcher.find()).isEqualTo(jdkMatcher.find());
+    assertThat(safeMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safeMatcher.end()).isEqualTo(jdkMatcher.end());
+    assertThat(safeMatcher.group()).isEqualTo(jdkMatcher.group());
+
+    assertThat(safeMatcher.find()).isEqualTo(jdkMatcher.find());
+    assertThat(safeMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safeMatcher.end()).isEqualTo(jdkMatcher.end());
+    assertThat(safeMatcher.group()).isEqualTo(jdkMatcher.group());
+
+    assertThat(safeMatcher.find()).isEqualTo(jdkMatcher.find());
+  }
+
+  @Test
   @DisplayName("Caret negation in java character class names is rejected")
   void caretNegationRejected() {
     assertThatThrownBy(() -> Pattern.compile("\\p{^javaLowerCase}+"))


### PR DESCRIPTION
## Summary

- Build `\p{java...}` character class range tables lazily per property instead of building all 18 tables on first use.
- Add a direct `find()` fast path for patterns that are exactly one character class, such as `\p{javaLetter}`.
- Add a focused JMH benchmark and regression coverage for single Java character class `find()` behavior.

Refs #355

## Benchmarks

Quick JMH signal:

```text
./run-java-benchmarks.sh --quick JavaCharacterClassBenchmark
```

Measured before by checking out the parent commit and copying in only the benchmark harness.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `compileAndFindJavaLetter_safere` | 1185.406 us/op | 26.118 us/op | 45.4x faster |
| `findJavaLetter_safere` | 0.187 us/op | 0.142 us/op | 1.3x faster |
| `compileAndFindJavaLetter_jdk` | 0.112 us/op | 0.108 us/op | baseline |
| `findJavaLetter_jdk` | 0.018 us/op | 0.017 us/op | baseline |

These are quick development measurements, not publication-quality benchmark results.

## Verification

- `mvn -pl safere -Dtest=JavaCharacterClassesTest,CharClassTest test -q`
- `mvn -pl safere-benchmarks -DskipTests package -q`
- `./run-java-benchmarks.sh --quick JavaCharacterClassBenchmark`
- `./run-java-benchmarks.sh JavaCharacterClassBenchmark`
- `mvn -pl safere test -q`
- `git diff --check`
