### PR TITLE
Bound hitEnd end-state replay

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -116,6 +116,14 @@ public final class Matcher implements MatchResult {
    */
   private static final int DIRECT_FALLBACK_TEXT_LIMIT = 512;
 
+  /**
+   * Maximum approximate work for exact accepted-path end-state replay when only best-effort {@link
+   * #hitEnd()} reporting is at stake.
+   *
+   * <p>Exact {@link #requireEnd()} behavior still uses the accepted path replay.
+   */
+  private static final long MAX_EXACT_END_STATE_REPLAY_WORK = 1_000_000L;
+
   private static final int REQUIRE_END_EMPTY_FLAGS =
       EmptyOp.DOLLAR_END
           | EmptyOp.END_LINE
@@ -2835,12 +2843,36 @@ public final class Matcher implements MatchResult {
       return;
     }
     boolean endedAtSensitiveEnd = matchEndsAtSensitiveEnd();
+    if (!shouldReplayAcceptedPathForEndState(operation, endedAtSensitiveEnd)) {
+      updateBestEffortEndState(endedAtSensitiveEnd);
+      return;
+    }
     int terminalEmptyFlags = endedAtSensitiveEnd ? terminalEmptyFlagsForAcceptedPath(operation) : 0;
     lastRequireEnd = (terminalEmptyFlags & REQUIRE_END_EMPTY_FLAGS) != 0;
     lastHitEnd =
         lastRequireEnd
             || ((terminalEmptyFlags & HIT_END_EMPTY_FLAGS) != 0)
             || (endedAtSensitiveEnd && matchCanExtendAtEnd(operation));
+  }
+
+  private boolean shouldReplayAcceptedPathForEndState(
+      MatchOperation operation, boolean endedAtSensitiveEnd) {
+    if (!endedAtSensitiveEnd) {
+      return true;
+    }
+    if (parentPattern.hasEndConstraint() || !parentPattern.hasHitEndConstraint()) {
+      return true;
+    }
+    int start = Math.max(0, groups[0]);
+    int end = operation == MatchOperation.MATCHES ? regionEnd : groups[1];
+    long span = Math.max(1, (long) end - start);
+    long work = span * parentPattern.prog().size();
+    return work <= MAX_EXACT_END_STATE_REPLAY_WORK;
+  }
+
+  private void updateBestEffortEndState(boolean endedAtSensitiveEnd) {
+    lastRequireEnd = false;
+    lastHitEnd = lastEngineHitEnd || endedAtSensitiveEnd;
   }
 
   private int terminalEmptyFlagsForAcceptedPath(MatchOperation operation) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -132,6 +132,22 @@ class MatcherTest {
     }
 
     @Test
+    @DisabledForCrosscheck("java.util.regex backtracking is not the SafeRE performance target")
+    @DisplayName("matches() end-state bookkeeping does not dominate nullable counted repeats")
+    void matchesEndStateBookkeepingDoesNotDominateNullableCountedRepeats() {
+      Pattern p = Pattern.compile(scimFilterPattern(), Pattern.UNIX_LINES | Pattern.MULTILINE);
+
+      long smallNanos =
+          runtimeNanos(() -> assertThat(p.matcher(scimFilterInput(10)).matches()).isTrue());
+      long largeNanos =
+          runtimeNanos(() -> assertThat(p.matcher(scimFilterInput(500)).matches()).isTrue());
+
+      assertThat(largeNanos)
+          .as("large accepted input should not be dominated by end-state replay")
+          .isLessThan(smallNanos * 20);
+    }
+
+    @Test
     @DisplayName("matches() with alternation and non-participating group")
     void matchesAlternation() {
       Pattern p = Pattern.compile("(a)|(b)");
@@ -2753,6 +2769,20 @@ class MatcherTest {
     return Pattern.compile(
         ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  }
+
+  private static String scimFilterPattern() {
+    return "\\A"
+        + "([Uu][Rr][Nn]:[Ii][Ee][Tt][Ff]:[Pp][Aa][Rr][Aa][Mm][Ss]:"
+        + "[Ss][Cc][Ii][Mm]:[Ss][Cc][Hh][Ee][Mm][Aa][Ss]:[Cc][Oo][Rr][Ee]:"
+        + "2\\.0:[Uu][Ss][Ee][Rr]:)?"
+        + "[Ii][Dd] [Ee][Qq] "
+        + "(?:\"(?:(?:[^\"\\\\]|(\\\\)+\")*){3,500}\"|null)"
+        + "\\z";
+  }
+
+  private static String scimFilterInput(int valueLength) {
+    return "id eq \"" + "a".repeat(valueLength) + "\"";
   }
 
   private static String nestedCapturingGroups(int depth) {


### PR DESCRIPTION
## Summary

- bound exact accepted-path end-state replay when only best-effort `hitEnd()` reporting is at stake
- keep exact `requireEnd()` replay for `$`, word-boundary, and other require-end-sensitive patterns
- add a regression test for the nullable counted-repeat SCIM-style filter from #424

## Performance

Quick JShell dev signal on the issue #424 reproducer (`matches()` plus `hitEnd()`/`requireEnd()` reads, 500-character quoted value):

| Version | Run 1 | Run 2 | Run 3 |
|---|---:|---:|---:|
| SafeRE before | 11217.543 ms | 13563.413 ms | 10869.353 ms |
| SafeRE after | 306.221 ms | 0.314 ms | 0.165 ms |

Patched result for the reproducer: `matches=true`, `hitEnd=true`, `requireEnd=false`.

These are quick development timings, not publication-quality JMH benchmark results.

## Verification

- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere -Dtest=MatcherStateMachineTraceTest,JdkSyntaxCompatibilityTest,BoundaryMatcherTest test -q`
- `mvn -pl safere test -q` (known flaky `ParserTest$CharacterClasses.manyPlainCharacterClassesCompileWithinRegressionBound` timeout; all other tests completed)
- `git diff --check`

Refs #424
