### PR TITLE
Fix JDK syntax compatibility for dangling quantifiers on reluctant quantifiers (`^+?+`)

### DIFF
--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -684,7 +684,11 @@ final class Parser {
   }
 
   private boolean canRepeatAfterUnary(RegexpOp op) {
-    return op == RegexpOp.PLUS && stacktop != null && isQuantifiedZeroWidth(stacktop.re);
+    return op == RegexpOp.PLUS
+        && stacktop != null
+        && stacktop.re.op == RegexpOp.PLUS
+        && !stacktop.re.nonGreedy()
+        && isQuantifiedZeroWidth(stacktop.re);
   }
 
   private boolean isQuantifiedZeroWidth(Regexp re) {

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -764,6 +764,13 @@ class ParserTest {
       Regexp re = parse("a*\\{");
       assertThat(re.op).isEqualTo(RegexpOp.CONCAT);
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"^+?+", "$*?+", "\\b+?+", "()+?+", "a+?+"})
+    void danglingQuantifierOnReluctantQuantifierRejected(String pattern) {
+      assertThatThrownBy(() -> parse(pattern))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -768,8 +768,7 @@ class ParserTest {
     @ParameterizedTest
     @ValueSource(strings = {"^+?+", "$*?+", "\\b+?+", "()+?+", "a+?+"})
     void danglingQuantifierOnReluctantQuantifierRejected(String pattern) {
-      assertThatThrownBy(() -> parse(pattern))
-          .isInstanceOf(PatternSyntaxException.class);
+      assertThatThrownBy(() -> parse(pattern)).isInstanceOf(PatternSyntaxException.class);
     }
   }
 


### PR DESCRIPTION
Standard `java.util.regex` rejects applying a quantifier directly to a reluctant quantifier (such as `+` applied to `+?` in `^+?+` or `a+?+`) with a `PatternSyntaxException` ("Dangling meta character '+'").

SafeRE correctly rejected nested quantifiers on standard atoms (`a+?+`) as invalid nested repetition operators. However, its coalescing rule for repeated zero-width assertions (`canRepeatAfterUnary()`) inspected only whether the target expression was zero-width (`isQuantifiedZeroWidth`), without verifying whether the preceding quantifier was greedy (`+`) or reluctant (`+?`). As a result, SafeRE incorrectly permitted `+` to coalesce with `+?` on zero-width assertions, accepting invalid patterns like `^+?+`.

**Changes:**
- Updated `canRepeatAfterUnary()` in `Parser.java` to require that the preceding quantifier on the parse stack was strictly greedy (`stacktop.re.op == RegexpOp.PLUS && !stacktop.re.nonGreedy()`).
- Attempts to quantify a reluctant quantifier on an anchor or empty group (e.g., `^+?+`, `()+?+`) are now immediately rejected with a `PatternSyntaxException` ("invalid nested repetition operator").
- Existing valid coalescing behaviors (like `^++`, `^{3,}`, or comments-mode coalescing `(?x) ^+ \n\n +^`) remain fully supported.
- Added parameterized test coverage in `ParserTest.java` verifying rejection across `^+?+`, `$*?+`, `\b+?+`, `()+?+`, and `a+?+`.

Fixes https://github.com/eaftan/safere/issues/391