### PR TITLE
Make grapheme allocation regression scaling-based

### DIFF
--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -480,23 +480,27 @@ class LinebreakGraphemeTest {
     }
 
     @Test
-    @DisplayName("unanchored multi-boundary \\X search keeps bounded startup allocation")
-    void unanchoredMultiBoundarySearchKeepsBoundedStartupAllocation() {
+    @DisplayName("unanchored multi-boundary \\X search allocation does not scale with input tail")
+    void unanchoredMultiBoundarySearchDoesNotAllocatePerInputPosition() {
       AllocationTracker allocationTracker = allocationTracker();
       long threadId = Thread.currentThread().threadId();
-      String text = "ab" + "c".repeat(100_000);
 
       for (String regex : List.of("\\X\\X", "\\X{2}", "(?:\\X)(?:\\X)")) {
         Pattern pattern = Pattern.compile(regex);
 
-        long before = allocationTracker.allocatedBytes(threadId);
-        Matcher matcher = pattern.matcher(text);
-        assertThat(matcher.find()).as("find() for /%s/", regex).isTrue();
-        assertThat(matcher.start()).as("start for /%s/", regex).isEqualTo(0);
-        assertThat(matcher.end()).as("end for /%s/", regex).isEqualTo(2);
-        long allocated = allocationTracker.allocatedBytes(threadId) - before;
+        assertImmediateTwoClusterMatch(pattern, "ab" + "c".repeat(1_000));
+        assertImmediateTwoClusterMatch(pattern, "ab" + "c".repeat(10_000));
 
-        assertThat(allocated).as("allocated bytes for /%s/", regex).isLessThan(4_000_000L);
+        long shortAllocated =
+            allocatedForImmediateTwoClusterFind(
+                allocationTracker, threadId, pattern, "ab" + "c".repeat(10_000));
+        long longAllocated =
+            allocatedForImmediateTwoClusterFind(
+                allocationTracker, threadId, pattern, "ab" + "c".repeat(100_000));
+
+        assertThat(longAllocated - shortAllocated)
+            .as("extra allocated bytes when input tail grows for /%s/", regex)
+            .isLessThan(64_000L);
       }
     }
 
@@ -732,6 +736,20 @@ class LinebreakGraphemeTest {
       assertThat(safeMatches)
           .as("find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
           .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
+    private long allocatedForImmediateTwoClusterFind(
+        AllocationTracker allocationTracker, long threadId, Pattern pattern, String text) {
+      long before = allocationTracker.allocatedBytes(threadId);
+      assertImmediateTwoClusterMatch(pattern, text);
+      return allocationTracker.allocatedBytes(threadId) - before;
+    }
+
+    private void assertImmediateTwoClusterMatch(Pattern pattern, String text) {
+      Matcher matcher = pattern.matcher(text);
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.start()).isZero();
+      assertThat(matcher.end()).isEqualTo(2);
     }
 
     private AllocationTracker allocationTracker() {


### PR DESCRIPTION
## Summary

- rewrite the `\X\X` allocation regression to compare short vs long input tails
- warm up grapheme matching before allocation measurement so JDK Unicode/class initialization is not charged to the scaling assertion
- keep the original multi-boundary `\X` regex coverage while asserting the intended invariant: allocation must not grow materially with an irrelevant input tail

Fixes #430

## Measurement

Local one-off allocation probe on OpenJDK 25.0.2:

```text
\X\X short=27016 long=27016 delta=0
\X{2} short=24872 long=24872 delta=0
(?:\X)(?:\X) short=27144 long=27144 delta=0
```

The test allows a 64 KB delta between the 10k and 100k tail cases.

## Verification

- `JAVA_HOME=$HOME/jdks/jdk-26.0.1 PATH=$HOME/jdks/jdk-26.0.1/bin:$PATH mvn -pl safere -Dtest=LinebreakGraphemeTest test -q`
  - OpenJDK `26.0.1+8-34`
- `mvn -pl safere -Dtest='LinebreakGraphemeTest$GraphemeClusterTests#unanchoredMultiBoundarySearchDoesNotAllocatePerInputPosition' test -q`
  - run 3 times successfully
- `mvn -pl safere -Dtest=LinebreakGraphemeTest test -q`

## Not Run

- Full `mvn -pl safere test -q`
- Full public API crosscheck profile

