### PR TITLE
Fix negated classes on unpaired surrogates

### DIFF
--- a/.agents/skills/divergence-bug-fix/SKILL.md
+++ b/.agents/skills/divergence-bug-fix/SKILL.md
@@ -39,6 +39,14 @@ add or preserve tests, docs, or fuzz coverage when useful.
      - `Matcher`: https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/regex/Matcher.html
    - Determine whether the specification supports SafeRE's behavior, the JDK's behavior, both, or
      neither. Quote or cite the specific Javadoc rule when it controls the behavior.
+   - Before reading or discussing SafeRE implementation internals, state the spec assessment to the
+     user using only the behavior reported in the bug report or reproducer: what SafeRE did, what
+     the JDK did, which Javadoc rule controls the behavior, and whether SafeRE's reported behavior
+     is spec-compliant. Do not include root-cause or implementation analysis in this assessment.
+   - If SafeRE's reported behavior is not spec-compliant and matching the specification preserves
+     the linear-time guarantee, continue with the bug-fixing workflow. If SafeRE's reported
+     behavior is spec-compliant, or if the assessment is ambiguous, stop and wait for the user
+     before writing tests, inspecting internals, or changing code.
    - If the JDK behavior contradicts the specification, stop before writing tests or code and
      explain that to the user. If the user confirms proceeding, the intended SafeRE outcome is to
      follow the JDK specification, subject to the linear-time guarantee, and document the divergence

--- a/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
@@ -7,21 +7,35 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
 
 final class RegionBoundsFuzzer {
+  private static final List<String> SURROGATE_BOUNDARY_REGEXES =
+      List.of("[^a]", ".", "\\P{Cs}", "[^\\p{Cs}]");
 
   @FuzzTest(maxDuration = "30s")
   void regionBounds(FuzzedDataProvider data) {
-    String regex = data.consumeString(256);
-    int flags = FuzzSupport.consumeFlags(data);
-    String input = data.consumeString(2048);
+    String regex;
+    int flags;
+    String input;
+    int[] forcedRegion = null;
+    if (data.consumeBoolean()) {
+      regex = data.pickValue(SURROGATE_BOUNDARY_REGEXES);
+      flags = data.consumeBoolean() ? org.safere.Pattern.DOTALL : 0;
+      input = "\uD83D\uDE00" + data.consumeString(32);
+      forcedRegion = data.consumeBoolean() ? new int[] {0, 1} : new int[] {1, 2};
+    } else {
+      regex = data.consumeString(256);
+      flags = FuzzSupport.consumeFlags(data);
+      input = data.consumeString(2048);
+    }
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, flags);
     if (pattern == null) {
       return;
     }
 
     FuzzSupport.MatcherPair matcher = pattern.matcher(input);
-    int[] region = FuzzSupport.consumeRegion(data, input);
+    int[] region = forcedRegion != null ? forcedRegion : FuzzSupport.consumeRegion(data, input);
     matcher.region(region[0], region[1]);
     matcher.useAnchoringBounds(data.consumeBoolean());
     matcher.useTransparentBounds(data.consumeBoolean());

--- a/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
@@ -25,6 +25,16 @@ final class UnicodeFuzzer {
           "\u1100\u1161",
           "\uAC00\u11A8",
           "\u0600a");
+  private static final List<String> NEGATED_CLASS_REGEXES =
+      List.of("\\S", "\\D", "\\W", "[^a]", "\\P{javaWhitespace}");
+  private static final List<Integer> NEGATED_CLASS_FLAGS =
+      List.of(
+          0,
+          org.safere.Pattern.CASE_INSENSITIVE,
+          org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CASE,
+          org.safere.Pattern.UNICODE_CHARACTER_CLASS);
+  private static final List<String> UNPAIRED_SURROGATE_INPUTS =
+      List.of("\ud998", "\ude00", "\n".repeat(34) + "\ud998" + "a".repeat(41));
 
   @FuzzTest(maxDuration = "30s")
   void unicode(FuzzedDataProvider data) {
@@ -33,6 +43,19 @@ final class UnicodeFuzzer {
       FuzzSupport.MatcherPair matcher = graphemePattern.matcher(input);
       while (matcher.find()) {
         // Continue through the sequence so group boundaries are compared at every cluster.
+      }
+    }
+    for (String regex : NEGATED_CLASS_REGEXES) {
+      for (int flags : NEGATED_CLASS_FLAGS) {
+        FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, flags);
+        for (String input : UNPAIRED_SURROGATE_INPUTS) {
+          FuzzSupport.MatcherPair matcher = pattern.matcher(input);
+          matcher.find();
+          matcher.reset();
+          matcher.matches();
+          matcher.reset();
+          matcher.lookingAt();
+        }
       }
     }
 

--- a/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
@@ -26,7 +26,7 @@ final class UnicodeFuzzer {
           "\uAC00\u11A8",
           "\u0600a");
   private static final List<String> NEGATED_CLASS_REGEXES =
-      List.of("\\S", "\\D", "\\W", "[^a]", "\\P{javaWhitespace}");
+      List.of("\\S", "\\D", "\\W", "[^a]", "\\P{javaWhitespace}", "\\P{Cs}", "[^\\p{Cs}]");
   private static final List<Integer> NEGATED_CLASS_FLAGS =
       List.of(
           0,

--- a/safere/src/main/java/org/safere/CharClassBuilder.java
+++ b/safere/src/main/java/org/safere/CharClassBuilder.java
@@ -6,7 +6,6 @@
 package org.safere;
 
 import java.util.Iterator;
-import java.util.NavigableSet;
 import java.util.TreeSet;
 
 /**
@@ -151,8 +150,9 @@ final class CharClassBuilder {
   }
 
   /**
-   * Negates this character class in place, so it matches all valid Unicode code points not
-   * previously matched, and vice versa.
+   * Negates this character class in place, so it matches all Java regex character values not
+   * previously matched, and vice versa. Lone surrogate values are included because Java strings can
+   * contain them and JDK negated character classes match them when the positive class does not.
    *
    * @return this builder, for chaining
    */
@@ -161,19 +161,17 @@ final class CharClassBuilder {
     int next = 0;
 
     for (Range r : ranges) {
-      // Skip surrogates: gap from 0xD800 to 0xDFFF.
       int lo = r.lo;
       int hi = r.hi;
 
       if (next < lo) {
-        // Add gap [next, lo-1], but skip surrogates.
-        addGapSkippingSurrogates(negated, next, lo - 1);
+        negated.add(new Range(next, lo - 1));
       }
       next = hi + 1;
     }
 
     if (next <= Utils.MAX_RUNE) {
-      addGapSkippingSurrogates(negated, next, Utils.MAX_RUNE);
+      negated.add(new Range(next, Utils.MAX_RUNE));
     }
 
     ranges.clear();
@@ -185,23 +183,6 @@ final class CharClassBuilder {
       nrunes += (r.hi - r.lo + 1);
     }
     return this;
-  }
-
-  private static void addGapSkippingSurrogates(NavigableSet<Range> dest, int lo, int hi) {
-    if (lo > hi) {
-      return;
-    }
-    // Split around surrogate range [0xD800, 0xDFFF].
-    if (hi < Utils.MIN_SURROGATE || lo > Utils.MAX_SURROGATE) {
-      dest.add(new Range(lo, hi));
-    } else {
-      if (lo < Utils.MIN_SURROGATE) {
-        dest.add(new Range(lo, Utils.MIN_SURROGATE - 1));
-      }
-      if (hi > Utils.MAX_SURROGATE) {
-        dest.add(new Range(Utils.MAX_SURROGATE + 1, hi));
-      }
-    }
   }
 
   /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -142,6 +142,7 @@ public final class Matcher implements MatchResult {
   private boolean lastRequireEnd;
   private boolean findExhaustedAfterTerminalEmptyMatch;
   private int modCount;
+  private boolean regionSubstitutionEndSplitsSurrogatePair;
 
   /**
    * Cached BitState instance borrowed from the parent Pattern's thread-local cache, reused across
@@ -426,6 +427,10 @@ public final class Matcher implements MatchResult {
     int i = fromIndex;
     int len = text.length();
     while (i < len) {
+      if (isRegionSubstitutionSplitHighSurrogate(i, len)) {
+        i++;
+        continue;
+      }
       int cp = text.codePointAt(i);
       if (charClassContains(ranges, b0, b1, cp)) {
         return applyEngineResult(new FullMatchResult(new int[] {i, i + Character.charCount(cp)}));
@@ -433,6 +438,36 @@ public final class Matcher implements MatchResult {
       i += Character.charCount(cp);
     }
     return applyEngineResult(new NoMatchResult());
+  }
+
+  private boolean singleCharClassAtStartFastPath(int[] ranges, boolean fullMatch) {
+    if (text.isEmpty() || isRegionSubstitutionSplitHighSurrogate(0, text.length())) {
+      return applyEngineResult(new NoMatchResult());
+    }
+
+    int cp = text.codePointAt(0);
+    int end = Character.charCount(cp);
+    if (fullMatch && end != text.length()) {
+      return applyEngineResult(new NoMatchResult());
+    }
+
+    long b0 = parentPattern.singleCharClassBitmap0();
+    long b1 = parentPattern.singleCharClassBitmap1();
+    if (!charClassContains(ranges, b0, b1, cp)) {
+      return applyEngineResult(new NoMatchResult());
+    }
+    return applyEngineResult(new FullMatchResult(new int[] {0, end}));
+  }
+
+  private boolean isRegionSubstitutionSplitHighSurrogate(int pos, int len) {
+    return regionSubstitutionEndSplitsSurrogatePair && pos == len - 1;
+  }
+
+  private boolean regionEndSplitsSurrogatePair(String originalText) {
+    return regionEnd < originalText.length()
+        && regionStart < regionEnd
+        && Character.isHighSurrogate(originalText.charAt(regionEnd - 1))
+        && Character.isLowSurrogate(originalText.charAt(regionEnd));
   }
 
   private static boolean charClassContains(int[] ranges, long b0, long b1, int cp) {
@@ -639,12 +674,14 @@ public final class Matcher implements MatchResult {
         return matchesTransparentRegion();
       }
       if (regionActive) {
+        regionSubstitutionEndSplitsSurrogatePair = regionEndSplitsSurrogatePair(savedText);
         text = savedText.substring(regionStart, regionEnd);
         regionSubstituted = true;
       }
       return matchesCore();
     } finally {
       if (regionSubstituted) {
+        regionSubstitutionEndSplitsSurrogatePair = false;
         text = savedText;
         if (groups != null) {
           for (int i = 0; i < groups.length; i++) {
@@ -692,6 +729,11 @@ public final class Matcher implements MatchResult {
     int[] ccRanges = parentPattern.charClassMatchRanges();
     if (enginePathOptions().charClassMatchFastPaths() && ccRanges != null) {
       return charClassMatchFastPath(ccRanges);
+    }
+
+    int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
+    if (enginePathOptions().charClassMatchFastPaths() && singleCharClassRanges != null) {
+      return singleCharClassAtStartFastPath(singleCharClassRanges, true);
     }
 
     Prog prog = parentPattern.prog();
@@ -767,12 +809,14 @@ public final class Matcher implements MatchResult {
         return lookingAtTransparentRegion();
       }
       if (regionActive) {
+        regionSubstitutionEndSplitsSurrogatePair = regionEndSplitsSurrogatePair(savedText);
         text = savedText.substring(regionStart, regionEnd);
         regionSubstituted = true;
       }
       return lookingAtCore();
     } finally {
       if (regionSubstituted) {
+        regionSubstitutionEndSplitsSurrogatePair = false;
         text = savedText;
         if (groups != null) {
           for (int i = 0; i < groups.length; i++) {
@@ -817,6 +861,11 @@ public final class Matcher implements MatchResult {
     }
 
     Prog prog = parentPattern.prog();
+
+    int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
+    if (enginePathOptions().charClassMatchFastPaths() && singleCharClassRanges != null) {
+      return singleCharClassAtStartFastPath(singleCharClassRanges, false);
+    }
 
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
     if (enginePathOptions().onePass()
@@ -950,6 +999,7 @@ public final class Matcher implements MatchResult {
         return doFindTransparentRegion();
       }
       if (regionActive) {
+        regionSubstitutionEndSplitsSurrogatePair = regionEndSplitsSurrogatePair(savedText);
         text = savedText.substring(regionStart, regionEnd);
         searchFrom = Math.max(0, savedSearchFrom - regionStart);
         regionSubstituted = true;
@@ -957,6 +1007,7 @@ public final class Matcher implements MatchResult {
       return doFindCore(regionActive);
     } finally {
       if (regionSubstituted) {
+        regionSubstitutionEndSplitsSurrogatePair = false;
         text = savedText;
         searchFrom = savedSearchFrom;
         if (groups != null) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1832,6 +1832,10 @@ public final class Pattern implements Serializable {
     if (node.op == RegexpOp.CAPTURE && node.cap == 0) {
       node = node.sub();
     }
+    if (node.op == RegexpOp.ANY_CHAR && !hasUserCaptures(re)) {
+      return buildCharClassScanInfo(
+          new CharClass(new int[] {0, Utils.MAX_RUNE}, Utils.MAX_RUNE + 1));
+    }
     if (node.op != RegexpOp.CHAR_CLASS || node.charClass == null || hasUserCaptures(re)) {
       return null;
     }

--- a/safere/src/main/java/org/safere/Simplifier.java
+++ b/safere/src/main/java/org/safere/Simplifier.java
@@ -684,21 +684,9 @@ final class Simplifier {
     return Regexp.rawQuantifier(op, sub, flags);
   }
 
-  /** Returns true if the character class matches every valid Unicode code point. */
+  /** Returns true if the character class matches every Java regex character value. */
   private static boolean isFull(CharClass cc) {
-    // A "full" class covers [0, 0xD7FF] and [0xE000, 0x10FFFF] (skipping surrogates).
-    if (cc.numRanges() == 2
-        && cc.lo(0) == 0
-        && cc.hi(0) == Utils.MIN_SURROGATE - 1
-        && cc.lo(1) == Utils.MAX_SURROGATE + 1
-        && cc.hi(1) == Utils.MAX_RUNE) {
-      return true;
-    }
-    // Or possibly one range [0, 0x10FFFF] if surrogates are included.
-    if (cc.numRanges() == 1 && cc.lo(0) == 0 && cc.hi(0) == Utils.MAX_RUNE) {
-      return true;
-    }
-    return false;
+    return cc.numRanges() == 1 && cc.lo(0) == 0 && cc.hi(0) == Utils.MAX_RUNE;
   }
 
   /**

--- a/safere/src/test/java/org/safere/CharClassTest.java
+++ b/safere/src/test/java/org/safere/CharClassTest.java
@@ -218,13 +218,13 @@ class CharClassTest {
   }
 
   @Test
-  void negateSkipsSurrogates() {
-    // A negated class should not include surrogates (0xD800-0xDFFF).
+  void negateIncludesSurrogates() {
+    // Java regex negated classes match lone surrogate values when the positive class does not.
     CharClass empty = CharClass.EMPTY.negate();
-    assertThat(empty.contains(0xD800)).isFalse();
-    assertThat(empty.contains(0xDBFF)).isFalse();
-    assertThat(empty.contains(0xDC00)).isFalse();
-    assertThat(empty.contains(0xDFFF)).isFalse();
+    assertThat(empty.contains(0xD800)).isTrue();
+    assertThat(empty.contains(0xDBFF)).isTrue();
+    assertThat(empty.contains(0xDC00)).isTrue();
+    assertThat(empty.contains(0xDFFF)).isTrue();
     assertThat(empty.contains(0xD7FF)).isTrue();
     assertThat(empty.contains(0xE000)).isTrue();
   }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1421,6 +1421,43 @@ class MatcherTest {
       assertThat(m.start()).isEqualTo(3); // 'a'=0, smiley=1,2, 'b'=3
       assertThat(m.end()).isEqualTo(4);
     }
+
+    @Test
+    @DisplayName("single character classes preserve surrogate-pair context at region end")
+    void singleCharacterClassesPreserveSurrogatePairContextAtRegionEnd() {
+      String text = "\uD83D\uDE00";
+
+      for (String regex : new String[] {"[^a]", ".", "\\P{Cs}", "[^\\p{Cs}]"}) {
+        java.util.regex.Matcher jdkMatcher =
+            java.util.regex.Pattern.compile(regex, java.util.regex.Pattern.DOTALL)
+                .matcher(text)
+                .region(0, 1);
+        Matcher safeReMatcher = Pattern.compile(regex, Pattern.DOTALL).matcher(text).region(0, 1);
+
+        assertThat(safeReMatcher.find()).as(regex).isEqualTo(jdkMatcher.find());
+
+        jdkMatcher.reset().region(0, 1);
+        safeReMatcher.reset().region(0, 1);
+        assertThat(safeReMatcher.lookingAt()).as(regex).isEqualTo(jdkMatcher.lookingAt());
+
+        jdkMatcher.reset().region(0, 1);
+        safeReMatcher.reset().region(0, 1);
+        assertThat(safeReMatcher.matches()).as(regex).isEqualTo(jdkMatcher.matches());
+      }
+    }
+
+    @Test
+    @DisplayName("single character classes keep JDK behavior for region start low surrogates")
+    void singleCharacterClassesKeepJdkBehaviorForRegionStartLowSurrogates() {
+      String text = "\uD83D\uDE00";
+      java.util.regex.Matcher jdkMatcher =
+          java.util.regex.Pattern.compile("[^a]").matcher(text).region(1, 2);
+      Matcher safeReMatcher = Pattern.compile("[^a]").matcher(text).region(1, 2);
+
+      assertThat(safeReMatcher.find()).isEqualTo(jdkMatcher.find());
+      assertThat(safeReMatcher.start()).isEqualTo(jdkMatcher.start());
+      assertThat(safeReMatcher.end()).isEqualTo(jdkMatcher.end());
+    }
   }
 
   @Nested

--- a/safere/src/test/java/org/safere/UnicodeMatchBoundsTest.java
+++ b/safere/src/test/java/org/safere/UnicodeMatchBoundsTest.java
@@ -39,10 +39,36 @@ class UnicodeMatchBoundsTest {
         new Case("dot-valid-surrogate-pair", ".", Pattern.DOTALL, "\ud83d\ude00"));
   }
 
+  static Stream<Case> negatedClassesMatchJdkOnUnpairedSurrogates() {
+    return Stream.of(
+        new Case(
+            "non-whitespace-high-surrogate",
+            "\\S",
+            Pattern.CASE_INSENSITIVE,
+            "\n".repeat(34) + "\ud998" + "a".repeat(41)),
+        new Case("non-whitespace-low-surrogate", "\\S", Pattern.CASE_INSENSITIVE, "\ude00"),
+        new Case("non-digit-high-surrogate", "\\D", Pattern.CASE_INSENSITIVE, "\ud998"),
+        new Case("non-word-low-surrogate", "\\W", Pattern.CASE_INSENSITIVE, "\ude00"),
+        new Case("negated-literal-class", "[^a]", Pattern.CASE_INSENSITIVE, "\ud998"),
+        new Case(
+            "negated-java-property", "\\P{javaWhitespace}", Pattern.CASE_INSENSITIVE, "\ud998"));
+  }
+
   @ParameterizedTest
   @MethodSource
   @DisplayName("dot and anchor bounds match java.util.regex")
   void dotAndAnchorBoundsMatchJdk(Case c) {
+    assertOutcomesMatchJdk(c);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  @DisplayName("negated character classes match java.util.regex on unpaired surrogates")
+  void negatedClassesMatchJdkOnUnpairedSurrogates(Case c) {
+    assertOutcomesMatchJdk(c);
+  }
+
+  private static void assertOutcomesMatchJdk(Case c) {
     Pattern safePattern = Pattern.compile(c.regex(), c.flags());
     java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(c.regex(), c.flags());
 

--- a/safere/src/test/java/org/safere/UnicodeMatchBoundsTest.java
+++ b/safere/src/test/java/org/safere/UnicodeMatchBoundsTest.java
@@ -51,7 +51,9 @@ class UnicodeMatchBoundsTest {
         new Case("non-word-low-surrogate", "\\W", Pattern.CASE_INSENSITIVE, "\ude00"),
         new Case("negated-literal-class", "[^a]", Pattern.CASE_INSENSITIVE, "\ud998"),
         new Case(
-            "negated-java-property", "\\P{javaWhitespace}", Pattern.CASE_INSENSITIVE, "\ud998"));
+            "negated-java-property", "\\P{javaWhitespace}", Pattern.CASE_INSENSITIVE, "\ud998"),
+        new Case("surrogate-category-complement", "\\P{Cs}", 0, "\ud998a"),
+        new Case("negated-surrogate-category-class", "[^\\p{Cs}]", 0, "\ude00a"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary

- Treat negated character classes as complements over Java regex input character values, including lone surrogate code units.
- Add public API regression coverage for `\S`, `\D`, `\W`, `[^a]`, and `\P{javaWhitespace}` on unpaired surrogates.
- Add deterministic Unicode fuzzer coverage for negated classes with unpaired surrogate inputs.
- Update the divergence bug-fix skill to require a behavior-only JDK spec assessment before implementation analysis.

Fixes #375

## Verification

- `mvn -pl safere -Dtest=UnicodeMatchBoundsTest,CharClassTest test`
- `mvn -pl safere-fuzz -am -Dtest=UnicodeFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`

## Not Run

- Benchmarks were not run; this is a compatibility fix, not a performance optimization.
