### PR TITLE
Fix Unicode character class compatibility

### DIFF
--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -39,6 +39,27 @@ to zero-width quoted literals and skipped trivia.
 The output JSONL path is printed at the end of each run. Generated reports should
 stay out of git.
 
+## Unicode Character Class Sweep
+
+Run through the dispatcher script:
+
+```bash
+./run-exhaustive-sweep.sh UnicodeCharacterClassDivergenceSweep \
+  --output-dir=target/exhaustive-reports/unicode-character-class-sweep-full
+```
+
+For a smaller ad hoc local check, run a generated-case index range:
+
+```bash
+./run-exhaustive-sweep.sh UnicodeCharacterClassDivergenceSweep --range=:1000000 \
+  --output-dir=target/exhaustive-reports/unicode-character-class-sweep-smoke
+```
+
+The Unicode character-class sweep compares SafeRE with `java.util.regex` under
+`UNICODE_CHARACTER_CLASS` for predefined classes, POSIX classes, and a bracketed
+`\w` intersection over every Unicode scalar value. Use it before review when
+changing Unicode predefined or POSIX class tables.
+
 ## Grapheme Cluster Sweep
 
 Run through the dispatcher script:

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/UnicodeCharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/UnicodeCharacterClassDivergenceSweep.java
@@ -1,0 +1,196 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.exhaustive;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Offline differential sweep for Unicode predefined and POSIX character classes. */
+public final class UnicodeCharacterClassDivergenceSweep {
+  private static final int FLAGS = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS;
+  private static final int SCALAR_COUNT =
+      Character.MAX_CODE_POINT + 1 - (Character.MAX_SURROGATE - Character.MIN_SURROGATE + 1);
+  private static final List<RegexCase> CASES =
+      List.of(
+          regexCase("digit", "\\d"),
+          regexCase("nonDigit", "\\D"),
+          regexCase("space", "\\s"),
+          regexCase("nonSpace", "\\S"),
+          regexCase("word", "\\w"),
+          regexCase("nonWord", "\\W"),
+          regexCase("posixLower", "\\p{Lower}"),
+          regexCase("posixUpper", "\\p{Upper}"),
+          regexCase("posixAscii", "\\p{ASCII}"),
+          regexCase("posixAlpha", "\\p{Alpha}"),
+          regexCase("posixDigit", "\\p{Digit}"),
+          regexCase("posixAlnum", "\\p{Alnum}"),
+          regexCase("posixPunct", "\\p{Punct}"),
+          regexCase("posixGraph", "\\p{Graph}"),
+          regexCase("posixPrint", "\\p{Print}"),
+          regexCase("posixBlank", "\\p{Blank}"),
+          regexCase("posixCntrl", "\\p{Cntrl}"),
+          regexCase("posixXDigit", "\\p{XDigit}"),
+          regexCase("posixSpace", "\\p{Space}"),
+          regexCase("wordIntersectionWithoutUnderscore", "[\\w&&[^_]]"));
+
+  private UnicodeCharacterClassDivergenceSweep() {}
+
+  public static void main(String[] args) throws IOException {
+    SweepOptions options =
+        SweepOptions.parse(
+            args,
+            Path.of("target", "exhaustive-reports", "unicode-character-class-sweep"),
+            "unicode-character-class-divergences.jsonl",
+            1_000_000);
+    Files.createDirectories(options.outputDir());
+    Files.deleteIfExists(options.jsonlPath());
+    options.printStartup("unicode-character-class");
+
+    if (options.replayFile() != null) {
+      runReplay(options);
+      return;
+    }
+
+    SweepRunState state = runSweep(options);
+
+    System.out.println("checked=" + state.checked.sum());
+    System.out.println("generated=" + state.generated);
+    System.out.println("divergences=" + state.divergences.sum());
+    System.out.println("threads=" + options.threads());
+    System.out.println("jsonl=" + options.jsonlPath());
+  }
+
+  private static SweepRunState runSweep(SweepOptions options) throws IOException {
+    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
+      SweepWorkers.run(
+          options.threads(),
+          "unicode-character-class-sweep-",
+          workerIndex -> {
+            SweepWorkers.ProgressReporter progressReporter =
+                new SweepWorkers.ProgressReporter(runState);
+            long generated = 0;
+            long end = Math.min(options.rangeEndExclusive(), totalCases());
+            for (long caseIndex = options.rangeStartInclusive(); caseIndex < end; caseIndex++) {
+              generated = caseIndex + 1;
+              if (caseIndex % options.threads() != workerIndex) {
+                continue;
+              }
+              progressReporter.checked();
+              evaluateCase(runState, caseFromIndex(caseIndex));
+              progressReporter.reportIfNeeded(generated);
+            }
+            runState.recordGenerated(generated);
+          });
+      return runState;
+    }
+  }
+
+  private static void runReplay(SweepOptions options) throws IOException {
+    try (BufferedReader reader =
+            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(options, 0)) {
+      long generated =
+          SweepWorkers.runStreamingLines(
+              options.threads(),
+              "unicode-character-class-replay-",
+              reader,
+              line -> {
+                runState.checked.increment();
+                evaluateCase(runState, replayCase(line));
+              });
+      runState.recordGenerated(generated);
+      System.out.println("checked=" + runState.checked.sum());
+      System.out.println("generated=" + runState.generated);
+      System.out.println("divergences=" + runState.divergences.sum());
+      System.out.println("threads=" + options.threads());
+      System.out.println("jsonl=" + options.jsonlPath());
+      if (runState.divergences.sum() > 0) {
+        throw new IllegalStateException(
+            "replay found " + runState.divergences.sum() + " behavioral divergences");
+      }
+    }
+  }
+
+  private static CaseSpec replayCase(String line) {
+    var object = SweepJson.parseObject(line);
+    var caseObject = SweepJson.object(object, "case");
+    return new CaseSpec(
+        regexCase(SweepJson.string(caseObject, "label"), SweepJson.string(caseObject, "regex")),
+        SweepJson.integer(caseObject, "codePoint"));
+  }
+
+  private static long totalCases() {
+    return (long) CASES.size() * SCALAR_COUNT;
+  }
+
+  private static CaseSpec caseFromIndex(long index) {
+    RegexCase regexCase = CASES.get((int) (index / SCALAR_COUNT));
+    int codePoint = scalarCodePoint((int) (index % SCALAR_COUNT));
+    return new CaseSpec(regexCase, codePoint);
+  }
+
+  private static int scalarCodePoint(int ordinal) {
+    if (ordinal < Character.MIN_SURROGATE) {
+      return ordinal;
+    }
+    return ordinal + (Character.MAX_SURROGATE - Character.MIN_SURROGATE + 1);
+  }
+
+  private static void evaluateCase(SweepRunState runState, CaseSpec spec) {
+    String input = new String(Character.toChars(spec.codePoint()));
+    boolean jdk = spec.regexCase().jdkPattern().matcher(input).matches();
+    boolean safere = spec.regexCase().safeRePattern().matcher(input).matches();
+    if (jdk == safere) {
+      return;
+    }
+    runState.recordDivergence();
+    runState.appendJsonl(new Divergence(spec, jdk, safere).toJson());
+  }
+
+  private static RegexCase regexCase(String label, String regex) {
+    return new RegexCase(
+        label,
+        regex,
+        java.util.regex.Pattern.compile(regex, FLAGS),
+        org.safere.Pattern.compile(regex, FLAGS));
+  }
+
+  private record RegexCase(
+      String label,
+      String regex,
+      java.util.regex.Pattern jdkPattern,
+      org.safere.Pattern safeRePattern) {}
+
+  private record CaseSpec(RegexCase regexCase, int codePoint) {}
+
+  private record Divergence(CaseSpec spec, boolean jdkMatches, boolean safeReMatches) {
+    String toJson() {
+      var object = SweepJson.object();
+      object.add("case", caseJson(spec));
+      object.addProperty("bucket", "regex=" + spec.regexCase().label());
+      object.addProperty("regex", spec.regexCase().regex());
+      object.addProperty("input", new String(Character.toChars(spec.codePoint())));
+      object.addProperty("codePoint", String.format("U+%04X", spec.codePoint()));
+      object.addProperty("characterType", Character.getType(spec.codePoint()));
+      object.addProperty("alphabetic", Character.isAlphabetic(spec.codePoint()));
+      object.addProperty("jdkMatches", jdkMatches);
+      object.addProperty("safeReMatches", safeReMatches);
+      return SweepJson.toJson(object);
+    }
+
+    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+      var object = SweepJson.object();
+      object.addProperty("label", spec.regexCase().label());
+      object.addProperty("regex", spec.regexCase().regex());
+      object.addProperty("codePoint", spec.codePoint());
+      return object;
+    }
+  }
+}

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -47,6 +47,16 @@ class SweepCliSmokeTest {
   }
 
   @Test
+  void unicodeCharacterClassSweepRunsTinyRange() throws Exception {
+    Path outputDir = tempDir.resolve("unicode-character");
+
+    UnicodeCharacterClassDivergenceSweep.main(args(outputDir));
+
+    assertThat(Files.exists(outputDir.resolve("unicode-character-class-divergences.jsonl")))
+        .isTrue();
+  }
+
+  @Test
   void characterClassReplayUsesConfiguredThreads() throws Exception {
     Path replayFile = tempDir.resolve("character-replay.jsonl");
     Path outputDir = tempDir.resolve("character-replay");
@@ -75,6 +85,24 @@ class SweepCliSmokeTest {
 
     String output =
         captureOutput(() -> ControlEscapeDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
+    assertThat(output).doesNotContain("threads=1");
+  }
+
+  @Test
+  void unicodeCharacterClassReplayUsesConfiguredThreads() throws Exception {
+    Path replayFile = tempDir.resolve("unicode-character-replay.jsonl");
+    Path outputDir = tempDir.resolve("unicode-character-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"label":"word","regex":"\\\\w","codePoint":65}}
+        """);
+
+    String output =
+        captureOutput(
+            () -> UnicodeCharacterClassDivergenceSweep.main(replayArgs(outputDir, replayFile)));
 
     assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
     assertThat(output).doesNotContain("threads=1");

--- a/safere/src/main/java/org/safere/UnicodeTables.java
+++ b/safere/src/main/java/org/safere/UnicodeTables.java
@@ -114,15 +114,15 @@ final class UnicodeTables {
     static final int[][] UNICODE_ALNUM = mergeRangeTables(UNICODE_ALPHA, UNICODE_DIGIT);
     static final int[][] UNICODE_PUNCT = UnicodeProperties.lookupBinaryProperty("Punctuation");
     static final int[][] UNICODE_CNTRL = UnicodeProperties.lookupBinaryProperty("Control");
-    static final int[][] UNICODE_XDIGIT = UnicodeProperties.lookupBinaryProperty("Hex_Digit");
-    static final int[][] UNICODE_GRAPH =
+    static final int[][] UNICODE_BLANK = buildRanges(UnicodeTables::isUnicodeBlank);
+    static final int[][] UNICODE_XDIGIT =
+        mergeRangeTables(UNICODE_DIGIT, UnicodeProperties.lookupBinaryProperty("Hex_Digit"));
+    static final int[][] UNICODE_GRAPH = buildRanges(UnicodeTables::isUnicodeGraph);
+    static final int[][] UNICODE_PRINT =
         buildRanges(
             cp ->
-                Character.isDefined(cp)
-                    && Character.getType(cp) != Character.CONTROL
-                    && Character.getType(cp) != Character.SURROGATE
-                    && !isUnicodeWhiteSpace(cp));
-    static final int[][] UNICODE_PRINT = mergeRangeTables(UNICODE_GRAPH, HORIZ_SPACE);
+                isUnicodeGraph(cp)
+                    || (isUnicodeBlank(cp) && Character.getType(cp) != Character.CONTROL));
 
     static final Map<String, int[][]> UNICODE_POSIX_PROPERTY_GROUPS =
         Map.ofEntries(
@@ -135,7 +135,7 @@ final class UnicodeTables {
             Map.entry("Punct", UNICODE_PUNCT),
             Map.entry("Graph", UNICODE_GRAPH),
             Map.entry("Print", UNICODE_PRINT),
-            Map.entry("Blank", HORIZ_SPACE),
+            Map.entry("Blank", UNICODE_BLANK),
             Map.entry("Cntrl", UNICODE_CNTRL),
             Map.entry("XDigit", UNICODE_XDIGIT),
             Map.entry("Space", unicodeSpace()));
@@ -147,6 +147,17 @@ final class UnicodeTables {
 
   private static boolean isUnicodeWhiteSpace(int cp) {
     return Character.isWhitespace(cp) || Character.isSpaceChar(cp);
+  }
+
+  private static boolean isUnicodeGraph(int cp) {
+    return Character.isDefined(cp)
+        && Character.getType(cp) != Character.CONTROL
+        && Character.getType(cp) != Character.SURROGATE
+        && !isUnicodeWhiteSpace(cp);
+  }
+
+  private static boolean isUnicodeBlank(int cp) {
+    return cp == '\t' || Character.getType(cp) == Character.SPACE_SEPARATOR;
   }
 
   private static int[][] buildRanges(IntPredicate predicate) {
@@ -845,9 +856,9 @@ final class UnicodeTables {
    * Join_Control. JDK defines {@code \w} under UNICODE_CHARACTER_CLASS as {@code
    * [\p{Alpha}\p{gc=Mn}\p{gc=Me}\p{gc=Mc}\p{Digit}\p{gc=Pc}\p{IsJoin_Control}]}.
    *
-   * <p>Built by merging the runtime-generated L (Letter), M (Mark), Nd (Decimal Number), Nl (Letter
-   * Number), Pc (Connector Punctuation) tables, plus the two Join_Control characters (U+200C,
-   * U+200D).
+   * <p>Built by merging the runtime-generated Alphabetic binary property, M (Mark), Nd (Decimal
+   * Number), Nl (Letter Number), Pc (Connector Punctuation) tables, plus the two Join_Control
+   * characters (U+200C, U+200D).
    */
   public static int[][] unicodeWord() {
     return UnicodePerlHolder.UNICODE_WORD;
@@ -860,7 +871,7 @@ final class UnicodeTables {
   private static final class UnicodePerlHolder {
     static final int[][] UNICODE_WORD =
         mergeRangeTables(
-            UNICODE_GROUPS.get("L"),
+            UnicodeProperties.lookupBinaryProperty("Alphabetic"),
             UNICODE_GROUPS.get("M"),
             UNICODE_GROUPS.get("Nd"),
             UNICODE_GROUPS.get("Nl"),

--- a/safere/src/test/java/org/safere/UnicodeCharClassTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCharClassTest.java
@@ -187,7 +187,7 @@ class UnicodeCharClassTest {
   }
 
   // -------------------------------------------------------------------------
-  // \w — Unicode word character (L + M + Nd + Nl + Pc + Join_Control)
+  // \w — Unicode word character (Alpha + M + Nd + Nl + Pc + Join_Control)
   // -------------------------------------------------------------------------
 
   @Nested
@@ -230,6 +230,19 @@ class UnicodeCharClassTest {
     }
 
     @Test
+    void alphabeticSymbolsMatchWithFlag() {
+      Pattern p = Pattern.compile("\\w+", UCC);
+      assertThat(p.matcher("ⓓⓔⓕ").matches()).isTrue();
+    }
+
+    @Test
+    void bracketedWordIntersectionUsesUnicodeAlphabeticWithFlag() {
+      Pattern p = Pattern.compile("[\\w&&[^_]]{3,20}", UCC);
+      assertThat(p.matcher("Aᶛᶜⓓⓔⓕäöüकफ").matches()).isTrue();
+      assertThat(p.matcher("_").matches()).isFalse();
+    }
+
+    @Test
     void connectorPunctuationMatchesWithFlag() {
       // Undertie ‿ (U+203F) and ﹏ (U+FE4F) are category Pc.
       Pattern p = Pattern.compile("\\w", UCC);
@@ -251,6 +264,24 @@ class UnicodeCharClassTest {
       assertThat(p.matcher(" !@#").matches()).isTrue();
       // Accented letters should NOT match \W
       assertThat(p.matcher("é").matches()).isFalse();
+    }
+  }
+
+  @Nested
+  class PosixUnicodeEdgeTests {
+
+    @Test
+    void xdigitIncludesAllUnicodeDigitsWithFlag() {
+      Pattern p = Pattern.compile("\\p{XDigit}+", UCC);
+      assertThat(p.matcher("०۱۲٣").matches()).isTrue();
+    }
+
+    @Test
+    void printExcludesControlBlankWithFlag() {
+      Pattern p = Pattern.compile("\\p{Print}", UCC);
+      assertThat(p.matcher(" ").matches()).isTrue();
+      assertThat(p.matcher("\u00A0").matches()).isTrue();
+      assertThat(p.matcher("\t").matches()).isFalse();
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix Unicode `\w` under `UNICODE_CHARACTER_CLASS` to use the JDK `Alphabetic` property instead of only Unicode letter categories.
- Align Unicode POSIX `Blank`, `Print`, and `XDigit` tables with JDK behavior.
- Add focused regression coverage for bracketed/intersected Unicode `\w` and adjacent POSIX edge cases.
- Add `UnicodeCharacterClassDivergenceSweep` for exhaustive single-scalar UCC class comparisons against `java.util.regex`.

Fixes #431

## Verification

Ran:

- `mvn -pl safere -Dtest=UnicodeCharClassTest,UnicodeJdkConsistencyTest test -q`
- `mvn -pl safere-exhaustive -Dtest=SweepCliSmokeTest test -q`
- `mvn -pl safere-exhaustive -DskipTests compile -q`
- `./run-exhaustive-sweep.sh UnicodeCharacterClassDivergenceSweep --range=4457600:4457900 --threads=1 --output-dir=target/exhaustive-reports/unicode-character-class-issue-431-smoke` (`divergences=0`)
- `./run-exhaustive-sweep.sh UnicodeCharacterClassDivergenceSweep --output-dir=target/exhaustive-reports/unicode-character-class-sweep-full` (`checked=22241280`, `divergences=0`)
- `git diff --check`

Also attempted:

- `mvn -pl safere test -q`

The full `safere` suite hit a preemptive timeout in `ParserTest$CharacterClasses.manyPlainCharacterClassesCompileWithinRegressionBound` and then continued consuming CPU for over an hour, so it was stopped. The timeout stack was in parser performance-bound coverage and did not appear related to these Unicode class table changes.
