### PR TITLE
Parallelize exhaustive replay evaluation

### DIFF
--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
@@ -258,56 +257,44 @@ public final class CharacterClassDivergenceSweep {
   }
 
   private static void runReplay(SweepOptions options) throws IOException {
-    long generated = 0;
-    long checked = 0;
-    long divergences = 0;
     try (BufferedReader reader =
-        Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8)) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        String trimmed = line.trim();
-        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-          continue;
-        }
-        generated++;
-        checked++;
-        String regex = SweepJson.field(trimmed, "regex");
-        regex = regex == null ? SweepJson.legacyUnescape(trimmed) : regex;
-        Outcome jdk = jdkOutcome(regex);
-        Outcome safere = safeReOutcome(regex);
-        if (semanticallyEqual(jdk, safere)) {
-          continue;
-        }
-        divergences++;
-        String replayLine = replayJson(regex, jdk, safere);
-        Files.writeString(
-            options.jsonlPath(),
-            replayLine + "\n",
-            StandardCharsets.UTF_8,
-            StandardOpenOption.CREATE,
-            StandardOpenOption.APPEND);
+            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(options, 0)) {
+      long generated =
+          SweepWorkers.runStreamingLines(
+              options.threads(),
+              "character-class-replay-",
+              reader,
+              line -> {
+                runState.checked.increment();
+                evaluateCase(runState, replayCase(line));
+              });
+      runState.recordGenerated(generated);
+      System.out.println("checked=" + runState.checked.sum());
+      System.out.println("generated=" + runState.generated);
+      System.out.println("divergences=" + runState.divergences.sum());
+      System.out.println("threads=" + options.threads());
+      System.out.println("jsonl=" + options.jsonlPath());
+      if (runState.divergences.sum() > 0) {
+        throw new IllegalStateException(
+            "replay found " + runState.divergences.sum() + " behavioral divergences");
       }
-    }
-    System.out.println("checked=" + checked);
-    System.out.println("generated=" + generated);
-    System.out.println("divergences=" + divergences);
-    System.out.println("threads=1");
-    System.out.println("jsonl=" + options.jsonlPath());
-    if (divergences > 0) {
-      throw new IllegalStateException("replay found " + divergences + " behavioral divergences");
     }
   }
 
-  private static String replayJson(String regex, Outcome jdk, Outcome safere) {
-    var object = SweepJson.object();
-    object.addProperty("regex", regex);
-    object.addProperty("jdkAccepted", jdk.accepted());
-    object.addProperty("safeReAccepted", safere.accepted());
-    object.addProperty("jdkMatches", jdk.matches());
-    object.addProperty("safeReMatches", safere.matches());
-    object.addProperty("jdkError", jdk.error());
-    object.addProperty("safeReError", safere.error());
-    return SweepJson.toJson(object);
+  private static CaseSpec replayCase(String line) {
+    var object = SweepJson.parseObject(line);
+    var caseObject = SweepJson.object(object, "case");
+    List<Piece> pieces = new ArrayList<>();
+    for (var element : SweepJson.array(caseObject, "pieces")) {
+      var piece = element.getAsJsonObject();
+      pieces.add(new Piece(SweepJson.string(piece, "label"), SweepJson.string(piece, "text")));
+    }
+    return new CaseSpec(
+        SweepJson.string(caseObject, "template"),
+        SweepJson.bool(caseObject, "comments"),
+        SweepJson.bool(caseObject, "negated"),
+        pieces);
   }
 
   private static long classicCases() {
@@ -848,6 +835,7 @@ public final class CharacterClassDivergenceSweep {
       CaseSpec spec, String regex, Outcome jdk, Outcome safere, String bucket, String reduced) {
     String toJson() {
       var object = SweepJson.object();
+      object.add("case", caseJson(spec));
       object.addProperty("bucket", bucket);
       object.addProperty("template", spec.template());
       object.addProperty("labels", spec.labels());
@@ -860,6 +848,22 @@ public final class CharacterClassDivergenceSweep {
       object.addProperty("jdkError", jdk.error());
       object.addProperty("safeReError", safere.error());
       return SweepJson.toJson(object);
+    }
+
+    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+      var object = SweepJson.object();
+      object.addProperty("template", spec.template());
+      object.addProperty("comments", spec.comments());
+      object.addProperty("negated", spec.negated());
+      var pieces = new com.google.gson.JsonArray();
+      for (Piece piece : spec.pieces()) {
+        var pieceObject = SweepJson.object();
+        pieceObject.addProperty("label", piece.label());
+        pieceObject.addProperty("text", piece.text());
+        pieces.add(pieceObject);
+      }
+      object.add("pieces", pieces);
+      return object;
     }
   }
 
@@ -889,7 +893,7 @@ public final class CharacterClassDivergenceSweep {
       if (!beginCase()) {
         return;
       }
-      checkOwned(new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5)));
+      evaluateCase(new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5)));
     }
 
     void check6(
@@ -905,7 +909,7 @@ public final class CharacterClassDivergenceSweep {
       if (!beginCase()) {
         return;
       }
-      checkOwned(new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5, p6)));
+      evaluateCase(new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5, p6)));
     }
 
     void check7(
@@ -922,7 +926,7 @@ public final class CharacterClassDivergenceSweep {
       if (!beginCase()) {
         return;
       }
-      checkOwned(new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5, p6, p7)));
+      evaluateCase(new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5, p6, p7)));
     }
 
     void check9(
@@ -941,7 +945,7 @@ public final class CharacterClassDivergenceSweep {
       if (!beginCase()) {
         return;
       }
-      checkOwned(
+      evaluateCase(
           new CaseSpec(template, comments, negated, List.of(p1, p2, p3, p4, p5, p6, p7, p8, p9)));
     }
 
@@ -962,7 +966,7 @@ public final class CharacterClassDivergenceSweep {
       if (!beginCase()) {
         return;
       }
-      checkOwned(
+      evaluateCase(
           new CaseSpec(
               template, comments, negated, List.of(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)));
     }
@@ -983,19 +987,8 @@ public final class CharacterClassDivergenceSweep {
       return true;
     }
 
-    void checkOwned(CaseSpec spec) {
-      String regex = spec.regex();
-      Outcome jdk = jdkOutcome(regex);
-      Outcome safere = safeReOutcome(regex);
-      if (semanticallyEqual(jdk, safere)) {
-        reportProgressIfNeeded();
-        return;
-      }
-      String bucketName = bucketFor(spec, jdk, safere);
-      runState.recordDivergence();
-      Divergence divergence =
-          new Divergence(spec, regex, jdk, safere, bucketName, reduce(spec, jdk, safere));
-      runState.appendJsonl(divergence.toJson());
+    void evaluateCase(CaseSpec spec) {
+      CharacterClassDivergenceSweep.evaluateCase(runState, spec);
       reportProgressIfNeeded();
     }
 
@@ -1006,6 +999,20 @@ public final class CharacterClassDivergenceSweep {
     void reportProgressIfNeeded() {
       progressReporter.reportIfNeeded(generated);
     }
+  }
+
+  private static void evaluateCase(SweepRunState runState, CaseSpec spec) {
+    String regex = spec.regex();
+    Outcome jdk = jdkOutcome(regex);
+    Outcome safere = safeReOutcome(regex);
+    if (semanticallyEqual(jdk, safere)) {
+      return;
+    }
+    String bucketName = bucketFor(spec, jdk, safere);
+    runState.recordDivergence();
+    Divergence divergence =
+        new Divergence(spec, regex, jdk, safere, bucketName, reduce(spec, jdk, safere));
+    runState.appendJsonl(divergence.toJson());
   }
 
   private static String reduce(CaseSpec spec, Outcome expectedJdk, Outcome expectedSafeRe) {

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -84,56 +83,43 @@ public final class ControlEscapeDivergenceSweep {
   }
 
   private static void runReplay(SweepOptions options) throws IOException {
-    long generated = 0;
-    long checked = 0;
-    long divergences = 0;
     try (BufferedReader reader =
-        Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8)) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        String trimmed = line.trim();
-        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-          continue;
-        }
-        generated++;
-        checked++;
-        String regex = SweepJson.field(trimmed, "regex");
-        regex = regex == null ? SweepJson.legacyUnescape(trimmed) : regex;
-        Outcome jdk = jdkOutcome(regex);
-        Outcome safere = safeReOutcome(regex);
-        if (semanticallyEqual(jdk, safere)) {
-          continue;
-        }
-        divergences++;
-        String replayLine = replayJson(regex, jdk, safere);
-        Files.writeString(
-            options.jsonlPath(),
-            replayLine + "\n",
-            StandardCharsets.UTF_8,
-            StandardOpenOption.CREATE,
-            StandardOpenOption.APPEND);
+            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(options, 0)) {
+      long generated =
+          SweepWorkers.runStreamingLines(
+              options.threads(),
+              "control-escape-replay-",
+              reader,
+              line -> {
+                runState.checked.increment();
+                evaluateCase(runState, replayCase(line));
+              });
+      runState.recordGenerated(generated);
+      System.out.println("checked=" + runState.checked.sum());
+      System.out.println("generated=" + runState.generated);
+      System.out.println("divergences=" + runState.divergences.sum());
+      System.out.println("threads=" + options.threads());
+      System.out.println("jsonl=" + options.jsonlPath());
+      if (runState.divergences.sum() > 0) {
+        throw new IllegalStateException(
+            "replay found " + runState.divergences.sum() + " behavioral divergences");
       }
-    }
-    System.out.println("checked=" + checked);
-    System.out.println("generated=" + generated);
-    System.out.println("divergences=" + divergences);
-    System.out.println("threads=1");
-    System.out.println("jsonl=" + options.jsonlPath());
-    if (divergences > 0) {
-      throw new IllegalStateException("replay found " + divergences + " behavioral divergences");
     }
   }
 
-  private static String replayJson(String regex, Outcome jdk, Outcome safere) {
-    var object = SweepJson.object();
-    object.addProperty("regex", regex);
-    object.addProperty("jdkAccepted", jdk.accepted());
-    object.addProperty("safeReAccepted", safere.accepted());
-    object.addProperty("jdkMatches", jdk.matches());
-    object.addProperty("safeReMatches", safere.matches());
-    object.addProperty("jdkError", jdk.error());
-    object.addProperty("safeReError", safere.error());
-    return SweepJson.toJson(object);
+  private static CaseSpec replayCase(String line) {
+    var object = SweepJson.parseObject(line);
+    var caseObject = SweepJson.object(object, "case");
+    return new CaseSpec(
+        SweepJson.integer(caseObject, "target"),
+        new Context(
+            SweepJson.string(caseObject, "contextLabel"),
+            SweepJson.string(caseObject, "contextTemplate")),
+        new FlagMode(
+            SweepJson.string(caseObject, "flagLabel"),
+            SweepJson.string(caseObject, "flagPrefix"),
+            SweepJson.integer(caseObject, "flags")));
   }
 
   private static long totalCases() {
@@ -364,6 +350,7 @@ public final class ControlEscapeDivergenceSweep {
       CaseSpec spec, String regex, Outcome jdk, Outcome safere, String bucket) {
     String toJson() {
       var object = SweepJson.object();
+      object.add("case", caseJson(spec));
       object.addProperty("bucket", bucket);
       object.addProperty("labels", spec.labels());
       object.addProperty("regex", regex);
@@ -377,6 +364,17 @@ public final class ControlEscapeDivergenceSweep {
       object.addProperty("jdkError", jdk.error());
       object.addProperty("safeReError", safere.error());
       return SweepJson.toJson(object);
+    }
+
+    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+      var object = SweepJson.object();
+      object.addProperty("target", spec.target());
+      object.addProperty("contextLabel", spec.context().label());
+      object.addProperty("contextTemplate", spec.context().template());
+      object.addProperty("flagLabel", spec.flagMode().label());
+      object.addProperty("flagPrefix", spec.flagMode().prefix());
+      object.addProperty("flags", spec.flagMode().flags());
+      return object;
     }
   }
 
@@ -406,22 +404,12 @@ public final class ControlEscapeDivergenceSweep {
           continue;
         }
         progressReporter.checked();
-        checkOwned(caseAt(caseIndex));
+        evaluateCase(caseAt(caseIndex));
       }
     }
 
-    void checkOwned(CaseSpec spec) {
-      String regex = spec.regex();
-      List<String> inputs = inputsFor(spec);
-      Outcome jdk = jdkOutcome(regex, spec.flagMode().flags(), inputs);
-      Outcome safere = safeReOutcome(regex, spec.flagMode().flags(), inputs);
-      if (semanticallyEqual(jdk, safere)) {
-        reportProgressIfNeeded();
-        return;
-      }
-      String bucketName = bucketFor(spec, jdk, safere);
-      runState.recordDivergence();
-      runState.appendJsonl(new Divergence(spec, regex, jdk, safere, bucketName).toJson());
+    void evaluateCase(CaseSpec spec) {
+      ControlEscapeDivergenceSweep.evaluateCase(runState, spec);
       reportProgressIfNeeded();
     }
 
@@ -432,5 +420,18 @@ public final class ControlEscapeDivergenceSweep {
     void reportProgressIfNeeded() {
       progressReporter.reportIfNeeded(generated);
     }
+  }
+
+  private static void evaluateCase(SweepRunState runState, CaseSpec spec) {
+    String regex = spec.regex();
+    List<String> inputs = inputsFor(spec);
+    Outcome jdk = jdkOutcome(regex, spec.flagMode().flags(), inputs);
+    Outcome safere = safeReOutcome(regex, spec.flagMode().flags(), inputs);
+    if (semanticallyEqual(jdk, safere)) {
+      return;
+    }
+    String bucketName = bucketFor(spec, jdk, safere);
+    runState.recordDivergence();
+    runState.appendJsonl(new Divergence(spec, regex, jdk, safere, bucketName).toJson());
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -199,41 +198,28 @@ public final class GraphemeClusterDivergenceSweep {
   }
 
   private static void runReplay(SweepOptions options) throws IOException {
-    long generated = 0;
-    long checked = 0;
-    long divergences = 0;
     try (BufferedReader reader =
-        Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8)) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        String trimmed = line.trim();
-        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-          continue;
-        }
-        generated++;
-        checked++;
-        CaseSpec spec = replayCase(trimmed);
-        Outcome jdk = jdkOutcome(spec);
-        Outcome safere = safeReOutcome(spec);
-        if (semanticallyEqual(jdk, safere)) {
-          continue;
-        }
-        divergences++;
-        Files.writeString(
-            options.jsonlPath(),
-            new Divergence(spec, jdk, safere, bucketFor(spec, jdk, safere)).toJson() + "\n",
-            StandardCharsets.UTF_8,
-            StandardOpenOption.CREATE,
-            StandardOpenOption.APPEND);
+            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(options, 0)) {
+      long generated =
+          SweepWorkers.runStreamingLines(
+              options.threads(),
+              "grapheme-cluster-replay-",
+              reader,
+              line -> {
+                runState.checked.increment();
+                evaluateCase(runState, replayCase(line));
+              });
+      runState.recordGenerated(generated);
+      System.out.println("checked=" + runState.checked.sum());
+      System.out.println("generated=" + runState.generated);
+      System.out.println("divergences=" + runState.divergences.sum());
+      System.out.println("threads=" + options.threads());
+      System.out.println("jsonl=" + options.jsonlPath());
+      if (runState.divergences.sum() > 0) {
+        throw new IllegalStateException(
+            "replay found " + runState.divergences.sum() + " behavioral divergences");
       }
-    }
-    System.out.println("checked=" + checked);
-    System.out.println("generated=" + generated);
-    System.out.println("divergences=" + divergences);
-    System.out.println("threads=1");
-    System.out.println("jsonl=" + options.jsonlPath());
-    if (divergences > 0) {
-      throw new IllegalStateException("replay found " + divergences + " behavioral divergences");
     }
   }
 
@@ -435,21 +421,23 @@ public final class GraphemeClusterDivergenceSweep {
   }
 
   private static CaseSpec replayCase(String line) {
-    String regex = SweepJson.field(line, "regex");
-    String input = SweepJson.field(line, "input");
-    String prefix = SweepJson.field(line, "prefix");
-    String suffix = SweepJson.field(line, "suffix");
-    String bounds = SweepJson.field(line, "bounds");
-    String operation = SweepJson.field(line, "operation");
-    if (regex == null || input == null || prefix == null || suffix == null) {
-      throw new IllegalArgumentException("replay line must contain regex, input, prefix, suffix");
-    }
+    var object = SweepJson.parseObject(line);
+    var caseObject = SweepJson.object(object, "case");
+    String regex = SweepJson.string(caseObject, "regex");
+    String regexLabel = SweepJson.string(caseObject, "regexLabel");
+    String input = SweepJson.string(caseObject, "input");
+    String inputLabel = SweepJson.string(caseObject, "inputLabel");
+    String regionLabel = SweepJson.string(caseObject, "region");
+    String prefix = SweepJson.string(caseObject, "prefix");
+    String suffix = SweepJson.string(caseObject, "suffix");
+    int regionStart = SweepJson.integer(caseObject, "regionStart");
+    int regionEnd = SweepJson.integer(caseObject, "regionEnd");
     return new CaseSpec(
-        new RegexTemplate("replay", regex),
-        new InputTemplate("replay", input),
-        region("replay", prefix, suffix, 0, 0),
-        bounds == null ? BOUNDS_MODES.get(0) : boundsMode(bounds),
-        operation == null ? OPERATION_MODES.get(0) : operationMode(operation));
+        new RegexTemplate(regexLabel, regex),
+        new InputTemplate(inputLabel, input),
+        new RegionMode(regionLabel, prefix, suffix, 0, 0, regionStart, regionEnd),
+        boundsMode(SweepJson.string(caseObject, "bounds")),
+        operationMode(SweepJson.string(caseObject, "operation")));
   }
 
   private static String bucketFor(CaseSpec spec, Outcome jdk, Outcome safere) {
@@ -893,6 +881,7 @@ public final class GraphemeClusterDivergenceSweep {
   private record Divergence(CaseSpec spec, Outcome jdk, Outcome safere, String bucket) {
     String toJson() {
       var object = SweepJson.object();
+      object.add("case", caseJson(spec));
       object.addProperty("bucket", bucket);
       object.addProperty("labels", spec.labels());
       object.addProperty("regex", spec.regex());
@@ -910,6 +899,22 @@ public final class GraphemeClusterDivergenceSweep {
       object.addProperty("jdkError", jdk.error());
       object.addProperty("safeReError", safere.error());
       return SweepJson.toJson(object);
+    }
+
+    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+      var object = SweepJson.object();
+      object.addProperty("regexLabel", spec.regexTemplate().label());
+      object.addProperty("regex", spec.regex());
+      object.addProperty("inputLabel", spec.inputTemplate().label());
+      object.addProperty("input", spec.input());
+      object.addProperty("region", spec.regionMode().label());
+      object.addProperty("prefix", spec.regionMode().prefix());
+      object.addProperty("suffix", spec.regionMode().suffix());
+      object.addProperty("regionStart", spec.regionStart());
+      object.addProperty("regionEnd", spec.regionEnd());
+      object.addProperty("bounds", spec.boundsMode().label());
+      object.addProperty("operation", spec.operationMode().label());
+      return object;
     }
   }
 
@@ -934,7 +939,7 @@ public final class GraphemeClusterDivergenceSweep {
         long caseIndex = generated;
         generated += options.threads();
         progressReporter.checked();
-        checkOwned(caseAt(caseIndex));
+        evaluateCase(caseAt(caseIndex));
       }
     }
 
@@ -945,16 +950,8 @@ public final class GraphemeClusterDivergenceSweep {
       return start + delta;
     }
 
-    void checkOwned(CaseSpec spec) {
-      Outcome jdk = jdkOutcome(spec);
-      Outcome safere = safeReOutcome(spec);
-      if (semanticallyEqual(jdk, safere)) {
-        reportProgressIfNeeded();
-        return;
-      }
-      String bucketName = bucketFor(spec, jdk, safere);
-      runState.recordDivergence();
-      runState.appendJsonl(new Divergence(spec, jdk, safere, bucketName).toJson());
+    void evaluateCase(CaseSpec spec) {
+      GraphemeClusterDivergenceSweep.evaluateCase(runState, spec);
       reportProgressIfNeeded();
     }
 
@@ -965,5 +962,16 @@ public final class GraphemeClusterDivergenceSweep {
     void reportProgressIfNeeded() {
       progressReporter.reportIfNeeded(generated);
     }
+  }
+
+  private static void evaluateCase(SweepRunState runState, CaseSpec spec) {
+    Outcome jdk = jdkOutcome(spec);
+    Outcome safere = safeReOutcome(spec);
+    if (semanticallyEqual(jdk, safere)) {
+      return;
+    }
+    String bucketName = bucketFor(spec, jdk, safere);
+    runState.recordDivergence();
+    runState.appendJsonl(new Divergence(spec, jdk, safere, bucketName).toJson());
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepJson.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepJson.java
@@ -6,6 +6,7 @@
 package org.safere.exhaustive;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -26,6 +27,72 @@ final class SweepJson {
   }
 
   static String field(String line, String field) {
+    JsonObject object = parseObjectOrNull(line);
+    if (object == null) {
+      return null;
+    }
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      return null;
+    }
+    return value.getAsString();
+  }
+
+  static JsonObject parseObject(String line) {
+    JsonObject object = parseObjectOrNull(line);
+    if (object == null) {
+      throw new IllegalArgumentException("expected JSON object: " + line);
+    }
+    return object;
+  }
+
+  static JsonObject object(JsonObject object, String field) {
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("missing JSON object field: " + field);
+    }
+    if (!value.isJsonObject()) {
+      throw new IllegalArgumentException("expected JSON object field: " + field);
+    }
+    return value.getAsJsonObject();
+  }
+
+  static JsonArray array(JsonObject object, String field) {
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("missing JSON array field: " + field);
+    }
+    if (!value.isJsonArray()) {
+      throw new IllegalArgumentException("expected JSON array field: " + field);
+    }
+    return value.getAsJsonArray();
+  }
+
+  static String string(JsonObject object, String field) {
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("missing JSON string field: " + field);
+    }
+    return value.getAsString();
+  }
+
+  static boolean bool(JsonObject object, String field) {
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("missing JSON boolean field: " + field);
+    }
+    return value.getAsBoolean();
+  }
+
+  static int integer(JsonObject object, String field) {
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("missing JSON integer field: " + field);
+    }
+    return value.getAsInt();
+  }
+
+  private static JsonObject parseObjectOrNull(String line) {
     JsonElement element;
     try {
       element = JsonParser.parseString(line);
@@ -35,42 +102,6 @@ final class SweepJson {
     if (!element.isJsonObject()) {
       return null;
     }
-    JsonElement value = element.getAsJsonObject().get(field);
-    if (value == null || value.isJsonNull()) {
-      return null;
-    }
-    return value.getAsString();
-  }
-
-  static String legacyUnescape(String value) {
-    StringBuilder result = new StringBuilder();
-    for (int i = 0; i < value.length(); i++) {
-      char c = value.charAt(i);
-      if (c != '\\') {
-        result.append(c);
-        continue;
-      }
-      if (++i >= value.length()) {
-        throw new IllegalArgumentException("trailing JSON escape in: " + value);
-      }
-      char escaped = value.charAt(i);
-      switch (escaped) {
-        case 'n' -> result.append('\n');
-        case 't' -> result.append('\t');
-        case 'r' -> result.append('\r');
-        case 'b' -> result.append('\b');
-        case 'f' -> result.append('\f');
-        case '"', '\\' -> result.append(escaped);
-        case 'u' -> {
-          if (i + 4 >= value.length()) {
-            throw new IllegalArgumentException("short JSON unicode escape in: " + value);
-          }
-          result.append((char) Integer.parseInt(value.substring(i + 1, i + 5), 16));
-          i += 4;
-        }
-        default -> result.append(escaped);
-      }
-    }
-    return result.toString();
+    return element.getAsJsonObject();
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepWorkers.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepWorkers.java
@@ -5,9 +5,14 @@
 
 package org.safere.exhaustive;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** Threading utilities for exhaustive sweep workers. */
@@ -83,6 +88,104 @@ final class SweepWorkers {
     return Math.max(1, progressInterval / threads);
   }
 
+  static long runStreamingLines(
+      int threads, String threadNamePrefix, BufferedReader reader, LineWorker worker)
+      throws IOException {
+    BlockingQueue<QueuedLine> queue = new ArrayBlockingQueue<>(Math.max(128, threads * 32));
+    AtomicLong produced = new AtomicLong();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    Thread producer =
+        new Thread(
+            () -> produceLines(reader, threads, queue, produced, failure),
+            threadNamePrefix + "reader");
+    List<Thread> workers = new ArrayList<>();
+    producer.start();
+    for (int i = 0; i < threads; i++) {
+      Thread thread = new Thread(() -> consumeLines(queue, worker, failure), threadNamePrefix + i);
+      thread.start();
+      workers.add(thread);
+    }
+    join(producer, "interrupted while waiting for replay reader");
+    for (Thread thread : workers) {
+      join(thread, "interrupted while waiting for replay workers");
+    }
+    Throwable throwable = failure.get();
+    if (throwable != null) {
+      propagate(throwable);
+    }
+    return produced.get();
+  }
+
+  private static void produceLines(
+      BufferedReader reader,
+      int threads,
+      BlockingQueue<QueuedLine> queue,
+      AtomicLong produced,
+      AtomicReference<Throwable> failure) {
+    try {
+      String line;
+      while (failure.get() == null && (line = reader.readLine()) != null) {
+        String trimmed = line.trim();
+        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+          continue;
+        }
+        putQueuedLine(queue, new QueuedLine(trimmed, false), failure);
+        produced.incrementAndGet();
+      }
+    } catch (Throwable t) {
+      failure.compareAndSet(null, t);
+    } finally {
+      if (failure.get() != null) {
+        queue.clear();
+      }
+      for (int i = 0; i < threads; i++) {
+        putQueuedLine(queue, new QueuedLine("", true), failure);
+      }
+    }
+  }
+
+  private static void consumeLines(
+      BlockingQueue<QueuedLine> queue, LineWorker worker, AtomicReference<Throwable> failure) {
+    try {
+      while (true) {
+        QueuedLine queuedLine = queue.poll(100, TimeUnit.MILLISECONDS);
+        if (queuedLine == null) {
+          if (failure.get() != null) {
+            return;
+          }
+          continue;
+        }
+        if (queuedLine.poison()) {
+          return;
+        }
+        worker.run(queuedLine.line());
+      }
+    } catch (Throwable t) {
+      failure.compareAndSet(null, t);
+    }
+  }
+
+  private static void putQueuedLine(
+      BlockingQueue<QueuedLine> queue, QueuedLine queuedLine, AtomicReference<Throwable> failure) {
+    try {
+      while (failure.get() == null && !queue.offer(queuedLine, 100, TimeUnit.MILLISECONDS)) {
+        // Retry until a worker drains the bounded queue or another thread fails.
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      failure.compareAndSet(null, e);
+    }
+  }
+
+  private static void join(Thread thread, String message) throws IOException {
+    try {
+      thread.join();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(message, e);
+    }
+  }
+
   static final class ProgressReporter {
     private final SweepRunState runState;
     private final long probeInterval;
@@ -115,4 +218,10 @@ final class SweepWorkers {
   interface Worker {
     void run(int workerIndex) throws Exception;
   }
+
+  interface LineWorker {
+    void run(String line) throws Exception;
+  }
+
+  private record QueuedLine(String line, boolean poison) {}
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -7,6 +7,9 @@ package org.safere.exhaustive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -43,7 +46,78 @@ class SweepCliSmokeTest {
     assertThat(Files.exists(outputDir.resolve("control-escape-divergences.jsonl"))).isTrue();
   }
 
+  @Test
+  void characterClassReplayUsesConfiguredThreads() throws Exception {
+    Path replayFile = tempDir.resolve("character-replay.jsonl");
+    Path outputDir = tempDir.resolve("character-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"template":"replay","comments":false,"negated":false,"pieces":[{"label":"literalA","text":"a"}]}}
+        """);
+
+    String output =
+        captureOutput(() -> CharacterClassDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
+    assertThat(output).doesNotContain("threads=1");
+  }
+
+  @Test
+  void controlEscapeReplayUsesConfiguredThreads() throws Exception {
+    Path replayFile = tempDir.resolve("control-replay.jsonl");
+    Path outputDir = tempDir.resolve("control-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"target":65,"contextLabel":"bare","contextTemplate":"\\\\c%s","flagLabel":"none","flagPrefix":"","flags":0}}
+        """);
+
+    String output =
+        captureOutput(() -> ControlEscapeDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
+    assertThat(output).doesNotContain("threads=1");
+  }
+
+  @Test
+  void graphemeClusterReplayUsesConfiguredThreads() throws Exception {
+    Path replayFile = tempDir.resolve("grapheme-replay.jsonl");
+    Path outputDir = tempDir.resolve("grapheme-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"regexLabel":"literal","regex":"a","inputLabel":"literal","input":"a","region":"full","prefix":"","suffix":"","regionStart":0,"regionEnd":1,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        """);
+
+    String output =
+        captureOutput(() -> GraphemeClusterDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
+    assertThat(output).doesNotContain("threads=1");
+  }
+
   private static String[] args(Path outputDir) {
     return new String[] {"--range=:10", "--threads=1", "--output-dir=" + outputDir};
+  }
+
+  private static String[] replayArgs(Path outputDir, Path replayFile) {
+    return new String[] {"--threads=2", "--output-dir=" + outputDir, "--replay-file=" + replayFile};
+  }
+
+  private static String captureOutput(ThrowingRunnable runnable) throws Exception {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+    try {
+      System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+      runnable.run();
+    } finally {
+      System.setOut(originalOut);
+    }
+    return output.toString(StandardCharsets.UTF_8);
+  }
+
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepJsonTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepJsonTest.java
@@ -6,6 +6,7 @@
 package org.safere.exhaustive;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,26 @@ class SweepJsonTest {
   }
 
   @Test
-  void legacyUnescapeDecodesOldReplayEscapes() {
-    assertThat(SweepJson.legacyUnescape("a\\nb\\t\\u0041\\\\\\\"")).isEqualTo("a\nb\tA\\\"");
+  void readsStructuredJsonFields() {
+    var object = SweepJson.object();
+    var nested = SweepJson.object();
+    nested.addProperty("text", "abc");
+    nested.addProperty("enabled", true);
+    nested.addProperty("count", 7);
+    object.add("nested", nested);
+
+    var parsed = SweepJson.parseObject(SweepJson.toJson(object));
+    var parsedNested = SweepJson.object(parsed, "nested");
+
+    assertThat(SweepJson.string(parsedNested, "text")).isEqualTo("abc");
+    assertThat(SweepJson.bool(parsedNested, "enabled")).isTrue();
+    assertThat(SweepJson.integer(parsedNested, "count")).isEqualTo(7);
+  }
+
+  @Test
+  void parseObjectRejectsLegacyRawReplayLine() {
+    assertThatThrownBy(() -> SweepJson.parseObject("\\Qabc\\E"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("expected JSON object");
   }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepWorkersTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepWorkersTest.java
@@ -8,7 +8,9 @@ package org.safere.exhaustive;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,34 @@ class SweepWorkersTest {
                     2,
                     "test-",
                     workerIndex -> {
+                      throw failure;
+                    }))
+        .isSameAs(failure);
+  }
+
+  @Test
+  void streamingLinesUsesWorkersAndSkipsBlankAndCommentLines() throws Exception {
+    Set<String> lines = new ConcurrentSkipListSet<>();
+
+    long produced =
+        SweepWorkers.runStreamingLines(
+            3, "test-", new BufferedReader(new StringReader("a\n\n# comment\nb\nc\n")), lines::add);
+
+    assertThat(produced).isEqualTo(3);
+    assertThat(lines).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  void streamingLineWorkerExceptionsPropagateWithoutWrapping() {
+    IllegalStateException failure = new IllegalStateException("boom");
+
+    assertThatThrownBy(
+            () ->
+                SweepWorkers.runStreamingLines(
+                    2,
+                    "test-",
+                    new BufferedReader(new StringReader("a\nb\n")),
+                    line -> {
                       throw failure;
                     }))
         .isSameAs(failure);


### PR DESCRIPTION
## Summary

- make replay JSONL store structured case data so replay reconstructs each sweep case spec
- run replay through a bounded streaming line queue with `--threads` worker evaluators
- share `evaluateCase` between generated and replay paths for all three exhaustive sweeps
- add replay smoke tests for character-class, control-escape, and grapheme-cluster sweeps with `--threads=2`

## Notes

- This intentionally does not preserve compatibility with older replay JSONL formats.

## Verification

- `mvn -pl safere-exhaustive test -q`
- `mvn -pl safere-exhaustive spotless:check -q`

## Not Run

- Full repository test suite
