### PR TITLE
Fix grapheme NFA allocation scaling

### DIFF
--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -740,16 +740,15 @@ public final class CharacterClassDivergenceSweep {
   private static final class SweepState {
     final SweepRunState runState;
     final SweepOptions options;
+    final SweepWorkers.ProgressReporter progressReporter;
     final int workerIndex;
     long generated;
-    long nextProgressReport;
 
     SweepState(SweepRunState runState, int workerIndex) {
       this.runState = runState;
       this.options = runState.options;
+      this.progressReporter = new SweepWorkers.ProgressReporter(runState);
       this.workerIndex = workerIndex;
-      this.nextProgressReport =
-          SweepWorkers.firstProgressAt(options.rangeStartInclusive(), options.progressInterval());
     }
 
     void check5(
@@ -852,10 +851,9 @@ public final class CharacterClassDivergenceSweep {
         return false;
       }
       if (caseIndex % options.threads() != workerIndex) {
-        reportProgressIfNeeded();
         return false;
       }
-      runState.checked.increment();
+      progressReporter.checked();
       return true;
     }
 
@@ -883,13 +881,7 @@ public final class CharacterClassDivergenceSweep {
     }
 
     void reportProgressIfNeeded() {
-      if (generated < nextProgressReport) {
-        return;
-      }
-      runState.reportProgressIfNeeded(generated);
-      while (nextProgressReport <= generated) {
-        nextProgressReport += options.progressInterval();
-      }
+      progressReporter.reportIfNeeded(generated);
     }
   }
 

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
@@ -385,16 +385,15 @@ public final class ControlEscapeDivergenceSweep {
   private static final class SweepState {
     final SweepRunState runState;
     final SweepOptions options;
+    final SweepWorkers.ProgressReporter progressReporter;
     final int workerIndex;
     long generated;
-    long nextProgressReport;
 
     SweepState(SweepRunState runState, int workerIndex) {
       this.runState = runState;
       this.options = runState.options;
+      this.progressReporter = new SweepWorkers.ProgressReporter(runState);
       this.workerIndex = workerIndex;
-      this.nextProgressReport =
-          SweepWorkers.firstProgressAt(options.rangeStartInclusive(), options.progressInterval());
     }
 
     void run() {
@@ -406,10 +405,9 @@ public final class ControlEscapeDivergenceSweep {
           continue;
         }
         if (caseIndex % options.threads() != workerIndex) {
-          reportProgressIfNeeded();
           continue;
         }
-        runState.checked.increment();
+        progressReporter.checked();
         checkOwned(caseAt(caseIndex));
       }
     }
@@ -437,13 +435,7 @@ public final class ControlEscapeDivergenceSweep {
     }
 
     void reportProgressIfNeeded() {
-      if (generated < nextProgressReport) {
-        return;
-      }
-      runState.reportProgressIfNeeded(generated);
-      while (nextProgressReport <= generated) {
-        nextProgressReport += options.progressInterval();
-      }
+      progressReporter.reportIfNeeded(generated);
     }
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -918,16 +918,15 @@ public final class GraphemeClusterDivergenceSweep {
   private static final class SweepState {
     final SweepRunState runState;
     final SweepOptions options;
+    final SweepWorkers.ProgressReporter progressReporter;
     final int workerIndex;
     long generated;
-    long nextProgressReport;
 
     SweepState(SweepRunState runState, int workerIndex) {
       this.runState = runState;
       this.options = runState.options;
+      this.progressReporter = new SweepWorkers.ProgressReporter(runState);
       this.workerIndex = workerIndex;
-      this.nextProgressReport =
-          SweepWorkers.firstProgressAt(options.rangeStartInclusive(), options.progressInterval());
     }
 
     void run() {
@@ -936,7 +935,7 @@ public final class GraphemeClusterDivergenceSweep {
       while (generated < end) {
         long caseIndex = generated;
         generated += options.threads();
-        runState.checked.increment();
+        progressReporter.checked();
         checkOwned(caseAt(caseIndex));
       }
     }
@@ -969,13 +968,7 @@ public final class GraphemeClusterDivergenceSweep {
     }
 
     void reportProgressIfNeeded() {
-      if (generated < nextProgressReport) {
-        return;
-      }
-      runState.reportProgressIfNeeded(generated);
-      while (nextProgressReport <= generated) {
-        nextProgressReport += options.progressInterval();
-      }
+      progressReporter.reportIfNeeded(generated);
     }
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepRunState.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepRunState.java
@@ -22,7 +22,7 @@ final class SweepRunState implements AutoCloseable {
   final LongAdder divergences = new LongAdder();
   private final BufferedWriter jsonlWriter;
   long generated;
-  long nextProgressReport;
+  long nextCheckedProgressReport;
 
   SweepRunState(SweepOptions options) throws IOException {
     this.options = options;
@@ -32,8 +32,7 @@ final class SweepRunState implements AutoCloseable {
             StandardCharsets.UTF_8,
             StandardOpenOption.CREATE,
             StandardOpenOption.APPEND);
-    this.nextProgressReport =
-        SweepWorkers.firstProgressAt(options.rangeStartInclusive(), options.progressInterval());
+    this.nextCheckedProgressReport = options.progressInterval();
   }
 
   synchronized void recordGenerated(long workerGenerated) {
@@ -44,14 +43,15 @@ final class SweepRunState implements AutoCloseable {
 
   synchronized void reportProgressIfNeeded(long workerGenerated) {
     recordGenerated(workerGenerated);
-    if (generated < nextProgressReport) {
+    long checkedCount = checked.sum();
+    if (checkedCount < nextCheckedProgressReport) {
       return;
     }
     System.out.printf(
         "progress generated=%,d checked=%,d divergences=%,d buckets=%,d jsonl=%s%n",
-        generated, checked.sum(), divergences.sum(), buckets.size(), options.jsonlPath());
-    while (nextProgressReport <= generated) {
-      nextProgressReport += options.progressInterval();
+        generated, checkedCount, divergences.sum(), buckets.size(), options.jsonlPath());
+    while (nextCheckedProgressReport <= checkedCount) {
+      nextCheckedProgressReport += options.progressInterval();
     }
   }
 

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepWorkers.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepWorkers.java
@@ -79,6 +79,39 @@ final class SweepWorkers {
     return rangeStartInclusive + (progressInterval - remainder);
   }
 
+  static long progressProbeInterval(long progressInterval, int threads) {
+    return Math.max(1, progressInterval / threads);
+  }
+
+  static final class ProgressReporter {
+    private final SweepRunState runState;
+    private final long probeInterval;
+    private long checkedByWorker;
+    private long nextProbe;
+
+    ProgressReporter(SweepRunState runState) {
+      this.runState = runState;
+      this.probeInterval =
+          progressProbeInterval(runState.options.progressInterval(), runState.options.threads());
+      this.nextProbe = probeInterval;
+    }
+
+    void checked() {
+      checkedByWorker++;
+      runState.checked.increment();
+    }
+
+    void reportIfNeeded(long generated) {
+      if (checkedByWorker < nextProbe) {
+        return;
+      }
+      runState.reportProgressIfNeeded(generated);
+      while (nextProbe <= checkedByWorker) {
+        nextProbe += probeInterval;
+      }
+    }
+  }
+
   interface Worker {
     void run(int workerIndex) throws Exception;
   }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
@@ -7,6 +7,9 @@ package org.safere.exhaustive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -53,7 +56,54 @@ class SweepRunStateTest {
     }
   }
 
+  @Test
+  void progressReportsAreTriggeredByCheckedCases() throws Exception {
+    SweepOptions options = options(Integer.MAX_VALUE, 0);
+    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 10);
+
+    assertThat(output.toString(StandardCharsets.UTF_8))
+        .contains("progress generated=10 checked=10 divergences=0 buckets=0");
+  }
+
+  @Test
+  void progressReportsUseCurrentRunCheckedCountForNonzeroRanges() throws Exception {
+    SweepOptions options = options(Integer.MAX_VALUE, 1_000_000);
+    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 1_010_000);
+
+    assertThat(output.toString(StandardCharsets.UTF_8))
+        .contains("progress generated=1,010,000 checked=10 divergences=0 buckets=0");
+  }
+
+  private ByteArrayOutputStream progressOutputAfterCheckedCases(
+      SweepOptions options, long generated) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+
+    try (SweepRunState state = new SweepRunState(options)) {
+      try {
+        System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+        state.reportProgressIfNeeded(generated);
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEmpty();
+
+        for (int i = 0; i < 10; i++) {
+          state.checked.increment();
+        }
+        state.reportProgressIfNeeded(generated);
+      } finally {
+        System.setOut(originalOut);
+      }
+    }
+
+    return output;
+  }
+
   private SweepOptions options(int maxPerBucket) {
-    return new SweepOptions(0, Long.MAX_VALUE, maxPerBucket, tempDir, 10, 1, null, "out.jsonl");
+    return options(maxPerBucket, 0);
+  }
+
+  private SweepOptions options(int maxPerBucket, long rangeStartInclusive) {
+    return new SweepOptions(
+        rangeStartInclusive, Long.MAX_VALUE, maxPerBucket, tempDir, 10, 1, null, "out.jsonl");
   }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepWorkersTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepWorkersTest.java
@@ -69,4 +69,10 @@ class SweepWorkersTest {
     assertThat(SweepWorkers.firstProgressAt(20, 10)).isEqualTo(20);
     assertThat(SweepWorkers.firstProgressAt(21, 10)).isEqualTo(30);
   }
+
+  @Test
+  void progressProbeIntervalSplitsProgressIntervalAcrossWorkers() {
+    assertThat(SweepWorkers.progressProbeInterval(1_000, 4)).isEqualTo(250);
+    assertThat(SweepWorkers.progressProbeInterval(10, 16)).isEqualTo(1);
+  }
 }

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -363,44 +363,43 @@ final class Nfa {
    * ordinary SafeRE programs.
    */
   private void doSearchEveryCharPosition(String text, int startPos, int searchLimit) {
-    int queueCount = endPos + 2;
-    List<List<NfaThread>> queues = new ArrayList<>(queueCount);
-    List<Set<Integer>> queueSets = new ArrayList<>(queueCount);
-    for (int i = 0; i < queueCount; i++) {
-      queues.add(new ArrayList<>());
-      queueSets.add(new HashSet<>());
-    }
-
     int start = Math.max(0, startPos);
-    for (int pos = start; pos < queueCount; pos++) {
-      List<NfaThread> currentQueue = queues.get(pos);
-      Set<Integer> currentSet = queueSets.get(pos);
+    Set<Integer> runqSet = new HashSet<>();
+    Set<Integer> nextqSet = new HashSet<>();
+    List<NfaThread> secondq = new ArrayList<>();
+    Set<Integer> secondqSet = new HashSet<>();
 
+    for (int pos = start; pos < endPos + 2; pos++) {
       if (!matched && pos <= searchLimit) {
         int[] cap = new int[threadArraySize];
         Arrays.fill(cap, -1);
         cap[0] = pos;
-        addToThreadq(currentQueue, currentSet, prog.start(), text, pos, cap, 0, false);
+        addToThreadq(runq, runqSet, prog.start(), text, pos, cap, 0, false);
       }
 
-      if (currentQueue.isEmpty()) {
-        continue;
+      if (!runq.isEmpty()) {
+        int cp = (pos < endPos) ? text.codePointAt(pos) : -1;
+        int nextPos = (pos < endPos) ? pos + Character.charCount(cp) : endPos + 1;
+        List<NfaThread> destinationQueue = (nextPos == pos + 1) ? nextq : secondq;
+        Set<Integer> destinationSet = (nextPos == pos + 1) ? nextqSet : secondqSet;
+        step(runq, runqSet, destinationQueue, destinationSet, cp, text, pos, nextPos, false);
       }
 
-      int cp = (pos < endPos) ? text.codePointAt(pos) : -1;
-      int nextPos = (pos < endPos) ? pos + Character.charCount(cp) : endPos + 1;
-      List<NfaThread> destinationQueue = queues.get(nextPos);
-      Set<Integer> destinationSet = queueSets.get(nextPos);
-      step(
-          currentQueue,
-          currentSet,
-          destinationQueue,
-          destinationSet,
-          cp,
-          text,
-          pos,
-          nextPos,
-          false);
+      if (matched && runq.isEmpty() && nextq.isEmpty() && secondq.isEmpty()) {
+        break;
+      }
+
+      List<NfaThread> oldRunq = runq;
+      runq = nextq;
+      nextq = secondq;
+      secondq = oldRunq;
+      secondq.clear();
+
+      Set<Integer> oldRunqSet = runqSet;
+      runqSet = nextqSet;
+      nextqSet = secondqSet;
+      secondqSet = oldRunqSet;
+      secondqSet.clear();
     }
   }
 

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -8,9 +8,12 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -477,6 +480,27 @@ class LinebreakGraphemeTest {
     }
 
     @Test
+    @DisplayName("unanchored multi-boundary \\X search keeps bounded startup allocation")
+    void unanchoredMultiBoundarySearchKeepsBoundedStartupAllocation() {
+      AllocationTracker allocationTracker = allocationTracker();
+      long threadId = Thread.currentThread().threadId();
+      String text = "ab" + "c".repeat(100_000);
+
+      for (String regex : List.of("\\X\\X", "\\X{2}", "(?:\\X)(?:\\X)")) {
+        Pattern pattern = Pattern.compile(regex);
+
+        long before = allocationTracker.allocatedBytes(threadId);
+        Matcher matcher = pattern.matcher(text);
+        assertThat(matcher.find()).as("find() for /%s/", regex).isTrue();
+        assertThat(matcher.start()).as("start for /%s/", regex).isEqualTo(0);
+        assertThat(matcher.end()).as("end for /%s/", regex).isEqualTo(2);
+        long allocated = allocationTracker.allocatedBytes(threadId) - before;
+
+        assertThat(allocated).as("allocated bytes for /%s/", regex).isLessThan(4_000_000L);
+      }
+    }
+
+    @Test
     @DisplayName("consecutive \\X atoms do not split a single grapheme cluster")
     void consecutiveAtomsDoNotSplitSingleCluster() {
       Pattern p = Pattern.compile("^\\X\\X$");
@@ -708,6 +732,43 @@ class LinebreakGraphemeTest {
       assertThat(safeMatches)
           .as("find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
           .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
+    private AllocationTracker allocationTracker() {
+      try {
+        Class<?> managementFactoryClass = Class.forName("java.lang.management.ManagementFactory");
+        Object threadBean = managementFactoryClass.getMethod("getThreadMXBean").invoke(null);
+        Class<?> allocationBeanClass = Class.forName("com.sun.management.ThreadMXBean");
+        Assumptions.assumeTrue(allocationBeanClass.isInstance(threadBean));
+
+        Method supportedMethod = allocationBeanClass.getMethod("isThreadAllocatedMemorySupported");
+        Method enabledMethod = allocationBeanClass.getMethod("isThreadAllocatedMemoryEnabled");
+        Method setEnabledMethod =
+            allocationBeanClass.getMethod("setThreadAllocatedMemoryEnabled", boolean.class);
+        Method allocatedBytesMethod =
+            allocationBeanClass.getMethod("getThreadAllocatedBytes", long.class);
+
+        Assumptions.assumeTrue((Boolean) supportedMethod.invoke(threadBean));
+        if (!(Boolean) enabledMethod.invoke(threadBean)) {
+          setEnabledMethod.invoke(threadBean, true);
+        }
+        return new AllocationTracker(threadBean, allocatedBytesMethod);
+      } catch (ReflectiveOperationException e) {
+        Assumptions.abort("thread allocation tracking is unavailable: " + e);
+        throw new AssertionError("unreachable");
+      }
+    }
+
+    private record AllocationTracker(Object threadBean, Method allocatedBytesMethod) {
+      long allocatedBytes(long threadId) {
+        try {
+          return (Long) allocatedBytesMethod.invoke(threadBean, threadId);
+        } catch (IllegalAccessException e) {
+          throw new AssertionError(e);
+        } catch (InvocationTargetException e) {
+          throw new AssertionError(e.getCause());
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- replace eager per-character grapheme NFA queues with bounded rolling queues
- add a large-input allocation regression for unanchored multi-boundary `\X` searches
- make exhaustive sweep progress reporting trigger from checked cases while preserving low-contention worker-local throttling

Fixes #409

## Verification

- `mvn -pl safere -Dtest=LinebreakGraphemeTest test`
- `mvn -pl safere-exhaustive test`
- `./run-exhaustive-sweep.sh GraphemeClusterDivergenceSweep --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-full`
  - `checked=1265705280`
  - `totalCases=1265705280`
  - `divergences=0`
  - `buckets=0`
- `./run-exhaustive-sweep.sh GraphemeClusterDivergenceSweep --range=1000000:1000040 --progress-interval=10 --threads=4 --output-dir=target/exhaustive-reports/grapheme-cluster-sweep-progress-nonzero-smoke`

## Not Run

- Full `mvn -pl safere test -q` after the final progress-reporting refactor. Earlier during this fix, `mvn -pl safere test -q` completed with one unrelated transient timeout in `ParserTest$CharacterClasses.manyPlainCharacterClassesCompileWithinRegressionBound`; rerunning `mvn -pl safere -Dtest='ParserTest$CharacterClasses' test` passed.
- Full public API crosscheck profile.
