### PR TITLE
Add progress estimates to exhaustive sweeps

### DIFF
--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -232,7 +232,7 @@ public final class CharacterClassDivergenceSweep {
   }
 
   private static SweepRunState runSweep(SweepOptions options) throws IOException {
-    try (SweepRunState runState = new SweepRunState(options)) {
+    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
       SweepWorkers.run(
           options.threads(),
           "character-class-sweep-",
@@ -247,6 +247,15 @@ public final class CharacterClassDivergenceSweep {
           });
       return runState;
     }
+  }
+
+  private static long totalCases() {
+    return sum(
+        separatedSingleAmpersandCases(),
+        classicCases(),
+        chainedAmpersandCases(),
+        grammarSequenceCases(),
+        rawAmpersandBeforeCloseCases());
   }
 
   private static void runReplay(SweepOptions options) throws IOException {
@@ -301,6 +310,40 @@ public final class CharacterClassDivergenceSweep {
     object.addProperty("jdkError", jdk.error());
     object.addProperty("safeReError", safere.error());
     return SweepJson.toJson(object);
+  }
+
+  private static long classicCases() {
+    long cases = 0;
+    for (boolean comments : List.of(false, true)) {
+      long separators = comments ? COMMENT_SEPARATORS.size() : nonCommentSeparators().size();
+      long twoLeftCases =
+          product(
+              BASE_PIECES.size(),
+              BASE_PIECES.size(),
+              separators,
+              OPERATORS.size(),
+              separators,
+              RIGHT_PIECES.size(),
+              TRAILING_PIECES.size());
+      long rawAmpLeftCases =
+          product(
+              BASE_PIECES.size(),
+              AMPERSAND_PIECES.size(),
+              separators,
+              OPERATORS.size(),
+              separators,
+              RIGHT_PIECES.size(),
+              TRAILING_PIECES.size());
+      long noLeftCases =
+          product(
+              separators,
+              OPERATORS.size(),
+              separators,
+              RIGHT_PIECES.size(),
+              TRAILING_PIECES.size());
+      cases = Math.addExact(cases, product(2, sum(twoLeftCases, rawAmpLeftCases, noLeftCases)));
+    }
+    return cases;
   }
 
   private static void runClassicMatrix(SweepState state) {
@@ -380,6 +423,33 @@ public final class CharacterClassDivergenceSweep {
     }
   }
 
+  private static long chainedAmpersandCases() {
+    long rawAmpCases =
+        product(
+            LEFT_PIECES.size(),
+            COMMENT_SEPARATORS.size(),
+            OPERATORS.size(),
+            COMMENT_SEPARATORS.size(),
+            AMPERSAND_PIECES.size(),
+            COMMENT_SEPARATORS.size(),
+            SECOND_OPERATORS.size(),
+            COMMENT_SEPARATORS.size(),
+            RIGHT_PIECES.size(),
+            TRAILING_PIECES.size());
+    long nestedRhsCases =
+        product(
+            LEFT_PIECES.size(),
+            COMMENT_SEPARATORS.size(),
+            OPERATORS.size(),
+            COMMENT_SEPARATORS.size(),
+            nestedRights().size(),
+            COMMENT_SEPARATORS.size(),
+            SECOND_OPERATORS.size(),
+            COMMENT_SEPARATORS.size(),
+            RIGHT_PIECES.size());
+    return product(2, sum(rawAmpCases, nestedRhsCases));
+  }
+
   private static void runChainedAmpersandMatrix(SweepState state) {
     for (boolean negated : List.of(false, true)) {
       for (Piece left : LEFT_PIECES) {
@@ -450,6 +520,25 @@ public final class CharacterClassDivergenceSweep {
     }
   }
 
+  private static long grammarSequenceCases() {
+    long cases = 0;
+    for (boolean comments : List.of(false, true)) {
+      long trivia = comments ? GRAMMAR_ZERO_WIDTH_AND_TRIVIA.size() : nonCommentSeparators().size();
+      cases =
+          Math.addExact(
+              cases,
+              product(
+                  2,
+                  GRAMMAR_LEFT_ATOMS.size(),
+                  OPERATORS.size(),
+                  GRAMMAR_RHS_ATOMS.size(),
+                  GRAMMAR_TAILS.size(),
+                  trivia,
+                  GRAMMAR_TAILS.size()));
+    }
+    return cases;
+  }
+
   private static void runGrammarSequenceMatrix(SweepState state) {
     for (boolean comments : List.of(false, true)) {
       for (boolean negated : List.of(false, true)) {
@@ -480,6 +569,17 @@ public final class CharacterClassDivergenceSweep {
     }
   }
 
+  private static long rawAmpersandBeforeCloseCases() {
+    return product(
+        2,
+        LEFT_PIECES.size(),
+        AMPERSAND_PIECES.size(),
+        COMMENT_SEPARATORS.size(),
+        OPERATORS.size(),
+        COMMENT_SEPARATORS.size(),
+        RAW_AMPERSAND_CLOSE_TAILS.size());
+  }
+
   private static void runRawAmpersandBeforeCloseMatrix(SweepState state) {
     for (boolean negated : List.of(false, true)) {
       for (Piece left : LEFT_PIECES) {
@@ -505,6 +605,18 @@ public final class CharacterClassDivergenceSweep {
         }
       }
     }
+  }
+
+  private static long separatedSingleAmpersandCases() {
+    return product(
+        2,
+        LEFT_PIECES.size(),
+        COMMENT_SEPARATORS.size(),
+        AMPERSAND_PIECES.size(),
+        COMMENT_SEPARATORS.size(),
+        AMPERSAND_PIECES.size(),
+        nestedRights().size(),
+        RAW_AMPERSAND_CLOSE_TAILS.size());
   }
 
   private static void runSeparatedSingleAmpersandMatrix(SweepState state) {
@@ -547,6 +659,22 @@ public final class CharacterClassDivergenceSweep {
 
   private static Piece piece(String label, String text) {
     return new Piece(label, text);
+  }
+
+  private static long product(long... factors) {
+    long result = 1;
+    for (long factor : factors) {
+      result = Math.multiplyExact(result, factor);
+    }
+    return result;
+  }
+
+  private static long sum(long... values) {
+    long result = 0;
+    for (long value : values) {
+      result = Math.addExact(result, value);
+    }
+    return result;
   }
 
   private static Outcome jdkOutcome(String regex) {

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
@@ -71,7 +71,7 @@ public final class ControlEscapeDivergenceSweep {
   }
 
   private static SweepRunState runSweep(SweepOptions options) throws IOException {
-    try (SweepRunState runState = new SweepRunState(options)) {
+    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
       SweepWorkers.run(
           options.threads(),
           "control-escape-sweep-",

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -186,7 +186,7 @@ public final class GraphemeClusterDivergenceSweep {
   }
 
   private static SweepRunState runSweep(SweepOptions options) throws IOException {
-    try (SweepRunState runState = new SweepRunState(options)) {
+    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
       SweepWorkers.run(
           options.threads(),
           "grapheme-cluster-sweep-",

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepOptions.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepOptions.java
@@ -22,6 +22,14 @@ record SweepOptions(
     return outputDir.resolve(jsonlFileName);
   }
 
+  long totalChecks(long totalCases) {
+    long end = Math.min(rangeEndExclusive, totalCases);
+    if (rangeStartInclusive >= end) {
+      return 0;
+    }
+    return end - rangeStartInclusive;
+  }
+
   void printStartup(String sweepName) {
     System.out.println("sweep=" + sweepName);
     System.out.println("mode=" + (replayFile == null ? "sweep" : "replay"));

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepRunState.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepRunState.java
@@ -11,21 +11,37 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.LongSupplier;
 
 /** Shared state and reporting for exhaustive sweep runs. */
 final class SweepRunState implements AutoCloseable {
   final SweepOptions options;
+  final long totalChecks;
   final Map<String, Bucket> buckets = new LinkedHashMap<>();
   final LongAdder checked = new LongAdder();
   final LongAdder divergences = new LongAdder();
   private final BufferedWriter jsonlWriter;
+  private final LongSupplier nanoTime;
+  private final long startNanos;
   long generated;
   long nextCheckedProgressReport;
 
-  SweepRunState(SweepOptions options) throws IOException {
+  SweepRunState(SweepOptions options, long totalChecks) throws IOException {
+    this(options, totalChecks, System::nanoTime);
+  }
+
+  SweepRunState(SweepOptions options, long totalChecks, LongSupplier nanoTime) throws IOException {
+    if (totalChecks < 0) {
+      throw new IllegalArgumentException("totalChecks must be non-negative");
+    }
     this.options = options;
+    this.totalChecks = totalChecks;
+    this.nanoTime = nanoTime;
+    this.startNanos = nanoTime.getAsLong();
     this.jsonlWriter =
         Files.newBufferedWriter(
             options.jsonlPath(),
@@ -47,12 +63,43 @@ final class SweepRunState implements AutoCloseable {
     if (checkedCount < nextCheckedProgressReport) {
       return;
     }
+    double progress = totalChecks == 0 ? 100.0 : checkedCount * 100.0 / totalChecks;
+    long elapsedNanos = Math.max(0, nanoTime.getAsLong() - startNanos);
+    long remainingNanos = estimatedRemainingNanos(elapsedNanos, checkedCount);
     System.out.printf(
-        "progress generated=%,d checked=%,d divergences=%,d buckets=%,d jsonl=%s%n",
-        generated, checkedCount, divergences.sum(), buckets.size(), options.jsonlPath());
+        Locale.ROOT,
+        "progress=%.1f%% elapsed=%s eta=%s total=%,d checked=%,d divergences=%,d%n",
+        progress,
+        formatDuration(elapsedNanos),
+        formatDuration(remainingNanos),
+        totalChecks,
+        checkedCount,
+        divergences.sum());
     while (nextCheckedProgressReport <= checkedCount) {
       nextCheckedProgressReport += options.progressInterval();
     }
+  }
+
+  private long estimatedRemainingNanos(long elapsedNanos, long checkedCount) {
+    if (checkedCount == 0 || checkedCount >= totalChecks) {
+      return 0;
+    }
+    long remainingChecks = totalChecks - checkedCount;
+    return (long) (elapsedNanos * ((double) remainingChecks / checkedCount));
+  }
+
+  private static String formatDuration(long nanos) {
+    long totalSeconds = TimeUnit.NANOSECONDS.toSeconds(nanos);
+    long hours = totalSeconds / 3_600;
+    long minutes = (totalSeconds % 3_600) / 60;
+    long seconds = totalSeconds % 60;
+    if (hours > 0) {
+      return String.format(Locale.ROOT, "%dh%02dm%02ds", hours, minutes, seconds);
+    }
+    if (minutes > 0) {
+      return String.format(Locale.ROOT, "%dm%02ds", minutes, seconds);
+    }
+    return seconds + "s";
   }
 
   boolean reserveDivergenceExample(String bucketName) {

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
@@ -12,6 +12,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -23,7 +24,7 @@ class SweepRunStateTest {
   void bucketReservationCountsDivergencesEvenPastSavedExampleCap() throws Exception {
     SweepOptions options = options(1);
 
-    try (SweepRunState state = new SweepRunState(options)) {
+    try (SweepRunState state = new SweepRunState(options, 10)) {
       assertThat(state.reserveDivergenceExample("bucket")).isTrue();
       assertThat(state.reserveDivergenceExample("bucket")).isFalse();
 
@@ -36,7 +37,7 @@ class SweepRunStateTest {
   void appendJsonlWritesOneLinePerCall() throws Exception {
     SweepOptions options = options(Integer.MAX_VALUE);
 
-    try (SweepRunState state = new SweepRunState(options)) {
+    try (SweepRunState state = new SweepRunState(options, 10)) {
       state.appendJsonl("{\"a\":1}");
       state.appendJsonl("{\"b\":2}");
     }
@@ -48,7 +49,7 @@ class SweepRunStateTest {
   void recordsLargestGeneratedValue() throws Exception {
     SweepOptions options = options(Integer.MAX_VALUE);
 
-    try (SweepRunState state = new SweepRunState(options)) {
+    try (SweepRunState state = new SweepRunState(options, 10)) {
       state.recordGenerated(10);
       state.recordGenerated(5);
 
@@ -59,34 +60,45 @@ class SweepRunStateTest {
   @Test
   void progressReportsAreTriggeredByCheckedCases() throws Exception {
     SweepOptions options = options(Integer.MAX_VALUE, 0);
-    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 10);
+    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 10, 10, 10);
 
     assertThat(output.toString(StandardCharsets.UTF_8))
-        .contains("progress generated=10 checked=10 divergences=0 buckets=0");
+        .contains("progress=100.0% elapsed=1m40s eta=0s total=10 checked=10 divergences=0");
+  }
+
+  @Test
+  void progressReportsPercentageOfTotalChecks() throws Exception {
+    SweepOptions options = options(Integer.MAX_VALUE, 0);
+    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 853, 853, 1_000);
+
+    assertThat(output.toString(StandardCharsets.UTF_8))
+        .contains("progress=85.3% elapsed=1m40s eta=17s total=1,000 checked=853 divergences=0");
   }
 
   @Test
   void progressReportsUseCurrentRunCheckedCountForNonzeroRanges() throws Exception {
     SweepOptions options = options(Integer.MAX_VALUE, 1_000_000);
-    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 1_010_000);
+    ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 10, 1_010_000, 10);
 
     assertThat(output.toString(StandardCharsets.UTF_8))
-        .contains("progress generated=1,010,000 checked=10 divergences=0 buckets=0");
+        .contains("progress=100.0% elapsed=1m40s eta=0s total=10 checked=10 divergences=0");
   }
 
   private ByteArrayOutputStream progressOutputAfterCheckedCases(
-      SweepOptions options, long generated) throws Exception {
+      SweepOptions options, long checkedCases, long generated, long totalChecks) throws Exception {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     PrintStream originalOut = System.out;
+    TestClock clock = new TestClock();
 
-    try (SweepRunState state = new SweepRunState(options)) {
+    try (SweepRunState state = new SweepRunState(options, totalChecks, clock::nanoTime)) {
       try {
         System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
 
         state.reportProgressIfNeeded(generated);
         assertThat(output.toString(StandardCharsets.UTF_8)).isEmpty();
 
-        for (int i = 0; i < 10; i++) {
+        clock.advanceSeconds(100);
+        for (long i = 0; i < checkedCases; i++) {
           state.checked.increment();
         }
         state.reportProgressIfNeeded(generated);
@@ -105,5 +117,17 @@ class SweepRunStateTest {
   private SweepOptions options(int maxPerBucket, long rangeStartInclusive) {
     return new SweepOptions(
         rangeStartInclusive, Long.MAX_VALUE, maxPerBucket, tempDir, 10, 1, null, "out.jsonl");
+  }
+
+  private static final class TestClock {
+    private long nanos;
+
+    long nanoTime() {
+      return nanos;
+    }
+
+    void advanceSeconds(long seconds) {
+      nanos += TimeUnit.SECONDS.toNanos(seconds);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add percentage, elapsed time, ETA, total, checked, and divergence counts to exhaustive sweep progress lines.
- Require sweep run state callers to provide the invocation-specific total check count after applying --range.
- Add constant-time structural total-case counting for the character-class sweep matrix.

## Verification

- Ran: `mvn -pl safere-exhaustive test -q`
- Not run: full repository test suite
