### PR TITLE
Fix control escape target compatibility

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
@@ -33,6 +33,10 @@ final class EscapeSyntaxFuzzer {
     "\\e",
     "\\cA",
     "\\ca",
+    "\\c!",
+    "\\cĀ",
+    "\\c",
+    "\\c😀",
     "\\©",
     "\\Ā",
     "\\é",
@@ -45,10 +49,13 @@ final class EscapeSyntaxFuzzer {
   };
   private static final String[] SUFFIXES = {"", "$", "]", "a", "-", "-z", "&&[a]"};
   private static final List<String> INPUTS =
-      List.of("", "a", "A", "0", "7", "@", "\u001b", "&", "-", "©", "Ā", "é", "☃", "😀", "\u0000");
+      List.of(
+          "", "a", "A", "0", "7", "@", "\u001b", "&", "-", "©", "Ā", "é", "☃", "😀", "🙀", "\u0000",
+          "\u0140", "\uf57f");
   private static final String[] REGRESSION_REGEXES = {
     "^\\©", "[\\©]", "\\Ā", "[\\Ā]", "\\☃", "[\\☃]", "\\😀", "[\\😀]", "\\0", "\\08", "\\400",
-    "\\777", "\\123", "(a)\\12", "\\h", "\\H", "\\v", "\\V"
+    "\\777", "\\123", "(a)\\12", "\\h", "\\H", "\\v", "\\V", "\\c!", "[\\c!]", "^\\c", "[\\c]",
+    "\\cĀ", "[\\cĀ]", "\\c😀"
   };
 
   @FuzzTest(maxDuration = "30s")

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -3968,11 +3968,7 @@ final class Parser {
         }
         int ctrl = pattern.codePointAt(pos);
         pos += Character.charCount(ctrl);
-        // JDK accepts ASCII letters and some symbols; the result is ctrl ^ 0x40.
-        if (ctrl >= 0x40 && ctrl <= 0x7F) {
-          return ctrl ^ 0x40;
-        }
-        throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 1);
+        return ctrl ^ 0x40;
       }
       default -> {
         // JDK reserves backslash before ASCII alphabetic characters for escaped constructs.

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -889,6 +889,24 @@ class JdkSyntaxCompatibilityTest {
     void controlCharM() {
       assertMatchesSame("\\cM", "\r");
     }
+
+    static Stream<Arguments> nonAsciiControlEscapes() {
+      return Stream.of(
+          Arguments.of("\\c!", "a"),
+          Arguments.of("[\\c!]", "a"),
+          Arguments.of("\\c\uf53f", "\uf57f"),
+          Arguments.of("^\\c\uf53f", "\uf57f"),
+          Arguments.of("[\\c\uf53f]", "\uf57f"),
+          Arguments.of("\\c\u0100", "\u0140"),
+          Arguments.of("[\\c\u0100]", "\u0140"));
+    }
+
+    @ParameterizedTest(name = "/{0}/ matches \"{1}\"")
+    @MethodSource("nonAsciiControlEscapes")
+    @DisplayName("control escapes accept non-ASCII targets like JDK")
+    void controlEscapesAcceptNonAsciiTargetsLikeJdk(String regex, String input) {
+      assertMatchesSame(regex, input);
+    }
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

- Accept `\c` control escapes for any following Unicode code point using the JDK-compatible `x ^ 0x40` mapping.
- Add syntax compatibility coverage for the original non-ASCII target from #372 and the duplicate `\c!` example from #392.
- Extend escape fuzz coverage with punctuation, BMP non-ASCII, PUA, and supplementary `\c` targets.

Fixes #372
Refs #392

## Verification

- `mvn -pl safere -Dtest='JdkSyntaxCompatibilityTest$CharactersAndEscapes' test -q`
- `mvn -pl safere-fuzz -am -Dtest=EscapeSyntaxFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
