### PR TITLE
Cover raw ampersands before class close in sweep

### DIFF
--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -31,7 +31,10 @@ The character-class sweep includes the original product matrix plus a bounded
 grammar-sequence matrix. The grammar-sequence matrix composes class atoms,
 intersection operators, nested classes, range tails, empty quoted literals,
 comments-mode trivia, close brackets, and property classes in freer token
-sequences so bugs in tail composition are not hidden by fixed templates.
+sequences so bugs in tail composition are not hidden by fixed templates. It also
+includes a targeted comments-mode matrix for raw ampersands immediately before a
+class close after range tails, where JDK syntax handling is especially sensitive
+to zero-width quoted literals and skipped trivia.
 
 The output JSONL path is printed at the end of each run. Generated reports should
 stay out of git.

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -188,6 +188,19 @@ public final class CharacterClassDivergenceSweep {
           piece("emptyQuoteSpace", "\\Q\\E "),
           piece("spaceEmptyQuote", " \\Q\\E"));
 
+  private static final List<Piece> RAW_AMPERSAND_CLOSE_TAILS =
+      List.of(
+          piece("rawAmpSpace", "& "),
+          piece("rawAmpEmptyQuote", "&\\Q\\E"),
+          piece("rawAmpEmptyQuoteSpace", "&\\Q\\E "),
+          piece("rangeToAmpRawAmp", "-&&"),
+          piece("rangeToAmpRawAmpSpace", "-& &"),
+          piece("rangeToAmpEmptyQuoteRawAmp", "-&\\Q\\E&"),
+          piece("rangeToAmpCommentRawAmp", "-& #x\n&"),
+          piece("rangeToARawAmp", "-a&"),
+          piece("rangeToARawAmpSpace", "-a& "),
+          piece("rangeToAEmptyQuoteRawAmpSpace", "-a\\Q\\E& "));
+
   private static final List<Piece> NESTED_RIGHTS =
       List.of(
           piece("nestedA", "[a]"),
@@ -226,6 +239,7 @@ public final class CharacterClassDivergenceSweep {
         runClassicMatrix(worker);
         runChainedAmpersandMatrix(worker);
         runGrammarSequenceMatrix(worker);
+        runRawAmpersandBeforeCloseMatrix(worker);
         worker.finish();
         return runState;
       }
@@ -242,6 +256,7 @@ public final class CharacterClassDivergenceSweep {
                     runClassicMatrix(state);
                     runChainedAmpersandMatrix(state);
                     runGrammarSequenceMatrix(state);
+                    runRawAmpersandBeforeCloseMatrix(state);
                     state.finish();
                   } catch (Throwable t) {
                     failure.compareAndSet(null, t);
@@ -563,6 +578,33 @@ public final class CharacterClassDivergenceSweep {
                         separator,
                         tail2);
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static void runRawAmpersandBeforeCloseMatrix(SweepState state) {
+    for (boolean negated : List.of(false, true)) {
+      for (Piece left : LEFT_PIECES) {
+        for (Piece ampersand : AMPERSAND_PIECES) {
+          for (Piece beforeOperator : COMMENT_SEPARATORS) {
+            for (Piece operator : OPERATORS) {
+              for (Piece afterOperator : COMMENT_SEPARATORS) {
+                for (Piece tail : RAW_AMPERSAND_CLOSE_TAILS) {
+                  state.check6(
+                      "raw-ampersand-before-close",
+                      true,
+                      negated,
+                      left,
+                      ampersand,
+                      beforeOperator,
+                      operator,
+                      afterOperator,
+                      tail);
                 }
               }
             }


### PR DESCRIPTION
## Summary

- add a targeted `raw-ampersand-before-close` matrix to the character-class exhaustive sweep
- document that the sweep now covers raw ampersands before class close after range tails and comments-mode trivia

## Notes

This is coverage only. It intentionally does not include the parser fix for the divergences exposed by the new matrix.

The new portion can be run by starting at the old sweep end:

```bash
tools/exhaustive/run-character-class-sweep.sh \
  --threads=1 \
  --range=916385200: \
  --progress-interval=10000 \
  --output-dir=target/exhaustive-reports/character-class-raw-amp-close
```

Refs #396

## Verification

- `mvn -pl safere-exhaustive -am -DskipTests compile -q`
- `git diff --check`
- New appended range on this coverage branch:

```text
checked=176400
generated=916561600
divergences=24888
buckets=336
threads=1
```

The divergences are expected for this coverage-only PR and are tracked in #396.
