### PR TITLE
Fix exhaustive sweep runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,14 +269,14 @@ it enumerates a large generated matrix against `java.util.regex`; run it when
 working on character-class parsing:
 
 ```bash
-./run-exhaustive-sweep.sh character-class \
+./run-exhaustive-sweep.sh CharacterClassDivergenceSweep \
   --output-dir=target/exhaustive-reports/character-class-sweep-full
 ```
 
 Use generated-case ranges when debugging a specific matrix region:
 
 ```bash
-./run-exhaustive-sweep.sh character-class --range=:1000000 \
+./run-exhaustive-sweep.sh CharacterClassDivergenceSweep --range=:1000000 \
   --output-dir=target/exhaustive-reports/character-class-sweep-smoke
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -172,11 +172,11 @@ mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests
 mvn verify -pl safere-crosscheck -Pcrosscheck-public-api-tests
 
 # Run the long generated character-class syntax sweep
-./run-exhaustive-sweep.sh character-class \
+./run-exhaustive-sweep.sh CharacterClassDivergenceSweep \
   --output-dir=target/exhaustive-reports/character-class-sweep-full
 
 # Run a bounded generated-case range for local debugging
-./run-exhaustive-sweep.sh character-class --range=:1000000 \
+./run-exhaustive-sweep.sh CharacterClassDivergenceSweep --range=:1000000 \
   --output-dir=target/exhaustive-reports/character-class-sweep-smoke
 
 # Run Jazzer fuzz targets in regression mode

--- a/run-exhaustive-sweep.sh
+++ b/run-exhaustive-sweep.sh
@@ -4,29 +4,14 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 if [[ "$#" -lt 1 ]]; then
-  echo "usage: $0 {character-class|grapheme-cluster|control-escape} [sweep args...]" >&2
+  echo "usage: $0 SweepClassName [sweep args...]" >&2
+  echo "example: $0 CharacterClassDivergenceSweep --range=:1000000" >&2
   exit 2
 fi
 
-sweep="$1"
+sweep_class="$1"
 shift
-
-case "$sweep" in
-  character-class)
-    main_class="org.safere.exhaustive.CharacterClassDivergenceSweep"
-    ;;
-  grapheme-cluster)
-    main_class="org.safere.exhaustive.GraphemeClusterDivergenceSweep"
-    ;;
-  control-escape)
-    main_class="org.safere.exhaustive.ControlEscapeDivergenceSweep"
-    ;;
-  *)
-    echo "unknown exhaustive sweep: $sweep" >&2
-    echo "usage: $0 {character-class|grapheme-cluster|control-escape} [sweep args...]" >&2
-    exit 2
-    ;;
-esac
+main_class="org.safere.exhaustive.$sweep_class"
 
 quote_exec_arg() {
   local value="$1"
@@ -42,5 +27,5 @@ for arg in "$@"; do
   exec_args+="$(quote_exec_arg "$arg")"
 done
 
-mvn -pl safere-exhaustive -am -DskipTests compile -q
+mvn -pl safere-exhaustive -am -DskipTests install -q
 mvn -pl safere-exhaustive exec:java -Dexec.mainClass="$main_class" -Dexec.args="$exec_args" -q

--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -10,14 +10,14 @@ failed or interrupted run still leaves useful repro data.
 Run through the dispatcher script so dependency classpaths are handled by Maven:
 
 ```bash
-./run-exhaustive-sweep.sh character-class \
+./run-exhaustive-sweep.sh CharacterClassDivergenceSweep \
   --output-dir=target/exhaustive-reports/character-class-sweep-full
 ```
 
 For a smaller ad hoc local check, run a generated-case index range:
 
 ```bash
-./run-exhaustive-sweep.sh character-class --range=:1000000 \
+./run-exhaustive-sweep.sh CharacterClassDivergenceSweep --range=:1000000 \
   --output-dir=target/exhaustive-reports/character-class-sweep-smoke
 ```
 
@@ -44,14 +44,14 @@ stay out of git.
 Run through the dispatcher script:
 
 ```bash
-./run-exhaustive-sweep.sh grapheme-cluster \
+./run-exhaustive-sweep.sh GraphemeClusterDivergenceSweep \
   --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-full
 ```
 
 For a smaller ad hoc local check, run a generated-case index range:
 
 ```bash
-./run-exhaustive-sweep.sh grapheme-cluster --range=:250 \
+./run-exhaustive-sweep.sh GraphemeClusterDivergenceSweep --range=:250 \
   --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-smoke
 ```
 
@@ -94,19 +94,20 @@ use the same conventions as the other exhaustive sweeps.
 Run through the dispatcher script:
 
 ```bash
-./run-exhaustive-sweep.sh control-escape \
+./run-exhaustive-sweep.sh ControlEscapeDivergenceSweep \
   --output-dir=target/exhaustive-reports/control-escape-sweep-full
 ```
 
 For a smaller ad hoc local check, run a generated-case index range:
 
 ```bash
-./run-exhaustive-sweep.sh control-escape --range=:100000 \
+./run-exhaustive-sweep.sh ControlEscapeDivergenceSweep --range=:100000 \
   --output-dir=target/exhaustive-reports/control-escape-sweep-smoke
 ```
 
-The first argument selects the sweep. All remaining arguments are passed through
-unchanged to the Java sweep, which owns option defaults and validation.
+The first argument is the sweep class name in `org.safere.exhaustive`. All
+remaining arguments are passed through unchanged to the Java sweep, which owns
+option defaults and validation.
 
 The control-escape sweep enumerates every possible Java code point as the target
 of a `\cX` escape, including lone UTF-16 surrogate values. For each target it


### PR DESCRIPTION
## Summary

- Change `run-exhaustive-sweep.sh` to take the sweep class name directly, e.g. `CharacterClassDivergenceSweep`, and derive `org.safere.exhaustive.<ClassName>` without a maintained case table.
- Build reactor dependencies with `mvn -pl safere-exhaustive -am -DskipTests install` before `exec:java` so the runner works from a clean checkout without a preinstalled `safere` snapshot.
- Update exhaustive sweep docs to use the class-name form.

## Verification

- `./run-exhaustive-sweep.sh CharacterClassDivergenceSweep --range=:0 --output-dir=target/exhaustive-reports/followup-script-smoke`
- `mvn -pl safere-exhaustive test -q`
- `git diff --check`
