### PR TITLE
Fix leftmost find start for overlapping suffixes

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -7,22 +7,41 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
+import org.junit.jupiter.api.Test;
 
 final class FindSequenceFuzzer {
+
+  @Test
+  void delimitedPrefixBeforeRequiredSuffixRegression() {
+    FuzzSupport.CompiledPattern pattern =
+        FuzzSupport.compileOrSkip("[^{']*(?:'[^']*'[^{']*)*\\{([^}]*)\\}", 0);
+
+    pattern.matcher("Foo '{0}' Bar: {0}").find();
+  }
 
   @FuzzTest(maxDuration = "30s")
   void sequence(FuzzedDataProvider data) {
     String regex;
     int flags;
     String input;
-    if (data.consumeBoolean()) {
-      regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
-      flags = 0;
-      input = data.consumeBoolean() ? "a" : "a!";
-    } else {
-      regex = data.consumeString(256);
-      flags = FuzzSupport.consumeFlags(data);
-      input = data.consumeString(2048);
+    switch (data.consumeInt(0, 2)) {
+      case 0 -> {
+        regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
+        flags = 0;
+        input = data.consumeBoolean() ? "a" : "a!";
+      }
+      case 1 -> {
+        String suffix = data.consumeBoolean() ? "\\{([^}]*)\\}" : "END";
+        regex = "[^']*(?:'[^']*'[^']*)*" + suffix;
+        flags = 0;
+        input = data.consumeBoolean() ? "Foo '{0}' Bar: {0}" : "prefix 'not END' suffix END";
+      }
+      case 2 -> {
+        regex = data.consumeString(256);
+        flags = FuzzSupport.consumeFlags(data);
+        input = data.consumeString(2048);
+      }
+      default -> throw new AssertionError();
     }
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, flags);
     if (pattern == null) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1343,26 +1343,10 @@ public final class Matcher implements MatchResult {
       effectiveStart = idx;
     }
 
-    // OnePass primary path for small texts: for OnePass-eligible unanchored patterns on short
-    // input, scan with OnePass directly. OnePass is faster than BitState — no visited bitmap
-    // or job stack allocation, deterministic single-pass traversal per start position.
-    // Skip for nullable alternation (see anchored path comment above).
-    if (options.onePass()
-        && (parentPattern.canOnePassPrimary()
-            || (!options.semanticGuards() && parentPattern.onePass() != null))
-        && !prog.hasGraphemeClusterBoundary()
-        && text.length() <= 256
-        && canUsePikeEquivalentCaptures(prog)
-        && (!options.semanticGuards() || !parentPattern.hasNullableAlternation())) {
-      int[] result =
-          parentPattern
-              .onePass()
-              .searchUnanchored(text, effectiveStart, text.length(), prog.numCaptures());
-      if (result != null) {
-        return applyEngineResult(new FullMatchResult(result));
-      }
-      return applyEngineResult(new NoMatchResult());
-    }
+    // Do not use OnePass as an unanchored find() producer. Even when a pattern is OnePass-eligible
+    // for anchored matching, trying deterministic anchored matches at successive positions can
+    // miss the leftmost start when a greedy leading repetition overlaps a later required literal.
+    // The DFA/BitState/NFA pipeline below preserves leftmost find() semantics and remains linear.
 
     // Reverse-first optimization for end-anchored patterns: for patterns ending with $ or \z
     // that are NOT anchored at the start, run the reverse DFA from the end of the text first.
@@ -1541,6 +1525,7 @@ public final class Matcher implements MatchResult {
               revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
           if (revResult != null && revResult.matched()) {
             int matchStart = revResult.pos();
+            boolean authoritativeStart = !options.semanticGuards() || matchStart == effectiveStart;
 
             // For dollarAnchorEnd patterns, the forward DFA's earlyEnd is always textLen
             // (it can't return early). But the correct leftmost match may end before the
@@ -1566,6 +1551,7 @@ public final class Matcher implements MatchResult {
                       && altRevResult.matched()
                       && altRevResult.pos() < matchStart) {
                     matchStart = altRevResult.pos();
+                    authoritativeStart = !options.semanticGuards() || matchStart == effectiveStart;
                   }
                 }
                 // For \r\n, try position before \r.
@@ -1576,23 +1562,33 @@ public final class Matcher implements MatchResult {
                       && altRevResult2.matched()
                       && altRevResult2.pos() < matchStart) {
                     matchStart = altRevResult2.pos();
+                    authoritativeStart = !options.semanticGuards() || matchStart == effectiveStart;
                   }
                 }
               }
             }
 
+            // The forward DFA finds the earliest match end, not necessarily the end of the
+            // leftmost-starting match. If the reverse DFA lands after the earliest candidate start,
+            // an earlier match may still exist and end later. Let the submatch engine decide.
+            if (!authoritativeStart) {
+              matchStart = -1;
+            }
+
             // Step 3: Forward DFA anchored at matchStart with longest=true to find actual end.
-            Dfa.SearchResult fwdLongest = dfa().doSearch(text, matchStart, true, true);
-            if (fwdLongest != null && fwdLongest.matched()) {
-              int matchEnd = fwdLongest.pos();
-              // Step 4: Store group(0) boundaries, defer inner captures until requested.
-              return applyEngineResult(
-                  new DeferredMatchResult(
-                      matchStart,
-                      matchEnd,
-                      prog.numCaptures(),
-                      !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
-                      false));
+            if (matchStart >= 0) {
+              Dfa.SearchResult fwdLongest = dfa().doSearch(text, matchStart, true, true);
+              if (fwdLongest != null && fwdLongest.matched()) {
+                int matchEnd = fwdLongest.pos();
+                // Step 4: Store group(0) boundaries, defer inner captures until requested.
+                return applyEngineResult(
+                    new DeferredMatchResult(
+                        matchStart,
+                        matchEnd,
+                        prog.numCaptures(),
+                        !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
+                        false));
+              }
             }
             // If anchored forward DFA fails, fall through to full search.
           }

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -73,7 +73,7 @@ class EnginePathEquivalenceTest {
   @Test
   @DisplayName("OnePass nullable-alternation guard has semantic content")
   void onePassNullableAlternationGuardHasSemanticContent() {
-    String regex = "(?:|a)";
+    String regex = "^(?:|a)";
     String input = "a";
     Pattern canonical = Pattern.compile(regex);
     Pattern unguarded =

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -573,6 +573,26 @@ class MatcherTest {
       assertAllFindsMatchJdk("(?m)^\\s+at\\s+(\\w+)$", "header\u2028\tat alpha\u2029\tat beta");
     }
 
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "[^{']*(?:'[^']*'[^{']*)*\\{([^}]*)\\}",
+          "[^']*(?:'[^']*'[^']*)*END",
+          "[^<]*(?:<[^>]*>[^<]*)*TARGET"
+        })
+    @DisplayName("find() preserves leftmost start before a later required literal")
+    void findPreservesLeftmostStartBeforeLaterRequiredLiteral(String regex) {
+      String input =
+          switch (regex) {
+            case "[^{']*(?:'[^']*'[^{']*)*\\{([^}]*)\\}" -> "Foo '{0}' Bar: {0}";
+            case "[^']*(?:'[^']*'[^']*)*END" -> "prefix 'not END' suffix END";
+            case "[^<]*(?:<[^>]*>[^<]*)*TARGET" -> "prefix <not TARGET> suffix TARGET";
+            default -> throw new AssertionError("unexpected regex: " + regex);
+          };
+
+      assertFirstFindMatchesJdk(regex, input);
+    }
+
     private void assertAllFindsMatchJdk(String regex, String input) {
       assertAllFindsMatchJdk(regex, 0, input);
     }


### PR DESCRIPTION
## Summary

- Preserve leftmost `find()` starts when greedy leading context overlaps a later required literal.
- Stop using unanchored OnePass as an authoritative `find()` producer; fall through to the linear DFA/BitState/NFA pipeline instead.
- Guard the DFA sandwich so a later reverse-DFA start falls through to the submatch engine.
- Add matcher regression coverage and FindSequenceFuzzer coverage for the issue shape.

Fixes #445

## Verification

- `mvn -pl safere -Dtest=MatcherTest test`
- `mvn -pl safere -Dtest=EnginePathEquivalenceTest test`
- `mvn -pl safere -Dtest=MatcherTest,EnginePathEquivalenceTest test`
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`

Not run: full public API crosscheck, because another heavy crosscheck JVM was already running in a separate workspace and running another in parallel would compete for CPU.
