### PR TITLE
Preserve linear time for grapheme compatibility paths

### DIFF
--- a/.agents/skills/linear-time-review/SKILL.md
+++ b/.agents/skills/linear-time-review/SKILL.md
@@ -56,8 +56,33 @@ reason each item may threaten linear time. Do not fix issues unless the user exp
      per-capture/per-position matching in ways that scale beyond linear in input for fixed pattern.
    - Public API methods such as `find`, `matches`, replacement, split, regions, and pattern sets
      that may call the engine repeatedly without consuming input or proving progress.
+   - JDK compatibility repairs that happen after engine execution by repeatedly invoking matchers,
+     replaying prefixes, rescanning unbounded context from many positions, or otherwise nesting
+     input-position work inside retry loops.
 
-5. Calibrate findings.
+5. Review JDK-compatibility pressure points explicitly.
+   - UTF-16 search positions: JDK `Matcher` positions are `char` indices, so compatibility may
+     expose starts inside surrogate pairs. Verify these positions are represented in engine state
+     or handled by a bounded linear pass, not by retrying a matcher from every candidate index.
+   - Grapheme constructs: `\X` and `\b{g}` require Unicode boundary context. Verify regional
+     indicator parity, emoji/ZWJ context, and other boundary state are computed incrementally or
+     cached per input instead of scanning backward from each boundary check.
+   - Region and bounds semantics: `region()`, transparent bounds, anchoring bounds, `^`, `$`,
+     `\A`, `\G`, word boundaries, `hitEnd()`, and `requireEnd()` depend on context around the
+     current search range. Verify that context is an explicit input to empty-width checks and
+     engine state rather than a post-hoc correction.
+   - Capture compatibility: JDK-compatible captures, especially quantified captures and
+     alternations, must not be recovered by per-capture or per-position matcher reruns. A bounded
+     extraction pass is acceptable; retry loops over captures or positions are not.
+   - Fallback engine selection: OnePass, DFA, BitState, and NFA fallbacks should compose as a
+     bounded number of passes over the relevant range. Treat repeated fallback invocations over
+     growing or overlapping ranges as high risk.
+   - Compatibility boundary: if observed JDK behavior appears to require nested matching over input
+     positions, report it as a compatibility boundary. Either identify an engine-native linear
+     formulation or recommend documenting an intentional divergence under SafeRE's linear-time
+     guarantee.
+
+6. Calibrate findings.
    - Distinguish proven issues, plausible risks, and false alarms.
    - For potential problems, describe the adversarial pattern/input shape that would expose the
      risk.
@@ -66,7 +91,7 @@ reason each item may threaten linear time. Do not fix issues unless the user exp
    - Do not mark an intentional bounded cost as a problem. Examples: work proportional to compiled
      program size, Unicode table setup at compile time, or a single forward scan of input.
 
-6. Report results.
+7. Report results.
    - Start with findings ordered by severity. Use file and line references.
    - For each finding include: risk, why it may break linear time, suspected trigger, and confidence
      level.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,15 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   specification, stop and explain the contradiction to the project owner; if
   they confirm proceeding, match the specification subject to linear time and
   document the intentional divergence from observed JDK behavior.
+- **Compatibility must be engine-native or bounded.** JDK compatibility code
+  may add explicit dimensions to engine state, use bounded per-input context,
+  or perform a bounded number of linear passes over the relevant input range.
+  It must not repair engine results by repeatedly invoking matchers, replaying
+  prefixes, rescanning unbounded context from many positions, or otherwise
+  nesting input-position work inside retry loops. If matching observed JDK
+  behavior appears to require that shape, stop and treat it as a compatibility
+  boundary: either find an engine-native linear formulation, or document an
+  intentional divergence under the linear-time guarantee.
 - **Linear time**: No backreferences, no lookahead/lookbehind, no possessive
   quantifiers. These features violate linear-time guarantees and must be
   rejected at parse time with a clear error.

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -256,6 +256,7 @@ final class BitState {
   private boolean longest;
   private boolean endMatch;
   private int ncap;
+  private Nfa.GraphemeContext graphemeContext;
 
   /**
    * Visited bitmap: bit {@code (instId * textSlots + pos)} tracks whether the given (instruction,
@@ -308,6 +309,7 @@ final class BitState {
     this.ncap = ncap;
     this.textSlots = textLen + 1;
     this.cycleAlts = prog.epsilonCycleAlts();
+    this.graphemeContext = Nfa.GraphemeContext.create(text, prog.hasGraphemeClusterBoundary());
 
     int totalBits = prog.size() * textSlots;
     int visitedLen = (totalBits + 63) / 64;
@@ -466,7 +468,8 @@ final class BitState {
 
         case InstOp.OP_EMPTY_WIDTH -> {
           int curFlags =
-              Nfa.emptyFlags(text, pos, prog.unixLines(), prog.hasGraphemeClusterBoundary());
+              Nfa.emptyFlags(
+                  text, pos, prog.unixLines(), prog.hasGraphemeClusterBoundary(), graphemeContext);
           if ((ip.arg & ~curFlags) == 0) {
             if (shouldVisit(ip.out, pos)) {
               push(ip.out, pos);
@@ -603,6 +606,7 @@ final class BitState {
     this.endMatch = endMatch || prog.anchorEnd();
     this.ncap = ncap;
     this.textSlots = textLen + 1;
+    this.graphemeContext = Nfa.GraphemeContext.create(text, prog.hasGraphemeClusterBoundary());
     this.bestMatch = null;
     this.jobCount = 0;
     // Incrementally clear only dirtied bitmap words (much faster than full Arrays.fill).

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -188,6 +188,9 @@ final class Dfa {
   /** Shared empty instruction array to avoid repeated zero-length allocations. */
   private static final int[] EMPTY_INSTS = new int[0];
 
+  /** Per-search grapheme context. Set only while a search method is active. */
+  private Nfa.GraphemeContext graphemeContext;
+
   // ---------------------------------------------------------------------------
   // Construction
   // ---------------------------------------------------------------------------
@@ -516,7 +519,8 @@ final class Dfa {
     if (startInst == 0) {
       return deadState;
     }
-    int emptyFlags = Nfa.emptyFlags(text, pos, prog.unixLines(), hasGraphemeClusterBoundary);
+    int emptyFlags =
+        Nfa.emptyFlags(text, pos, prog.unixLines(), hasGraphemeClusterBoundary, graphemeContext);
 
     // Determine word-character context for \b/\B support.
     boolean lastWord;
@@ -630,7 +634,9 @@ final class Dfa {
     // This allows empty-width assertions like $ and \b to fire.
     if (cp < 0) {
       // Compute empty flags for end-of-text, but override word boundary using state context.
-      int emptyFlags = Nfa.emptyFlags(text, nextPos, prog.unixLines(), hasGraphemeClusterBoundary);
+      int emptyFlags =
+          Nfa.emptyFlags(
+              text, nextPos, prog.unixLines(), hasGraphemeClusterBoundary, graphemeContext);
       // At end-of-text the "current" character is not a word char.
       boolean wasWord = (s.flags & FLAG_LAST_WORD) != 0;
       if (wasWord) {
@@ -805,7 +811,9 @@ final class Dfa {
     // word boundary (depends on the next character) and END_LINE (depends on what's at
     // nextPos, not deterministic for cache). Unsatisfied EMPTY_WIDTH instructions will
     // remain in the frontier for re-evaluation when the next character arrives.
-    int emptyFlags = Nfa.emptyFlags(text, nextPos, prog.unixLines(), hasGraphemeClusterBoundary);
+    int emptyFlags =
+        Nfa.emptyFlags(
+            text, nextPos, prog.unixLines(), hasGraphemeClusterBoundary, graphemeContext);
     emptyFlags &=
         ~(EmptyOp.WORD_BOUNDARY
             | EmptyOp.NON_WORD_BOUNDARY
@@ -944,6 +952,7 @@ final class Dfa {
    *     exceeded its state budget
    */
   SearchResult doSearch(String text, int startPos, boolean anchored, boolean longest) {
+    graphemeContext = Nfa.GraphemeContext.create(text, hasGraphemeClusterBoundary);
     int textLen = text.length();
     // If the compiled program requires end-of-text matching (stripped $ or \z), enforce it.
     boolean needEndMatch = prog.anchorEnd();
@@ -1107,6 +1116,7 @@ final class Dfa {
    */
   SearchResult doSearchReverse(
       String text, int endPos, int startLimit, boolean anchored, boolean longest) {
+    graphemeContext = Nfa.GraphemeContext.create(text, hasGraphemeClusterBoundary);
     // The reversed program's "start of text" corresponds to endPos (the right edge of the match
     // region), and its "end of text" corresponds to startLimit (the left edge). We scan from
     // endPos backward to startLimit, feeding characters in reverse order.
@@ -1248,6 +1258,7 @@ final class Dfa {
    * states reached along the way.
    */
   ManyMatchResult doSearchMany(String text, boolean anchored) {
+    graphemeContext = Nfa.GraphemeContext.create(text, hasGraphemeClusterBoundary);
     int textLen = text.length();
     boolean needEndMatch = prog.anchorEnd();
     boolean dollarEnd = prog.dollarAnchorEnd();

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -163,6 +163,8 @@ public final class Matcher implements MatchResult {
 
   private Dfa cachedReverseDfa;
   private boolean reverseDfaLookedUp;
+  private String graphemeContextText;
+  private Nfa.GraphemeContext graphemeContext;
 
   /**
    * Creates a new matcher that will match the given input against the given pattern.
@@ -272,6 +274,8 @@ public final class Matcher implements MatchResult {
 
   private void resetStateForCurrentInput() {
     text = charSequenceToString(inputSequence);
+    graphemeContextText = null;
+    graphemeContext = null;
     regionStart = 0;
     regionEnd = text.length();
     resetSearchStateForInputStart();
@@ -297,12 +301,16 @@ public final class Matcher implements MatchResult {
       cachedBitState = null;
     }
     bitStateResult = null;
+    graphemeContextText = null;
+    graphemeContext = null;
   }
 
   private void invalidateInputDependentCaches() {
     bitStateBorrowed = false;
     cachedBitState = null;
     bitStateResult = null;
+    graphemeContextText = null;
+    graphemeContext = null;
   }
 
   private void preserveResultAcrossBoundsChange() {
@@ -750,9 +758,12 @@ public final class Matcher implements MatchResult {
               text,
               0,
               text.length(),
+              text.length(),
+              0,
               Nfa.Anchor.ANCHORED,
               Nfa.MatchKind.FULL_MATCH,
-              prog.numCaptures());
+              prog.numCaptures(),
+              graphemeContextFor(prog));
       result = nfaResult.groups();
     }
     return applyEngineResult(new FullMatchResult(result));
@@ -923,10 +934,24 @@ public final class Matcher implements MatchResult {
 
   private int nextGraphemeClusterBoundary(int start) {
     int pos = Math.min(start + 1, regionEnd);
-    while (pos < regionEnd && !Nfa.isGraphemeClusterBoundary(text, pos)) {
+    Nfa.GraphemeContext context = graphemeContext();
+    while (pos < regionEnd && !Nfa.isGraphemeClusterBoundary(text, pos, context)) {
       pos++;
     }
     return pos;
+  }
+
+  private Nfa.GraphemeContext graphemeContext() {
+    if (graphemeContext == null || !Objects.equals(graphemeContextText, text)) {
+      graphemeContextText = text;
+      graphemeContext =
+          Nfa.GraphemeContext.create(text, parentPattern.prog().hasGraphemeClusterBoundary());
+    }
+    return graphemeContext;
+  }
+
+  private Nfa.GraphemeContext graphemeContextFor(Prog prog) {
+    return prog.hasGraphemeClusterBoundary() ? graphemeContext() : null;
   }
 
   /**
@@ -1135,7 +1160,7 @@ public final class Matcher implements MatchResult {
           nextValidGraphemeCandidate(
               result, text, searchFrom, regionEnd, endPos, prog.numCaptures(), regionStart);
       if (result == null && !parentPattern.startsWithGraphemeClusterBoundary()) {
-        result = searchLowSurrogateStarts(text, searchFrom, regionEnd, prog.numCaptures());
+        result = searchLowSurrogateStarts(text, searchFrom, regionEnd, endPos, prog.numCaptures());
       }
     }
     return applyEngineResult(new FullMatchResult(result));
@@ -1612,7 +1637,9 @@ public final class Matcher implements MatchResult {
               nsubmatch,
               candidateRegionStart);
       if (result == null && !parentPattern.startsWithGraphemeClusterBoundary()) {
-        result = searchLowSurrogateStarts(text, effectiveStart, text.length(), prog.numCaptures());
+        result =
+            searchLowSurrogateStarts(
+                text, effectiveStart, text.length(), text.length(), prog.numCaptures());
         fullCapturesFromGraphemeFallback = result != null;
       }
     }
@@ -1628,18 +1655,17 @@ public final class Matcher implements MatchResult {
   }
 
   private int[] searchLowSurrogateStarts(
-      String text, int effectiveStart, int searchLimit, int nsubmatch) {
-    for (int pos = Math.max(0, effectiveStart); pos < searchLimit; pos++) {
-      if (!Character.isLowSurrogate(text.charAt(pos))) {
-        continue;
-      }
-      Matcher verifier = parentPattern.matcher(text).region(pos, searchLimit);
-      if (verifier.lookingAt()) {
-        int ncap = 2 * Math.max(nsubmatch, 1);
-        return Arrays.copyOf(verifier.groups, ncap);
-      }
-    }
-    return null;
+      String text, int effectiveStart, int searchLimit, int endPos, int nsubmatch) {
+    Nfa.SearchResult result =
+        Nfa.searchLowSurrogateStarts(
+            parentPattern.prog(),
+            text,
+            effectiveStart,
+            searchLimit,
+            endPos,
+            nsubmatch,
+            graphemeContext());
+    return result.groups();
   }
 
   private int[] nextValidGraphemeCandidate(
@@ -2080,7 +2106,8 @@ public final class Matcher implements MatchResult {
             nfaRegionStart,
             nfaAnchor,
             nfaKind,
-            nsubmatch);
+            nsubmatch,
+            graphemeContextFor(prog));
     return nfaResult.groups();
   }
 

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -58,6 +58,62 @@ final class Nfa {
   @SuppressWarnings("ArrayRecordComponent")
   record SearchResult(int[] groups) {}
 
+  /**
+   * Per-input grapheme segmentation context.
+   *
+   * <p>UAX #29 boundary checks are finite-state, but some rules need state from earlier code
+   * points. Keep that state here so engines can answer boundary questions in O(1) while scanning.
+   */
+  static final class GraphemeContext {
+    private static final GraphemeContext EMPTY = new GraphemeContext(null);
+
+    private final String text;
+    private boolean[] computedOddRegionalIndicatorsBefore;
+
+    private GraphemeContext(String text) {
+      this.text = text;
+    }
+
+    static GraphemeContext create(String text, boolean includeGraphemeClusterBoundary) {
+      if (!includeGraphemeClusterBoundary) {
+        return EMPTY;
+      }
+      return new GraphemeContext(text);
+    }
+
+    boolean hasEvenRegionalIndicatorsBefore(int pos) {
+      if (text == null) {
+        return true;
+      }
+      boolean[] oddRegionalIndicatorsBefore = oddRegionalIndicatorsBefore();
+      return pos < 0
+          || pos >= oddRegionalIndicatorsBefore.length
+          || !oddRegionalIndicatorsBefore[pos];
+    }
+
+    private boolean[] oddRegionalIndicatorsBefore() {
+      if (computedOddRegionalIndicatorsBefore != null) {
+        return computedOddRegionalIndicatorsBefore;
+      }
+      computedOddRegionalIndicatorsBefore = computeOddRegionalIndicatorsBefore(text);
+      return computedOddRegionalIndicatorsBefore;
+    }
+
+    private static boolean[] computeOddRegionalIndicatorsBefore(String text) {
+      boolean[] oddRegionalIndicatorsBefore = new boolean[text.length() + 1];
+      int runLength = 0;
+      int pos = 0;
+      while (pos < text.length()) {
+        int cp = text.codePointAt(pos);
+        int next = pos + Character.charCount(cp);
+        runLength = isRegionalIndicator(cp) ? runLength + 1 : 0;
+        oddRegionalIndicatorsBefore[next] = (runLength & 1) != 0;
+        pos = next;
+      }
+      return oddRegionalIndicatorsBefore;
+    }
+  }
+
   private final Prog prog;
   private final int ncapture;
 
@@ -68,6 +124,9 @@ final class Nfa {
   private final boolean endmatch;
   private final int endPos;
   private final int regionStart;
+  private final GraphemeContext graphemeContext;
+  private final boolean useMatchStartAsRegionStart;
+  private final boolean lowSurrogateStartsOnly;
 
   private boolean matched;
   private int[] bestMatch;
@@ -77,7 +136,15 @@ final class Nfa {
   private List<NfaThread> nextq;
 
   private Nfa(
-      Prog prog, int ncapture, boolean longest, boolean endmatch, int endPos, int regionStart) {
+      Prog prog,
+      GraphemeContext graphemeContext,
+      int ncapture,
+      boolean longest,
+      boolean endmatch,
+      int endPos,
+      int regionStart,
+      boolean useMatchStartAsRegionStart,
+      boolean lowSurrogateStartsOnly) {
     this.prog = prog;
     this.ncapture = ncapture;
     this.threadArraySize = ncapture + prog.numLoopRegs();
@@ -85,6 +152,9 @@ final class Nfa {
     this.endmatch = endmatch;
     this.endPos = endPos;
     this.regionStart = regionStart;
+    this.graphemeContext = graphemeContext;
+    this.useMatchStartAsRegionStart = useMatchStartAsRegionStart;
+    this.lowSurrogateStartsOnly = lowSurrogateStartsOnly;
     this.runq = new ArrayList<>();
     this.nextq = new ArrayList<>();
     this.bestMatch = new int[ncapture];
@@ -172,6 +242,21 @@ final class Nfa {
       Anchor anchor,
       MatchKind kind,
       int nsubmatch) {
+    return search(
+        prog, text, startPos, searchLimit, endPos, regionStart, anchor, kind, nsubmatch, null);
+  }
+
+  static SearchResult search(
+      Prog prog,
+      String text,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int regionStart,
+      Anchor anchor,
+      MatchKind kind,
+      int nsubmatch,
+      GraphemeContext graphemeContext) {
     if (prog.start() == 0) {
       return new SearchResult(null);
     }
@@ -191,7 +276,12 @@ final class Nfa {
     // We always need at least capture[0..1] to track the match boundaries.
     int ncapture = 2 * Math.max(nsubmatch, 1);
 
-    Nfa nfa = new Nfa(prog, ncapture, longestMode, endmatch, endPos, regionStart);
+    GraphemeContext context =
+        graphemeContext != null
+            ? graphemeContext
+            : GraphemeContext.create(text, prog.hasGraphemeClusterBoundary());
+    Nfa nfa =
+        new Nfa(prog, context, ncapture, longestMode, endmatch, endPos, regionStart, false, false);
     if (!anchored && prog.hasGraphemeClusterBoundary()) {
       nfa.doSearchEveryCharPosition(text, startPos, searchLimit);
     } else {
@@ -212,6 +302,32 @@ final class Nfa {
       result[i] = -1;
     }
     return new SearchResult(result);
+  }
+
+  static SearchResult searchLowSurrogateStarts(
+      Prog prog, String text, int startPos, int searchLimit, int endPos, int nsubmatch) {
+    return searchLowSurrogateStarts(prog, text, startPos, searchLimit, endPos, nsubmatch, null);
+  }
+
+  static SearchResult searchLowSurrogateStarts(
+      Prog prog,
+      String text,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int nsubmatch,
+      GraphemeContext graphemeContext) {
+    if (prog.start() == 0) {
+      return new SearchResult(null);
+    }
+    int ncapture = 2 * Math.max(nsubmatch, 1);
+    GraphemeContext context =
+        graphemeContext != null
+            ? graphemeContext
+            : GraphemeContext.create(text, prog.hasGraphemeClusterBoundary());
+    Nfa nfa = new Nfa(prog, context, ncapture, false, prog.anchorEnd(), endPos, 0, true, true);
+    nfa.doSearchEveryCharPosition(text, startPos, searchLimit);
+    return new SearchResult(nfa.matched ? nfa.bestMatch : null);
   }
 
   /**
@@ -239,7 +355,10 @@ final class Nfa {
       // (no point starting new threads to the right of an existing match).
       // Also don't start threads past searchLimit — the DFA has already determined
       // there's no match starting beyond that position.
-      if (!matched && pos <= searchLimit && (!anchored || pos == startPos)) {
+      if (!matched
+          && pos <= searchLimit
+          && (!anchored || pos == startPos)
+          && canStartAt(text, pos)) {
         int[] cap = new int[threadArraySize];
         Arrays.fill(cap, -1);
         cap[0] = pos;
@@ -306,7 +425,7 @@ final class Nfa {
     Set<Integer> secondqSet = new HashSet<>();
 
     for (int pos = start; pos < endPos + 2; pos++) {
-      if (!matched && pos <= searchLimit) {
+      if (!matched && pos <= searchLimit && canStartAt(text, pos)) {
         int[] cap = new int[threadArraySize];
         Arrays.fill(cap, -1);
         cap[0] = pos;
@@ -337,6 +456,11 @@ final class Nfa {
       secondqSet = oldRunqSet;
       secondqSet.clear();
     }
+  }
+
+  private boolean canStartAt(String text, int pos) {
+    return !lowSurrogateStartsOnly
+        || (pos >= 0 && pos < text.length() && Character.isLowSurrogate(text.charAt(pos)));
   }
 
   /**
@@ -452,14 +576,16 @@ final class Nfa {
         }
 
         case EMPTY_WIDTH -> {
+          int effectiveRegionStart = useMatchStartAsRegionStart ? t0[0] : regionStart;
           int flags =
               emptyFlags(
                   text,
                   pos,
                   prog.unixLines(),
                   prog.hasGraphemeClusterBoundary(),
+                  graphemeContext,
                   t0[0],
-                  regionStart,
+                  effectiveRegionStart,
                   consumedInput,
                   endPos);
           if ((ip.arg & ~flags) == 0) {
@@ -685,7 +811,18 @@ final class Nfa {
 
   static int emptyFlags(
       String text, int pos, boolean unixLines, boolean includeGraphemeClusterBoundary) {
-    return emptyFlags(text, pos, unixLines, includeGraphemeClusterBoundary, -1);
+    return emptyFlags(
+        text, pos, unixLines, includeGraphemeClusterBoundary, (GraphemeContext) null, -1, 0, false);
+  }
+
+  static int emptyFlags(
+      String text,
+      int pos,
+      boolean unixLines,
+      boolean includeGraphemeClusterBoundary,
+      GraphemeContext graphemeContext) {
+    return emptyFlags(
+        text, pos, unixLines, includeGraphemeClusterBoundary, graphemeContext, -1, 0, false);
   }
 
   static int emptyFlags(
@@ -694,7 +831,15 @@ final class Nfa {
       boolean unixLines,
       boolean includeGraphemeClusterBoundary,
       int matchStart) {
-    return emptyFlags(text, pos, unixLines, includeGraphemeClusterBoundary, matchStart, 0);
+    return emptyFlags(
+        text,
+        pos,
+        unixLines,
+        includeGraphemeClusterBoundary,
+        (GraphemeContext) null,
+        matchStart,
+        0,
+        false);
   }
 
   static int emptyFlags(
@@ -705,7 +850,7 @@ final class Nfa {
       int matchStart,
       int regionStart) {
     return emptyFlags(
-        text, pos, unixLines, includeGraphemeClusterBoundary, matchStart, regionStart, false);
+        text, pos, unixLines, includeGraphemeClusterBoundary, null, matchStart, regionStart, false);
   }
 
   private static int emptyFlags(
@@ -713,6 +858,7 @@ final class Nfa {
       int pos,
       boolean unixLines,
       boolean includeGraphemeClusterBoundary,
+      GraphemeContext graphemeContext,
       int matchStart,
       int regionStart,
       boolean consumedInput) {
@@ -721,6 +867,7 @@ final class Nfa {
         pos,
         unixLines,
         includeGraphemeClusterBoundary,
+        graphemeContext,
         matchStart,
         regionStart,
         consumedInput,
@@ -732,6 +879,7 @@ final class Nfa {
       int pos,
       boolean unixLines,
       boolean includeGraphemeClusterBoundary,
+      GraphemeContext graphemeContext,
       int matchStart,
       int regionStart,
       boolean consumedInput,
@@ -831,7 +979,7 @@ final class Nfa {
         if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart)) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
-      } else if (isGraphemeClusterBoundary(text, pos, regionStart)) {
+      } else if (isGraphemeClusterBoundary(text, pos, regionStart, graphemeContext)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
         if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart)
             || !isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
@@ -877,10 +1025,15 @@ final class Nfa {
    * of JDK {@code \X}.
    */
   static boolean isGraphemeClusterBoundary(String text, int pos) {
-    return isGraphemeClusterBoundary(text, pos, 0);
+    return isGraphemeClusterBoundary(text, pos, 0, GraphemeContext.create(text, true));
   }
 
-  private static boolean isGraphemeClusterBoundary(String text, int pos, int regionStart) {
+  static boolean isGraphemeClusterBoundary(String text, int pos, GraphemeContext graphemeContext) {
+    return isGraphemeClusterBoundary(text, pos, 0, graphemeContext);
+  }
+
+  private static boolean isGraphemeClusterBoundary(
+      String text, int pos, int regionStart, GraphemeContext graphemeContext) {
     if (pos < 0 || pos > text.length()) {
       return false;
     }
@@ -922,7 +1075,9 @@ final class Nfa {
       return false;
     }
     if (isRegionalIndicator(prev) && isRegionalIndicator(next)) {
-      return countPrecedingRegionalIndicators(text, pos) % 2 == 0;
+      GraphemeContext context =
+          graphemeContext != null ? graphemeContext : GraphemeContext.create(text, true);
+      return context.hasEvenRegionalIndicatorsBefore(pos);
     }
     return true;
   }
@@ -1165,20 +1320,6 @@ final class Nfa {
 
   private static boolean isRegionalIndicator(int c) {
     return 0x1F1E6 <= c && c <= 0x1F1FF;
-  }
-
-  private static int countPrecedingRegionalIndicators(String text, int pos) {
-    int count = 0;
-    int current = pos;
-    while (current > 0) {
-      int cp = text.codePointBefore(current);
-      if (!isRegionalIndicator(cp)) {
-        break;
-      }
-      count++;
-      current -= Character.charCount(cp);
-    }
-    return count;
   }
 
   private static boolean containsCodePoint(int[][] ranges, int c) {

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -482,6 +482,18 @@ final class OnePass {
    * @return submatch positions relative to {@code text}, or null if no match
    */
   SearchResult search(String text, int startPos, int endPos, boolean endMatch, int nsubmatch) {
+    Nfa.GraphemeContext graphemeContext =
+        Nfa.GraphemeContext.create(text, hasGraphemeClusterBoundary);
+    return search(text, startPos, endPos, endMatch, nsubmatch, graphemeContext);
+  }
+
+  private SearchResult search(
+      String text,
+      int startPos,
+      int endPos,
+      boolean endMatch,
+      int nsubmatch,
+      Nfa.GraphemeContext graphemeContext) {
     int ncap = 2 * Math.max(nsubmatch, 1);
     int[] cap = new int[ncap];
     Arrays.fill(cap, -1);
@@ -507,7 +519,9 @@ final class OnePass {
         long matchAct = ma[state];
         int reqEmpty = (int) (matchAct & EMPTY_MASK);
         if (reqEmpty == 0
-            || (reqEmpty & ~Nfa.emptyFlags(text, pos, unixLines, hasGraphemeClusterBoundary))
+            || (reqEmpty
+                    & ~Nfa.emptyFlags(
+                        text, pos, unixLines, hasGraphemeClusterBoundary, graphemeContext))
                 == 0) {
           int capMask = (int) ((matchAct >>> CAP_SHIFT) & CAP_REG_MASK);
           if (capMask != 0) {
@@ -551,7 +565,8 @@ final class OnePass {
       if (conditions != 0) {
         int reqEmpty = (int) (conditions & EMPTY_MASK);
         if (reqEmpty != 0) {
-          int curEmpty = Nfa.emptyFlags(text, pos, unixLines, hasGraphemeClusterBoundary);
+          int curEmpty =
+              Nfa.emptyFlags(text, pos, unixLines, hasGraphemeClusterBoundary, graphemeContext);
           if ((reqEmpty & ~curEmpty) != 0) {
             break;
           }
@@ -570,7 +585,10 @@ final class OnePass {
       long matchAct = ma[state];
       int reqEmpty = (int) (matchAct & EMPTY_MASK);
       if (reqEmpty == 0
-          || (reqEmpty & ~Nfa.emptyFlags(text, pos, unixLines, hasGraphemeClusterBoundary)) == 0) {
+          || (reqEmpty
+                  & ~Nfa.emptyFlags(
+                      text, pos, unixLines, hasGraphemeClusterBoundary, graphemeContext))
+              == 0) {
         int capMask = (int) ((matchAct >>> CAP_SHIFT) & CAP_REG_MASK);
         if (capMask != 0) {
           applyCaptures(capMask, pos, cap);
@@ -612,8 +630,10 @@ final class OnePass {
   int[] searchUnanchored(String text, int startPos, int searchLimit, int nsubmatch) {
     int textLen = text.length();
     int limit = Math.min(searchLimit, textLen) + 1;
+    Nfa.GraphemeContext graphemeContext =
+        Nfa.GraphemeContext.create(text, hasGraphemeClusterBoundary);
     for (int start = startPos; start < limit; start++) {
-      SearchResult result = search(text, start, textLen, false, nsubmatch);
+      SearchResult result = search(text, start, textLen, false, nsubmatch, graphemeContext);
       if (result.groups() != null) {
         return result.groups();
       }

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -7,11 +7,14 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.IntConsumer;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +26,7 @@ import org.junit.jupiter.api.Test;
  * Validates behavior against JDK 21's {@link java.util.regex.Pattern} specification.
  */
 class LinebreakGraphemeTest {
+  private static final Duration PERFORMANCE_SCENARIO_TIMEOUT = Duration.ofSeconds(30);
 
   @Nested
   @DisplayName("\\R (Unicode linebreak)")
@@ -505,6 +509,46 @@ class LinebreakGraphemeTest {
     }
 
     @Test
+    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
+    @DisplayName("repeated find() over grapheme clusters reuses per-input context")
+    void repeatedFindOverGraphemeClustersReusesPerInputContext() {
+      Pattern pattern = Pattern.compile("\\X");
+
+      assertFourXInputStaysNearLinear(
+          "repeated find() over grapheme clusters",
+          length -> {
+            Matcher matcher = pattern.matcher("a".repeat(length));
+            int count = 0;
+            while (matcher.find()) {
+              count++;
+            }
+            assertThat(count).isEqualTo(length);
+          });
+    }
+
+    @Test
+    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
+    @DisplayName("JDK-compatible low-surrogate search positions stay near-linear")
+    void lowSurrogateSearchPositionsStayNearLinear() {
+      Pattern pattern = Pattern.compile(".*\\b{g}z");
+
+      assertFourXInputStaysNearLinear(
+          "low-surrogate search-position miss",
+          length -> assertThat(pattern.matcher("\uDC00".repeat(length)).find()).isFalse());
+    }
+
+    @Test
+    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
+    @DisplayName("regional-indicator grapheme boundary misses stay near-linear")
+    void regionalIndicatorBoundaryMissesStayNearLinear() {
+      Pattern pattern = Pattern.compile("\\b{g}z");
+
+      assertFourXInputStaysNearLinear(
+          "regional-indicator boundary miss",
+          length -> assertThat(pattern.matcher("\uD83C\uDDE6".repeat(length)).find()).isFalse());
+    }
+
+    @Test
     @DisplayName("consecutive \\X atoms do not split a single grapheme cluster")
     void consecutiveAtomsDoNotSplitSingleCluster() {
       Pattern p = Pattern.compile("^\\X\\X$");
@@ -750,6 +794,36 @@ class LinebreakGraphemeTest {
       assertThat(matcher.find()).isTrue();
       assertThat(matcher.start()).isZero();
       assertThat(matcher.end()).isEqualTo(2);
+    }
+
+    private void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
+      task.accept(100);
+      long smallerNanos = bestRuntimeNanos(() -> task.accept(1_000));
+      long largerNanos = bestRuntimeNanos(() -> task.accept(4_000));
+
+      assertThat(largerNanos)
+          .as(
+              "%s: 4x input should stay near-linear, smaller=%dns larger=%dns",
+              scenario, smallerNanos, largerNanos)
+          .isLessThan(smallerNanos * 10);
+    }
+
+    private long bestRuntimeNanos(Runnable task) {
+      long best = Long.MAX_VALUE;
+      for (int i = 0; i < 3; i++) {
+        best = Math.min(best, runtimeNanos(task));
+      }
+      return best;
+    }
+
+    private long runtimeNanos(Runnable task) {
+      return assertTimeoutPreemptively(
+          PERFORMANCE_SCENARIO_TIMEOUT,
+          () -> {
+            long start = System.nanoTime();
+            task.run();
+            return System.nanoTime() - start;
+          });
     }
 
     private AllocationTracker allocationTracker() {

--- a/safere/src/test/java/org/safere/PatternSetTest.java
+++ b/safere/src/test/java/org/safere/PatternSetTest.java
@@ -7,8 +7,11 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.function.IntConsumer;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /** Tests for {@link PatternSet}. */
 @DisabledForCrosscheck("PatternSet is a SafeRE-only API with no java.util.regex equivalent")
 class PatternSetTest {
+  private static final Duration PERFORMANCE_SCENARIO_TIMEOUT = Duration.ofSeconds(30);
 
   // ---------------------------------------------------------------------------
   // Builder
@@ -141,6 +145,17 @@ class PatternSetTest {
 
       assertThat(set.matches("foo bar")).isTrue();
       assertThat(set.matches("nothing")).isFalse();
+    }
+
+    @Test
+    void regionalIndicatorGraphemeBoundaryMissesStayNearLinear() {
+      PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.UNANCHORED);
+      b.add("\\b{g}z");
+      PatternSet set = b.compile();
+
+      assertFourXInputStaysNearLinear(
+          "PatternSet regional-indicator boundary miss",
+          length -> assertThat(set.match("\uD83C\uDDE6".repeat(length))).isEmpty());
     }
   }
 
@@ -534,5 +549,35 @@ class PatternSetTest {
       PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.ANCHOR_BOTH);
       assertThatThrownBy(b::compile).isInstanceOf(IllegalStateException.class);
     }
+  }
+
+  private static void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
+    task.accept(100);
+    long smallerNanos = bestRuntimeNanos(() -> task.accept(1_000));
+    long largerNanos = bestRuntimeNanos(() -> task.accept(4_000));
+
+    assertThat(largerNanos)
+        .as(
+            "%s: 4x input should stay near-linear, smaller=%dns larger=%dns",
+            scenario, smallerNanos, largerNanos)
+        .isLessThan(smallerNanos * 10);
+  }
+
+  private static long bestRuntimeNanos(Runnable task) {
+    long best = Long.MAX_VALUE;
+    for (int i = 0; i < 3; i++) {
+      best = Math.min(best, runtimeNanos(task));
+    }
+    return best;
+  }
+
+  private static long runtimeNanos(Runnable task) {
+    return assertTimeoutPreemptively(
+        PERFORMANCE_SCENARIO_TIMEOUT,
+        () -> {
+          long start = System.nanoTime();
+          task.run();
+          return System.nanoTime() - start;
+        });
   }
 }


### PR DESCRIPTION
## Summary
- Preserve linear time for grapheme/JDK compatibility paths by replacing the per-low-surrogate matcher retry loop with one bounded NFA pass.
- Add lazy per-input grapheme context for regional-indicator parity and thread it through NFA, DFA, OnePass, BitState, and Matcher paths.
- Add scaling regressions for low-surrogate search positions, RI grapheme boundaries, repeated grapheme find(), and PatternSet.
- Document the engine-native-or-bounded compatibility rule in AGENTS.md and the linear-time review skill.

## Verification
- `mvn -pl safere -Dtest=LinebreakGraphemeTest,BoundaryMatcherTest,MatcherTest,PatternSetTest test -q`
- `mvn -pl safere test -q`
- `git diff --check`

## Not Run
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
- JMH benchmarks; this PR fixes asymptotic behavior covered by scaling regressions rather than a throughput optimization.
