### PR TITLE
Fix grapheme clusters with leading combining marks

### DIFF
--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -39,6 +39,34 @@ to zero-width quoted literals and skipped trivia.
 The output JSONL path is printed at the end of each run. Generated reports should
 stay out of git.
 
+## Grapheme Cluster Sweep
+
+Run through the wrapper script:
+
+```bash
+tools/exhaustive/run-grapheme-cluster-sweep.sh \
+  --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-full
+```
+
+For a smaller ad hoc local check, run a generated-case index range:
+
+```bash
+tools/exhaustive/run-grapheme-cluster-sweep.sh --range=:250 \
+  --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-smoke
+```
+
+The grapheme-cluster sweep compares SafeRE with `java.util.regex` for anchored
+and region-start `\X` and `\b{g}` compile acceptance, `matches()`,
+`lookingAt()`, and repeated `find()` traces including match bounds and captured
+group text. It covers bounded combinations of leading combining marks,
+base-plus-extend clusters, CRLF, Prepend characters, Hangul sequences, regional
+indicators, emoji modifiers, ZWJ emoji sequences, supplementary code points, and
+full/wrapped/prefixed regions.
+
+Use this sweep before review when changing grapheme-cluster parsing or boundary
+behavior. Range bounds and replay files use the same conventions as the other
+exhaustive sweeps.
+
 ## Control Escape Sweep
 
 Run through the wrapper script:

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -1,0 +1,790 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.exhaustive;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.regex.PatternSyntaxException;
+
+/** Offline differential sweep for {@code \X} and {@code \b{g}} grapheme-cluster bugs. */
+public final class GraphemeClusterDivergenceSweep {
+  private static final int DEFAULT_MAX_PER_BUCKET = Integer.MAX_VALUE;
+  private static final int FIND_LIMIT = 32;
+
+  private static final List<RegexTemplate> REGEX_TEMPLATES =
+      List.of(
+          regex("oneCluster", "\\X"),
+          regex("anchoredTwoClusters", "^\\X\\X"),
+          regex("anchoredOptionalCaretTwoClusters", "^\\^?\\X\\X"),
+          regex("exactTwoClusters", "^\\X\\X$"),
+          regex("anchoredTwoClusterRepeat", "^\\X{2}"),
+          regex("exactTwoClusterRepeat", "^\\X{2}$"),
+          regex("capturedCluster", "(\\X)"),
+          regex("anchoredCapturedTwoClusters", "^(\\X)(\\X)"),
+          regex("anchoredClusterPlus", "^\\X+"),
+          regex("boundary", "\\b{g}"),
+          regex("anchoredClusterThenBoundary", "^\\X\\b{g}"),
+          regex("anchoredBoundaryClusterBoundary", "^\\b{g}\\X\\b{g}"));
+
+  private static final List<InputTemplate> INPUT_TEMPLATES =
+      List.of(
+          input("empty", ""),
+          input("ascii", "a"),
+          input("twoAscii", "ab"),
+          input("baseExtend", "e\u0301"),
+          input("baseExtendAscii", "e\u0301a"),
+          input("leadingExtend", "\u0301"),
+          input("twoLeadingExtends", "\u0301\u0301"),
+          input("leadingExtendsThenBase", "\u0301\u0301a"),
+          input("longLeadingExtendsThenBase", "\u0301".repeat(44) + "a".repeat(8)),
+          input("crlf", "\r\n"),
+          input("prependBase", "\u0600a"),
+          input("hangulJamo", "\u1100\u1161"),
+          input("hangulSyllableTail", "\uAC00\u11A8"),
+          input("regionalPair", "\uD83C\uDDFA\uD83C\uDDF8"),
+          input("regionalTriple", "\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8"),
+          input("emojiModifier", "\uD83D\uDC4D\uD83C\uDFFD"),
+          input("zwjEmoji", "\uD83D\uDC69\u200D\uD83D\uDCBB"),
+          input("zwjEmojiModifier", "\uD83D\uDC69\uD83C\uDFFD\u200D\uD83D\uDCBB"),
+          input("supplementary", "\uD83D\uDE00"),
+          input("zwjAfterAscii", "a\u200D"));
+
+  private static final List<RegionMode> REGION_MODES =
+      List.of(
+          new RegionMode("full", "", ""),
+          new RegionMode("wrapped", "#", "$"),
+          new RegionMode("prefixed", "zz", ""));
+
+  private GraphemeClusterDivergenceSweep() {}
+
+  public static void main(String[] args) throws IOException {
+    Options options = Options.parse(args);
+    Files.createDirectories(options.outputDir());
+    Files.deleteIfExists(options.jsonlPath());
+
+    if (options.replayFile() != null) {
+      runReplay(options);
+      return;
+    }
+
+    RunState state = runSweep(options);
+
+    System.out.println("checked=" + state.checked.sum());
+    System.out.println("generated=" + state.generated);
+    System.out.println("totalCases=" + totalCases());
+    System.out.println("divergences=" + state.divergences.sum());
+    System.out.println("buckets=" + state.buckets.size());
+    System.out.println("threads=" + options.threads());
+    System.out.println("jsonl=" + options.jsonlPath());
+  }
+
+  private static RunState runSweep(Options options) throws IOException {
+    try (RunState runState = new RunState(options)) {
+      if (options.threads() == 1) {
+        SweepState worker = new SweepState(runState, 0);
+        worker.run();
+        worker.finish();
+        return runState;
+      }
+
+      AtomicReference<Throwable> failure = new AtomicReference<>();
+      List<Thread> workers = new ArrayList<>();
+      for (int i = 0; i < options.threads(); i++) {
+        int workerIndex = i;
+        Thread worker =
+            new Thread(
+                () -> {
+                  try {
+                    SweepState state = new SweepState(runState, workerIndex);
+                    state.run();
+                    state.finish();
+                  } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                  }
+                },
+                "grapheme-cluster-sweep-" + workerIndex);
+        worker.start();
+        workers.add(worker);
+      }
+      for (Thread worker : workers) {
+        try {
+          worker.join();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("interrupted while waiting for sweep workers", e);
+        }
+      }
+      Throwable throwable = failure.get();
+      if (throwable != null) {
+        if (throwable instanceof Error error) {
+          throw error;
+        }
+        if (throwable instanceof RuntimeException runtimeException) {
+          throw runtimeException;
+        }
+        throw new IOException("sweep worker failed", throwable);
+      }
+      return runState;
+    }
+  }
+
+  private static void runReplay(Options options) throws IOException {
+    long generated = 0;
+    long checked = 0;
+    long divergences = 0;
+    try (BufferedReader reader =
+        Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String trimmed = line.trim();
+        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+          continue;
+        }
+        generated++;
+        checked++;
+        CaseSpec spec = replayCase(trimmed);
+        Outcome jdk = jdkOutcome(spec);
+        Outcome safere = safeReOutcome(spec);
+        if (semanticallyEqual(jdk, safere)) {
+          continue;
+        }
+        divergences++;
+        Files.writeString(
+            options.jsonlPath(),
+            new Divergence(spec, jdk, safere, bucketFor(spec, jdk, safere)).toJson() + "\n",
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND);
+      }
+    }
+    System.out.println("checked=" + checked);
+    System.out.println("generated=" + generated);
+    System.out.println("divergences=" + divergences);
+    System.out.println("buckets=" + divergences);
+    System.out.println("threads=1");
+    System.out.println("jsonl=" + options.jsonlPath());
+    if (divergences > 0) {
+      throw new IllegalStateException("replay found " + divergences + " behavioral divergences");
+    }
+  }
+
+  private static long totalCases() {
+    return (long) REGEX_TEMPLATES.size() * INPUT_TEMPLATES.size() * REGION_MODES.size();
+  }
+
+  private static CaseSpec caseAt(long index) {
+    int regionIndex = (int) (index % REGION_MODES.size());
+    index /= REGION_MODES.size();
+    int inputIndex = (int) (index % INPUT_TEMPLATES.size());
+    index /= INPUT_TEMPLATES.size();
+    int regexIndex = (int) index;
+    return new CaseSpec(
+        REGEX_TEMPLATES.get(regexIndex),
+        INPUT_TEMPLATES.get(inputIndex),
+        REGION_MODES.get(regionIndex));
+  }
+
+  private static Outcome jdkOutcome(CaseSpec spec) {
+    try {
+      java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(spec.regex());
+      return new Outcome(true, operationTrace(pattern, spec), "");
+    } catch (PatternSyntaxException e) {
+      return new Outcome(false, "", e.getDescription());
+    } catch (RuntimeException e) {
+      return new Outcome(false, "", e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+  }
+
+  private static Outcome safeReOutcome(CaseSpec spec) {
+    try {
+      org.safere.Pattern pattern = org.safere.Pattern.compile(spec.regex());
+      return new Outcome(true, operationTrace(pattern, spec), "");
+    } catch (PatternSyntaxException e) {
+      return new Outcome(false, "", e.getDescription());
+    } catch (RuntimeException e) {
+      return new Outcome(false, "", e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+  }
+
+  private static String operationTrace(java.util.regex.Pattern pattern, CaseSpec spec) {
+    StringBuilder result = new StringBuilder();
+    String text = spec.text();
+    int start = spec.regionStart();
+    int end = spec.regionEnd();
+    java.util.regex.Matcher matcher = pattern.matcher(text).region(start, end);
+    result.append("matches=").append(matchResult(matcher.matches(), matcher));
+    matcher.reset(text).region(start, end);
+    result.append(";lookingAt=").append(matchResult(matcher.lookingAt(), matcher));
+    matcher.reset(text).region(start, end);
+    result.append(";find=");
+    appendFindTrace(result, matcher);
+    return result.toString();
+  }
+
+  private static String operationTrace(org.safere.Pattern pattern, CaseSpec spec) {
+    StringBuilder result = new StringBuilder();
+    String text = spec.text();
+    int start = spec.regionStart();
+    int end = spec.regionEnd();
+    org.safere.Matcher matcher = pattern.matcher(text).region(start, end);
+    result.append("matches=").append(matchResult(matcher.matches(), matcher));
+    matcher.reset(text).region(start, end);
+    result.append(";lookingAt=").append(matchResult(matcher.lookingAt(), matcher));
+    matcher.reset(text).region(start, end);
+    result.append(";find=");
+    appendFindTrace(result, matcher);
+    return result.toString();
+  }
+
+  private static String matchResult(boolean matched, java.util.regex.Matcher matcher) {
+    if (!matched) {
+      return "false";
+    }
+    return "true@" + matchSpan(matcher);
+  }
+
+  private static String matchResult(boolean matched, org.safere.Matcher matcher) {
+    if (!matched) {
+      return "false";
+    }
+    return "true@" + matchSpan(matcher);
+  }
+
+  private static void appendFindTrace(StringBuilder result, java.util.regex.Matcher matcher) {
+    int count = 0;
+    while (matcher.find()) {
+      if (count > 0) {
+        result.append('|');
+      }
+      result.append(matchSpan(matcher));
+      if (++count >= FIND_LIMIT) {
+        result.append("|...");
+        return;
+      }
+    }
+    if (count == 0) {
+      result.append("false");
+    }
+  }
+
+  private static void appendFindTrace(StringBuilder result, org.safere.Matcher matcher) {
+    int count = 0;
+    while (matcher.find()) {
+      if (count > 0) {
+        result.append('|');
+      }
+      result.append(matchSpan(matcher));
+      if (++count >= FIND_LIMIT) {
+        result.append("|...");
+        return;
+      }
+    }
+    if (count == 0) {
+      result.append("false");
+    }
+  }
+
+  private static String matchSpan(java.util.regex.Matcher matcher) {
+    return matchSpan(matcher.start(), matcher.end(), matcher.groupCount(), matcher::group);
+  }
+
+  private static String matchSpan(org.safere.Matcher matcher) {
+    return matchSpan(matcher.start(), matcher.end(), matcher.groupCount(), matcher::group);
+  }
+
+  private static String matchSpan(int start, int end, int groupCount, GroupValue groupValue) {
+    StringBuilder result = new StringBuilder();
+    result.append(start).append('-').append(end).append(':').append(escape(groupValue.group(0)));
+    for (int i = 1; i <= groupCount; i++) {
+      result.append(':');
+      String group = groupValue.group(i);
+      result.append(group == null ? "<null>" : escape(group));
+    }
+    return result.toString();
+  }
+
+  private static CaseSpec replayCase(String line) {
+    String regex = jsonField(line, "regex");
+    String input = jsonField(line, "input");
+    String prefix = jsonField(line, "prefix");
+    String suffix = jsonField(line, "suffix");
+    if (regex == null || input == null || prefix == null || suffix == null) {
+      throw new IllegalArgumentException("replay line must contain regex, input, prefix, suffix");
+    }
+    return new CaseSpec(
+        new RegexTemplate("replay", regex),
+        new InputTemplate("replay", input),
+        new RegionMode("replay", prefix, suffix));
+  }
+
+  private static String bucketFor(CaseSpec spec, Outcome jdk, Outcome safere) {
+    String kind = jdk.accepted() != safere.accepted() ? "compile" : "behavior";
+    return String.join(
+        "|",
+        "kind=" + kind,
+        "direction=" + direction(jdk, safere),
+        "regex=" + spec.regexTemplate().label(),
+        "input=" + spec.inputTemplate().label(),
+        "region=" + spec.regionMode().label());
+  }
+
+  private static String direction(Outcome jdk, Outcome safere) {
+    if (jdk.accepted() && !safere.accepted()) {
+      return "jdk-accepts";
+    }
+    if (!jdk.accepted() && safere.accepted()) {
+      return "safere-accepts";
+    }
+    return "trace";
+  }
+
+  private static boolean semanticallyEqual(Outcome left, Outcome right) {
+    if (left.accepted() != right.accepted()) {
+      return false;
+    }
+    return !left.accepted() || left.trace().equals(right.trace());
+  }
+
+  private static String escape(String value) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\' -> result.append("\\\\");
+        case '\n' -> result.append("\\n");
+        case '\t' -> result.append("\\t");
+        case '\r' -> result.append("\\r");
+        case '"' -> result.append("\\\"");
+        default -> {
+          if (Character.isISOControl(c) || Character.isSurrogate(c)) {
+            result.append(String.format("\\u%04X", (int) c));
+          } else {
+            result.append(c);
+          }
+        }
+      }
+    }
+    return result.toString();
+  }
+
+  private static String json(String value) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\' -> result.append("\\\\");
+        case '"' -> result.append("\\\"");
+        case '\n' -> result.append("\\n");
+        case '\t' -> result.append("\\t");
+        case '\r' -> result.append("\\r");
+        case '\b' -> result.append("\\b");
+        case '\f' -> result.append("\\f");
+        default -> {
+          if (c < 0x20 || Character.isSurrogate(c)) {
+            result.append(String.format("\\u%04X", (int) c));
+          } else {
+            result.append(c);
+          }
+        }
+      }
+    }
+    return result.toString();
+  }
+
+  private static String jsonField(String line, String field) {
+    String prefix = "\"" + field + "\":\"";
+    int start = line.indexOf(prefix);
+    if (start < 0) {
+      return null;
+    }
+    start += prefix.length();
+    StringBuilder value = new StringBuilder();
+    boolean escaped = false;
+    for (int i = start; i < line.length(); i++) {
+      char c = line.charAt(i);
+      if (escaped) {
+        value.append('\\').append(c);
+        escaped = false;
+      } else if (c == '\\') {
+        escaped = true;
+      } else if (c == '"') {
+        return unjson(value.toString());
+      } else {
+        value.append(c);
+      }
+    }
+    throw new IllegalArgumentException("unterminated JSON field in line: " + line);
+  }
+
+  private static String unjson(String value) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c != '\\') {
+        result.append(c);
+        continue;
+      }
+      if (++i >= value.length()) {
+        throw new IllegalArgumentException("trailing JSON escape in: " + value);
+      }
+      char escaped = value.charAt(i);
+      switch (escaped) {
+        case 'n' -> result.append('\n');
+        case 't' -> result.append('\t');
+        case 'r' -> result.append('\r');
+        case 'b' -> result.append('\b');
+        case 'f' -> result.append('\f');
+        case '"', '\\' -> result.append(escaped);
+        case 'u' -> {
+          if (i + 4 >= value.length()) {
+            throw new IllegalArgumentException("short JSON unicode escape in: " + value);
+          }
+          result.append((char) Integer.parseInt(value.substring(i + 1, i + 5), 16));
+          i += 4;
+        }
+        default -> result.append(escaped);
+      }
+    }
+    return result.toString();
+  }
+
+  private static RegexTemplate regex(String label, String regex) {
+    return new RegexTemplate(label, regex);
+  }
+
+  private static InputTemplate input(String label, String input) {
+    return new InputTemplate(label, input);
+  }
+
+  private interface GroupValue {
+    String group(int group);
+  }
+
+  private record RegexTemplate(String label, String regex) {}
+
+  private record InputTemplate(String label, String input) {}
+
+  private record RegionMode(String label, String prefix, String suffix) {}
+
+  private record CaseSpec(
+      RegexTemplate regexTemplate, InputTemplate inputTemplate, RegionMode regionMode) {
+    String regex() {
+      return regexTemplate.regex();
+    }
+
+    String input() {
+      return inputTemplate.input();
+    }
+
+    String text() {
+      return regionMode.prefix() + input() + regionMode.suffix();
+    }
+
+    int regionStart() {
+      return regionMode.prefix().length();
+    }
+
+    int regionEnd() {
+      return regionStart() + input().length();
+    }
+
+    String labels() {
+      return "regex="
+          + regexTemplate.label()
+          + ",input="
+          + inputTemplate.label()
+          + ",region="
+          + regionMode.label();
+    }
+  }
+
+  private record Outcome(boolean accepted, String trace, String error) {}
+
+  private record Divergence(CaseSpec spec, Outcome jdk, Outcome safere, String bucket) {
+    String toJson() {
+      return "{"
+          + "\"bucket\":\""
+          + json(bucket)
+          + "\","
+          + "\"labels\":\""
+          + json(spec.labels())
+          + "\","
+          + "\"regex\":\""
+          + json(spec.regex())
+          + "\","
+          + "\"input\":\""
+          + json(spec.input())
+          + "\","
+          + "\"prefix\":\""
+          + json(spec.regionMode().prefix())
+          + "\","
+          + "\"suffix\":\""
+          + json(spec.regionMode().suffix())
+          + "\","
+          + "\"regionStart\":"
+          + spec.regionStart()
+          + ","
+          + "\"regionEnd\":"
+          + spec.regionEnd()
+          + ","
+          + "\"jdkAccepted\":"
+          + jdk.accepted()
+          + ","
+          + "\"safeReAccepted\":"
+          + safere.accepted()
+          + ","
+          + "\"jdkTrace\":\""
+          + json(jdk.trace())
+          + "\","
+          + "\"safeReTrace\":\""
+          + json(safere.trace())
+          + "\","
+          + "\"jdkError\":\""
+          + json(jdk.error())
+          + "\","
+          + "\"safeReError\":\""
+          + json(safere.error())
+          + "\""
+          + "}";
+    }
+  }
+
+  private static final class RunState implements AutoCloseable {
+    final Options options;
+    final Map<String, Bucket> buckets = new LinkedHashMap<>();
+    final LongAdder checked = new LongAdder();
+    final LongAdder divergences = new LongAdder();
+    final BufferedWriter jsonlWriter;
+    long generated;
+    long nextProgressReport;
+
+    RunState(Options options) throws IOException {
+      this.options = options;
+      this.jsonlWriter =
+          Files.newBufferedWriter(
+              options.jsonlPath(),
+              StandardCharsets.UTF_8,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.APPEND);
+      this.nextProgressReport =
+          firstProgressAt(options.rangeStartInclusive(), options.progressInterval());
+    }
+
+    synchronized void recordGenerated(long workerGenerated) {
+      if (workerGenerated > generated) {
+        generated = workerGenerated;
+      }
+    }
+
+    synchronized void reportProgressIfNeeded(long workerGenerated) {
+      recordGenerated(workerGenerated);
+      if (generated < nextProgressReport) {
+        return;
+      }
+      System.out.printf(
+          "progress generated=%,d checked=%,d divergences=%,d buckets=%,d jsonl=%s%n",
+          generated, checked.sum(), divergences.sum(), buckets.size(), options.jsonlPath());
+      while (nextProgressReport <= generated) {
+        nextProgressReport += options.progressInterval();
+      }
+    }
+
+    boolean reserveDivergenceExample(String bucketName) {
+      synchronized (this) {
+        divergences.increment();
+        Bucket bucket = buckets.computeIfAbsent(bucketName, Bucket::new);
+        if (bucket.savedExamples >= options.maxPerBucket()) {
+          return false;
+        }
+        bucket.savedExamples++;
+        return true;
+      }
+    }
+
+    synchronized void appendJsonl(Divergence divergence) {
+      try {
+        jsonlWriter.write(divergence.toJson());
+        jsonlWriter.newLine();
+      } catch (IOException e) {
+        throw new IllegalStateException("failed to write divergence report", e);
+      }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+      jsonlWriter.close();
+    }
+  }
+
+  private static final class SweepState {
+    final RunState runState;
+    final Options options;
+    final int workerIndex;
+    long generated;
+    long nextProgressReport;
+
+    SweepState(RunState runState, int workerIndex) {
+      this.runState = runState;
+      this.options = runState.options;
+      this.workerIndex = workerIndex;
+      this.nextProgressReport =
+          firstProgressAt(options.rangeStartInclusive(), options.progressInterval());
+    }
+
+    void run() {
+      long end = Math.min(options.rangeEndExclusive(), totalCases());
+      while (generated < end) {
+        long caseIndex = generated++;
+        if (caseIndex < options.rangeStartInclusive()) {
+          reportProgressIfNeeded();
+          continue;
+        }
+        if (caseIndex % options.threads() != workerIndex) {
+          reportProgressIfNeeded();
+          continue;
+        }
+        runState.checked.increment();
+        checkOwned(caseAt(caseIndex));
+      }
+    }
+
+    void checkOwned(CaseSpec spec) {
+      Outcome jdk = jdkOutcome(spec);
+      Outcome safere = safeReOutcome(spec);
+      if (semanticallyEqual(jdk, safere)) {
+        reportProgressIfNeeded();
+        return;
+      }
+      String bucketName = bucketFor(spec, jdk, safere);
+      if (!runState.reserveDivergenceExample(bucketName)) {
+        reportProgressIfNeeded();
+        return;
+      }
+      runState.appendJsonl(new Divergence(spec, jdk, safere, bucketName));
+      reportProgressIfNeeded();
+    }
+
+    void finish() {
+      runState.recordGenerated(generated);
+    }
+
+    void reportProgressIfNeeded() {
+      if (generated < nextProgressReport) {
+        return;
+      }
+      runState.reportProgressIfNeeded(generated);
+      while (nextProgressReport <= generated) {
+        nextProgressReport += options.progressInterval();
+      }
+    }
+  }
+
+  private static final class Bucket {
+    final String name;
+    int savedExamples;
+
+    Bucket(String name) {
+      this.name = name;
+    }
+  }
+
+  private static long firstProgressAt(long rangeStartInclusive, long progressInterval) {
+    if (rangeStartInclusive <= 0) {
+      return progressInterval;
+    }
+    long remainder = rangeStartInclusive % progressInterval;
+    if (remainder == 0) {
+      return rangeStartInclusive;
+    }
+    return rangeStartInclusive + (progressInterval - remainder);
+  }
+
+  private record Options(
+      long rangeStartInclusive,
+      long rangeEndExclusive,
+      int maxPerBucket,
+      Path outputDir,
+      long progressInterval,
+      int threads,
+      Path replayFile) {
+    Path jsonlPath() {
+      return outputDir.resolve("grapheme-cluster-divergences.jsonl");
+    }
+
+    static Options parse(String[] args) {
+      long rangeStartInclusive = 0;
+      long rangeEndExclusive = Long.MAX_VALUE;
+      int maxPerBucket = DEFAULT_MAX_PER_BUCKET;
+      Path outputDir = Path.of("target", "exhaustive-reports", "grapheme-cluster-sweep");
+      long progressInterval = 1_000;
+      int threads = 1;
+      Path replayFile = null;
+      for (String arg : args) {
+        if (arg.startsWith("--range=")) {
+          String value = arg.substring("--range=".length());
+          int colon = value.indexOf(':');
+          if (colon < 0) {
+            throw new IllegalArgumentException("--range must use start:end syntax");
+          }
+          String start = value.substring(0, colon);
+          String end = value.substring(colon + 1);
+          rangeStartInclusive = start.isEmpty() ? 0 : Long.parseLong(start);
+          rangeEndExclusive = end.isEmpty() ? Long.MAX_VALUE : Long.parseLong(end);
+        } else if (arg.startsWith("--max-per-bucket=")) {
+          String value = arg.substring("--max-per-bucket=".length());
+          maxPerBucket = value.equals("uncapped") ? Integer.MAX_VALUE : Integer.parseInt(value);
+        } else if (arg.startsWith("--output-dir=")) {
+          outputDir = Path.of(arg.substring("--output-dir=".length()));
+        } else if (arg.startsWith("--progress-interval=")) {
+          progressInterval = Long.parseLong(arg.substring("--progress-interval=".length()));
+        } else if (arg.startsWith("--threads=")) {
+          threads = Integer.parseInt(arg.substring("--threads=".length()));
+        } else if (arg.startsWith("--replay-file=")) {
+          replayFile = Path.of(arg.substring("--replay-file=".length()));
+        } else {
+          throw new IllegalArgumentException("unknown argument: " + arg);
+        }
+      }
+      if (rangeStartInclusive < 0 || rangeEndExclusive < 0) {
+        throw new IllegalArgumentException("--range bounds must be non-negative");
+      }
+      if (rangeEndExclusive < rangeStartInclusive) {
+        throw new IllegalArgumentException("--range end must be greater than or equal to start");
+      }
+      if (maxPerBucket < 0) {
+        throw new IllegalArgumentException("--max-per-bucket must be non-negative");
+      }
+      if (progressInterval < 1) {
+        throw new IllegalArgumentException("--progress-interval must be at least 1");
+      }
+      if (threads < 1) {
+        throw new IllegalArgumentException("--threads must be at least 1");
+      }
+      if (replayFile != null && !Files.isRegularFile(replayFile)) {
+        throw new IllegalArgumentException("--replay-file must be a regular file");
+      }
+      return new Options(
+          rangeStartInclusive,
+          rangeEndExclusive,
+          maxPerBucket,
+          outputDir,
+          progressInterval,
+          threads,
+          replayFile);
+    }
+  }
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
@@ -11,10 +11,14 @@ import java.util.List;
 
 final class UnicodeFuzzer {
 
+  private static final List<String> GRAPHEME_CLUSTER_REGEXES = List.of("\\X", "^\\^?\\X\\X");
+
   private static final List<String> GRAPHEME_CLUSTER_INPUTS =
       List.of(
           "a",
           "e\u0301",
+          "\u0301\u0301a",
+          "\u0301".repeat(44) + "a".repeat(8),
           "\r\n",
           "\uD83C\uDDFA\uD83C\uDDF8",
           "\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8",
@@ -28,11 +32,13 @@ final class UnicodeFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void unicode(FuzzedDataProvider data) {
-    FuzzSupport.CompiledPattern graphemePattern = FuzzSupport.compileOrSkip("\\X", 0);
-    for (String input : GRAPHEME_CLUSTER_INPUTS) {
-      FuzzSupport.MatcherPair matcher = graphemePattern.matcher(input);
-      while (matcher.find()) {
-        // Continue through the sequence so group boundaries are compared at every cluster.
+    for (String regex : GRAPHEME_CLUSTER_REGEXES) {
+      FuzzSupport.CompiledPattern graphemePattern = FuzzSupport.compileOrSkip(regex, 0);
+      for (String input : GRAPHEME_CLUSTER_INPUTS) {
+        FuzzSupport.MatcherPair matcher = graphemePattern.matcher(input);
+        while (matcher.find()) {
+          // Continue through the sequence so group boundaries are compared at every cluster.
+        }
       }
     }
 

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -29,6 +29,8 @@ import java.util.Set;
  * </pre>
  */
 final class Nfa {
+  private static final int[][] EXTENDED_PICTOGRAPHIC =
+      UnicodeProperties.lookupBinaryProperty("Extended_Pictographic");
 
   /** Anchor mode for matching. */
   enum Anchor {
@@ -741,7 +743,7 @@ final class Nfa {
 
   /**
    * Returns true if {@code pos} is a grapheme cluster boundary for SafeRE's supported approximation
-   * of JDK {@code \X}: CRLF is atomic, and combining marks extend the preceding cluster.
+   * of JDK {@code \X}.
    */
   static boolean isGraphemeClusterBoundary(String text, int pos) {
     if (pos < 0 || pos > text.length()) {
@@ -758,7 +760,25 @@ final class Nfa {
     if (prevChar == '\r' && nextChar == '\n') {
       return false;
     }
-    return !isCombiningMark(text.codePointAt(pos));
+    int prev = text.codePointBefore(pos);
+    int next = text.codePointAt(pos);
+    if (isGraphemeExtend(next) || isGraphemePrepend(prev)) {
+      return false;
+    }
+    if (isHangulGraphemeContinuation(prev, next)) {
+      return false;
+    }
+    if (prev == 0x200D && containsCodePoint(EXTENDED_PICTOGRAPHIC, next)) {
+      return false;
+    }
+    if (isRegionalIndicator(prev) && isRegionalIndicator(next)) {
+      return countPrecedingRegionalIndicators(text, pos) % 2 == 0;
+    }
+    return true;
+  }
+
+  private static boolean isGraphemeExtend(int c) {
+    return isCombiningMark(c) || isEmojiModifier(c) || c == 0x200D;
   }
 
   private static boolean isCombiningMark(int c) {
@@ -766,6 +786,81 @@ final class Nfa {
     return type == Character.NON_SPACING_MARK
         || type == Character.ENCLOSING_MARK
         || type == Character.COMBINING_SPACING_MARK;
+  }
+
+  private static boolean isEmojiModifier(int c) {
+    return 0x1F3FB <= c && c <= 0x1F3FF;
+  }
+
+  private static boolean isGraphemePrepend(int c) {
+    return (0x0600 <= c && c <= 0x0605)
+        || c == 0x06DD
+        || c == 0x070F
+        || (0x0890 <= c && c <= 0x0891)
+        || c == 0x08E2
+        || c == 0x110BD
+        || c == 0x110CD;
+  }
+
+  private static boolean isHangulGraphemeContinuation(int prev, int next) {
+    return (isHangulL(prev) && (isHangulL(next) || isHangulV(next) || isHangulLv(next)))
+        || ((isHangulV(prev) || isHangulLv(prev)) && (isHangulV(next) || isHangulT(next)))
+        || ((isHangulT(prev) || isHangulLvt(prev)) && isHangulT(next));
+  }
+
+  private static boolean isHangulL(int c) {
+    return (0x1100 <= c && c <= 0x115F) || (0xA960 <= c && c <= 0xA97C);
+  }
+
+  private static boolean isHangulV(int c) {
+    return (0x1160 <= c && c <= 0x11A7) || (0xD7B0 <= c && c <= 0xD7C6);
+  }
+
+  private static boolean isHangulT(int c) {
+    return (0x11A8 <= c && c <= 0x11FF) || (0xD7CB <= c && c <= 0xD7FB);
+  }
+
+  private static boolean isHangulLv(int c) {
+    return 0xAC00 <= c && c <= 0xD7A3 && (c - 0xAC00) % 28 == 0;
+  }
+
+  private static boolean isHangulLvt(int c) {
+    return 0xAC00 <= c && c <= 0xD7A3 && (c - 0xAC00) % 28 != 0;
+  }
+
+  private static boolean isRegionalIndicator(int c) {
+    return 0x1F1E6 <= c && c <= 0x1F1FF;
+  }
+
+  private static int countPrecedingRegionalIndicators(String text, int pos) {
+    int count = 0;
+    int current = pos;
+    while (current > 0) {
+      int cp = text.codePointBefore(current);
+      if (!isRegionalIndicator(cp)) {
+        break;
+      }
+      count++;
+      current -= Character.charCount(cp);
+    }
+    return count;
+  }
+
+  private static boolean containsCodePoint(int[][] ranges, int c) {
+    int lo = 0;
+    int hi = ranges.length - 1;
+    while (lo <= hi) {
+      int mid = (lo + hi) >>> 1;
+      int[] range = ranges[mid];
+      if (c < range[0]) {
+        hi = mid - 1;
+      } else if (c > range[1]) {
+        lo = mid + 1;
+      } else {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Returns true if the code point is a word character ({@code [A-Za-z0-9_]}). */

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -4701,20 +4701,25 @@ final class Parser {
         Regexp.concat(
             List.of(Regexp.plus(buildGraphemePrependClass(), flags), baseWithExtends), flags);
 
+    Regexp leadingExtends = Regexp.plus(extend, flags);
+
     // Alternative 3: any single character (fallback for standalone combining marks, controls, etc.)
     // Use ANY_CHAR with DOT_NL to match all characters including newlines.
     Regexp anyOne = Regexp.anyChar(flags | ParseFlags.DOT_NL);
 
-    return Regexp.alternate(
-        List.of(
-            crLf,
-            zwjSequence,
-            regionalIndicatorPair,
-            hangulCluster,
-            prependCluster,
-            baseWithExtends,
-            anyOne),
-        flags);
+    Regexp clusterBody =
+        Regexp.alternate(
+            List.of(
+                crLf,
+                zwjSequence,
+                regionalIndicatorPair,
+                hangulCluster,
+                prependCluster,
+                baseWithExtends,
+                leadingExtends,
+                anyOne),
+            flags);
+    return Regexp.concat(List.of(clusterBody, Regexp.graphemeClusterBoundary(flags)), flags);
   }
 
   private Regexp buildGraphemeExtendClass(boolean includeZwj) {

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -248,6 +248,37 @@ class LinebreakGraphemeTest {
     }
 
     @Test
+    @DisplayName("\\X groups leading combining marks before the next base character")
+    void groupsLeadingCombiningMarksBeforeNextBaseCharacter() {
+      String text = "\u0301\u0301a";
+      Matcher m = Pattern.compile("\\X").matcher(text);
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isZero();
+      assertThat(m.end()).isEqualTo(2);
+      assertThat(m.group()).isEqualTo("\u0301\u0301");
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.end()).isEqualTo(3);
+      assertThat(m.group()).isEqualTo("a");
+
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("consecutive \\X atoms preserve match bounds after leading combining marks")
+    void consecutiveAtomsPreserveBoundsAfterLeadingCombiningMarks() {
+      String text = "\u0301".repeat(44) + "a".repeat(8);
+      Matcher m = Pattern.compile("^\\^?\\X\\X").matcher(text);
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isZero();
+      assertThat(m.end()).isEqualTo(45);
+      assertThat(m.group()).isEqualTo("\u0301".repeat(44) + "a");
+    }
+
+    @Test
     @DisplayName("\\X matches multiple combining marks with a base character")
     void matchesMultipleCombiningMarks() {
       // a + combining tilde (U+0303) + combining acute accent (U+0301)
@@ -299,7 +330,21 @@ class LinebreakGraphemeTest {
       Pattern p = Pattern.compile("\\X{2}");
       assertThat(p.matcher("ab").matches()).isTrue();
       assertThat(p.matcher("e\u0301a\u0302").matches()).isTrue();
+      assertThat(p.matcher("e\u0301").matches()).isFalse();
       assertThat(p.matcher("a").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("consecutive \\X atoms do not split a single grapheme cluster")
+    void consecutiveAtomsDoNotSplitSingleCluster() {
+      Pattern p = Pattern.compile("^\\X\\X$");
+
+      assertThat(p.matcher("e\u0301").matches()).isFalse();
+      assertThat(p.matcher("\uD83D\uDC4D\uD83C\uDFFD").matches()).isFalse();
+      assertThat(p.matcher("\uD83C\uDDFA\uD83C\uDDF8").matches()).isFalse();
+      assertThat(p.matcher("\u0600a").matches()).isFalse();
+      assertThat(p.matcher("\u1100\u1161").matches()).isFalse();
+      assertThat(p.matcher("e\u0301a").matches()).isTrue();
     }
 
     @Test

--- a/tools/exhaustive/run-grapheme-cluster-sweep.sh
+++ b/tools/exhaustive/run-grapheme-cluster-sweep.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+physical_core_count() {
+  local cores
+  if command -v lscpu >/dev/null 2>&1; then
+    cores="$(
+      lscpu -p=Core,Socket 2>/dev/null \
+        | awk -F, '!/^#/ && NF >= 2 { print $1 "," $2 }' \
+        | sort -u \
+        | wc -l \
+        | tr -d '[:space:]'
+    )"
+    if [[ "$cores" =~ ^[0-9]+$ ]] && [[ "$cores" -gt 0 ]]; then
+      echo "$cores"
+      return
+    fi
+  fi
+
+  if [[ "$(uname -s)" == "Darwin" ]] && command -v sysctl >/dev/null 2>&1; then
+    cores="$(sysctl -n hw.physicalcpu 2>/dev/null || true)"
+    if [[ "$cores" =~ ^[0-9]+$ ]] && [[ "$cores" -gt 0 ]]; then
+      echo "$cores"
+      return
+    fi
+  fi
+
+  echo 1
+}
+
+threads="$(physical_core_count)"
+output_dir="target/exhaustive-reports/grapheme-cluster-sweep"
+java_args=()
+for arg in "$@"; do
+  case "$arg" in
+    --threads=*)
+      threads="${arg#--threads=}"
+      ;;
+    --output-dir=*)
+      output_dir="${arg#--output-dir=}"
+      ;;
+    *)
+      java_args+=("$arg")
+      ;;
+  esac
+done
+
+if ! [[ "$threads" =~ ^[0-9]+$ ]] || [[ "$threads" -lt 1 ]]; then
+  echo "--threads must be a positive integer" >&2
+  exit 2
+fi
+
+mvn -pl safere-exhaustive -am -DskipTests package -q
+classpath="safere-exhaustive/target/classes:safere/target/classes"
+main_class="org.safere.exhaustive.GraphemeClusterDivergenceSweep"
+
+java -cp "$classpath" "$main_class" \
+  "${java_args[@]}" \
+  "--threads=$threads" \
+  "--output-dir=$output_dir"


### PR DESCRIPTION
## Summary

- Fix `\X` so leading grapheme-extend runs are matched as a single cluster before the next base character.
- Require expanded `\X` cluster bodies to end at a grapheme-cluster boundary, so consecutive `\X` atoms do not split supported cluster forms.
- Extend grapheme-boundary checks to match SafeRE's supported `\X` approximation for Extend/ZWJ, emoji modifiers, Prepend, Hangul, ZWJ pictographic joins, and regional indicators.
- Add deterministic `safere-exhaustive` grapheme-cluster differential sweep coverage.

## Spec Assessment

JDK 26 `Pattern` defines `\X` as any Unicode extended grapheme cluster and states that Unicode extended grapheme clusters are supported by `\X` and `\b{g}`. JDK 26 `Matcher.end()` returns the offset after the last character matched. For `^\^?\X\X` on leading combining marks followed by `a`, the JDK result ending after the leading mark cluster plus the first `a` cluster is consistent with that specification. SafeRE ending after two combining marks was not supported by the spec. Matching this behavior preserves SafeRE's linear-time guarantee because grapheme segmentation is deterministic over the input.

## Verification

- `mvn -pl safere-exhaustive -am -DskipTests package -q`
- `tools/exhaustive/run-grapheme-cluster-sweep.sh --threads=1 --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-issue-374` — 720 checked, 0 divergences
- `mvn -pl safere -Dtest=LinebreakGraphemeTest,BoundaryMatcherTest test`
- `mvn -pl safere-fuzz -am -Dtest=UnicodeFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`

Full `mvn -pl safere test -q` was attempted twice after rebasing, but hit an unrelated timeout in `ParserTest$CharacterClasses.manyPlainCharacterClassesCompileWithinRegressionBound`; tracked separately as #404.

Fixes #374
