### PR TITLE
Warn about hitEnd and requireEnd compatibility

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2481,6 +2481,11 @@ public final class Matcher implements MatchResult {
    * performed by this matcher. When this method returns true, it is possible that more input would
    * have changed the result of the last search.
    *
+   * <p><strong>Warning:</strong> support for this method is best effort. SafeRE's linear-time
+   * engines explore matches differently from the JDK's backtracking engine, so exactly matching JDK
+   * behavior for this method is fundamentally difficult and may be impossible in some cases. Use
+   * this method with caution if exact JDK parity is required.
+   *
    * @return true if the end of input was hit in the last match; false otherwise
    */
   public boolean hitEnd() {
@@ -2497,6 +2502,11 @@ public final class Matcher implements MatchResult {
    * {@code $}, {@code \Z}, or word-boundary assertions ({@code \b}, {@code \B}) and the last match
    * reached the end of the input region. Like the JDK, {@code \z} does not trigger {@code
    * requireEnd}.
+   *
+   * <p><strong>Warning:</strong> support for this method is best effort. SafeRE's linear-time
+   * engines explore matches differently from the JDK's backtracking engine, so exactly matching JDK
+   * behavior for this method is fundamentally difficult and may be impossible in some cases. Use
+   * this method with caution if exact JDK parity is required.
    *
    * @return true if more input could change a positive match into a negative one
    */


### PR DESCRIPTION
## Summary
- Add best-effort compatibility warnings to the Javadocs for `Matcher.hitEnd()` and `Matcher.requireEnd()`.
- Explain that exact JDK parity is difficult or impossible because SafeRE uses linear-time engines rather than JDK-style backtracking.

Fixes #411

## Verification
- `mvn -pl safere -DskipTests compile -q`

## Not run
- Full test suite (documentation-only change).
