### PR TITLE
Fix character class ampersand normalization regressions

### DIFF
--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -236,6 +236,7 @@ public final class CharacterClassDivergenceSweep {
     try (RunState runState = new RunState(options)) {
       if (options.threads() == 1) {
         SweepState worker = new SweepState(runState, 0);
+        runSeparatedSingleAmpersandMatrix(worker);
         runClassicMatrix(worker);
         runChainedAmpersandMatrix(worker);
         runGrammarSequenceMatrix(worker);
@@ -253,6 +254,7 @@ public final class CharacterClassDivergenceSweep {
                 () -> {
                   try {
                     SweepState state = new SweepState(runState, workerIndex);
+                    runSeparatedSingleAmpersandMatrix(state);
                     runClassicMatrix(state);
                     runChainedAmpersandMatrix(state);
                     runGrammarSequenceMatrix(state);
@@ -605,6 +607,36 @@ public final class CharacterClassDivergenceSweep {
                       operator,
                       afterOperator,
                       tail);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static void runSeparatedSingleAmpersandMatrix(SweepState state) {
+    for (boolean negated : List.of(false, true)) {
+      for (Piece left : LEFT_PIECES) {
+        for (Piece beforeFirstAmp : COMMENT_SEPARATORS) {
+          for (Piece firstAmp : AMPERSAND_PIECES) {
+            for (Piece betweenAmps : COMMENT_SEPARATORS) {
+              for (Piece secondAmp : AMPERSAND_PIECES) {
+                for (Piece nested : nestedRights()) {
+                  for (Piece tail : RAW_AMPERSAND_CLOSE_TAILS) {
+                    state.check7(
+                        "separated-single-ampersands-before-nested",
+                        true,
+                        negated,
+                        left,
+                        beforeFirstAmp,
+                        firstAmp,
+                        betweenAmps,
+                        secondAmp,
+                        nested,
+                        tail);
+                  }
                 }
               }
             }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -118,6 +118,7 @@ final class Parser {
   // Parse state
   private int flags;
   private final String pattern;
+  private final boolean containsEmptyQuotedLiteral;
   private int pos; // current parse position (char index into pattern)
   private StackEntry stacktop;
   private int ncap;
@@ -128,6 +129,7 @@ final class Parser {
 
   private Parser(String pattern, int flags) {
     this.pattern = pattern;
+    this.containsEmptyQuotedLiteral = pattern.contains("\\Q\\E");
     this.flags = flags;
     this.pos = 0;
     this.stacktop = null;
@@ -1070,6 +1072,9 @@ final class Parser {
           if (token.isSingleAmpersand()
               && token.skippedZeroWidthSyntax()
               && !token.skippedCommentsTrivia()) {
+            if (rawAmpersandBeforeCommentsModeCloseAt(pos)) {
+              throw new PatternSyntaxException("bad class syntax", pattern, pos);
+            }
             if (hasInvalidRangeTailAfterRawAmpersand(pos)) {
               throw new PatternSyntaxException("illegal character range", pattern, pos + 1);
             }
@@ -1153,6 +1158,9 @@ final class Parser {
                 && tail.pos() < pattern.length()
                 && pattern.charAt(tail.pos()) == '&'
                 && token.ampersandTailHasSingleAmpersand()) {
+              if (rawAmpersandBeforeCommentsModeCloseAt(tail.pos())) {
+                throw new PatternSyntaxException("bad class syntax", pattern, tail.pos());
+              }
               if (hasInvalidRangeTailAfterRawAmpersand(tail.pos())) {
                 throw new PatternSyntaxException(
                     "illegal character range", pattern, tail.pos() + 1);
@@ -1195,6 +1203,9 @@ final class Parser {
             }
           }
           if (token.isSingleAmpersand() && frame.intersectionRightStartedAfterCommentsTrivia) {
+            if (rawAmpersandBeforeCommentsModeCloseAt(pos)) {
+              throw new PatternSyntaxException("bad class syntax", pattern, pos);
+            }
             if (frame.intersectionRightHasExpression && frame.intersectionRightOnlyNestedClasses) {
               finishNestedRightBeforeTrailingAmpersand(frame);
               continue;
@@ -1240,6 +1251,9 @@ final class Parser {
                 && tail.pos() < pattern.length()
                 && pattern.charAt(tail.pos()) == '&'
                 && token.ampersandTailHasSingleAmpersand()) {
+              if (rawAmpersandBeforeCommentsModeCloseAt(tail.pos())) {
+                throw new PatternSyntaxException("bad class syntax", pattern, tail.pos());
+              }
               if (frame.intersectionRightHasExpression
                   && frame.intersectionRightOnlyNestedClasses) {
                 pos = tail.pos();
@@ -1432,7 +1446,7 @@ final class Parser {
   }
 
   private NormalizedClassPattern removeEmptyQuotedLiteralsFromClassIfNeeded() {
-    if ((flags & ParseFlags.COMMENTS) == 0 && pattern.indexOf("\\Q\\E", pos) < 0) {
+    if ((flags & ParseFlags.COMMENTS) == 0 && !containsEmptyQuotedLiteral) {
       return null;
     }
     if (pos >= pattern.length() || pattern.charAt(pos) != '[') {
@@ -1541,15 +1555,16 @@ final class Parser {
             && trailingAmpersandRunSkippedCommentsTrivia
             && frame != null
             && frame.hasContent
-            && trailingAmpersandRun % 2 == 1
-            && index + 1 < pattern.length()
-            && pattern.charAt(index + 1) == ']') {
-          appendMapped(normalized, originalIndexes, c, index);
-          markClassPatternContent(frame);
-          trailingAmpersandRun = 0;
-          trailingAmpersandRunSkippedCommentsTrivia = false;
-          index++;
-          continue;
+            && trailingAmpersandRun % 2 == 1) {
+          if (index + 1 < pattern.length() && pattern.charAt(index + 1) == ']') {
+            appendMapped(normalized, originalIndexes, c, index);
+            markClassPatternContent(frame);
+            trailingAmpersandRun = 0;
+            trailingAmpersandRunSkippedCommentsTrivia = false;
+            index++;
+            continue;
+          }
+          return null;
         }
         appendMapped(normalized, originalIndexes, c, index);
         if (frame != null && frame.hasContent) {
@@ -1872,6 +1887,9 @@ final class Parser {
 
   private void finishNestedRightBeforeTrailingAmpersand(ClassExpressionFrame frame) {
     boolean rawAmpersandRangeTail = rawAmpersandStartsRangeAt(pos);
+    if (!rawAmpersandRangeTail && rawAmpersandBeforeCommentsModeCloseAt(pos)) {
+      throw new PatternSyntaxException("bad class syntax", pattern, pos);
+    }
     boolean rawAmpersandRangeTailPreservesDeferredScalars =
         rawAmpersandRangeTail && rawAmpersandRangeAtAmpersandPreservesDeferredScalars(pos);
     boolean preserveDeferredOrdinaryScalars =
@@ -1905,6 +1923,16 @@ final class Parser {
     frame.intersectionRight = null;
     frame.intersectionRightHasExpression = false;
     frame.intersectionRightOnlyNestedClasses = false;
+  }
+
+  private boolean rawAmpersandBeforeCommentsModeCloseAt(int ampersandIndex) {
+    if ((flags & ParseFlags.COMMENTS) == 0) {
+      return false;
+    }
+    ClassSyntaxLookahead tail = inspectNormalizedClassSyntax(ampersandIndex + 1);
+    return tail.skippedCommentsTrivia()
+        && tail.pos() < pattern.length()
+        && pattern.charAt(tail.pos()) == ']';
   }
 
   private CharClassBuilder nestedRightBeforeTrailingAmpersandExpression(

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -10,7 +10,9 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import java.time.Duration;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,6 +63,14 @@ class ParserTest {
     pattern.append('a');
     for (int i = 0; i < depth; i++) {
       pattern.append(']');
+    }
+    return pattern.toString();
+  }
+
+  private static String repeatedPlainCharacterClasses(int count) {
+    StringBuilder pattern = new StringBuilder(count * 3);
+    for (int i = 0; i < count; i++) {
+      pattern.append("[a]");
     }
     return pattern.toString();
   }
@@ -326,6 +336,13 @@ class ParserTest {
 
       assertThat(fullMatch(pattern, "a", ParseFlags.LIKE_PERL)).isTrue();
       assertThat(fullMatch(pattern, "b", ParseFlags.LIKE_PERL)).isFalse();
+    }
+
+    @Test
+    void manyPlainCharacterClassesCompileWithinRegressionBound() {
+      String pattern = repeatedPlainCharacterClasses(100_000);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(10), () -> parse(pattern));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- avoid quadratic suffix rescans before plain character class parsing by caching whether the pattern contains empty quoted literal syntax
- reject comments-mode raw ampersand tails before a skipped class close consistently with `java.util.regex`
- add exhaustive sweep coverage for separated single ampersands before nested character classes
- replace the parser scaling ratio test with a fixed large-input timeout regression tripwire

Fixes #398

## Verification

- `mvn -pl safere -Dtest='ParserTest$CharacterClasses#manyPlainCharacterClassesCompileWithinRegressionBound' test -q`
- Verified the timeout regression test fails before the parser caching fix and passes after it
- `mvn -pl safere -Dtest=ParserTest,JdkSyntaxCompatibilityTest test -q`
- `tools/exhaustive/run-character-class-sweep.sh --range=0:423360 --max-per-bucket=uncapped --output-dir=target/exhaustive-reports/character-class-sweep-new-additions --progress-interval=100000` returned `divergences=0`
- replay of the previously found 3360 full-sweep divergences returned `divergences=0`
- `tools/exhaustive/run-character-class-sweep.sh --output-dir=target/exhaustive-reports/character-class-sweep-full` returned `checked=916984960`, `generated=916984960`, `divergences=0`, `buckets=0`

## Not Run

- Full `mvn -pl safere test -q`
- Crosscheck public API suite
