### PR TITLE
Fix grapheme sweep divergences

### DIFF
--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.regex.PatternSyntaxException;
@@ -24,6 +26,10 @@ import java.util.regex.PatternSyntaxException;
 public final class GraphemeClusterDivergenceSweep {
   private static final int DEFAULT_MAX_PER_BUCKET = Integer.MAX_VALUE;
   private static final int FIND_LIMIT = 32;
+  private static final ConcurrentMap<String, java.util.regex.Pattern> JDK_PATTERN_CACHE =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, org.safere.Pattern> SAFERE_PATTERN_CACHE =
+      new ConcurrentHashMap<>();
 
   private static final List<GraphemeAtom> GRAPHEME_CLASS_ATOMS =
       List.of(
@@ -295,7 +301,8 @@ public final class GraphemeClusterDivergenceSweep {
 
   private static Outcome jdkOutcome(CaseSpec spec) {
     try {
-      java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(spec.regex());
+      java.util.regex.Pattern pattern =
+          JDK_PATTERN_CACHE.computeIfAbsent(spec.regex(), java.util.regex.Pattern::compile);
       return new Outcome(true, operationTrace(pattern, spec), "");
     } catch (PatternSyntaxException e) {
       return new Outcome(false, "", e.getDescription());
@@ -306,7 +313,8 @@ public final class GraphemeClusterDivergenceSweep {
 
   private static Outcome safeReOutcome(CaseSpec spec) {
     try {
-      org.safere.Pattern pattern = org.safere.Pattern.compile(spec.regex());
+      org.safere.Pattern pattern =
+          SAFERE_PATTERN_CACHE.computeIfAbsent(spec.regex(), org.safere.Pattern::compile);
       return new Outcome(true, operationTrace(pattern, spec), "");
     } catch (PatternSyntaxException e) {
       return new Outcome(false, "", e.getDescription());
@@ -1138,19 +1146,20 @@ public final class GraphemeClusterDivergenceSweep {
 
     void run() {
       long end = Math.min(options.rangeEndExclusive(), totalCases());
+      generated = firstOwnedCaseIndex();
       while (generated < end) {
-        long caseIndex = generated++;
-        if (caseIndex < options.rangeStartInclusive()) {
-          reportProgressIfNeeded();
-          continue;
-        }
-        if (caseIndex % options.threads() != workerIndex) {
-          reportProgressIfNeeded();
-          continue;
-        }
+        long caseIndex = generated;
+        generated += options.threads();
         runState.checked.increment();
         checkOwned(caseAt(caseIndex));
       }
+    }
+
+    private long firstOwnedCaseIndex() {
+      long start = options.rangeStartInclusive();
+      long remainder = start % options.threads();
+      long delta = (workerIndex - remainder + options.threads()) % options.threads();
+      return start + delta;
     }
 
     void checkOwned(CaseSpec spec) {
@@ -1221,7 +1230,7 @@ public final class GraphemeClusterDivergenceSweep {
       long rangeEndExclusive = Long.MAX_VALUE;
       int maxPerBucket = DEFAULT_MAX_PER_BUCKET;
       Path outputDir = Path.of("target", "exhaustive-reports", "grapheme-cluster-sweep");
-      long progressInterval = 1_000;
+      long progressInterval = 1_000_000;
       int threads = 1;
       Path replayFile = null;
       for (String arg : args) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -139,9 +139,11 @@ public final class Matcher implements MatchResult {
   private int regionStart;
   private int regionEnd;
   private boolean regionStartInsideSurrogatePairContext;
+  private boolean opaqueGraphemeRegionContext;
   private boolean lastHitEnd;
   private boolean lastRequireEnd;
   private boolean findExhaustedAfterTerminalEmptyMatch;
+  private boolean boundaryStartedRepeatedFindAdvance;
   private int modCount;
 
   /**
@@ -635,6 +637,7 @@ public final class Matcher implements MatchResult {
     try {
       if (regionActive) {
         regionStartInsideSurrogatePairContext = regionStartsInsideSurrogatePair();
+        opaqueGraphemeRegionContext = !transparentBounds && needsFullTextGraphemeRegion();
       }
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
         return applyEngineResult(new NoMatchResult());
@@ -663,6 +666,7 @@ public final class Matcher implements MatchResult {
         }
       }
       regionStartInsideSurrogatePairContext = false;
+      opaqueGraphemeRegionContext = false;
       updateEndState(MatchOperation.MATCHES);
     }
   }
@@ -768,6 +772,7 @@ public final class Matcher implements MatchResult {
     try {
       if (regionActive) {
         regionStartInsideSurrogatePairContext = regionStartsInsideSurrogatePair();
+        opaqueGraphemeRegionContext = !transparentBounds && needsFullTextGraphemeRegion();
       }
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
         return applyEngineResult(new NoMatchResult());
@@ -796,6 +801,7 @@ public final class Matcher implements MatchResult {
         }
       }
       regionStartInsideSurrogatePairContext = false;
+      opaqueGraphemeRegionContext = false;
       updateEndState(MatchOperation.LOOKING_AT);
     }
   }
@@ -893,10 +899,27 @@ public final class Matcher implements MatchResult {
         }
         searchFrom++;
       } else if (parentPattern.startsWithGraphemeClusterBoundary() && searchFrom < regionEnd) {
+        searchFrom = nextGraphemeClusterBoundary(searchFrom);
+        boundaryStartedRepeatedFindAdvance = true;
+      } else if (parentPattern.hasInternalGraphemeClusterBoundary()
+          && searchFrom < regionEnd
+          && endedAfterCrLf(searchFrom)) {
         searchFrom++;
       }
     }
     return doFind();
+  }
+
+  private boolean endedAfterCrLf(int pos) {
+    return pos >= 2 && text.charAt(pos - 2) == '\r' && text.charAt(pos - 1) == '\n';
+  }
+
+  private int nextGraphemeClusterBoundary(int start) {
+    int pos = Math.min(start + 1, regionEnd);
+    while (pos < regionEnd && !Nfa.isGraphemeClusterBoundary(text, pos)) {
+      pos++;
+    }
+    return pos;
   }
 
   /**
@@ -958,6 +981,7 @@ public final class Matcher implements MatchResult {
     try {
       if (regionActive) {
         regionStartInsideSurrogatePairContext = regionStartsInsideSurrogatePair();
+        opaqueGraphemeRegionContext = !transparentBounds && needsFullTextGraphemeRegion();
       }
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
         return applyEngineResult(new NoMatchResult());
@@ -988,7 +1012,9 @@ public final class Matcher implements MatchResult {
         }
       }
       regionStartInsideSurrogatePairContext = false;
+      opaqueGraphemeRegionContext = false;
       updateEndState(MatchOperation.FIND);
+      boundaryStartedRepeatedFindAdvance = false;
     }
   }
 
@@ -1018,7 +1044,17 @@ public final class Matcher implements MatchResult {
   private boolean needsFullTextGraphemeRegion() {
     return parentPattern.hasInternalGraphemeClusterBoundary()
         || regionStartsInsideSurrogatePair()
+        || regionStartsAtZwjAfterPairedLowSurrogate()
         || regionEndsInsideSurrogatePair();
+  }
+
+  private boolean regionStartsAtZwjAfterPairedLowSurrogate() {
+    return parentPattern.prog().hasGraphemeClusterBoundary()
+        && regionStart > 1
+        && regionStart < text.length()
+        && text.charAt(regionStart) == 0x200D
+        && Character.isLowSurrogate(text.charAt(regionStart - 1))
+        && Character.isHighSurrogate(text.charAt(regionStart - 2));
   }
 
   private boolean regionStartsInsideSurrogatePair() {
@@ -1088,8 +1124,13 @@ public final class Matcher implements MatchResult {
     int[] result =
         searchWithBitStateOrNfa(
             prog, text, searchFrom, regionEnd, endPos, false, false, false, prog.numCaptures());
-    if (isSplitLowSurrogateZwjBoundaryWrappedMatch(result)) {
-      result = null;
+    if (prog.hasGraphemeClusterBoundary() && !prog.anchorStart()) {
+      result =
+          nextValidGraphemeCandidate(
+              result, text, searchFrom, regionEnd, endPos, prog.numCaptures(), regionStart);
+      if (result == null && !parentPattern.startsWithGraphemeClusterBoundary()) {
+        result = searchLowSurrogateStarts(text, searchFrom, regionEnd, prog.numCaptures());
+      }
     }
     return applyEngineResult(new FullMatchResult(result));
   }
@@ -1098,16 +1139,14 @@ public final class Matcher implements MatchResult {
     return prog.anchorEnd() && regionEndsInsideSurrogatePair() ? regionEnd + 1 : regionEnd;
   }
 
-  private boolean isSplitLowSurrogateZwjBoundaryWrappedMatch(int[] result) {
-    return result != null
-        && hasBoundaryWrappedConsumingBody(parentPattern.ast())
+  private boolean startsAtRegionStartSplitLowSurrogateZwjBoundaryWrappedMatch(int start) {
+    return hasBoundaryWrappedConsumingBody(parentPattern.ast())
         && regionStartsInsideSurrogatePair()
-        && startsAtRegionStartSplitLowSurrogateZwj(result[0]);
+        && startsAtRegionStartSplitLowSurrogateZwj(start);
   }
 
   private boolean startsAtRegionStartSplitLowSurrogateZwj(int start) {
-    return (start == regionStart + 1 && start < text.length() && text.charAt(start) == 0x200D)
-        || (start == regionStart + 2 && start > 0 && text.charAt(start - 1) == 0x200D);
+    return start == regionStart + 1 && start < text.length() && text.charAt(start) == 0x200D;
   }
 
   private static boolean hasBoundaryWrappedConsumingBody(Regexp re) {
@@ -1535,13 +1574,27 @@ public final class Matcher implements MatchResult {
             false,
             false,
             nsubmatch);
-    if (result == null && parentPattern.charOffsetGraphemeSearch() && !prog.anchorStart()) {
-      result = searchLowSurrogateStarts(prog, text, effectiveStart, nsubmatch);
+    boolean fullCapturesFromGraphemeFallback = false;
+    if (prog.hasGraphemeClusterBoundary() && !prog.anchorStart()) {
+      int candidateRegionStart = regionActive ? 0 : regionStart;
+      result =
+          nextValidGraphemeCandidate(
+              result,
+              text,
+              effectiveStart,
+              text.length(),
+              text.length(),
+              nsubmatch,
+              candidateRegionStart);
+      if (result == null && !parentPattern.startsWithGraphemeClusterBoundary()) {
+        result = searchLowSurrogateStarts(text, effectiveStart, text.length(), prog.numCaptures());
+        fullCapturesFromGraphemeFallback = result != null;
+      }
     }
     if (result == null) {
       return applyEngineResult(new NoMatchResult());
     }
-    if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
+    if (!lazyFallbackCaptures || prog.numCaptures() <= 1 || fullCapturesFromGraphemeFallback) {
       return applyEngineResult(new FullMatchResult(result));
     } else {
       return applyEngineResult(
@@ -1550,19 +1603,246 @@ public final class Matcher implements MatchResult {
   }
 
   private int[] searchLowSurrogateStarts(
-      Prog prog, String text, int effectiveStart, int nsubmatch) {
-    for (int pos = Math.max(0, effectiveStart); pos < text.length(); pos++) {
+      String text, int effectiveStart, int searchLimit, int nsubmatch) {
+    for (int pos = Math.max(0, effectiveStart); pos < searchLimit; pos++) {
       if (!Character.isLowSurrogate(text.charAt(pos))) {
         continue;
       }
-      int[] result =
-          searchWithBitStateOrNfa(
-              prog, text, pos, text.length(), text.length(), true, false, false, nsubmatch);
-      if (result != null) {
-        return result;
+      Matcher verifier = parentPattern.matcher(text).region(pos, searchLimit);
+      if (verifier.lookingAt()) {
+        int ncap = 2 * Math.max(nsubmatch, 1);
+        return Arrays.copyOf(verifier.groups, ncap);
       }
     }
     return null;
+  }
+
+  private int[] nextValidGraphemeCandidate(
+      int[] result,
+      String text,
+      int start,
+      int searchLimit,
+      int endPos,
+      int nsubmatch,
+      int candidateRegionStart) {
+    Prog prog = parentPattern.prog();
+    int retryStart = start;
+    while (result != null
+        && result[0] != result[1]
+        && (!isAnchoredCandidate(result, text, searchLimit)
+            || startsAtNonRegionLowSurrogateAfterExplicitGraphemeBoundary(
+                text, result[0], candidateRegionStart)
+            || startsAtExtenderAfterRegionStartSplitLowSurrogate(
+                text, result[0], candidateRegionStart)
+            || startsAtSupplementaryAfterRegionStartSplitLowSurrogateZwj(
+                text, result[0], candidateRegionStart)
+            || startsAtRegionStartSplitLowSurrogateZwjBoundaryWrappedMatch(result[0])
+            || startsInsideRegionStartSplitLowSurrogateZwjPictographicContinuation(
+                text, result[0], candidateRegionStart)
+            || startsInsidePairedSupplementaryClusterAfterRepeatedBoundaryFind(text, result[0])
+            || (hasExplicitGraphemeClusterBoundary(parentPattern.ast())
+                && endsInsideFullTextPictographicZwjSequence(
+                    text, result[0], result[1], candidateRegionStart)))) {
+      retryStart = Math.max(result[0] + 1, retryStart + 1);
+      if (retryStart > searchLimit) {
+        return null;
+      }
+      result =
+          searchWithBitStateOrNfa(
+              prog, text, retryStart, searchLimit, endPos, false, false, false, nsubmatch);
+    }
+    if (result != null && result[0] != result[1] && result[0] > start) {
+      int[] earlier =
+          searchAnchoredGraphemeCandidates(
+              text, start, result[0], searchLimit, nsubmatch, candidateRegionStart);
+      if (earlier != null) {
+        return earlier;
+      }
+    }
+    return result;
+  }
+
+  private boolean endsInsideFullTextPictographicZwjSequence(
+      String text, int pos, int end, int candidateRegionStart) {
+    if (pos <= candidateRegionStart
+        || candidateRegionStart < 0
+        || candidateRegionStart >= text.length()
+        || !Character.isLowSurrogate(text.charAt(candidateRegionStart))
+        || candidateRegionStart == 0
+        || !Character.isHighSurrogate(text.charAt(candidateRegionStart - 1))
+        || !Nfa.isExtendedPictographicAt(text, end)) {
+      return false;
+    }
+    int lastZwj = -1;
+    int scan = pos;
+    while (scan < end) {
+      if (!Nfa.hasGraphemeExtendAt(text, scan)) {
+        return false;
+      }
+      if (text.charAt(scan) == 0x200D) {
+        lastZwj = scan;
+      }
+      scan += Character.charCount(text.codePointAt(scan));
+    }
+    return lastZwj == end - 1 && Nfa.hasExtendedPictographicBeforeZwj(text, lastZwj, 0);
+  }
+
+  private boolean startsAtNonRegionLowSurrogateAfterExplicitGraphemeBoundary(
+      String text, int pos, int candidateRegionStart) {
+    return parentPattern.startsWithGraphemeClusterBoundary()
+        && pos != candidateRegionStart
+        && pos > 0
+        && pos < text.length()
+        && Character.isHighSurrogate(text.charAt(pos - 1))
+        && Character.isLowSurrogate(text.charAt(pos));
+  }
+
+  private boolean startsAtExtenderAfterRegionStartSplitLowSurrogate(
+      String text, int pos, int candidateRegionStart) {
+    if (!parentPattern.startsWithGraphemeClusterBoundary()
+        || pos <= candidateRegionStart
+        || candidateRegionStart <= 0
+        || candidateRegionStart >= text.length()
+        || !Character.isLowSurrogate(text.charAt(candidateRegionStart))
+        || !Character.isHighSurrogate(text.charAt(candidateRegionStart - 1))
+        || !Nfa.hasGraphemeExtendAt(text, pos)) {
+      return false;
+    }
+    int scan = pos;
+    while (scan > candidateRegionStart + 1) {
+      int previous = text.codePointBefore(scan);
+      int previousPos = scan - Character.charCount(previous);
+      if (!Nfa.hasGraphemeExtendAt(text, previousPos)) {
+        return false;
+      }
+      scan = previousPos;
+    }
+    return scan == candidateRegionStart + 1;
+  }
+
+  private boolean startsAtSupplementaryAfterRegionStartSplitLowSurrogateZwj(
+      String text, int pos, int candidateRegionStart) {
+    return parentPattern.startsWithGraphemeClusterBoundary()
+        && pos > candidateRegionStart + 1
+        && pos < text.length()
+        && Nfa.isExtendedPictographicAt(text, pos)
+        && text.charAt(pos - 1) == 0x200D
+        && startsAtExtenderAfterRegionStartSplitLowSurrogate(text, pos - 1, candidateRegionStart);
+  }
+
+  private boolean startsInsideRegionStartSplitLowSurrogateZwjPictographicContinuation(
+      String text, int pos, int candidateRegionStart) {
+    if (!parentPattern.startsWithGraphemeClusterBoundary()
+        || candidateRegionStart <= 0
+        || !Character.isLowSurrogate(text.charAt(candidateRegionStart))
+        || !Character.isHighSurrogate(text.charAt(candidateRegionStart - 1))) {
+      return false;
+    }
+    int firstPictographic = -1;
+    boolean sawZwj = false;
+    int scan = candidateRegionStart + 1;
+    while (scan < pos && scan < text.length()) {
+      if (Nfa.isExtendedPictographicAt(text, scan)) {
+        firstPictographic = scan;
+        break;
+      }
+      if (!Nfa.hasGraphemeExtendAt(text, scan)) {
+        return false;
+      }
+      sawZwj |= text.codePointAt(scan) == 0x200D;
+      scan += Character.charCount(text.codePointAt(scan));
+    }
+    if (firstPictographic < 0 || !sawZwj || pos <= firstPictographic) {
+      return false;
+    }
+    scan = firstPictographic + Character.charCount(text.codePointAt(firstPictographic));
+    while (scan < pos) {
+      if (!Nfa.hasGraphemeExtendAt(text, scan)) {
+        return false;
+      }
+      scan += Character.charCount(text.codePointAt(scan));
+    }
+    if (scan != pos) {
+      return false;
+    }
+    if (Nfa.hasGraphemeExtendAt(text, pos)) {
+      return true;
+    }
+    return Nfa.isExtendedPictographicAt(text, pos)
+        && pos > 0
+        && text.codePointBefore(pos) == 0x200D;
+  }
+
+  private boolean startsInsidePairedSupplementaryClusterAfterRepeatedBoundaryFind(
+      String text, int pos) {
+    if (!boundaryStartedRepeatedFindAdvance || !Nfa.hasGraphemeExtendAt(text, pos)) {
+      return false;
+    }
+    int scan = pos;
+    while (scan > 0) {
+      int previous = text.codePointBefore(scan);
+      int previousPos = scan - Character.charCount(previous);
+      if (Character.charCount(previous) == 2) {
+        return true;
+      }
+      if (!Nfa.hasGraphemeExtendAt(text, previousPos)) {
+        return false;
+      }
+      scan = previousPos;
+    }
+    return false;
+  }
+
+  private int[] searchAnchoredGraphemeCandidates(
+      String text,
+      int start,
+      int endExclusive,
+      int searchLimit,
+      int nsubmatch,
+      int candidateRegionStart) {
+    for (int pos = Math.max(0, start); pos < endExclusive; pos++) {
+      Matcher verifier = parentPattern.matcher(text).region(pos, searchLimit);
+      if (verifier.lookingAt()
+          && !startsAtNonRegionLowSurrogateAfterExplicitGraphemeBoundary(
+              text, pos, candidateRegionStart)
+          && !startsAtExtenderAfterRegionStartSplitLowSurrogate(text, pos, candidateRegionStart)
+          && !startsAtSupplementaryAfterRegionStartSplitLowSurrogateZwj(
+              text, pos, candidateRegionStart)
+          && !startsAtRegionStartSplitLowSurrogateZwjBoundaryWrappedMatch(pos)
+          && !startsInsideRegionStartSplitLowSurrogateZwjPictographicContinuation(
+              text, pos, candidateRegionStart)
+          && !startsInsidePairedSupplementaryClusterAfterRepeatedBoundaryFind(text, pos)
+          && (!hasExplicitGraphemeClusterBoundary(parentPattern.ast())
+              || !endsInsideFullTextPictographicZwjSequence(
+                  text, pos, verifier.end(), candidateRegionStart))) {
+        int ncap = 2 * Math.max(nsubmatch, 1);
+        return Arrays.copyOf(verifier.groups, ncap);
+      }
+    }
+    return null;
+  }
+
+  private static boolean hasExplicitGraphemeClusterBoundary(Regexp re) {
+    ArrayDeque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = stack.pop();
+      if (node.op == RegexpOp.GRAPHEME_CLUSTER_BOUNDARY
+          && (node.flags & ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY) == 0) {
+        return true;
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(sub);
+        }
+      }
+    }
+    return false;
+  }
+
+  private boolean isAnchoredCandidate(int[] result, String text, int searchLimit) {
+    Matcher verifier = parentPattern.matcher(text).region(result[0], searchLimit);
+    return verifier.lookingAt() && verifier.start() == result[0] && verifier.end() == result[1];
   }
 
   private boolean findKeywordAlternation(
@@ -1762,7 +2042,8 @@ public final class Matcher implements MatchResult {
     } else {
       nfaKind = Nfa.MatchKind.FIRST_MATCH;
     }
-    int nfaRegionStart = regionStartInsideSurrogatePairContext ? regionStart : 0;
+    int nfaRegionStart =
+        (regionStartInsideSurrogatePairContext || opaqueGraphemeRegionContext) ? regionStart : 0;
     return Nfa.search(
         prog, text, startPos, searchLimit, endPos, nfaRegionStart, nfaAnchor, nfaKind, nsubmatch);
   }

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -208,7 +208,7 @@ final class Nfa {
     int ncapture = 2 * Math.max(nsubmatch, 1);
 
     Nfa nfa = new Nfa(prog, ncapture, longestMode, endmatch, endPos, regionStart);
-    if (!anchored && prog.hasMultipleGraphemeClusterBoundaries()) {
+    if (!anchored && prog.hasGraphemeClusterBoundary()) {
       nfa.doSearchEveryCharPosition(text, startPos, searchLimit);
     } else {
       nfa.doSearch(text, startPos, searchLimit, anchored);
@@ -540,7 +540,7 @@ final class Nfa {
                   endPos);
           if ((ip.arg & ~flags) == 0) {
             int nextTerminalEmptyFlags = terminalEmptyFlags;
-            if (pos == endPos || isAtTrailingLineTerminator(text, pos, prog.unixLines())) {
+            if (pos == endPos || isAtTrailingLineTerminator(text, pos, prog.unixLines(), endPos)) {
               nextTerminalEmptyFlags |= ip.arg;
             }
             stack.add(new int[] {ip.out, -1});
@@ -673,7 +673,7 @@ final class Nfa {
               endmatch
                   && matchPos != endPos
                   && (!prog.dollarAnchorEnd()
-                      || !isAtTrailingLineTerminator(text, matchPos, prog.unixLines()));
+                      || !isAtTrailingLineTerminator(text, matchPos, prog.unixLines(), endPos));
           if (!skip) {
             if (longest) {
               if (!matched
@@ -736,7 +736,12 @@ final class Nfa {
    * @param unixLines if true, only {@code '\n'} is recognized as a line terminator
    */
   static boolean isAtTrailingLineTerminator(String text, int pos, boolean unixLines) {
-    int len = text.length();
+    return isAtTrailingLineTerminator(text, pos, unixLines, text.length());
+  }
+
+  private static boolean isAtTrailingLineTerminator(
+      String text, int pos, boolean unixLines, int logicalEndPos) {
+    int len = logicalEndPos;
     if (pos < 0 || pos >= len) {
       return false;
     }
@@ -750,7 +755,8 @@ final class Nfa {
       return pos == 0 || text.charAt(pos - 1) != '\r';
     }
     if (ch == '\r') {
-      return pos + 1 == len || (pos + 2 == len && text.charAt(pos + 1) == '\n');
+      return pos + 1 == len
+          || (pos + 2 == len && pos + 1 < text.length() && text.charAt(pos + 1) == '\n');
     }
     return (ch == '\u0085' || ch == '\u2028' || ch == '\u2029') && pos + 1 == len;
   }
@@ -876,7 +882,7 @@ final class Nfa {
         boolean isAtomicLF = (ch == '\n' && pos > 0 && text.charAt(pos - 1) == '\r');
         if (!isAtomicLF) {
           flags |= EmptyOp.END_LINE;
-          if (isAtTrailingLineTerminator(text, pos, false)) {
+          if (isAtTrailingLineTerminator(text, pos, false, logicalEndPos)) {
             flags |= EmptyOp.DOLLAR_END;
           }
         }
@@ -907,29 +913,44 @@ final class Nfa {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
       } else if (isAfterRegionStartSplitLowSurrogateBoundary(text, pos, regionStart)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-        if (!(consumedInput && pos < logicalEndPos && isBeforeZwj(text, pos))) {
+        if (!(consumedInput && pos < logicalEndPos && hasGraphemeExtendAt(text, pos))) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
-      } else if (isGraphemeClusterBoundary(text, pos)) {
-        flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
+      } else if (consumedInput
+          && isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
+        flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
+        if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart)) {
+          flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
+        }
+      } else if (isGraphemeClusterBoundary(text, pos, regionStart)) {
+        flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
+        if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart)
+            || !isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
+          flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
+        }
       } else if (isLowHighSurrogateBoundary(text, pos) && matchStart > 0 && pos > matchStart) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
-      } else if (startsAtLowSurrogate(text, matchStart) && pos > matchStart) {
+      } else if (startsAtLowSurrogate(text, matchStart) && pos == matchStart + 1) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-        if (!suppressesRegionStartSplitExplicitBoundary(
-            text, regionStart, matchStart, consumedInput)) {
+        if (!hasGraphemeExtendAt(text, pos)
+            && !suppressesRegionStartSplitExplicitBoundary(
+                text, regionStart, matchStart, consumedInput)) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
-      } else if (startsAtStandaloneZwj(text, matchStart, regionStart) && pos == matchStart + 1) {
+      } else if (startsAtStandaloneZwj(text, matchStart, regionStart)
+          && pos == matchStart + 1
+          && !hasGraphemeExtendAt(text, pos)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-        if (!suppressesRegionStartSplitExplicitBoundary(
-            text, regionStart, matchStart, consumedInput)) {
+        if (!consumedInput
+            && !suppressesRegionStartSplitExplicitBoundary(
+                text, regionStart, matchStart, consumedInput)) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
       } else if (!consumedInput
           && (isLowSurrogateBeforeZwjBoundary(text, pos, matchStart, regionStart)
               || isStandaloneZwjAfterLowSurrogateBoundary(text, pos, matchStart, regionStart))
-          && !isAfterRegionStartSplitLowSurrogate(text, pos, regionStart)) {
+          && !isAfterRegionStartSplitLowSurrogate(text, pos, regionStart)
+          && !hasGraphemeExtendAt(text, pos)) {
         flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
       } else if (!consumedInput
           && isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
@@ -947,6 +968,10 @@ final class Nfa {
    * of JDK {@code \X}.
    */
   static boolean isGraphemeClusterBoundary(String text, int pos) {
+    return isGraphemeClusterBoundary(text, pos, 0);
+  }
+
+  private static boolean isGraphemeClusterBoundary(String text, int pos, int regionStart) {
     if (pos < 0 || pos > text.length()) {
       return false;
     }
@@ -961,15 +986,30 @@ final class Nfa {
     if (prevChar == '\r' && nextChar == '\n') {
       return false;
     }
+    if (isGraphemeControl(prevChar) || isGraphemeControl(nextChar)) {
+      return true;
+    }
+    if (Character.isHighSurrogate(prevChar) && !Character.isLowSurrogate(nextChar)) {
+      return true;
+    }
+    if (Character.isLowSurrogate(prevChar)
+        && !hasHighSurrogateBeforeLowSurrogateInRegion(text, pos - 1, regionStart)) {
+      return true;
+    }
     int prev = text.codePointBefore(pos);
     int next = text.codePointAt(pos);
+    if (isGraphemePrepend(prev) && isUnpairedSurrogateAt(text, pos)) {
+      return true;
+    }
     if (isGraphemeExtend(next) || isGraphemePrepend(prev)) {
       return false;
     }
     if (isHangulGraphemeContinuation(prev, next)) {
       return false;
     }
-    if (prev == 0x200D && containsCodePoint(EXTENDED_PICTOGRAPHIC, next)) {
+    if (prev == 0x200D
+        && containsCodePoint(EXTENDED_PICTOGRAPHIC, next)
+        && hasExtendedPictographicBeforeZwj(text, pos - 1, regionStart)) {
       return false;
     }
     if (isRegionalIndicator(prev) && isRegionalIndicator(next)) {
@@ -1023,10 +1063,6 @@ final class Nfa {
         && isRegionStartSplitSurrogateBoundary(text, regionStart, regionStart);
   }
 
-  private static boolean isBeforeZwj(String text, int pos) {
-    return pos >= 0 && pos < text.length() && text.charAt(pos) == 0x200D;
-  }
-
   private static boolean isRegionEndSplitSurrogateBoundary(String text, int pos, int regionEnd) {
     return pos == regionEnd
         && regionEnd > 0
@@ -1072,14 +1108,26 @@ final class Nfa {
         && !hasExtendedPictographicBeforeZwj(text, pos - 1, regionStart);
   }
 
+  private static boolean isAfterPairedExtendedPictographicZwj(
+      String text, int pos, int regionStart) {
+    int lowSurrogatePos = pos - 2;
+    if (regionStart <= lowSurrogatePos && regionStart > 0) {
+      return false;
+    }
+    return pos > 2
+        && text.charAt(pos - 1) == 0x200D
+        && Character.isLowSurrogate(text.charAt(lowSurrogatePos))
+        && Character.isHighSurrogate(text.charAt(pos - 3))
+        && hasExtendedPictographicBeforeZwj(text, pos - 1, 0);
+  }
+
   private static boolean isAfterRegionStartSplitLowSurrogate(
       String text, int pos, int regionStart) {
     return pos == regionStart + 1
         && isRegionStartSplitSurrogateBoundary(text, regionStart, regionStart);
   }
 
-  private static boolean hasExtendedPictographicBeforeZwj(
-      String text, int zwjPos, int regionStart) {
+  static boolean hasExtendedPictographicBeforeZwj(String text, int zwjPos, int regionStart) {
     int pos = zwjPos;
     while (pos > regionStart && pos > 0) {
       int previous = text.codePointBefore(pos);
@@ -1088,7 +1136,7 @@ final class Nfa {
         return false;
       }
       if (containsCodePoint(EXTENDED_PICTOGRAPHIC, previous)) {
-        return true;
+        return !hasPrependImmediatelyBefore(text, previousPos, regionStart);
       }
       if (!isGraphemeExtend(previous)) {
         return false;
@@ -1096,6 +1144,13 @@ final class Nfa {
       pos = previousPos;
     }
     return false;
+  }
+
+  private static boolean hasPrependImmediatelyBefore(String text, int pos, int regionStart) {
+    if (pos <= regionStart || pos <= 0) {
+      return false;
+    }
+    return isGraphemePrepend(text.codePointBefore(pos));
   }
 
   private static boolean hasHighSurrogateBeforeLowSurrogateInRegion(
@@ -1125,6 +1180,32 @@ final class Nfa {
     return isCombiningMark(c) || isEmojiModifier(c) || c == 0x200D;
   }
 
+  private static boolean isUnpairedSurrogateAt(String text, int pos) {
+    char c = text.charAt(pos);
+    if (Character.isLowSurrogate(c)) {
+      return true;
+    }
+    return Character.isHighSurrogate(c)
+        && (pos + 1 >= text.length() || !Character.isLowSurrogate(text.charAt(pos + 1)));
+  }
+
+  static boolean hasGraphemeExtendAt(String text, int pos) {
+    return pos >= 0 && pos < text.length() && isGraphemeExtend(text.codePointAt(pos));
+  }
+
+  static boolean isExtendedPictographicAt(String text, int pos) {
+    return pos >= 0
+        && pos < text.length()
+        && containsCodePoint(EXTENDED_PICTOGRAPHIC, text.codePointAt(pos));
+  }
+
+  private static boolean isGraphemeControl(int c) {
+    int type = Character.getType(c);
+    return type == Character.CONTROL
+        || type == Character.LINE_SEPARATOR
+        || type == Character.PARAGRAPH_SEPARATOR;
+  }
+
   private static boolean isCombiningMark(int c) {
     int type = Character.getType(c);
     return type == Character.NON_SPACING_MARK
@@ -1147,7 +1228,8 @@ final class Nfa {
   }
 
   private static boolean isHangulGraphemeContinuation(int prev, int next) {
-    return (isHangulL(prev) && (isHangulL(next) || isHangulV(next) || isHangulLv(next)))
+    return (isHangulL(prev)
+            && (isHangulL(next) || isHangulV(next) || isHangulLv(next) || isHangulLvt(next)))
         || ((isHangulV(prev) || isHangulLv(prev)) && (isHangulV(next) || isHangulT(next)))
         || ((isHangulT(prev) || isHangulLvt(prev)) && isHangulT(next));
   }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -4673,14 +4673,15 @@ final class Parser {
 
     Regexp extend = buildGraphemeExtendClass(true);
     Regexp extendStar = Regexp.star(extend, flags);
-    Regexp extendNoZwjStar = Regexp.star(buildGraphemeExtendClass(false), flags);
+    Regexp connectorExtends = Regexp.star(extend, flags | ParseFlags.NON_GREEDY);
 
     // Extended pictographic sequences joined by ZWJ, e.g. emoji presentation chains.
     Regexp pictographic =
         charClassFromTable(UnicodeProperties.lookupBinaryProperty("Extended_Pictographic"));
-    Regexp pictographicWithExtends = Regexp.concat(List.of(pictographic, extendNoZwjStar), flags);
+    Regexp pictographicWithExtends = Regexp.concat(List.of(pictographic, connectorExtends), flags);
     Regexp zwjPictographicSegment =
-        Regexp.concat(List.of(Regexp.literal(0x200D, flags), pictographic, extendNoZwjStar), flags);
+        Regexp.concat(
+            List.of(Regexp.literal(0x200D, flags), pictographic, connectorExtends), flags);
     Regexp zwjSequence =
         Regexp.concat(
             List.of(pictographicWithExtends, Regexp.plus(zwjPictographicSegment, flags)), flags);
@@ -4688,25 +4689,38 @@ final class Parser {
     // Regional indicators pair into flag clusters.
     Regexp regionalIndicator = charClassFromRange(0x1F1E6, 0x1F1FF);
     Regexp regionalIndicatorPair =
-        Regexp.concat(List.of(regionalIndicator, regionalIndicator), flags);
+        Regexp.concat(List.of(regionalIndicator, regionalIndicator, extendStar), flags);
+    Regexp regionalIndicatorWithExtends =
+        Regexp.concat(List.of(regionalIndicator, extendStar), flags);
 
-    Regexp hangulCluster = buildHangulGraphemeCluster();
+    Regexp hangulCluster = Regexp.concat(List.of(buildHangulGraphemeCluster(), extendStar), flags);
 
     // \P{M} plus grapheme-extending code points keeps the historical base+mark behavior and
     // covers emoji modifier sequences such as thumbs-up plus skin tone.
     CharClassBuilder nonMarkCcb = new CharClassBuilder();
     addTable(nonMarkCcb, UnicodeTables.UNICODE_GROUPS.get("M"));
     nonMarkCcb.negate(); // \P{M}
-    nonMarkCcb.removeRange(0xDC00, 0xDFFF);
+    removeGraphemeControlCodePoints(nonMarkCcb);
+    nonMarkCcb.removeRange(0xD800, 0xDFFF);
+    nonMarkCcb.removeRange(0x1F1E6, 0x1F1FF);
     Regexp nonMark = Regexp.charClass(nonMarkCcb.build(), flags);
 
     Regexp lowSurrogate = charClassFromRange(0xDC00, 0xDFFF);
     Regexp baseWithExtends = Regexp.concat(List.of(nonMark, extendStar), flags);
+    Regexp leadingExtends = Regexp.plus(extend, flags);
     Regexp prependCluster =
         Regexp.concat(
-            List.of(Regexp.plus(buildGraphemePrependClass(), flags), baseWithExtends), flags);
-
-    Regexp leadingExtends = Regexp.plus(extend, flags);
+            List.of(
+                Regexp.plus(buildGraphemePrependClass(), flags),
+                Regexp.alternate(
+                    List.of(
+                        regionalIndicatorPair,
+                        regionalIndicatorWithExtends,
+                        hangulCluster,
+                        baseWithExtends,
+                        leadingExtends),
+                    flags)),
+            flags);
 
     // Alternative 3: any single character (fallback for standalone combining marks, controls, etc.)
     // Use ANY_CHAR with DOT_NL to match all characters including newlines.
@@ -4718,6 +4732,7 @@ final class Parser {
                 crLf,
                 zwjSequence,
                 regionalIndicatorPair,
+                regionalIndicatorWithExtends,
                 hangulCluster,
                 prependCluster,
                 lowSurrogate,
@@ -4740,6 +4755,12 @@ final class Parser {
       ccb.addRune(0x200D);
     }
     return Regexp.charClass(ccb.build(), flags);
+  }
+
+  private static void removeGraphemeControlCodePoints(CharClassBuilder ccb) {
+    ccb.removeRange(0x0000, 0x001F);
+    ccb.removeRange(0x007F, 0x009F);
+    ccb.removeRange(0x2028, 0x2029);
   }
 
   private Regexp buildGraphemePrependClass() {

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -272,7 +272,128 @@ class LinebreakGraphemeTest {
       assertTraceSameAsJdk("\\X", "\u0301\u200D", 0, 2);
       assertTraceSameAsJdk("\\X", "\u0301\u0301\u200D", 0, 3);
       assertTraceSameAsJdk("\\X", "\u0301\u200Da", 0, 3);
+      assertTraceSameAsJdk("\\X", "a\u0301\u200D\uD83D\uDE00\u0300", 1, 5);
+      assertTraceSameAsJdk("\\X", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
       assertTraceSameAsJdk("\\X\\X", "\u0301\u200Da", 0, 3);
+      assertTraceSameAsJdk("\\X\\b{g}", "\u200D\uD83D\uDC69", 0, 3);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uDE00\u200D\uD83D\uDC69", 0, 4);
+    }
+
+    @Test
+    @DisplayName("\\X treats controls as standalone grapheme clusters")
+    void treatsControlsAsStandaloneGraphemeClusters() {
+      assertTraceSameAsJdk("\\X", "\r\u0301", 0, 2);
+      assertTraceSameAsJdk("\\X", "\n\u0301", 0, 2);
+      assertTraceSameAsJdk("\\X", "\u0000\u0301", 0, 2);
+      assertTraceSameAsJdk("\\X", "\u0600\r", 0, 2);
+      assertTraceSameAsJdk("\\X", "\u0600\n", 0, 2);
+      assertTraceSameAsJdk("\\X", "\u0600\uDE00", 0, 2);
+      assertTraceSameAsJdk("\\X", "\uD83D\u0301", 0, 2);
+      assertTraceSameAsJdk("\\X", "\uD83D\u200D", 0, 2);
+    }
+
+    @Test
+    @DisplayName("\\X keeps trailing extenders with non-base cluster forms")
+    void keepsTrailingExtendersWithNonBaseClusterForms() {
+      assertTraceSameAsJdk("\\X", "\uD83C\uDDFA\uD83C\uDDFA\u0301", 0, 5);
+      assertTraceSameAsJdk("\\X", "\uD83C\uDDFA\uD83C\uDDFA\u200D", 0, 5);
+      assertTraceSameAsJdk("\\X", "\uD83C\uDDFA\uD83C\uDDFA\uD83C\uDFFD", 0, 6);
+      assertTraceSameAsJdk("\\X\\X", "#\r\r\uD83C\uDDFA\uD83C\uDDFA\u0301$", 1, 8);
+      assertTraceSameAsJdk("\\X", "\u1100\u1161\u0301", 0, 3);
+      assertTraceSameAsJdk("\\X", "\uAC00\u11A8\u0301", 0, 3);
+    }
+
+    @Test
+    @DisplayName("\\X keeps prepend characters with following non-base cluster forms")
+    void keepsPrependCharactersWithFollowingNonBaseClusterForms() {
+      assertTraceSameAsJdk("\\X", "\u0600\uD83C\uDDFA\uD83C\uDDFA", 0, 5);
+      assertTraceSameAsJdk("\\X", "\u0600\u1100\u1161", 0, 3);
+      assertTraceSameAsJdk("\\X", "\u0600\uAC00\u11A8", 0, 3);
+      assertTraceSameAsJdk("\\X", "\u0600\u0301", 0, 2);
+      assertTraceSameAsJdk("\\X", "\u0600\uD83D\uDC69\u200D\uD83D\uDC69", 0, 6);
+      assertTraceSameAsJdk("\\X\\b{g}", "\u0600\uD83D\uDC69\u200D\uD83D\uDC69", 0, 6);
+    }
+
+    @Test
+    @DisplayName("\\X keeps ZWJ extenders inside pictographic sequences")
+    void keepsZwjExtendersInsidePictographicSequences() {
+      assertTraceSameAsJdk("\\X", "\uD83D\uDC69\u200D\u200D\uD83D\uDC69", 0, 6);
+      assertTraceSameAsJdk("\\X", "\uD83D\uDC69\u200D\u0301\u200D\uD83D\uDC69", 0, 7);
+      assertTraceSameAsJdk("\\X", "\uD83D\uDC69\u200D\uD83D\uDC69\u200D", 0, 6);
+      assertTraceSameAsJdk("\\X", "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\u0301", 0, 7);
+      assertTraceSameAsJdk(
+          "\\X\\X", "#\uDE00\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC69$", 1, 10);
+    }
+
+    @Test
+    @DisplayName("repeated find with an internal grapheme boundary follows JDK CRLF state")
+    void repeatedFindWithInternalGraphemeBoundaryFollowsJdkCrLfState() {
+      assertTraceSameAsJdk("\\r\\b{g}\\n", "#\r\n\r\n$", 1, 5);
+    }
+
+    @Test
+    @DisplayName("consecutive \\X atoms do not split leading extenders or Hangul clusters")
+    void consecutiveAtomsDoNotSplitLeadingExtendersOrHangulClusters() {
+      assertTraceSameAsJdk("\\X\\X", "\u200D\u0301", 0, 2);
+      assertTraceSameAsJdk("\\X\\X", "\u200D\u200D", 0, 2);
+      assertTraceSameAsJdk("\\X\\X", "\u1100\uAC01", 0, 2);
+    }
+
+    @Test
+    @DisplayName("\\X treats standalone low surrogates as separate from following extenders")
+    void treatsStandaloneLowSurrogatesAsSeparateFromFollowingExtenders() {
+      assertTraceSameAsJdk("\\X", "\uDE00\u0301", 0, 2);
+      assertTraceSameAsJdk("\\b{g}", "\uD83D\u0600\uD83D\uDE00", 1, 3);
+      assertTraceSameAsJdk("\\b{g}", "#\uDE00\u200D\u0301$", 1, 4);
+      assertTraceSameAsJdk("\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
+      assertFindGroupsSameAsJdk("(\\b{g})", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u200D\uD83D\uDE00", 1, 6);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u0301\uDE00", 1, 4);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\uD83C\uDDFA", 1, 5);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83C\uDDFA", 1, 6);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u0301\uD83C\uDDFA", 1, 6);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\uD83C\uDFFD\uD83D\uDE00", 1, 6);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\uD83C\uDFFD\u200D\uD83D\uDE00", 1, 7);
+      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDC69\u200D\uD83D\uDCBB\uDE00", 1, 5);
+      assertTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 5);
+      assertFindGroupsSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 5);
+      assertTraceSameAsJdk("\\X\\X", "\r\uDE00\u0301", 0, 3);
+      assertTraceSameAsJdk("\\X\\X", "\uDE00\uDE00\u0301", 0, 3);
+      assertTraceSameAsJdk("\\X\\X", "#\uDE00\uD83D\uDC69\u200D\uD83D\uDC69\u0301$", 1, 8);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8$", 1, 7);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\r\uD83C\uDDFA$", 1, 4);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\u200D\uD83D\uDC69$", 1, 4);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\r\r\uDE00", 1, 5);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\r\r", 1, 5);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\r\n", 1, 5);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uDE00\uDE00", 1, 5);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u0301\r", 1, 7);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u200D\uDE00a", 1, 8);
+      assertTraceSameAsJdk(
+          "\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u200D\uD83D\uDC69", 1, 8);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDC69\u0301a", 1, 8);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\u200D\uD83D\uDC69\u200Da", 1, 8);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83C\uDDFA", 1, 6);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D", 1, 5);
+      assertTraceSameAsJdk("^\\X\\X$", "\uD83D\uDE00\r\r\uDE00", 1, 4);
+      assertTraceSameAsJdk("^\\X\\X$", "\uD83D\uDE00a\u0903\r\n\uDE00", 1, 6);
+      assertTraceSameAsJdk(
+          "\\X\\X",
+          "#\uD83D\uDC69\uD83C\uDFFD\u200D\uD83D\uDC69\uD83C\uDFFD"
+              + "\u200D\uD83D\uDC69\uD83C\uDFFD$",
+          1,
+          15);
+    }
+
+    @Test
+    @DisplayName("repeated find does not split regional-indicator pairs after controls")
+    void repeatedFindDoesNotSplitRegionalIndicatorPairsAfterControls() {
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uAC01\uD83C\uDDFA\uD83C\uDDFA\r", 0, 6);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "a\uD83C\uDDFA\u200D\uD83C\uDDFA", 0, 6);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\r\u0903\u0903\u0903\u1100", 0, 5);
+      assertTraceSameAsJdk("\\X\\X", "#\r\r\uD83C\uDDFA\uD83C\uDDFA$", 1, 7);
     }
 
     @Test
@@ -541,6 +662,20 @@ class LinebreakGraphemeTest {
       assertThat(safeMatches)
           .as("find() positions for /%s/ on %s", regex, input)
           .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
+    private void assertFindGroupsSameAsJdk(String regex, String input, int start, int end) {
+      java.util.regex.Matcher jdkMatcher =
+          java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
+      Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
+
+      assertThat(safeMatcher.find()).as("SafeRE find() should match").isEqualTo(jdkMatcher.find());
+      assertThat(safeMatcher.groupCount()).isEqualTo(jdkMatcher.groupCount());
+      for (int group = 0; group <= jdkMatcher.groupCount(); group++) {
+        assertThat(safeMatcher.group(group))
+            .as("group %s for /%s/ on %s region [%s,%s]", group, regex, input, start, end)
+            .isEqualTo(jdkMatcher.group(group));
+      }
     }
 
     private void assertTraceSameAsJdk(String regex, String input, int start, int end) {


### PR DESCRIPTION
## Summary

Fixes #406.

This PR completes the expanded grapheme-cluster sweep work by making the full sweep clean against `java.util.regex` and fixing the remaining grapheme-cluster divergences exposed by the broader matrix.

Changes include:
- cache compiled JDK/SafeRE patterns in the grapheme sweep and make worker range partitioning efficient
- reduce grapheme sweep progress output to the character-class-style default cadence
- broaden grapheme cluster matching for leading extenders, prepend forms, CR/LF controls, Hangul, RI pairs, ZWJ/pictographic continuations, and split surrogate region contexts
- align repeated `find()` behavior for explicit grapheme-boundary cluster patterns with JDK behavior
- add focused public API regression coverage for the divergence classes found by the sweep

## Verification

Ran:
- `tools/exhaustive/run-grapheme-cluster-sweep.sh --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-full`
  - final summary: `checked=1265705280`, `divergences=0`, `buckets=0`, `threads=8`
  - `target/exhaustive-reports/grapheme-cluster-sweep-full/grapheme-cluster-divergences.jsonl` has 0 lines
- `mvn -pl safere -Dtest=LinebreakGraphemeTest test -q`
- `mvn -pl safere -Dtest='ParserTest$CharacterClasses#manyPlainCharacterClassesCompileWithinRegressionBound' test -q`
- `git diff --check origin/main..HEAD`

Also attempted:
- `mvn -pl safere test -q`
  - completed with one timeout in `ParserTest$CharacterClasses.manyPlainCharacterClassesCompileWithinRegressionBound`; rerunning that exact timed test passed, so this appears load-sensitive rather than a deterministic failure from this change.

Not run:
- crosscheck public API suite
