### PR TITLE
Remove exhaustive sweep bucket retention

### DIFF
--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -86,8 +86,8 @@ operations.
 
 Use this sweep before review when changing grapheme-cluster parsing or boundary
 behavior. A run may report known or newly discovered divergences; inspect the
-JSONL output and bucket summary to triage them. Range bounds and replay files
-use the same conventions as the other exhaustive sweeps.
+JSONL output to triage them. Range bounds and replay files use the same
+conventions as the other exhaustive sweeps.
 
 ## Control Escape Sweep
 

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -226,7 +226,6 @@ public final class CharacterClassDivergenceSweep {
     System.out.println("checked=" + state.checked.sum());
     System.out.println("generated=" + state.generated);
     System.out.println("divergences=" + state.divergences.sum());
-    System.out.println("buckets=" + state.buckets.size());
     System.out.println("threads=" + options.threads());
     System.out.println("jsonl=" + options.jsonlPath());
   }
@@ -292,7 +291,6 @@ public final class CharacterClassDivergenceSweep {
     System.out.println("checked=" + checked);
     System.out.println("generated=" + generated);
     System.out.println("divergences=" + divergences);
-    System.out.println("buckets=" + divergences);
     System.out.println("threads=1");
     System.out.println("jsonl=" + options.jsonlPath());
     if (divergences > 0) {
@@ -994,10 +992,7 @@ public final class CharacterClassDivergenceSweep {
         return;
       }
       String bucketName = bucketFor(spec, jdk, safere);
-      if (!runState.reserveDivergenceExample(bucketName)) {
-        reportProgressIfNeeded();
-        return;
-      }
+      runState.recordDivergence();
       Divergence divergence =
           new Divergence(spec, regex, jdk, safere, bucketName, reduce(spec, jdk, safere));
       runState.appendJsonl(divergence.toJson());

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
@@ -65,7 +65,6 @@ public final class ControlEscapeDivergenceSweep {
     System.out.println("generated=" + state.generated);
     System.out.println("totalCases=" + totalCases());
     System.out.println("divergences=" + state.divergences.sum());
-    System.out.println("buckets=" + state.buckets.size());
     System.out.println("threads=" + options.threads());
     System.out.println("jsonl=" + options.jsonlPath());
   }
@@ -118,7 +117,6 @@ public final class ControlEscapeDivergenceSweep {
     System.out.println("checked=" + checked);
     System.out.println("generated=" + generated);
     System.out.println("divergences=" + divergences);
-    System.out.println("buckets=" + divergences);
     System.out.println("threads=1");
     System.out.println("jsonl=" + options.jsonlPath());
     if (divergences > 0) {
@@ -422,10 +420,7 @@ public final class ControlEscapeDivergenceSweep {
         return;
       }
       String bucketName = bucketFor(spec, jdk, safere);
-      if (!runState.reserveDivergenceExample(bucketName)) {
-        reportProgressIfNeeded();
-        return;
-      }
+      runState.recordDivergence();
       runState.appendJsonl(new Divergence(spec, regex, jdk, safere, bucketName).toJson());
       reportProgressIfNeeded();
     }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -180,7 +180,6 @@ public final class GraphemeClusterDivergenceSweep {
     System.out.println("inputCases=" + INPUT_CASES);
     System.out.println("inputFamilies=" + INPUT_SPACE.familySummary());
     System.out.println("divergences=" + state.divergences.sum());
-    System.out.println("buckets=" + state.buckets.size());
     System.out.println("threads=" + options.threads());
     System.out.println("jsonl=" + options.jsonlPath());
   }
@@ -231,7 +230,6 @@ public final class GraphemeClusterDivergenceSweep {
     System.out.println("checked=" + checked);
     System.out.println("generated=" + generated);
     System.out.println("divergences=" + divergences);
-    System.out.println("buckets=" + divergences);
     System.out.println("threads=1");
     System.out.println("jsonl=" + options.jsonlPath());
     if (divergences > 0) {
@@ -955,10 +953,7 @@ public final class GraphemeClusterDivergenceSweep {
         return;
       }
       String bucketName = bucketFor(spec, jdk, safere);
-      if (!runState.reserveDivergenceExample(bucketName)) {
-        reportProgressIfNeeded();
-        return;
-      }
+      runState.recordDivergence();
       runState.appendJsonl(new Divergence(spec, jdk, safere, bucketName).toJson());
       reportProgressIfNeeded();
     }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepOptions.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepOptions.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 record SweepOptions(
     long rangeStartInclusive,
     long rangeEndExclusive,
-    int maxPerBucket,
     Path outputDir,
     long progressInterval,
     int threads,
@@ -34,7 +33,6 @@ record SweepOptions(
     System.out.println("sweep=" + sweepName);
     System.out.println("mode=" + (replayFile == null ? "sweep" : "replay"));
     System.out.println("range=" + rangeDescription());
-    System.out.println("maxPerBucket=" + maxPerBucketDescription());
     System.out.println("outputDir=" + outputDir);
     System.out.println("progressInterval=" + progressInterval);
     System.out.println("threads=" + threads);
@@ -46,7 +44,6 @@ record SweepOptions(
       String[] args, Path defaultOutputDir, String jsonlFileName, long defaultProgressInterval) {
     long rangeStartInclusive = 0;
     long rangeEndExclusive = Long.MAX_VALUE;
-    int maxPerBucket = Integer.MAX_VALUE;
     Path outputDir = defaultOutputDir;
     long progressInterval = defaultProgressInterval;
     int threads = Runtime.getRuntime().availableProcessors();
@@ -62,9 +59,6 @@ record SweepOptions(
         String end = value.substring(colon + 1);
         rangeStartInclusive = start.isEmpty() ? 0 : Long.parseLong(start);
         rangeEndExclusive = end.isEmpty() ? Long.MAX_VALUE : Long.parseLong(end);
-      } else if (arg.startsWith("--max-per-bucket=")) {
-        String value = arg.substring("--max-per-bucket=".length());
-        maxPerBucket = value.equals("uncapped") ? Integer.MAX_VALUE : Integer.parseInt(value);
       } else if (arg.startsWith("--output-dir=")) {
         outputDir = Path.of(arg.substring("--output-dir=".length()));
       } else if (arg.startsWith("--progress-interval=")) {
@@ -83,9 +77,6 @@ record SweepOptions(
     if (rangeEndExclusive < rangeStartInclusive) {
       throw new IllegalArgumentException("--range end must be greater than or equal to start");
     }
-    if (maxPerBucket < 0) {
-      throw new IllegalArgumentException("--max-per-bucket must be non-negative");
-    }
     if (progressInterval < 1) {
       throw new IllegalArgumentException("--progress-interval must be at least 1");
     }
@@ -98,7 +89,6 @@ record SweepOptions(
     return new SweepOptions(
         rangeStartInclusive,
         rangeEndExclusive,
-        maxPerBucket,
         outputDir,
         progressInterval,
         threads,
@@ -109,9 +99,5 @@ record SweepOptions(
   private String rangeDescription() {
     String end = rangeEndExclusive == Long.MAX_VALUE ? "" : Long.toString(rangeEndExclusive);
     return rangeStartInclusive + ":" + end;
-  }
-
-  private String maxPerBucketDescription() {
-    return maxPerBucket == Integer.MAX_VALUE ? "uncapped" : Integer.toString(maxPerBucket);
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepRunState.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepRunState.java
@@ -10,9 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.LinkedHashMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongSupplier;
@@ -21,7 +19,6 @@ import java.util.function.LongSupplier;
 final class SweepRunState implements AutoCloseable {
   final SweepOptions options;
   final long totalChecks;
-  final Map<String, Bucket> buckets = new LinkedHashMap<>();
   final LongAdder checked = new LongAdder();
   final LongAdder divergences = new LongAdder();
   private final BufferedWriter jsonlWriter;
@@ -102,16 +99,8 @@ final class SweepRunState implements AutoCloseable {
     return seconds + "s";
   }
 
-  boolean reserveDivergenceExample(String bucketName) {
-    synchronized (this) {
-      divergences.increment();
-      Bucket bucket = buckets.computeIfAbsent(bucketName, Bucket::new);
-      if (bucket.savedExamples >= options.maxPerBucket()) {
-        return false;
-      }
-      bucket.savedExamples++;
-      return true;
-    }
+  void recordDivergence() {
+    divergences.increment();
   }
 
   synchronized void appendJsonl(String line) {
@@ -126,11 +115,5 @@ final class SweepRunState implements AutoCloseable {
   @Override
   public synchronized void close() throws IOException {
     jsonlWriter.close();
-  }
-
-  private static final class Bucket {
-    int savedExamples;
-
-    Bucket(String name) {}
   }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepOptionsTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepOptionsTest.java
@@ -24,7 +24,6 @@ class SweepOptionsTest {
 
     assertThat(options.rangeStartInclusive()).isZero();
     assertThat(options.rangeEndExclusive()).isEqualTo(Long.MAX_VALUE);
-    assertThat(options.maxPerBucket()).isEqualTo(Integer.MAX_VALUE);
     assertThat(options.outputDir()).isEqualTo(tempDir.resolve("out"));
     assertThat(options.progressInterval()).isEqualTo(123);
     assertThat(options.threads()).isEqualTo(Runtime.getRuntime().availableProcessors());
@@ -41,7 +40,6 @@ class SweepOptionsTest {
         SweepOptions.parse(
             new String[] {
               "--range=5:10",
-              "--max-per-bucket=7",
               "--output-dir=" + tempDir.resolve("custom"),
               "--progress-interval=99",
               "--threads=3",
@@ -53,7 +51,6 @@ class SweepOptionsTest {
 
     assertThat(options.rangeStartInclusive()).isEqualTo(5);
     assertThat(options.rangeEndExclusive()).isEqualTo(10);
-    assertThat(options.maxPerBucket()).isEqualTo(7);
     assertThat(options.outputDir()).isEqualTo(tempDir.resolve("custom"));
     assertThat(options.progressInterval()).isEqualTo(99);
     assertThat(options.threads()).isEqualTo(3);
@@ -61,17 +58,13 @@ class SweepOptionsTest {
   }
 
   @Test
-  void parsesOpenEndedRangeAndUncappedBucketLimit() {
+  void parsesOpenEndedRange() {
     SweepOptions options =
         SweepOptions.parse(
-            new String[] {"--range=5:", "--max-per-bucket=uncapped"},
-            tempDir.resolve("out"),
-            "divergences.jsonl",
-            123);
+            new String[] {"--range=5:"}, tempDir.resolve("out"), "divergences.jsonl", 123);
 
     assertThat(options.rangeStartInclusive()).isEqualTo(5);
     assertThat(options.rangeEndExclusive()).isEqualTo(Long.MAX_VALUE);
-    assertThat(options.maxPerBucket()).isEqualTo(Integer.MAX_VALUE);
   }
 
   @Test

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
@@ -21,21 +21,20 @@ class SweepRunStateTest {
   @TempDir Path tempDir;
 
   @Test
-  void bucketReservationCountsDivergencesEvenPastSavedExampleCap() throws Exception {
-    SweepOptions options = options(1);
+  void recordDivergenceCountsEveryDivergence() throws Exception {
+    SweepOptions options = options();
 
     try (SweepRunState state = new SweepRunState(options, 10)) {
-      assertThat(state.reserveDivergenceExample("bucket")).isTrue();
-      assertThat(state.reserveDivergenceExample("bucket")).isFalse();
+      state.recordDivergence();
+      state.recordDivergence();
 
       assertThat(state.divergences.sum()).isEqualTo(2);
-      assertThat(state.buckets).hasSize(1);
     }
   }
 
   @Test
   void appendJsonlWritesOneLinePerCall() throws Exception {
-    SweepOptions options = options(Integer.MAX_VALUE);
+    SweepOptions options = options();
 
     try (SweepRunState state = new SweepRunState(options, 10)) {
       state.appendJsonl("{\"a\":1}");
@@ -47,7 +46,7 @@ class SweepRunStateTest {
 
   @Test
   void recordsLargestGeneratedValue() throws Exception {
-    SweepOptions options = options(Integer.MAX_VALUE);
+    SweepOptions options = options();
 
     try (SweepRunState state = new SweepRunState(options, 10)) {
       state.recordGenerated(10);
@@ -59,7 +58,7 @@ class SweepRunStateTest {
 
   @Test
   void progressReportsAreTriggeredByCheckedCases() throws Exception {
-    SweepOptions options = options(Integer.MAX_VALUE, 0);
+    SweepOptions options = options(0);
     ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 10, 10, 10);
 
     assertThat(output.toString(StandardCharsets.UTF_8))
@@ -68,7 +67,7 @@ class SweepRunStateTest {
 
   @Test
   void progressReportsPercentageOfTotalChecks() throws Exception {
-    SweepOptions options = options(Integer.MAX_VALUE, 0);
+    SweepOptions options = options(0);
     ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 853, 853, 1_000);
 
     assertThat(output.toString(StandardCharsets.UTF_8))
@@ -77,7 +76,7 @@ class SweepRunStateTest {
 
   @Test
   void progressReportsUseCurrentRunCheckedCountForNonzeroRanges() throws Exception {
-    SweepOptions options = options(Integer.MAX_VALUE, 1_000_000);
+    SweepOptions options = options(1_000_000);
     ByteArrayOutputStream output = progressOutputAfterCheckedCases(options, 10, 1_010_000, 10);
 
     assertThat(output.toString(StandardCharsets.UTF_8))
@@ -110,13 +109,12 @@ class SweepRunStateTest {
     return output;
   }
 
-  private SweepOptions options(int maxPerBucket) {
-    return options(maxPerBucket, 0);
+  private SweepOptions options() {
+    return options(0);
   }
 
-  private SweepOptions options(int maxPerBucket, long rangeStartInclusive) {
-    return new SweepOptions(
-        rangeStartInclusive, Long.MAX_VALUE, maxPerBucket, tempDir, 10, 1, null, "out.jsonl");
+  private SweepOptions options(long rangeStartInclusive) {
+    return new SweepOptions(rangeStartInclusive, Long.MAX_VALUE, tempDir, 10, 1, null, "out.jsonl");
   }
 
   private static final class TestClock {


### PR DESCRIPTION
## Summary

- remove exhaustive sweep bucket caps and in-memory bucket retention
- always write every divergence to JSONL while keeping bucket labels for offline grouping
- remove bucket count/max-per-bucket reporting and update tests/docs

Fixes #418

## Verification

- `mvn -pl safere-exhaustive test -q`

## Not Run

- Full repository test suite
