### PR TITLE
Fix grapheme replay of surrogate-boundary cases

### DIFF
--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -436,7 +436,7 @@ public final class GraphemeClusterDivergenceSweep {
         new RegexTemplate(regexLabel, regex),
         new InputTemplate(inputLabel, input),
         new RegionMode(regionLabel, prefix, suffix, 0, 0, regionStart, regionEnd),
-        boundsMode(SweepJson.string(caseObject, "bounds")),
+        replayBoundsMode(SweepJson.string(caseObject, "bounds")),
         operationMode(SweepJson.string(caseObject, "operation")));
   }
 
@@ -528,6 +528,14 @@ public final class GraphemeClusterDivergenceSweep {
         .filter(mode -> mode.label().equals(label))
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException("unknown bounds mode: " + label));
+  }
+
+  private static BoundsMode replayBoundsMode(String label) {
+    return switch (label) {
+      case "transparentAnchoring" -> bounds("transparentAnchoring", true, true);
+      case "transparentNonAnchoring" -> bounds("transparentNonAnchoring", true, false);
+      default -> boundsMode(label);
+    };
   }
 
   private static OperationMode operationMode(String label) {

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepJson.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/SweepJson.java
@@ -23,7 +23,7 @@ final class SweepJson {
   }
 
   static String toJson(JsonObject object) {
-    return GSON.toJson(object);
+    return escapeUnpairedSurrogates(GSON.toJson(object));
   }
 
   static String field(String line, String field) {
@@ -103,5 +103,35 @@ final class SweepJson {
       return null;
     }
     return element.getAsJsonObject();
+  }
+
+  private static String escapeUnpairedSurrogates(String json) {
+    StringBuilder result = new StringBuilder(json.length());
+    for (int i = 0; i < json.length(); i++) {
+      char c = json.charAt(i);
+      if (Character.isHighSurrogate(c)) {
+        if (i + 1 < json.length() && Character.isLowSurrogate(json.charAt(i + 1))) {
+          result.append(c);
+          result.append(json.charAt(i + 1));
+          i++;
+        } else {
+          appendUnicodeEscape(result, c);
+        }
+      } else if (Character.isLowSurrogate(c)) {
+        appendUnicodeEscape(result, c);
+      } else {
+        result.append(c);
+      }
+    }
+    return result.toString();
+  }
+
+  private static void appendUnicodeEscape(StringBuilder result, char c) {
+    result.append("\\u");
+    String hex = Integer.toHexString(c);
+    for (int i = hex.length(); i < 4; i++) {
+      result.append('0');
+    }
+    result.append(hex);
   }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepJsonTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepJsonTest.java
@@ -26,6 +26,19 @@ class SweepJsonTest {
   }
 
   @Test
+  void toJsonEscapesUnpairedSurrogates() {
+    var object = SweepJson.object();
+    object.addProperty("high", "\uD83D");
+    object.addProperty("low", "\uDE00");
+    object.addProperty("pair", "\uD83D\uDE00");
+
+    String line = SweepJson.toJson(object);
+
+    assertThat(line).contains("\"high\":\"\\ud83d\"", "\"low\":\"\\ude00\"");
+    assertThat(line).contains("😀");
+  }
+
+  @Test
   void fieldReturnsNullForLegacyRawReplayLine() {
     assertThat(SweepJson.field("\\Qabc\\E", "regex")).isNull();
   }


### PR DESCRIPTION
## Summary

- allow grapheme replay JSONL to reconstruct transparent bounds modes present in existing structured reports
- escape unpaired surrogate code units when writing JSONL so surrogate-boundary cases can be replayed and re-reported

## Context

- Found while benchmarking a 1,000,000-line subset of the grapheme replay file under `target/replay-bench/grapheme-replay-1m.jsonl`.
- The batching experiment was not kept; queue batching was effectively tied with the current one-line queue on this workload.

## Verification

- `mvn -pl safere-exhaustive test -q`
- `mvn -pl safere-exhaustive spotless:check -q`

## Not Run

- Full repository test suite
