### PR TITLE
Fix control escape sweep divergences

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
@@ -33,8 +33,11 @@ final class EscapeSyntaxFuzzer {
     "\\e",
     "\\cA",
     "\\ca",
+    "\\c\t",
+    "\\c#\na",
     "\\c!",
     "\\cĀ",
+    "\\c\uD800",
     "\\c",
     "\\c😀",
     "\\©",
@@ -51,11 +54,11 @@ final class EscapeSyntaxFuzzer {
   private static final List<String> INPUTS =
       List.of(
           "", "a", "A", "0", "7", "@", "\u001b", "&", "-", "©", "Ā", "é", "☃", "😀", "🙀", "\u0000",
-          "\u0140", "\uf57f");
+          "\u0140", "\uD800", "\uD840", "\uf57f");
   private static final String[] REGRESSION_REGEXES = {
     "^\\©", "[\\©]", "\\Ā", "[\\Ā]", "\\☃", "[\\☃]", "\\😀", "[\\😀]", "\\0", "\\08", "\\400",
     "\\777", "\\123", "(a)\\12", "\\h", "\\H", "\\v", "\\V", "\\c!", "[\\c!]", "^\\c", "[\\c]",
-    "\\cĀ", "[\\cĀ]", "\\c😀"
+    "\\cĀ", "[\\cĀ]", "\\c😀", "(?x)\\c\ta", "(?x)\\c#\na", "[^\\c\uD800]"
   };
 
   @FuzzTest(maxDuration = "30s")

--- a/safere/src/main/java/org/safere/CharClassBuilder.java
+++ b/safere/src/main/java/org/safere/CharClassBuilder.java
@@ -6,7 +6,6 @@
 package org.safere;
 
 import java.util.Iterator;
-import java.util.NavigableSet;
 import java.util.TreeSet;
 
 /**
@@ -151,8 +150,8 @@ final class CharClassBuilder {
   }
 
   /**
-   * Negates this character class in place, so it matches all valid Unicode code points not
-   * previously matched, and vice versa.
+   * Negates this character class in place, so it matches all Java string code points not previously
+   * matched, and vice versa.
    *
    * @return this builder, for chaining
    */
@@ -161,19 +160,14 @@ final class CharClassBuilder {
     int next = 0;
 
     for (Range r : ranges) {
-      // Skip surrogates: gap from 0xD800 to 0xDFFF.
-      int lo = r.lo;
-      int hi = r.hi;
-
-      if (next < lo) {
-        // Add gap [next, lo-1], but skip surrogates.
-        addGapSkippingSurrogates(negated, next, lo - 1);
+      if (next < r.lo) {
+        negated.add(new Range(next, r.lo - 1));
       }
-      next = hi + 1;
+      next = r.hi + 1;
     }
 
     if (next <= Utils.MAX_RUNE) {
-      addGapSkippingSurrogates(negated, next, Utils.MAX_RUNE);
+      negated.add(new Range(next, Utils.MAX_RUNE));
     }
 
     ranges.clear();
@@ -185,23 +179,6 @@ final class CharClassBuilder {
       nrunes += (r.hi - r.lo + 1);
     }
     return this;
-  }
-
-  private static void addGapSkippingSurrogates(NavigableSet<Range> dest, int lo, int hi) {
-    if (lo > hi) {
-      return;
-    }
-    // Split around surrogate range [0xD800, 0xDFFF].
-    if (hi < Utils.MIN_SURROGATE || lo > Utils.MAX_SURROGATE) {
-      dest.add(new Range(lo, hi));
-    } else {
-      if (lo < Utils.MIN_SURROGATE) {
-        dest.add(new Range(lo, Utils.MIN_SURROGATE - 1));
-      }
-      if (hi > Utils.MAX_SURROGATE) {
-        dest.add(new Range(Utils.MAX_SURROGATE + 1, hi));
-      }
-    }
   }
 
   /**

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -3991,6 +3991,9 @@ final class Parser {
       }
       // Control character: \cX → X ^ 0x40
       case 'c' -> {
+        if ((flags & ParseFlags.COMMENTS) != 0) {
+          skipCommentsAndWhitespace();
+        }
         if (pos >= pattern.length()) {
           throw new PatternSyntaxException("invalid escape sequence", pattern, pos - 2);
         }

--- a/safere/src/test/java/org/safere/CharClassTest.java
+++ b/safere/src/test/java/org/safere/CharClassTest.java
@@ -218,13 +218,13 @@ class CharClassTest {
   }
 
   @Test
-  void negateSkipsSurrogates() {
-    // A negated class should not include surrogates (0xD800-0xDFFF).
+  void negateIncludesLoneSurrogates() {
+    // java.util.regex character-class negation can match lone surrogate code units.
     CharClass empty = CharClass.EMPTY.negate();
-    assertThat(empty.contains(0xD800)).isFalse();
-    assertThat(empty.contains(0xDBFF)).isFalse();
-    assertThat(empty.contains(0xDC00)).isFalse();
-    assertThat(empty.contains(0xDFFF)).isFalse();
+    assertThat(empty.contains(0xD800)).isTrue();
+    assertThat(empty.contains(0xDBFF)).isTrue();
+    assertThat(empty.contains(0xDC00)).isTrue();
+    assertThat(empty.contains(0xDFFF)).isTrue();
     assertThat(empty.contains(0xD7FF)).isTrue();
     assertThat(empty.contains(0xE000)).isTrue();
   }

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -907,6 +907,48 @@ class JdkSyntaxCompatibilityTest {
     void controlEscapesAcceptNonAsciiTargetsLikeJdk(String regex, String input) {
       assertMatchesSame(regex, input);
     }
+
+    static Stream<Arguments> commentsModeControlEscapesSkipTriviaBeforeTarget() {
+      return Stream.of(
+          Arguments.of("(?x)\\c\ta", "!"),
+          Arguments.of("(?x)^\\c\t$", "d"),
+          Arguments.of("(?x)\\c\t?", "\u007f"),
+          Arguments.of("(?x)\\c#\na", "!"));
+    }
+
+    @ParameterizedTest(name = "/{0}/ matches \"{1}\"")
+    @MethodSource("commentsModeControlEscapesSkipTriviaBeforeTarget")
+    @DisplayName("comments-mode control escapes skip trivia before target like JDK")
+    void commentsModeControlEscapesSkipTriviaBeforeTargetLikeJdk(String regex, String input) {
+      assertMatchesFull(regex, input);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"(?x)\\c\t", "(?x)\\c#", "(?x)[\\c\t]", "(?x)[^\\c#]"})
+    @DisplayName("comments-mode control escapes reject when skipped trivia leaves no valid target")
+    void commentsModeControlEscapesRejectWhenSkippedTriviaLeavesNoValidTarget(String regex) {
+      assertRejectedByJdkAndSafeRe(regex);
+    }
+
+    static Stream<Arguments> controlEscapeNegatedClassesIncludeLoneSurrogates() {
+      return Stream.of(
+          Arguments.of("[^\\c\uD800]", "\uD840", false),
+          Arguments.of("[^\\c\uD800]", "\uD800", true),
+          Arguments.of("[^\\c\ud7bf]", "\uD800", true),
+          Arguments.of("[\\c\uD800]", "\uD840", true));
+    }
+
+    @ParameterizedTest(name = "/{0}/ matches \"{1}\" = {2}")
+    @MethodSource("controlEscapeNegatedClassesIncludeLoneSurrogates")
+    @DisplayName("control escape character classes handle lone surrogates like JDK")
+    void controlEscapeCharacterClassesHandleLoneSurrogatesLikeJdk(
+        String regex, String input, boolean expected) {
+      java.util.regex.Matcher jdkM = java.util.regex.Pattern.compile(regex).matcher(input);
+      assertThat(jdkM.matches()).as("JDK sanity for /%s/", regex).isEqualTo(expected);
+
+      Matcher safeM = Pattern.compile(regex).matcher(input);
+      assertThat(safeM.matches()).as("SafeRE matches() for /%s/", regex).isEqualTo(expected);
+    }
   }
 
   // ===========================================================================

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1421,6 +1421,12 @@ class MatcherTest {
       assertThat(m.start()).isEqualTo(3); // 'a'=0, smiley=1,2, 'b'=3
       assertThat(m.end()).isEqualTo(4);
     }
+
+    @Test
+    @DisplayName("find() with negated classes can start at lone surrogates like JDK")
+    void findWithNegatedClassesCanStartAtLoneSurrogatesLikeJdk() {
+      assertFirstFindMatchesJdk("[^a-z]..", "\uD801\uD800\uDC00xyz");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

- make comments-mode `\c` parsing skip whitespace and `#` comments before selecting the control target, matching `java.util.regex`
- include lone surrogate code units in negated character-class complements so control-escape class membership and related `find()` bounds match the JDK
- add focused JDK compatibility regressions and expand escape syntax fuzz coverage for the discovered shapes

Fixes #401
Fixes #361

## Spec assessment

JDK `Pattern` documents control escapes as `\cx` and COMMENTS mode as permitting whitespace and comments in patterns:

- Pattern javadoc: https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/regex/Pattern.html
- Matcher javadoc: https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/regex/Matcher.html

The sweep failures were compatible with the JDK behavior and do not require any non-linear regex feature, so SafeRE can follow the JDK behavior while preserving the linear-time guarantee.

## Verification

Ran:

```bash
tools/exhaustive/run-control-escape-sweep.sh --output-dir=target/exhaustive-reports/control-escape-sweep-full
```

Result:

```text
checked=35651584
generated=35651584
totalCases=35651584
divergences=0
buckets=0
threads=8
jsonl=target/exhaustive-reports/control-escape-sweep-full/control-escape-divergences.jsonl
```

Also passed:

```bash
mvn -pl safere -Dtest='MatcherTest$UnicodeTests#findWithNegatedClassesCanStartAtLoneSurrogatesLikeJdk,JdkSyntaxCompatibilityTest$CharactersAndEscapes,CharClassTest' test -q
mvn -pl safere -Dtest='JdkSyntaxCompatibilityTest$CharactersAndEscapes,CharClassTest' test -q
mvn -pl safere-fuzz -am -Dtest=EscapeSyntaxFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q
mvn -pl safere -Dtest='ParserTest$CharacterClasses#manyPlainCharacterClassesCompileWithinRegressionBound' test -q
```

Pre-PR repro check for #361 on `origin/main` (`417373c`):

```text
SafeRE find=true
SafeRE start=1
JDK find=true
JDK start=0
```

The same repro on this PR branch reports `SafeRE start=0`.

Not fully completed:

```bash
mvn -pl safere test -q
```

The default full suite hit the existing `ParserTest$CharacterClasses.manyPlainCharacterClassesCompileWithinRegressionBound` 10s preemptive timeout under the normal 16-way concurrent test profile. The same guard passed in isolation on this branch. A serial full-suite attempt was stopped after it spent a long time in the JDK oracle for `CrossEngineExhaustiveTest$CaseInsensitiveDfa.caseInsensitiveBoundaries`, outside the changed code path.
