### PR TITLE
Add support for Python style named capturing groups

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
@@ -13,7 +13,6 @@ final class DialectSyntaxFuzzer {
 
   private static final String[] CONTEXT_PREFIXES = {"", "^", "(?:", "a|", "[", "[^"};
   private static final String[] DIALECT_FRAGMENTS = {
-    "(?P<name>a)",
     "(?P=name)",
     "(?'name'a)",
     "\\g{name}",
@@ -42,7 +41,6 @@ final class DialectSyntaxFuzzer {
           "", "a", "b", "a\u0300", "\r\n", "Braille", "Latin", ":", "[", "]", "l", "o", "w", "e",
           "r");
   private static final String[] REGRESSION_REGEXES = {
-    "(?P<name>a)",
     "\\p{Braille}",
     "\\p{Latin}",
     "[[:lower:]]",
@@ -55,9 +53,13 @@ final class DialectSyntaxFuzzer {
     "a{,2}",
     "a{2,1}"
   };
+  private static final String[] SAFE_RE_EXTENSION_REGEXES = {"(?P<name>a)", "(?P<test_group>a)"};
 
   @FuzzTest(maxDuration = "30s")
   void dialectSyntax(FuzzedDataProvider data) {
+    for (String regex : SAFE_RE_EXTENSION_REGEXES) {
+      assertSafeRePythonNamedGroupExtension(regex);
+    }
     for (String regex : REGRESSION_REGEXES) {
       FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
     }
@@ -76,5 +78,16 @@ final class DialectSyntaxFuzzer {
 
     String regex = prefix + data.pickValue(DIALECT_FRAGMENTS) + suffix;
     FuzzSupport.assertFullMatchesJdk(regex, FuzzSupport.consumeParserFlags(data), INPUTS);
+  }
+
+  private static void assertSafeRePythonNamedGroupExtension(String regex) {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(regex);
+    org.safere.Matcher matcher = pattern.matcher("a");
+    if (!matcher.matches()) {
+      throw new AssertionError("SafeRE Python-style named group did not match: " + regex);
+    }
+    if (!"a".equals(matcher.group(1))) {
+      throw new AssertionError("SafeRE Python-style named group captured wrong text: " + regex);
+    }
   }
 }

--- a/safere/src/main/java/org/safere/ParseFlags.java
+++ b/safere/src/main/java/org/safere/ParseFlags.java
@@ -109,8 +109,8 @@ final class ParseFlags {
    */
   public static final int SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY = 1 << 18;
 
-  /** Allow RE2 named capturing group syntax {@code (?P<name>...)}. */
-  public static final int RE2_NAMED_GROUPS = 1 << 19;
+  /** Allow python named capturing group syntax {@code (?P<name>...)}. */
+  public static final int PYTHON_NAMED_GROUPS = 1 << 19;
 
   /** Mask of all valid parse flags. */
   public static final int ALL_FLAGS = (1 << 20) - 1;

--- a/safere/src/main/java/org/safere/ParseFlags.java
+++ b/safere/src/main/java/org/safere/ParseFlags.java
@@ -109,11 +109,8 @@ final class ParseFlags {
    */
   public static final int SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY = 1 << 18;
 
-  /** Allow python named capturing group syntax {@code (?P<name>...)}. */
-  public static final int PYTHON_NAMED_GROUPS = 1 << 19;
-
   /** Mask of all valid parse flags. */
-  public static final int ALL_FLAGS = (1 << 20) - 1;
+  public static final int ALL_FLAGS = (1 << 19) - 1;
 
   private ParseFlags() {} // Non-instantiable.
 }

--- a/safere/src/main/java/org/safere/ParseFlags.java
+++ b/safere/src/main/java/org/safere/ParseFlags.java
@@ -109,8 +109,11 @@ final class ParseFlags {
    */
   public static final int SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY = 1 << 18;
 
+  /** Allow RE2 named capturing group syntax {@code (?P<name>...)}. */
+  public static final int RE2_NAMED_GROUPS = 1 << 19;
+
   /** Mask of all valid parse flags. */
-  public static final int ALL_FLAGS = (1 << 19) - 1;
+  public static final int ALL_FLAGS = (1 << 20) - 1;
 
   private ParseFlags() {} // Non-instantiable.
 }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -4466,8 +4466,7 @@ final class Parser {
           throw new PatternSyntaxException("invalid named capture", pattern, pos);
         }
         String name = pattern.substring(begin, end);
-        boolean allowUnderscores = (flags & ParseFlags.PYTHON_NAMED_GROUPS) != 0;
-        if (!isValidCaptureName(name, allowUnderscores)) {
+        if (!isValidCaptureName(name, false)) {
           throw new PatternSyntaxException("invalid named capture: " + name, pattern, pos);
         }
         doLeftParen(name);
@@ -4475,8 +4474,9 @@ final class Parser {
         return false;
       }
     }
-    // (?P<name>expr)
-    if ((flags & ParseFlags.PYTHON_NAMED_GROUPS) != 0 && pos + 4 < pattern.length()) {
+    // (?P<name>expr) is a SafeRE extension that supports Python-style named groups in
+    // addition to the JDK (?<name>expr) syntax above.
+    if (pos + 4 < pattern.length()) {
       if (pattern.charAt(pos + 2) == 'P' && pattern.charAt(pos + 3) == '<') {
         int begin = pos + 4;
         int end = pattern.indexOf('>', begin);
@@ -4484,8 +4484,7 @@ final class Parser {
           throw new PatternSyntaxException("invalid named capture", pattern, pos);
         }
         String name = pattern.substring(begin, end);
-        boolean allowUnderscores = (flags & ParseFlags.PYTHON_NAMED_GROUPS) != 0;
-        if (!isValidCaptureName(name, allowUnderscores)) {
+        if (!isValidCaptureName(name, true)) {
           throw new PatternSyntaxException("invalid named capture: " + name, pattern, pos);
         }
         doLeftParen(name);

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -4466,7 +4466,7 @@ final class Parser {
           throw new PatternSyntaxException("invalid named capture", pattern, pos);
         }
         String name = pattern.substring(begin, end);
-        boolean allowUnderscores = (flags & ParseFlags.RE2_NAMED_GROUPS) != 0;
+        boolean allowUnderscores = (flags & ParseFlags.PYTHON_NAMED_GROUPS) != 0;
         if (!isValidCaptureName(name, allowUnderscores)) {
           throw new PatternSyntaxException("invalid named capture: " + name, pattern, pos);
         }
@@ -4476,7 +4476,7 @@ final class Parser {
       }
     }
     // (?P<name>expr)
-    if ((flags & ParseFlags.RE2_NAMED_GROUPS) != 0 && pos + 4 < pattern.length()) {
+    if ((flags & ParseFlags.PYTHON_NAMED_GROUPS) != 0 && pos + 4 < pattern.length()) {
       if (pattern.charAt(pos + 2) == 'P' && pattern.charAt(pos + 3) == '<') {
         int begin = pos + 4;
         int end = pattern.indexOf('>', begin);
@@ -4484,7 +4484,7 @@ final class Parser {
           throw new PatternSyntaxException("invalid named capture", pattern, pos);
         }
         String name = pattern.substring(begin, end);
-        boolean allowUnderscores = (flags & ParseFlags.RE2_NAMED_GROUPS) != 0;
+        boolean allowUnderscores = (flags & ParseFlags.PYTHON_NAMED_GROUPS) != 0;
         if (!isValidCaptureName(name, allowUnderscores)) {
           throw new PatternSyntaxException("invalid named capture: " + name, pattern, pos);
         }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -4466,7 +4466,26 @@ final class Parser {
           throw new PatternSyntaxException("invalid named capture", pattern, pos);
         }
         String name = pattern.substring(begin, end);
-        if (!isValidCaptureName(name)) {
+        boolean allowUnderscores = (flags & ParseFlags.RE2_NAMED_GROUPS) != 0;
+        if (!isValidCaptureName(name, allowUnderscores)) {
+          throw new PatternSyntaxException("invalid named capture: " + name, pattern, pos);
+        }
+        doLeftParen(name);
+        pos = end + 1; // skip past '>'
+        return false;
+      }
+    }
+    // (?P<name>expr)
+    if ((flags & ParseFlags.RE2_NAMED_GROUPS) != 0 && pos + 4 < pattern.length()) {
+      if (pattern.charAt(pos + 2) == 'P' && pattern.charAt(pos + 3) == '<') {
+        int begin = pos + 4;
+        int end = pattern.indexOf('>', begin);
+        if (end < 0) {
+          throw new PatternSyntaxException("invalid named capture", pattern, pos);
+        }
+        String name = pattern.substring(begin, end);
+        boolean allowUnderscores = (flags & ParseFlags.RE2_NAMED_GROUPS) != 0;
+        if (!isValidCaptureName(name, allowUnderscores)) {
           throw new PatternSyntaxException("invalid named capture: " + name, pattern, pos);
         }
         doLeftParen(name);
@@ -4628,17 +4647,23 @@ final class Parser {
 
   // ---- Capture name validation ----
 
-  private static boolean isValidCaptureName(String name) {
+  private static boolean isValidCaptureName(String name, boolean allowUnderscores) {
     if (name.isEmpty()) return false;
     // Match java.util.regex.Pattern rules: first character must be an ASCII letter,
-    // subsequent characters must be ASCII letters or digits.
+    // subsequent characters must be ASCII letters or digits. When allowUnderscores is true,
+    // underscores are also permitted.
     char first = name.charAt(0);
-    if (!((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z'))) {
+    if (!((first >= 'A' && first <= 'Z')
+        || (first >= 'a' && first <= 'z')
+        || (allowUnderscores && first == '_'))) {
       return false;
     }
     for (int i = 1; i < name.length(); i++) {
       char c = name.charAt(i);
-      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+      if ((c >= 'A' && c <= 'Z')
+          || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9')
+          || (allowUnderscores && c == '_')) {
         continue;
       }
       return false;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1108,8 +1108,6 @@ public final class Pattern implements Serializable {
     if ((flags & UNIX_LINES) != 0) {
       pf |= ParseFlags.UNIX_LINES;
     }
-    pf |= ParseFlags.PYTHON_NAMED_GROUPS;
-
     return pf;
   }
 

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -94,6 +94,9 @@ public final class Pattern implements Serializable {
   public static final int UNICODE_CHARACTER_CLASS =
       java.util.regex.Pattern.UNICODE_CHARACTER_CLASS; // 256
 
+  /** Enables RE2 style named capturing group syntax {@code (?P<name>...)}. */
+  public static final int RE2_NAMED_GROUPS = 1 << 20;
+
   private final String pattern;
   private final int flags;
   private final transient Prog prog;
@@ -1051,7 +1054,8 @@ public final class Pattern implements Serializable {
           | LITERAL
           | DOTALL
           | UNICODE_CASE
-          | UNICODE_CHARACTER_CLASS;
+          | UNICODE_CHARACTER_CLASS
+          | RE2_NAMED_GROUPS;
 
   /** Validates that no unsupported flag bits are set. */
   private static void validateFlags(int flags) {
@@ -1107,6 +1111,9 @@ public final class Pattern implements Serializable {
     }
     if ((flags & UNIX_LINES) != 0) {
       pf |= ParseFlags.UNIX_LINES;
+    }
+    if ((flags & RE2_NAMED_GROUPS) != 0) {
+      pf |= ParseFlags.RE2_NAMED_GROUPS;
     }
 
     return pf;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -94,9 +94,6 @@ public final class Pattern implements Serializable {
   public static final int UNICODE_CHARACTER_CLASS =
       java.util.regex.Pattern.UNICODE_CHARACTER_CLASS; // 256
 
-  /** Enables RE2 style named capturing group syntax {@code (?P<name>...)}. */
-  public static final int RE2_NAMED_GROUPS = 1 << 20;
-
   private final String pattern;
   private final int flags;
   private final transient Prog prog;
@@ -1054,8 +1051,7 @@ public final class Pattern implements Serializable {
           | LITERAL
           | DOTALL
           | UNICODE_CASE
-          | UNICODE_CHARACTER_CLASS
-          | RE2_NAMED_GROUPS;
+          | UNICODE_CHARACTER_CLASS;
 
   /** Validates that no unsupported flag bits are set. */
   private static void validateFlags(int flags) {
@@ -1112,9 +1108,7 @@ public final class Pattern implements Serializable {
     if ((flags & UNIX_LINES) != 0) {
       pf |= ParseFlags.UNIX_LINES;
     }
-    if ((flags & RE2_NAMED_GROUPS) != 0) {
-      pf |= ParseFlags.RE2_NAMED_GROUPS;
-    }
+    pf |= ParseFlags.PYTHON_NAMED_GROUPS;
 
     return pf;
   }

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 @DisplayName("JDK syntax compatibility")
 class JdkSyntaxCompatibilityTest {
-
   // ---- Helpers ----
 
   /** Asserts SafeRE compiles the pattern without error. */
@@ -269,7 +268,6 @@ class JdkSyntaxCompatibilityTest {
 
     static Stream<Arguments> nonJdkDialectSpellings() {
       return Stream.of(
-          Arguments.of(new DialectRejection("Python named capture", "(?P<word>a)")),
           Arguments.of(new DialectRejection("PCRE single-quoted named capture", "(?'word'a)")),
           Arguments.of(new DialectRejection("Python named backreference", "(?P=word)")),
           Arguments.of(new DialectRejection("PCRE subroutine call", "(?&word)")),
@@ -299,7 +297,6 @@ class JdkSyntaxCompatibilityTest {
     static Stream<Arguments> generatedNonJdkDialectSpellings() {
       List<DialectRejection> groupSpellings =
           List.of(
-              new DialectRejection("Python named capture", "(?P<name>a)"),
               new DialectRejection("PCRE single-quoted named capture", "(?'name'a)"),
               new DialectRejection("Python named backreference", "(?P=name)"),
               new DialectRejection("PCRE subroutine call", "(?&name)"),
@@ -2466,12 +2463,12 @@ class JdkSyntaxCompatibilityTest {
     }
 
     @Test
-    @DisplayName("Python-style named capturing group (?P<name>X) is rejected")
+    @DisplayName("Python-style named capturing group (?P<name>X) is accepted")
     void pythonStyleNamedCapturingGroupRejected() {
       String regex = "(?" + "P<word>\\w+)";
       assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
           .isInstanceOf(PatternSyntaxException.class);
-      assertThatThrownBy(() -> Pattern.compile(regex)).isInstanceOf(PatternSyntaxException.class);
+      var unused = Pattern.compile(regex);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -2465,7 +2465,7 @@ class JdkSyntaxCompatibilityTest {
     @Test
     @DisplayName("Python-style named capturing group (?P<name>X) is accepted")
     @DisabledForCrosscheck("SafeRE supports Python-style named capturing groups")
-    void pythonStyleNamedCapturingGroupRejected() {
+    void pythonStyleNamedCapturingGroupAccepted() {
       String regex = "(?" + "P<word>\\w+)";
       assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))
           .isInstanceOf(PatternSyntaxException.class);

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -2464,6 +2464,7 @@ class JdkSyntaxCompatibilityTest {
 
     @Test
     @DisplayName("Python-style named capturing group (?P<name>X) is accepted")
+    @DisabledForCrosscheck("SafeRE supports Python-style named capturing groups")
     void pythonStyleNamedCapturingGroupRejected() {
       String regex = "(?" + "P<word>\\w+)";
       assertThatThrownBy(() -> java.util.regex.Pattern.compile(regex))

--- a/safere/src/test/java/org/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/org/safere/ParseFlagsTest.java
@@ -35,7 +35,7 @@ class ParseFlagsTest {
     assertThat(ParseFlags.UNIX_LINES).isEqualTo(65536);
     assertThat(ParseFlags.UNICODE_CASE).isEqualTo(131072);
     assertThat(ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY).isEqualTo(262144);
-    assertThat(ParseFlags.RE2_NAMED_GROUPS).isEqualTo(524288);
+    assertThat(ParseFlags.PYTHON_NAMED_GROUPS).isEqualTo(524288);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/org/safere/ParseFlagsTest.java
@@ -33,6 +33,9 @@ class ParseFlagsTest {
     assertThat(ParseFlags.NEVER_CAPTURE).isEqualTo(16384);
     assertThat(ParseFlags.WAS_DOLLAR).isEqualTo(32768);
     assertThat(ParseFlags.UNIX_LINES).isEqualTo(65536);
+    assertThat(ParseFlags.UNICODE_CASE).isEqualTo(131072);
+    assertThat(ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY).isEqualTo(262144);
+    assertThat(ParseFlags.RE2_NAMED_GROUPS).isEqualTo(524288);
   }
 
   @Test
@@ -54,7 +57,7 @@ class ParseFlagsTest {
 
   @Test
   void allFlagsCoversAllBits() {
-    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 19) - 1);
+    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 20) - 1);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/org/safere/ParseFlagsTest.java
@@ -35,7 +35,6 @@ class ParseFlagsTest {
     assertThat(ParseFlags.UNIX_LINES).isEqualTo(65536);
     assertThat(ParseFlags.UNICODE_CASE).isEqualTo(131072);
     assertThat(ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY).isEqualTo(262144);
-    assertThat(ParseFlags.PYTHON_NAMED_GROUPS).isEqualTo(524288);
   }
 
   @Test
@@ -57,7 +56,7 @@ class ParseFlagsTest {
 
   @Test
   void allFlagsCoversAllBits() {
-    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 20) - 1);
+    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 19) - 1);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -844,8 +844,10 @@ class ParserTest {
     }
 
     @Test
-    void namedCapture_pythonSyntaxRejected() {
-      assertThatThrownBy(() -> parse("(?P<name>a)")).isInstanceOf(PatternSyntaxException.class);
+    void namedCapture_pythonSyntax() {
+      Regexp re = parse("(?P<name>a)");
+      assertThat(re.op).isEqualTo(RegexpOp.CAPTURE);
+      assertThat(re.name).isEqualTo("name");
     }
 
     @Test
@@ -1499,6 +1501,13 @@ class ParserTest {
     void invalidNamedCapture_underscore() {
       assertThatThrownBy(() -> parse("(?<test_group>.*)"))
           .isInstanceOf(PatternSyntaxException.class);
+    }
+
+    @Test
+    void pythonStyleNamedCapture_underscoreAccepted() {
+      Regexp re = parse("(?P<test_group>.*)");
+      assertThat(re.op).isEqualTo(RegexpOp.CAPTURE);
+      assertThat(re.name).isEqualTo("test_group");
     }
 
     @Test

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -526,7 +526,8 @@ class PatternTest {
 
     @Test
     @DisplayName("PYTHON_NAMED_GROUPS flag enables (?P<name>expr) syntax with underscores")
-    void re2NamedGroups() {
+    @DisabledForCrosscheck("SafeRE supports Python-style named capturing groups")
+    void pythonNamedGroups() {
       Pattern p = Pattern.compile("(?P<user_name>[\\w.]+)@(?P<host_name>[\\w.]+)");
       assertThat(p.namedGroups()).containsEntry("user_name", 1);
       assertThat(p.namedGroups()).containsEntry("host_name", 2);

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -525,24 +525,15 @@ class PatternTest {
     }
 
     @Test
-    @DisplayName("RE2_NAMED_GROUPS flag enables (?P<name>expr) syntax with underscores")
+    @DisplayName("PYTHON_NAMED_GROUPS flag enables (?P<name>expr) syntax with underscores")
     void re2NamedGroups() {
-      Pattern p =
-          Pattern.compile(
-              "(?P<user_name>[\\w.]+)@(?P<host_name>[\\w.]+)", Pattern.RE2_NAMED_GROUPS);
+      Pattern p = Pattern.compile("(?P<user_name>[\\w.]+)@(?P<host_name>[\\w.]+)");
       assertThat(p.namedGroups()).containsEntry("user_name", 1);
       assertThat(p.namedGroups()).containsEntry("host_name", 2);
       Matcher m = p.matcher("alice_smith@example.com");
       assertThat(m.matches()).isTrue();
       assertThat(m.group("user_name")).isEqualTo("alice_smith");
       assertThat(m.group("host_name")).isEqualTo("example.com");
-    }
-
-    @Test
-    @DisplayName("(?P<name>expr) syntax is rejected without RE2_NAMED_GROUPS flag")
-    void re2NamedGroupsRejectedWithoutFlag() {
-      assertThatThrownBy(() -> Pattern.compile("(?P<user_name>\\w+)@(?P<host_name>\\w+)"))
-          .isInstanceOf(PatternSyntaxException.class);
     }
   }
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -525,7 +525,7 @@ class PatternTest {
     }
 
     @Test
-    @DisplayName("PYTHON_NAMED_GROUPS flag enables (?P<name>expr) syntax with underscores")
+    @DisplayName("Python-style named groups support (?P<name>expr) syntax with underscores")
     @DisabledForCrosscheck("SafeRE supports Python-style named capturing groups")
     void pythonNamedGroups() {
       Pattern p = Pattern.compile("(?P<user_name>[\\w.]+)@(?P<host_name>[\\w.]+)");
@@ -535,6 +535,13 @@ class PatternTest {
       assertThat(m.matches()).isTrue();
       assertThat(m.group("user_name")).isEqualTo("alice_smith");
       assertThat(m.group("host_name")).isEqualTo("example.com");
+    }
+
+    @Test
+    @DisplayName("Java-style named groups keep JDK name rules")
+    void javaStyleNamedGroupsRejectUnderscores() {
+      assertThatThrownBy(() -> Pattern.compile("(?<user_name>a)"))
+          .isInstanceOf(PatternSyntaxException.class);
     }
   }
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -523,6 +523,27 @@ class PatternTest {
       assertThatThrownBy(() -> p.namedGroups().put("foo", 99))
           .isInstanceOf(UnsupportedOperationException.class);
     }
+
+    @Test
+    @DisplayName("RE2_NAMED_GROUPS flag enables (?P<name>expr) syntax with underscores")
+    void re2NamedGroups() {
+      Pattern p =
+          Pattern.compile(
+              "(?P<user_name>[\\w.]+)@(?P<host_name>[\\w.]+)", Pattern.RE2_NAMED_GROUPS);
+      assertThat(p.namedGroups()).containsEntry("user_name", 1);
+      assertThat(p.namedGroups()).containsEntry("host_name", 2);
+      Matcher m = p.matcher("alice_smith@example.com");
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group("user_name")).isEqualTo("alice_smith");
+      assertThat(m.group("host_name")).isEqualTo("example.com");
+    }
+
+    @Test
+    @DisplayName("(?P<name>expr) syntax is rejected without RE2_NAMED_GROUPS flag")
+    void re2NamedGroupsRejectedWithoutFlag() {
+      assertThatThrownBy(() -> Pattern.compile("(?P<user_name>\\w+)@(?P<host_name>\\w+)"))
+          .isInstanceOf(PatternSyntaxException.class);
+    }
   }
 
   @Nested


### PR DESCRIPTION
This adds support for Python style `?P<GROUP_NAME>` named capturing groups, with the `P` and allowing underscores in group names.

This syntax isn't allowed by `java.util.regex`, but is supported by RE2 family implementations like RE2J. Supporting it here provides an easier migration path for users of RE2 regex engines.

This PR unconditionally allows the syntax in `Pattern.compile`. I thought about making it configurable, but the current set of `Pattern` flags exactly matches `java.util.regex`, and it seems nice to keep them in sync (especially if `Pattern` ever added another flag in the future). It'd be possible to have a separate set of SafeRE-specific configuration and expose that in the `Pattern` API. I also don't see significant downsides to unconditionally supporting the syntax, I think the `?P` syntax has been [claimed by Python](https://web.archive.org/web/20221023212326/http://markmail.org/message/oyezhwvefvotacc3) and is unlikely to collide with anything or cause problems.