### PR TITLE
Add required-class matches fast reject

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -12,9 +12,20 @@ final class MatchFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void match(FuzzedDataProvider data) {
-    String regex = data.consumeString(256);
-    int flags = FuzzSupport.consumeFlags(data);
-    String input = data.consumeRemainingAsString();
+    String regex;
+    int flags;
+    String input;
+    if (data.consumeBoolean()) {
+      String atom = distinctLiteralRun(data.consumeInt(16, 192));
+      int repetitions = data.consumeInt(1, 16);
+      regex = "(?:" + atom + "){" + repetitions + "}";
+      flags = 0;
+      input = data.consumeBoolean() ? atom.repeat(repetitions) : data.consumeString(512);
+    } else {
+      regex = data.consumeString(256);
+      flags = FuzzSupport.consumeFlags(data);
+      input = data.consumeRemainingAsString();
+    }
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, flags);
     if (pattern == null) {
       return;
@@ -28,5 +39,13 @@ final class MatchFuzzer {
     matcher.find();
     matcher.reset();
     matcher.find(FuzzSupport.consumeIndex(data, input));
+  }
+
+  private static String distinctLiteralRun(int count) {
+    StringBuilder pattern = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      pattern.appendCodePoint(0x1000 + i * 2);
+    }
+    return pattern.toString();
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -441,6 +441,22 @@ public final class Matcher implements MatchResult {
     return applyEngineResult(new NoMatchResult());
   }
 
+  private boolean containsRequiredMatchClass(int[] ranges) {
+    long b0 = parentPattern.requiredMatchClassBitmap0();
+    long b1 = parentPattern.requiredMatchClassBitmap1();
+
+    int i = 0;
+    int len = text.length();
+    while (i < len) {
+      int cp = text.codePointAt(i);
+      if (charClassContains(ranges, b0, b1, cp)) {
+        return true;
+      }
+      i += Character.charCount(cp);
+    }
+    return false;
+  }
+
   /**
    * Checks if the remaining input from {@code offset} is a prefix of the literal pattern but
    * shorter than it, meaning more input could potentially result in a match.
@@ -719,6 +735,16 @@ public final class Matcher implements MatchResult {
     int[] ccRanges = parentPattern.charClassMatchRanges();
     if (enginePathOptions().charClassMatchFastPaths() && ccRanges != null) {
       return charClassMatchFastPath(ccRanges);
+    }
+
+    int[] requiredRanges = parentPattern.requiredMatchClassRanges();
+    if (enginePathOptions().charClassMatchFastPaths()
+        && requiredRanges != null
+        && !containsRequiredMatchClass(requiredRanges)) {
+      // This negative-only accelerator may conservatively over-report hitEnd for some failed
+      // matches; hitEnd/requireEnd compatibility is best-effort. See #435.
+      this.lastEngineHitEnd = true;
+      return applyEngineResult(new NoMatchResult());
     }
 
     Prog prog = parentPattern.prog();

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -41,6 +41,12 @@ final class OnePass {
 
   private static final int MAX_CAP_REGS = 2 * MAX_CAPTURE_GROUPS;
 
+  // OnePass is an optional accelerator. Keep its dense transition table within a fixed raw
+  // payload budget and fall back to the other engines when a pattern would exceed it.
+  private static final int MAX_STATES = 65_000;
+  private static final long MAX_ACTION_BYTES = 16L * 1024L * 1024L;
+  static final long MAX_ACTION_CELLS = MAX_ACTION_BYTES / Long.BYTES;
+
   // -------------------------------------------------------------------------
   // Action encoding: each action is packed into a single long.
   //
@@ -118,20 +124,17 @@ final class OnePass {
   private final long matchStateBits;
 
   private OnePass(
-      long[][] actions,
+      long[] flatActions,
+      int numStates,
+      int numClasses,
       long[] matchAction,
       int[] boundaries,
       boolean anchorEnd,
       boolean dollarAnchorEnd,
       boolean unixLines,
       boolean hasGraphemeClusterBoundary) {
-    int numStates = actions.length;
-    int nc = (numStates > 0) ? actions[0].length : 0;
-    this.numClasses = nc;
-    this.flatActions = new long[numStates * nc];
-    for (int s = 0; s < numStates; s++) {
-      System.arraycopy(actions[s], 0, flatActions, s * nc, nc);
-    }
+    this.numClasses = numClasses;
+    this.flatActions = flatActions;
     this.matchAction = matchAction;
     this.boundaries = boundaries;
     this.asciiClassMap = buildAsciiClassMap(boundaries);
@@ -160,7 +163,8 @@ final class OnePass {
 
   /**
    * Attempts to build a one-pass automaton from the compiled program. Returns {@code null} if the
-   * pattern is not one-pass or exceeds the capture group limit.
+   * pattern is not one-pass, exceeds the capture group limit, or exceeds the transition-table
+   * memory budget.
    */
   static OnePass build(Prog prog) {
     if (prog.start() == 0) {
@@ -181,24 +185,20 @@ final class OnePass {
     int[] boundaries = buildBoundaries(prog);
     int numClasses = boundaries.length;
 
+    int maxStates = maxOnePassStates(prog);
+    if (maxStates > MAX_STATES || exceedsActionBudget(maxStates, numClasses)) {
+      return null;
+    }
+
     // State table. States are identified by instruction IDs.
     // nodeMap: instruction ID -> state index.
     Map<Integer, Integer> nodeMap = new HashMap<>();
-    int stateCount = 0;
-
-    // Pre-allocate generously; we'll trim later.
-    int maxStates = prog.size();
-    long[][] actions = new long[maxStates][numClasses];
-    long[] matchActions = new long[maxStates];
-    for (long[] row : actions) {
-      Arrays.fill(row, NO_ACTION);
-    }
-    Arrays.fill(matchActions, NO_ACTION);
+    BuildTables tables = new BuildTables(numClasses, maxStates);
 
     // BFS: process each state (instruction ID).
     Deque<Integer> worklist = new ArrayDeque<>();
     int startInst = prog.start();
-    nodeMap.put(startInst, stateCount++);
+    nodeMap.put(startInst, tables.addState());
     worklist.add(startInst);
 
     while (!worklist.isEmpty()) {
@@ -266,20 +266,21 @@ final class OnePass {
               if (nodeMap.containsKey(ip.out)) {
                 nextState = nodeMap.get(ip.out);
               } else {
-                if (stateCount >= maxStates) {
+                if (tables.stateCount() >= maxStates) {
                   return null; // too many states
                 }
-                nextState = stateCount++;
+                nextState = tables.addState();
                 nodeMap.put(ip.out, nextState);
                 worklist.add(ip.out);
               }
 
               long action = encodeAction(nextState, capMask, emptyFlags);
-              if (actions[stateIndex][cls] != NO_ACTION && actions[stateIndex][cls] != action) {
+              long existing = tables.action(stateIndex, cls);
+              if (existing != NO_ACTION && existing != action) {
                 // Two different transitions for the same equivalence class -> not one-pass.
                 return null;
               }
-              actions[stateIndex][cls] = action;
+              tables.setAction(stateIndex, cls, action);
             }
           }
           case CHAR_CLASS -> {
@@ -301,46 +302,123 @@ final class OnePass {
                 if (nodeMap.containsKey(ip.out)) {
                   nextState = nodeMap.get(ip.out);
                 } else {
-                  if (stateCount >= maxStates) {
+                  if (tables.stateCount() >= maxStates) {
                     return null;
                   }
-                  nextState = stateCount++;
+                  nextState = tables.addState();
                   nodeMap.put(ip.out, nextState);
                   worklist.add(ip.out);
                 }
 
                 long action = encodeAction(nextState, capMask, emptyFlags);
-                if (actions[stateIndex][cls] != NO_ACTION && actions[stateIndex][cls] != action) {
+                long existing = tables.action(stateIndex, cls);
+                if (existing != NO_ACTION && existing != action) {
                   return null;
                 }
-                actions[stateIndex][cls] = action;
+                tables.setAction(stateIndex, cls, action);
               }
             }
           }
           case MATCH -> {
             long action = encodeAction(0, capMask, emptyFlags);
-            if (matchActions[stateIndex] != NO_ACTION && matchActions[stateIndex] != action) {
+            long existing = tables.matchAction(stateIndex);
+            if (existing != NO_ACTION && existing != action) {
               // Two match paths with different conditions -> not one-pass.
               return null;
             }
-            matchActions[stateIndex] = action;
+            tables.setMatchAction(stateIndex, action);
           }
           default -> {}
         }
       }
     }
 
-    // Trim tables to actual state count.
-    long[][] trimmedActions = Arrays.copyOf(actions, stateCount);
-    long[] trimmedMatch = Arrays.copyOf(matchActions, stateCount);
     return new OnePass(
-        trimmedActions,
-        trimmedMatch,
+        tables.actions(),
+        tables.stateCount(),
+        numClasses,
+        tables.matchActions(),
         boundaries,
         prog.anchorEnd(),
         prog.dollarAnchorEnd(),
         prog.unixLines(),
         prog.hasGraphemeClusterBoundary());
+  }
+
+  private static boolean exceedsActionBudget(int maxStates, int numClasses) {
+    return maxStates > MAX_ACTION_CELLS / numClasses;
+  }
+
+  private static int maxOnePassStates(Prog prog) {
+    int maxStates = 1; // start state
+    for (int i = 0; i < prog.size(); i++) {
+      Inst inst = prog.inst(i);
+      if (inst.op == InstOp.CHAR_RANGE || inst.op == InstOp.CHAR_CLASS) {
+        maxStates++;
+      }
+    }
+    return maxStates;
+  }
+
+  private static final class BuildTables {
+    private final int numClasses;
+    private final int maxStates;
+    private long[] actions = new long[0];
+    private long[] matchActions = new long[0];
+    private int allocatedStates;
+    private int stateCount;
+
+    BuildTables(int numClasses, int maxStates) {
+      this.numClasses = numClasses;
+      this.maxStates = maxStates;
+    }
+
+    int stateCount() {
+      return stateCount;
+    }
+
+    int addState() {
+      ensureStateCapacity(stateCount + 1);
+      int state = stateCount++;
+      Arrays.fill(actions, state * numClasses, (state + 1) * numClasses, NO_ACTION);
+      matchActions[state] = NO_ACTION;
+      return state;
+    }
+
+    long action(int state, int cls) {
+      return actions[state * numClasses + cls];
+    }
+
+    void setAction(int state, int cls, long action) {
+      actions[state * numClasses + cls] = action;
+    }
+
+    long matchAction(int state) {
+      return matchActions[state];
+    }
+
+    void setMatchAction(int state, long action) {
+      matchActions[state] = action;
+    }
+
+    long[] actions() {
+      return actions;
+    }
+
+    long[] matchActions() {
+      return Arrays.copyOf(matchActions, stateCount);
+    }
+
+    private void ensureStateCapacity(int minStates) {
+      if (allocatedStates >= minStates) {
+        return;
+      }
+      int newStates = Math.max(minStates, Math.max(4, allocatedStates * 2));
+      newStates = Math.min(newStates, maxStates);
+      actions = Arrays.copyOf(actions, Math.toIntExact((long) newStates * numClasses));
+      matchActions = Arrays.copyOf(matchActions, newStates);
+      allocatedStates = newStates;
+    }
   }
 
   /** Builds sorted code point boundaries from all CHAR_RANGE and CHAR_CLASS instructions. */

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -143,6 +143,17 @@ public final class Pattern implements Serializable {
   private final transient long singleCharClassBitmap1;
 
   /**
+   * Precomputed character class data for a mandatory character class in a full-match pattern.
+   * Non-null when {@code matches()} can reject by scanning for an absent required code point before
+   * invoking the full engine cascade. This is intentionally a negative-only accelerator: if the
+   * class is present, normal matching still determines the result.
+   */
+  private final transient int[] requiredMatchClassRanges;
+
+  private final transient long requiredMatchClassBitmap0;
+  private final transient long requiredMatchClassBitmap1;
+
+  /**
    * Lazily computed OnePass analysis results. Holds the OnePass automaton (if eligible) and derived
    * flags ({@code canOnePassFind}, {@code canOnePassSubmatch}). Computed on first access to avoid
    * paying the OnePass BFS cost at compile time.
@@ -225,6 +236,9 @@ public final class Pattern implements Serializable {
       int[] singleCharClassRanges,
       long singleCharClassBitmap0,
       long singleCharClassBitmap1,
+      int[] requiredMatchClassRanges,
+      long requiredMatchClassBitmap0,
+      long requiredMatchClassBitmap1,
       EnginePathOptions enginePathOptions) {
     this.pattern = pattern;
     this.flags = flags;
@@ -254,6 +268,9 @@ public final class Pattern implements Serializable {
     this.singleCharClassRanges = singleCharClassRanges;
     this.singleCharClassBitmap0 = singleCharClassBitmap0;
     this.singleCharClassBitmap1 = singleCharClassBitmap1;
+    this.requiredMatchClassRanges = requiredMatchClassRanges;
+    this.requiredMatchClassBitmap0 = requiredMatchClassBitmap0;
+    this.requiredMatchClassBitmap1 = requiredMatchClassBitmap1;
   }
 
   /**
@@ -323,6 +340,7 @@ public final class Pattern implements Serializable {
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
+    CharClassScanInfo requiredMatchClass = extractRequiredMatchClass(metadataAst);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -352,6 +370,9 @@ public final class Pattern implements Serializable {
         singleCharClass != null ? singleCharClass.ranges : null,
         singleCharClass != null ? singleCharClass.bitmap0 : 0,
         singleCharClass != null ? singleCharClass.bitmap1 : 0,
+        requiredMatchClass != null ? requiredMatchClass.ranges : null,
+        requiredMatchClass != null ? requiredMatchClass.bitmap0 : 0,
+        requiredMatchClass != null ? requiredMatchClass.bitmap1 : 0,
         enginePathOptions);
   }
 
@@ -888,6 +909,24 @@ public final class Pattern implements Serializable {
   /** ASCII bitmap (code points 64–127) for the single-character-class fast path. */
   long singleCharClassBitmap1() {
     return singleCharClassBitmap1;
+  }
+
+  /**
+   * Returns precomputed ranges for a required character class in {@code matches()}, or {@code
+   * null}.
+   */
+  int[] requiredMatchClassRanges() {
+    return requiredMatchClassRanges;
+  }
+
+  /** ASCII bitmap (code points 0–63) for the required-character-class fast path. */
+  long requiredMatchClassBitmap0() {
+    return requiredMatchClassBitmap0;
+  }
+
+  /** ASCII bitmap (code points 64–127) for the required-character-class fast path. */
+  long requiredMatchClassBitmap1() {
+    return requiredMatchClassBitmap1;
   }
 
   /**
@@ -2112,6 +2151,49 @@ public final class Pattern implements Serializable {
       return null;
     }
     return buildCharClassScanInfo(cc);
+  }
+
+  /**
+   * Detects a mandatory character class in a full-match pattern, such as {@code .*\\s+.*}. The
+   * resulting class is only used to reject inputs that contain no matching code point; positive
+   * results still go through the normal engine to preserve full regex semantics.
+   */
+  private static CharClassScanInfo extractRequiredMatchClass(Regexp re) {
+    if (hasUserCaptures(re)) {
+      return null;
+    }
+    Regexp node = re;
+    if (node.op == RegexpOp.CAPTURE && node.cap == 0) {
+      node = node.sub();
+    }
+    if (node.op != RegexpOp.CONCAT || node.subs == null) {
+      CharClass cc = requiredCharClass(node);
+      return cc != null ? buildCharClassScanInfo(cc) : null;
+    }
+    for (Regexp sub : node.subs) {
+      CharClass cc = requiredCharClass(sub);
+      if (cc != null) {
+        return buildCharClassScanInfo(cc);
+      }
+    }
+    return null;
+  }
+
+  private static CharClass requiredCharClass(Regexp re) {
+    Regexp node = re;
+    if (node.op == RegexpOp.NON_CAPTURE) {
+      node = node.sub();
+    }
+    if (node.op == RegexpOp.CHAR_CLASS && node.charClass != null) {
+      return node.charClass.isEmpty() ? null : node.charClass;
+    }
+    if ((node.op == RegexpOp.PLUS || (node.op == RegexpOp.REPEAT && node.min > 0))
+        && node.sub().op == RegexpOp.CHAR_CLASS
+        && node.sub().charClass != null
+        && !node.sub().charClass.isEmpty()) {
+      return node.sub().charClass;
+    }
+    return null;
   }
 
   private static CharClassScanInfo buildCharClassScanInfo(CharClass cc) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -110,6 +110,28 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("matches() fast-rejects when required whitespace is absent")
+    void matchesFastRejectsWhenRequiredWhitespaceIsAbsent() {
+      Matcher m = Pattern.compile(".*\\s+.*").matcher("44241504-44f6-4d2a-bdcb-1bf7fd927ba9");
+
+      assertThat(m.matches()).isFalse();
+      assertThat(m.hitEnd()).isTrue();
+      assertThat(m.requireEnd()).isFalse();
+    }
+
+    @Test
+    @DisplayName("matches() required-class precheck preserves positive cases")
+    void matchesRequiredClassPrecheckPreservesPositiveCases() {
+      Pattern p = Pattern.compile(".*\\s+.*");
+
+      for (String input : new String[] {"a b", "a\nb c", "a\n \nc", "a\n\nc"}) {
+        assertThat(p.matcher(input).matches())
+            .as("SafeRE and JDK should agree on %s", input.replace("\n", "\\n"))
+            .isEqualTo(java.util.regex.Pattern.compile(".*\\s+.*").matcher(input).matches());
+      }
+    }
+
+    @Test
     @DisplayName("matches() with alternation and non-participating group")
     void matchesAlternation() {
       Pattern p = Pattern.compile("(a)|(b)");

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -201,6 +201,23 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() falls back when OnePass analysis exceeds its memory budget")
+    void findFallsBackWhenOnePassAnalysisExceedsMemoryBudget() {
+      String regex =
+          "SELECT"
+              + " REGE|||~\\u06ec?<?|||GEXP_REPLACe(^\"\\uffff\\uffff\\uffff\\uffff"
+              + "\\uffff\\uffff\\uffff\\uffff"
+              + " \\u00bf\\u7000\\u0400\\u5000\\u07b7@\\u02aa \\X@?` \\u0296"
+              + " \\ua03d,\\u0106mv &.\\u017c&.?\t\t?\t\\uffff\\ufff1end1 68  ){680}"
+              + "$ .1";
+      String input = ",69\u00c3";
+
+      boolean expected = java.util.regex.Pattern.compile(regex).matcher(input).find();
+
+      assertThat(Pattern.compile(regex).matcher(input).find()).isEqualTo(expected);
+    }
+
+    @Test
     @DisplayName("group access after lookingAt() works correctly")
     void lookingAtUpdatesGroupInfo() {
       Pattern p = Pattern.compile("(\\d+)(\\w+)");

--- a/safere/src/test/java/org/safere/OnePassTest.java
+++ b/safere/src/test/java/org/safere/OnePassTest.java
@@ -30,6 +30,14 @@ class OnePassTest {
     return OnePass.build(prog);
   }
 
+  private static String distinctLiteralRun(int count) {
+    StringBuilder pattern = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      pattern.appendCodePoint(0x1000 + i * 2);
+    }
+    return pattern.toString();
+  }
+
   /** Helper: run one-pass search (anchored, endMatch=false). */
   private static int[] search(String pattern, String text) {
     Regexp re = Parser.parse(pattern, FLAGS);
@@ -122,6 +130,14 @@ class OnePassTest {
     @Test
     void emptyPattern() {
       assertThat(build("")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("oversized transition tables are rejected before allocation")
+    void oversizedTransitionTablesAreRejectedBeforeAllocation() {
+      int literalCount = (int) Math.ceil(Math.sqrt(OnePass.MAX_ACTION_CELLS / 2.0)) + 64;
+
+      assertThat(build(distinctLiteralRun(literalCount))).isNull();
     }
   }
 

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -54,6 +54,20 @@ class PatternInternalTest {
     assertThat(p.keywordAlternation()).isNotNull();
   }
 
+  @Test
+  void dotStarAroundWhitespaceRecordsRequiredWhitespaceClass() {
+    Pattern p = Pattern.compile(".*\\s+.*");
+
+    assertThat(p.requiredMatchClassRanges()).isNotNull();
+  }
+
+  @Test
+  void pureNullablePatternsDoNotRecordRequiredCharacterClasses() {
+    Pattern p = Pattern.compile(".*");
+
+    assertThat(p.requiredMatchClassRanges()).isNull();
+  }
+
   @ParameterizedTest(name = "compile(\"{0}\").numGroups() == {1}")
   @CsvSource({
     "'',         0",

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -100,6 +100,7 @@ class PatternTest {
 
   @Nested
   @DisplayName("required character class acceleration")
+  @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
   class RequiredCharacterClassAcceleration {
 
     @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -99,28 +99,6 @@ class PatternTest {
   }
 
   @Nested
-  @DisplayName("required character class acceleration")
-  @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
-  class RequiredCharacterClassAcceleration {
-
-    @Test
-    @DisplayName("dot-star around whitespace records required whitespace class")
-    void dotStarAroundWhitespaceRecordsRequiredWhitespaceClass() {
-      Pattern p = Pattern.compile(".*\\s+.*");
-
-      assertThat(p.requiredMatchClassRanges()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("pure nullable patterns do not record required character classes")
-    void pureNullablePatternsDoNotRecordRequiredCharacterClasses() {
-      Pattern p = Pattern.compile(".*");
-
-      assertThat(p.requiredMatchClassRanges()).isNull();
-    }
-  }
-
-  @Nested
   @DisplayName("Unsupported features")
   class UnsupportedFeatures {
     @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -99,6 +99,27 @@ class PatternTest {
   }
 
   @Nested
+  @DisplayName("required character class acceleration")
+  class RequiredCharacterClassAcceleration {
+
+    @Test
+    @DisplayName("dot-star around whitespace records required whitespace class")
+    void dotStarAroundWhitespaceRecordsRequiredWhitespaceClass() {
+      Pattern p = Pattern.compile(".*\\s+.*");
+
+      assertThat(p.requiredMatchClassRanges()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("pure nullable patterns do not record required character classes")
+    void pureNullablePatternsDoNotRecordRequiredCharacterClasses() {
+      Pattern p = Pattern.compile(".*");
+
+      assertThat(p.requiredMatchClassRanges()).isNull();
+    }
+  }
+
+  @Nested
   @DisplayName("Unsupported features")
   class UnsupportedFeatures {
     @Test


### PR DESCRIPTION
## Summary

- Add a negative-only `matches()` fast reject for patterns with a required character class, such as `.*\\s+.*`.
- Avoid invoking OnePass/DFA/BitState/NFA when a full-match input contains no required-class code point.
- Add regression coverage for the required-class detector and the reported UUID/no-whitespace workload.

Fixes #423
Refs #435

## Measurements

Copied the issue repro into a standalone Java file and ran it exactly as reported.

Before this change (`fc39d93`):

```text
safere
kb: 15033
PT0.368811387S
java.util.
kb: 39
PT0.023630317S
re2j
kb: 206
PT0.021098724S
```

After this change:

```text
safere
kb: 6320
PT0.084290578S
java.util.
kb: 39
PT0.022814038S
re2j
kb: 195
PT0.023172292S
```

Adapted repro, third iteration in the same JVM:

```text
Before: safere kb: 991 PT0.018651617S
After:  safere kb: 34  PT0.018259359S
```

## Verification

- `mvn -pl safere -Dtest=PatternTest,MatcherTest test`
- `mvn -pl safere -Dtest=EnginePathEquivalenceTest test`
- `git diff --check`

## Notes

This fast path is negative-only: if the required class is present, normal matching still determines the result. The fast reject may conservatively over-report `hitEnd()` for some failed matches; `hitEnd()`/`requireEnd()` compatibility is best-effort and tracked separately in #435.
