### PR TITLE
Implement principled grapheme-region matching

### DIFF
--- a/.agents/skills/divergence-result-review/SKILL.md
+++ b/.agents/skills/divergence-result-review/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: divergence-result-review
+description: Review SafeRE/java.util.regex divergence sweep outputs, JSONL reports, fuzz result sets, or differential matrices by bucketing related failures, classifying whether each bucket is specification-required, reasonable compatibility behavior, intentional JDK implementation detail, or unsupported under SafeRE's linear-time guarantee, and assessing whether each bucket can be fixed with a principled linear-time implementation. Use when asked to analyze, inventory, categorize, triage, summarize, or decide next steps for divergence results rather than immediately fixing a single bug.
+---
+
+# Divergence Result Review
+
+## Goal
+
+Turn raw SafeRE/JDK divergence artifacts into a small set of semantic buckets with a decision for
+each bucket:
+
+1. Does the JDK behavior follow the official specification, is it otherwise reasonable behavior
+   SafeRE should target, or is it an observed JDK implementation detail?
+2. Can SafeRE support that behavior with a principled implementation that preserves the linear-time
+   guarantee?
+
+This skill is for review and triage. Do not fix code unless the user explicitly asks.
+
+## Sources Of Truth
+
+Use the SafeRE compatibility policy:
+
+1. Preserve SafeRE's linear-time guarantee.
+2. Within that constraint, follow the official JDK specification.
+3. If the specification is ambiguous or silent, match observed JDK behavior only when it can be
+   expressed as principled engine semantics and remains linear.
+4. If observed JDK behavior appears to be an implementation detail or requires retry loops,
+   verifier matchers, pattern-specific exceptions, or repeated rescans, classify it as an
+   intentional divergence candidate rather than a bug to emulate.
+
+When spec interpretation matters, check the official JDK Javadocs:
+
+- `Pattern`: `https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/regex/Pattern.html`
+- `Matcher`: `https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/regex/Matcher.html`
+
+For Unicode grapheme behavior, use Unicode UAX #29 and the project design:
+
+- UAX #29: `https://www.unicode.org/reports/tr29/`
+- `design/GRAPHEME_REGION_MATCHING.md`
+
+## Artifact Triage
+
+1. Inventory the run directory before reading large files:
+   - `rg --files <report-dir>`
+   - `du -h <report-dir>/*`
+   - inspect summary TSV/JSON files first if they exist.
+2. If only a huge JSONL exists, treat it as a stream:
+   - sample `head`, `tail`, and evenly spaced byte offsets;
+   - use bounded streaming scripts, `jq`, `rg -m`, or `python3` generators;
+   - never load the full file or build an exact unbounded hash map over all buckets.
+3. State whether the run is complete:
+   - complete if final summary files were written or the run reported completion;
+   - incomplete if the process was stopped before summary output.
+4. Do not claim exact counts from samples. Report exact counts only from completed summary files or
+   bounded explicit passes whose scope you state.
+
+## Bucketing Workflow
+
+1. Parse each divergence into stable dimensions:
+   - regex label and regex;
+   - operation (`matches`, `lookingAt`, `find`, repeated find, reset/reuse, replacement, compile);
+   - region shape, transparent bounds, anchoring bounds;
+   - input family or Unicode class shape;
+   - mismatch direction: accept/reject, trace bounds, captures, errors, stateful behavior.
+2. Bucket by semantic shape, not by raw input string. Prefer labels such as:
+   - `matches()` end condition mismatch;
+   - non-anchoring anchor context;
+   - transparent boundary visibility;
+   - repeated-find cursor after empty boundary;
+   - grapheme cluster segmentation context;
+   - capture trace mismatch;
+   - parser acceptance/rejection mismatch.
+3. For each bucket, keep representative examples:
+   - smallest readable reproducer if available;
+   - one high-risk Unicode/region example if it reveals the real boundary condition;
+   - one example showing captures or statefulness if relevant.
+4. Separate already-known intentional classes from unknown classes. Use existing project tests and
+   design docs to avoid reopening decisions already made.
+
+## Classification
+
+Classify each bucket with both a behavior status and a feasibility status.
+
+Behavior statuses:
+
+- `SPEC_REQUIRED`: JDK behavior is required by Pattern/Matcher Javadocs and can be stated as a
+  normal regex/API rule.
+- `REASONABLE_COMPAT`: the spec is ambiguous or silent, but the observed JDK behavior is coherent,
+  useful, and fits SafeRE's model.
+- `JDK_DETAIL`: observed behavior appears to come from java.util.regex implementation mechanics
+  rather than from the spec or a coherent compositional model.
+- `LINEAR_TIME_UNSUPPORTED`: the behavior may be specified or useful, but supporting it would break
+  SafeRE's linear-time guarantee or require unsupported regex semantics.
+- `NEEDS_MORE_DATA`: the artifact is too incomplete or ambiguous to classify responsibly.
+
+Feasibility statuses:
+
+- `ENGINE_NATIVE_LINEAR`: can be implemented as a bounded engine transition, predicate, cache key,
+  or context parameter.
+- `LINEAR_WITH_CACHING`: can be implemented linearly if per-input or per-context state is cached
+  instead of rescanned.
+- `LINEAR_BY_GUARDING_PATHS`: can be supported by routing affected programs away from optimized
+  paths until those paths share the canonical semantics.
+- `NOT_PRINCIPLED`: exact emulation would require verifier matchers, repeated re-search, post-hoc
+  retries, pattern/input special cases, or behavior that does not compose.
+- `UNKNOWN_FEASIBILITY`: more code review or targeted testing is needed.
+
+## Linear-Time Assessment
+
+For each bucket that might be fixable, identify the intended implementation shape:
+
+- explicit engine context dimension;
+- cache key dimension;
+- single-pass or amortized-O(1) boundary table;
+- monotonic search cursor rule;
+- parser acceptance/rejection rule;
+- optimized-engine guard or shared semantic primitive.
+
+Reject or flag designs that require:
+
+- launching a new matcher for many nearby candidate positions;
+- scanning backward through an unbounded prefix per boundary query;
+- retrying NFA/DFA searches after a candidate was selected;
+- pattern-string or input-shape exceptions;
+- recovering captures by repeatedly rerunning searches.
+
+## Report Format
+
+Lead with a concise inventory:
+
+```
+Artifacts reviewed:
+- <path>: <size/status>
+- Run status: complete/incomplete
+- Counting method: exact summary / bounded sample / targeted stream scan
+```
+
+Then report buckets in a table or compact sections:
+
+```
+Bucket: <semantic name>
+Representative: /regex/ on <input/region summary>
+Observed: JDK <trace>; SafeRE <trace>
+Behavior classification: SPEC_REQUIRED | REASONABLE_COMPAT | JDK_DETAIL | ...
+Linear-time feasibility: ENGINE_NATIVE_LINEAR | NOT_PRINCIPLED | ...
+Decision: fix / document intentional divergence / investigate
+Reasoning: <spec/design/linear-time explanation>
+```
+
+End with recommended next steps:
+
+- buckets to fix now;
+- buckets to document as intentional divergences;
+- buckets needing targeted tests or a narrower sweep;
+- sweep harness improvements only if the artifact itself prevents useful review.
+
+## Discipline
+
+- Do not fix code unless asked.
+- Do not overfit to one fuzzer seed or one JSON row.
+- Do not treat observed JDK behavior as automatically correct.
+- Do not dismiss JDK behavior as a quirk without explaining why it is unspecified, incoherent, or
+  not expressible in SafeRE's linear-time engine model.
+- Cite official docs or project design files when classification depends on them.
+- If a new actionable bug is discovered outside the current task, preserve issue traceability under
+  the repository's AGENTS.md rules.

--- a/.agents/skills/divergence-result-review/agents/openai.yaml
+++ b/.agents/skills/divergence-result-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Divergence Result Review"
+  short_description: "Classify SafeRE/JDK divergence sweep results"
+  default_prompt: "Use $divergence-result-review to analyze SafeRE/JDK divergence sweep outputs, bucket related failures, classify each bucket against the JDK specification and SafeRE compatibility policy, and assess whether it can be supported within the linear-time guarantee."

--- a/design/GRAPHEME_REGION_MATCHING.md
+++ b/design/GRAPHEME_REGION_MATCHING.md
@@ -1,0 +1,509 @@
+# Grapheme And Region Matching Design
+
+## Problem
+
+SafeRE supports `\X` and `\b{g}` while also trying to be a drop-in
+`java.util.regex` replacement.  These constructs are unusually sensitive to
+Java's indexing model:
+
+- public `Matcher` APIs use UTF-16 indices;
+- ordinary regex atoms should consume a Unicode scalar when a surrogate pair is
+  visible;
+- a matcher region can split a surrogate pair or a grapheme cluster;
+- transparent bounds let boundary matchers inspect text outside the region;
+- opaque bounds make region edges visible to boundary matchers;
+- repeated `find()` is defined in terms of Java character indices, not an
+  abstract code-point cursor.
+
+SafeRE's current implementation handles many of these cases with local
+compatibility logic around the matcher and NFA.  Some of that logic is
+principled, but some is patchwork: post-hoc candidate rejection, verifier
+matchers, and repeated retries over nearby start positions.
+
+That patchwork is the wrong direction.  It may match a reported JDK behavior,
+but it risks turning one public match operation into many engine searches.  The
+goal of this design is to replace that compatibility layer with engine-native
+semantics that remain linear.  When exact observed JDK behavior cannot be
+represented by those semantics, SafeRE should document an intentional
+compatibility divergence rather than add more search loops.
+
+## Specification Baseline
+
+The JDK `Pattern` specification names both `\X` and `\b{g}`:
+
+- `\X` matches a Unicode extended grapheme cluster.
+- `\b{g}` matches a Unicode extended grapheme cluster boundary.
+- Unicode support includes extended grapheme clusters.
+
+The JDK `Matcher` specification defines regions using Java indices and says
+that searches are limited to `[regionStart, regionEnd)`.  It also says that
+transparent bounds allow lookaround and boundary constructs to see beyond the
+region, while opaque bounds prevent those constructs from seeing beyond it.
+
+Those rules are enough to define SafeRE's target model, but they do not specify
+every observed JDK edge case involving:
+
+- regions that split surrogate pairs;
+- regions that split grapheme clusters;
+- `\X` implemented internally using boundary logic;
+- repeated `find()` after boundary-starting alternatives;
+- transparent bounds combined with explicit trailing `\b{g}`.
+
+For unspecified cases, SafeRE may match observed JDK behavior only when doing so
+preserves the linear-time guarantee and fits the engine model below.
+
+## Design Goal
+
+The goal is not "match every JDK quirk at any cost."  The goal is a principled
+design:
+
+> Support grapheme matching with UTF-16 public coordinates, region-aware
+> Unicode decoding, and pure boundary predicates, while preserving a single
+> linear pass per engine search.
+
+This implies three negative requirements:
+
+- no verifier `Matcher` calls inside the match engine;
+- no unbounded post-hoc retries after an engine has selected a candidate;
+- no compatibility rule whose cost depends on repeatedly re-running the NFA
+  over neighboring start positions.
+
+## Supported Grapheme-Region Contract
+
+SafeRE's supported grapheme-region behavior is the intersection of the JDK
+specification, observed JDK behavior that fits this engine model, and SafeRE's
+linear-time guarantee.  The active compatibility contract is:
+
+1. Public positions are UTF-16 indices.
+2. Candidate starts for `find()` remain inside the matcher region.
+3. Ordinary consuming atoms never report bounds that end inside a valid
+   surrogate pair.
+4. A consuming `\X` may complete a surrogate pair whose high surrogate starts
+   inside the region.
+5. `matches()` remains strict about the logical region end, even when `\X`
+   completion lets `find()` or `lookingAt()` report a bound past `regionEnd`.
+6. End anchors in `find()` and `lookingAt()` may accept the `\X` scalar
+   completion end when the logical region end splits that scalar.
+7. Opaque bounds make region edges grapheme-boundary context edges.
+8. Transparent bounds let grapheme boundary predicates and `\X` segmentation
+   see context outside the region, while still keeping candidate starts inside
+   the region.
+9. Regional-indicator parity, extended-pictographic/ZWJ context, and
+   Indic-conjunct linker state are computed relative to the active grapheme
+   context, not by rescanning from each candidate start.
+10. Opaque region-local grapheme behavior is compositional.  If an explicit
+    `\b{g}` predicate is true, `\X` can consume at that position, and a trailing
+    explicit `\b{g}` predicate is true, the concatenated regex can match even
+    when observed JDK repeated-`find()` behavior skips that composition.
+11. Unanchored `\X` chains may start at suffix positions inside a larger
+    full-text grapheme cluster.  The atom-local grapheme view decides what is
+    visible from that candidate start using bounded cached state.
+
+The focused active tests for this contract are
+`GraphemeRegionCompatibilityMatrixTest` for JDK-aligned cases and
+`GraphemeRegionModelTest` for intentional SafeRE/JDK divergences.  The offline
+exhaustive sweep remains a discovery tool, and
+`GraphemeJdkImplementationDetailTest` quarantines exact JDK traces that are not
+currently SafeRE compatibility requirements.
+
+## Non-Goals
+
+SafeRE should not try to reproduce every observed JDK edge case.  In
+particular, it should not reproduce behavior that appears to fall out of the
+JDK's backtracking implementation rather than from the documented regex
+language or region API.
+
+The non-goals are:
+
+- no compatibility by verifier matcher;
+- no compatibility by repeated re-search;
+- no compatibility by pattern-string or input-shape exceptions;
+- no support for behavior that cannot be stated as a bounded engine transition
+  or a bounded zero-width predicate;
+- no optimized-engine support for grapheme programs until that engine shares
+  the canonical grapheme model.
+
+The project should use judgment here.  If a JDK behavior is specified, linear,
+and expressible in the model below, SafeRE should support it.  If a behavior is
+unspecified, surprising, and only reproducible by adding local retry logic,
+SafeRE should prefer a documented intentional divergence.
+
+## Core Model
+
+### Positions Are UTF-16 Indices
+
+All engine positions, capture registers, matcher regions, search cursors, and
+public result offsets are Java UTF-16 indices.  This is already close to how
+SafeRE stores positions today.  The important point is to make it explicit:
+positions are not code-point ordinals.
+
+A transition may advance by one UTF-16 code unit, two code units, or more,
+depending on what it consumes.  The position space remains UTF-16 either way.
+
+### Consumption Uses A Region-Local Scalar View
+
+For ordinary consuming atoms, SafeRE should decode a Unicode scalar at the
+current UTF-16 position when the scalar is visible in the active consumption
+range.
+
+Examples:
+
+- A valid surrogate pair fully inside the region is one scalar and is consumed
+  as `[high, low]`.
+- A low surrogate at `regionStart` is visible as an unpaired scalar value and
+  may be consumed as one UTF-16 code unit.
+- A high surrogate at `regionEnd - 1` that is paired with a low surrogate just
+  outside the region is not an ordinary scalar.  Ordinary atoms must not report
+  a match ending inside that surrogate pair.
+- A scalar transition never consumes past `regionEnd`.
+
+This preserves JDK-compatible public offsets without forcing the entire engine
+to become UTF-16-code-unit based.  Full surrogate pairs still behave like one
+Unicode scalar when they are visible.
+
+Consuming `\X` has one extra limit: it may complete a surrogate pair whose high
+surrogate starts inside the region.  That completion limit is separate from the
+logical end position used by `matches()` and ordinary atoms.  End anchors may
+accept the completion limit for `find()` and `lookingAt()`, but `matches()`
+still performs its final whole-region check against the logical end.
+For example, with region `[0,1]` over a supplementary character, `\X.find()`
+may report `[0,2]`, while `\X.matches()` still fails because the logical region
+end is `1`.
+
+### Boundary Assertions Use A Separate Boundary View
+
+Zero-width boundary predicates must not be implemented by substring
+substitution.  They need an explicit boundary context:
+
+- current UTF-16 position;
+- consumption start and end;
+- boundary-context start and end;
+- transparent vs opaque bounds;
+- anchoring bounds;
+- cached grapheme state for the input.
+
+The consumption range answers "what may this match consume?"  The boundary
+context answers "what text may this assertion inspect?"
+
+For opaque bounds, the boundary context is normally the region.  For transparent
+bounds, boundary assertions may inspect the full input.  Anchoring bounds remain
+separate because `^`, `$`, `\A`, `\Z`, and `\z` have their own region semantics.
+
+## `\X` As A Primitive
+
+SafeRE should stop compiling `\X` as a regex expansion plus a synthetic
+grapheme boundary.  That expansion couples a consuming construct to
+empty-width machinery, which is where region and transparent-bound semantics are
+most complicated.
+
+Instead, `\X` should compile to a primitive consuming instruction, for example
+`GRAPHEME_CLUSTER`.
+
+The transition is:
+
+```
+end = nextGraphemeClusterEnd(text, pos, consumptionContext, graphemeContext)
+if end >= 0:
+  add thread at end
+```
+
+The primitive owns the cluster-consumption rule.  It does not ask the
+empty-width assertion machinery whether a synthetic boundary happens to hold.
+
+This separates two concepts that are different in the public language:
+
+- `\X` consumes one grapheme cluster within the matchable region.
+- `\b{g}` is a zero-width boundary assertion affected by boundary visibility.
+
+### Linear-Time Requirement For `\X`
+
+`nextGraphemeClusterEnd` must be linear over a full match operation.  There are
+two acceptable implementation strategies:
+
+- compute a grapheme-boundary table for the active input once per matcher input;
+- compute boundaries lazily while caching enough per-position state that each
+  UTF-16 position is classified a bounded number of times.
+
+The result must be bounded by:
+
+```
+O(pattern_size * input_utf16_length) + O(input_utf16_length)
+```
+
+The grapheme segmenter may keep finite-state context such as regional-indicator
+parity, extended-pictographic/ZWJ state, and Indic-conjunct linker state.  It
+must not scan backward through an unbounded prefix for each boundary query.
+
+That finite-state context is scoped to the active grapheme view.  For example,
+regional-indicator parity for an opaque region starts at the boundary-context
+start, not at the beginning of the full input.  A transparent boundary predicate
+may use full-input parity.  Consuming `\X` still starts only at candidate
+positions inside the region, but under transparent bounds its grapheme
+segmentation context can see text outside the region.
+
+## Explicit `\b{g}` As A Pure Predicate
+
+Explicit `\b{g}` should remain an `EMPTY_WIDTH` predicate, but its input should
+be a named boundary context rather than ad hoc matcher fields.
+
+The predicate should answer:
+
+```
+isGraphemeBoundary(text, pos, boundaryContext, graphemeContext)
+```
+
+It should not run a matcher.  It should not retry from a different start
+position.  It should not depend on which engine path selected the candidate.
+
+For transparent bounds, the predicate may inspect text outside the region.  For
+opaque bounds, region edges act as boundaries for predicate purposes where the
+JDK specification assigns that role to opaque bounds.  That remains true when a
+region edge cuts through a non-surrogate grapheme cluster such as a base-plus-mark
+or Hangul sequence.
+
+## Search Starts And Repeated `find()`
+
+Repeated `find()` must use UTF-16 cursor semantics because the Java API is
+defined in Java indices.  After a non-empty match, the next search starts from
+the prior match end.  After an empty match, it advances by one UTF-16 code unit,
+subject to the region end.
+
+For grapheme programs, the engine may need to consider candidate starts at
+UTF-16 offsets that are not Unicode-scalar boundaries in the full input.  That
+does not mean every match should consume one code unit.  It means the
+region-local scalar view must decide what is visible at that candidate start.
+
+The important invariant is:
+
+> Candidate starts may be UTF-16 positions, but confirming a candidate is still
+> an engine-native operation with bounded local context.
+
+This rules out scanning a list of candidate starts and launching fresh
+matchers until one reproduces observed JDK behavior.
+
+## Engine Context Object
+
+The matcher should pass one explicit context object into all engines that can
+execute grapheme or boundary constructs.
+
+The context should contain at least:
+
+- `String text`;
+- `int searchStart`;
+- `int searchLimit`;
+- `int consumeStart`;
+- `int consumeEnd`;
+- `int boundaryStart`;
+- `int boundaryEnd`;
+- `boolean transparentBounds`;
+- `boolean anchoringBounds`;
+- cached grapheme segmentation data.
+
+`consumeEnd` is not the same as `boundaryEnd`.  Transparent trailing-boundary
+cases require exactly that distinction: the match may be unable to consume past
+the region, while an explicit boundary assertion may still inspect the
+following text.
+
+Similarly, `consumeStart` is not always the same as `boundaryStart`.  A region
+can begin inside a surrogate pair or a larger grapheme cluster.  The consuming
+view may treat the visible low surrogate as a standalone unit, while a
+transparent boundary predicate can still see the paired high surrogate before
+the region.
+
+Each primitive `\X` atom also has its own consuming view start.  In an
+unanchored search, a candidate can begin at a UTF-16 low-surrogate offset inside
+a supplementary code point.  The active `\X` atom should treat that visible low
+surrogate as unpaired for its own cluster consumption, without changing the
+boundary context used by explicit `\b{g}` assertions.
+
+Because unanchored search can create many distinct `\X` atom starts, grapheme
+state such as regional-indicator parity and Indic-conjunct linker visibility
+must be cached by input position/run rather than by every possible atom start.
+Boundary queries with arbitrary context starts must remain O(1).
+
+When the NFA deduplicates active `GRAPHEME_CLUSTER` instructions, the key must
+include bounded grapheme-consumption state, not just the instruction id.  For
+example, a thread whose atom-local view can see an extended pictographic before
+a ZWJ is not equivalent to a thread that started at the ZWJ.  The key must also
+not include the exact arbitrary atom start, because long extender runs can create
+many starts with equivalent future behavior.
+
+## Engine Responsibilities
+
+### Parser
+
+The parser should preserve `\X` as a distinct AST operation instead of expanding
+it into a normal regex tree with a synthetic boundary.
+
+### Compiler
+
+The compiler should emit a dedicated instruction for `\X`.  This instruction
+is a consuming instruction, not an `EMPTY_WIDTH` assertion.
+
+### Pike VM NFA
+
+The Pike VM NFA should be the semantic authority for grapheme programs.
+
+It must:
+
+- consume ordinary character ranges through the region-local scalar decoder;
+- consume `GRAPHEME_CLUSTER` through the grapheme segmenter;
+- evaluate `\b{g}` through the boundary predicate;
+- keep all of the above inside the normal thread-queue execution model.
+
+### DFA, OnePass, BitState, And Fast Paths
+
+No optimized path should implement independent grapheme compatibility rules.
+
+The conservative first design is:
+
+- grapheme programs run through Pike VM NFA;
+- accelerators may only narrow candidate positions when they are proven not to
+  skip valid UTF-16 starts;
+- DFA, reverse DFA, OnePass, and BitState remain guarded out for grapheme
+  programs until they can share the same scalar decoder, grapheme transition,
+  and boundary predicate.
+
+Later optimization is possible, but each optimized engine must use the same
+context object and the same primitive grapheme operations.  It must not
+duplicate compatibility logic.
+
+## Linear-Time Invariants
+
+The implementation must preserve these invariants:
+
+1. Each engine search performs at most bounded work per instruction per UTF-16
+   position.
+2. Grapheme-boundary classification is O(1) amortized per UTF-16 position.
+3. `\X` transition computation never scans an unbounded prefix per candidate.
+4. Boundary predicates never invoke a regex engine.
+5. Candidate filtering never reruns the full NFA over a sequence of nearby
+   starts.
+6. Capture resolution for grapheme programs stays inside the selected engine
+   result and does not search alternate explanations after the match.
+7. Engine-path selection cannot change grapheme semantics.
+
+If a compatibility behavior requires violating one of these invariants, SafeRE
+must not implement it as observed-JDK compatibility.  It should be documented as
+an intentional divergence or held until a linear formulation exists.
+
+## Compatibility Policy
+
+SafeRE should classify grapheme-region behavior in this order:
+
+1. If the JDK specification clearly defines the behavior and the behavior is
+   compatible with linear time, implement it.
+2. If the specification is silent or ambiguous, match observed JDK behavior only
+   when it can be expressed by the engine context model above.
+3. If observed JDK behavior requires verifier matchers, repeated re-search,
+   pattern-specific exceptions, or stateful local hacks, do not match it through
+   patchwork.
+4. If a JDK/spec contradiction is found, stop and decide explicitly which side
+   SafeRE follows under the project compatibility policy.
+
+This policy is especially important for repeated `find()` after
+boundary-starting grapheme expressions.  SafeRE intentionally does not copy
+observed JDK traces where `\X`, `\b{g}`, and `\b{g}\X\b{g}` do not compose
+cleanly.  Repeated `find()` resumes at the previous non-empty match end, and
+the next candidate is evaluated by the same region-local grapheme predicates as
+any other candidate.
+
+## Migration Plan
+
+### Phase 1: Freeze Patchwork
+
+- Do not add new verifier matcher calls.
+- Do not add new post-hoc retry predicates around grapheme candidates.
+- Keep existing regression tests and divergence sweeps as inventory, but
+  classify failures by whether they fit the new model.
+
+### Phase 2: Introduce Context Types
+
+- Add an engine context object that separates consumption bounds from boundary
+  bounds.
+- Route current NFA empty-width flag computation through that object.
+- Remove duplicated matcher fields once the context carries the same facts.
+
+### Phase 3: Add Primitive `\X`
+
+- Add a `RegexpOp` for `\X`.
+- Add an `InstOp` for grapheme-cluster consumption.
+- Compile `\X` directly to that instruction.
+- Keep explicit `\b{g}` as an empty-width assertion.
+
+### Phase 4: Centralize Grapheme Segmentation
+
+- Implement a single grapheme segmenter used by both `\X` and `\b{g}`.
+- Cache per-input boundary state so all boundary checks are O(1) amortized.
+- Include region-local surrogate handling in the scalar decoder, not in matcher
+  candidate filters.
+
+### Phase 5: Remove Verifier Retries
+
+- Delete verifier matcher checks from grapheme candidate validation.
+- Replace accepted behaviors with engine-native semantics.
+- Document any remaining observed-JDK divergences that cannot be represented
+  without risking non-linear behavior.
+
+### Phase 6: Re-enable Optimized Paths Carefully
+
+- Keep grapheme programs on Pike VM NFA until optimized engines share the same
+  context and primitive operations.
+- Re-enable OnePass, BitState, or DFA support only with equivalence tests
+  proving the same `\X`, `\b{g}`, region, and capture behavior.
+
+## Testing Requirements
+
+Regression tests should cover behavior classes, not issue-specific strings:
+
+- `\X` on full surrogate pairs, split surrogate pairs, combining marks, ZWJ
+  sequences, Hangul sequences, regional indicators, controls, prepend
+  characters, and Indic conjuncts;
+- explicit `\b{g}` at region starts, region ends, split surrogate positions,
+  and split grapheme positions;
+- transparent and opaque bounds for both consuming `\X` and explicit `\b{g}`;
+- repeated `find()` after non-empty matches and empty boundary matches;
+- alternatives that mix `\X`, explicit `\b{g}`, literals, and empty branches;
+- capture groups around `\X` and `\b{g}`;
+- forced-engine tests proving that unsupported optimized paths stay guarded out
+  until they share the canonical grapheme model.
+
+Scaling tests should assert algorithmic behavior, not wall-clock constants.
+They should include inputs with long runs of combining marks, regional
+indicators, ZWJ sequences, repeated low surrogates, and Indic linker sequences.
+
+## Open Questions
+
+- Should SafeRE intentionally diverge from observed JDK behavior when `\X` and
+  explicit `\b{g}` disagree under transparent bounds, if the specification does
+  not define the interaction?
+- Should the grapheme boundary cache be a full boundary table, a compact
+  per-position state table, or a lazy cache tied to matcher input?
+- Which optimized engines should be allowed to support grapheme programs first?
+
+## Acceptance Criteria
+
+This redesign is complete when:
+
+- `\X` is represented as a primitive consuming instruction;
+- explicit `\b{g}` is represented as a pure boundary predicate;
+- region-local consumption and transparent boundary context are separate in the
+  engine API;
+- grapheme matching uses no verifier matchers and no unbounded retry loops;
+- focused JDK compatibility tests pass for all behaviors that fit the model;
+- every remaining observed-JDK divergence is documented with the linear-time
+  reason SafeRE does not emulate it;
+- scaling tests show linear behavior for grapheme-heavy inputs.
+
+## Regression Checklist
+
+The implementation and tests should preserve these interaction points:
+
+- When `\X` completes a split trailing surrogate under opaque bounds, a trailing
+  explicit `\b{g}` uses the same effective grapheme edge.  The logical region
+  end still controls ordinary atoms and strict `matches()` behavior.
+- A split low surrogate can be a region-local `\X` consumption start, but a
+  trailing explicit `\b{g}` after that consumed low surrogate must not become an
+  unconditional boundary.  Contextual rules such as regional-indicator parity,
+  extended-pictographic/ZWJ state, Hangul continuation, extender and
+  spacing-mark handling, and Indic-conjunct linker state still apply.

--- a/design/SEMANTIC_INVARIANTS.md
+++ b/design/SEMANTIC_INVARIANTS.md
@@ -314,7 +314,8 @@ Scope: #225, #226, and related public API lifecycle behavior.
 
 This design should model `Matcher` as an explicit state machine.  It should
 define state transitions for `find`, `matches`, `lookingAt`, `reset`, `region`,
-`usePattern`, replacement operations, and `results`, then map each transition to JDK-compatible behavior.
+`usePattern`, replacement operations, and `results`, then map each transition
+to JDK-compatible behavior.
 
 ### Parser Dialect Compatibility Design
 
@@ -336,6 +337,21 @@ This design should define when generated crosscheck tests are expected to run,
 when `@DisabledForCrosscheck` is legitimate, how skip counts and test counts are
 validated, and how linear-time or scaling regressions are tested without
 ordinary correctness tests becoming timing-sensitive.
+
+### Grapheme And Region Matching Design
+
+Focused design: [GRAPHEME_REGION_MATCHING.md](GRAPHEME_REGION_MATCHING.md).
+
+Scope: grapheme matching, grapheme boundaries, matcher regions, transparent
+bounds, and observed JDK compatibility behavior that risks non-linear
+patchwork.
+
+This design should define `\X` and `\b{g}` around UTF-16 public coordinates,
+region-local consumption, and pure boundary predicates.  It should remove
+verifier matcher retries and other post-hoc compatibility repairs from the
+grapheme path.  It should also define when SafeRE intentionally diverges from
+unspecified observed JDK edge cases instead of copying behavior that cannot be
+represented as bounded engine work.
 
 ## Design Goals
 

--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -2,8 +2,8 @@
 
 This module contains deterministic, long-running differential validation tools.
 These tools are not ordinary unit tests: they stream large bounded search spaces,
-compare SafeRE with `java.util.regex`, and write every divergence to JSONL so a
-failed or interrupted run still leaves useful repro data.
+compare SafeRE with `java.util.regex`, and write machine-readable divergence
+reports so a failed or interrupted run still leaves useful repro data.
 
 ## Character Class Sweep
 
@@ -88,7 +88,8 @@ Control, Extend, ZWJ, Regional_Indicator, Prepend, SpacingMark, Hangul
 L/V/T/LV/LVT, emoji modifier, Extended_Pictographic, ordinary BMP,
 supplementary, and lone surrogate code units. Additional focused families cover
 longer high-risk sequences around leading Extend/ZWJ runs, regional-indicator
-parity, emoji ZWJ chains, Hangul composition chains, and surrogate boundaries.
+parity, emoji ZWJ chains, Hangul composition chains, Indic conjunct linker/ZWJ
+sequences, and surrogate boundaries.
 Generated input labels include the grapheme-class sequence, so JSONL buckets
 make missed rule neighborhoods visible instead of hiding them behind opaque
 seed names.
@@ -106,9 +107,43 @@ starting position for the first `find()` in a region and for later successful
 operations.
 
 Use this sweep before review when changing grapheme-cluster parsing or boundary
-behavior. A run may report known or newly discovered divergences; inspect the
-JSONL output to triage them. Range bounds and replay files use the same
-conventions as the other exhaustive sweeps.
+behavior. A run may report known intentional divergences, known actionable
+divergences, or newly discovered unknown divergences. Inspect the class-count
+summary first; it is the authoritative exact summary for a completed run.
+Known intentional divergences are summarized there, but are not written into
+the raw divergence JSONL.
+
+This differs from the character-class and control-escape sweeps because the
+grapheme sweep intentionally covers compatibility gray areas around regions,
+transparent bounds, repeated `find()`, `\X`, and explicit `\b{g}` composition.
+Some observed JDK traces are known implementation details rather than SafeRE
+compatibility targets, and those classes can occur in very large numbers. The
+grapheme report format therefore separates exact aggregate counts from bounded
+example files: exact counts remain cheap and complete, while unknown examples
+stay useful without scaling disk or heap usage with every observed divergence.
+
+The grapheme sweep writes these files under `--output-dir`:
+
+- `grapheme-cluster-class-counts.tsv`: exact count by divergence class,
+  classification status, and rationale. Use this first to decide whether the run
+  found anything actionable or unknown.
+- `grapheme-cluster-divergences.jsonl`: full raw JSONL for known actionable
+  divergence classes whose expected count is zero. An empty file means no
+  currently-known actionable grapheme divergences were emitted; it does not mean
+  there were no known intentional divergences.
+- `grapheme-cluster-actionable-examples.jsonl`: bounded representative examples
+  for known actionable divergence classes.
+- `grapheme-cluster-unknown-first.jsonl`: first bounded examples for unknown
+  divergence classes, useful for quick repros near the start of the generated
+  case space.
+- `grapheme-cluster-unknown-stratified.jsonl`: bounded stratified examples for
+  unknown divergence classes, spread across the generated case space so a run
+  with many unknown divergences does not only preserve examples from one early
+  region. Configure the limit with `--unknown-stratified-samples=N`.
+
+The default grapheme sweep progress interval is 10 million checked cases. Use
+`--progress-interval=N` to override it for a particular run. Range bounds and
+replay files use the same conventions as the other exhaustive sweeps.
 
 ## Control Escape Sweep
 

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -6,21 +6,31 @@
 package org.safere.exhaustive;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.regex.PatternSyntaxException;
 
 /** Offline differential sweep for {@code \X} and {@code \b{g}} grapheme-cluster bugs. */
 public final class GraphemeClusterDivergenceSweep {
   private static final int FIND_LIMIT = 32;
+  private static final int FIRST_UNKNOWN_LIMIT = 100;
+  private static final int UNKNOWN_STRATIFIED_SAMPLE_LIMIT = 100_000;
+  private static final int ACTIONABLE_SAMPLE_LIMIT = 100;
+  private static final long DEFAULT_PROGRESS_INTERVAL = 10_000_000;
   private static final ConcurrentMap<String, java.util.regex.Pattern> JDK_PATTERN_CACHE =
       new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, org.safere.Pattern> SAFERE_PATTERN_CACHE =
@@ -118,7 +128,35 @@ public final class GraphemeClusterDivergenceSweep {
           regex("clusterThenBoundary", "\\X\\b{g}"),
           regex("anchoredClusterThenBoundary", "^\\X\\b{g}"),
           regex("boundaryClusterBoundary", "\\b{g}\\X\\b{g}"),
-          regex("anchoredBoundaryClusterBoundary", "^\\b{g}\\X\\b{g}"));
+          regex("anchoredBoundaryClusterBoundary", "^\\b{g}\\X\\b{g}"),
+          regex("boundaryOnlyAlternativeAfterAscii", "a|\\b{g}"),
+          regex("boundaryOnlyAlternativeBeforeAscii", "\\b{g}|a"),
+          regex("groupedBoundaryOnlyAlternativeAfterAscii", "(?:a|\\b{g})"),
+          regex("groupedBoundaryOnlyAlternativeBeforeAscii", "(?:\\b{g}|a)"),
+          regex("capturedBoundaryOnlyAlternativeAfterAscii", "(a)|(\\b{g})"),
+          regex("capturedBoundaryOnlyAlternativeBeforeAscii", "(\\b{g})|(a)"),
+          regex("nestedBoundaryOnlyAlternativeAfterAscii", "(?:a|(?:\\b{g}))"),
+          regex("nestedBoundaryOnlyAlternativeBeforeAscii", "(?:(?:\\b{g})|a)"),
+          regex("boundaryOnlyAlternativeAfterCluster", "\\X|\\b{g}"),
+          regex("boundaryOnlyAlternativeBeforeCluster", "\\b{g}|\\X"),
+          regex("groupedBoundaryOnlyAlternativeAfterCluster", "(?:\\X|\\b{g})"),
+          regex("groupedBoundaryOnlyAlternativeBeforeCluster", "(?:\\b{g}|\\X)"),
+          regex("capturedBoundaryOnlyAlternativeAfterCluster", "(\\X)|(\\b{g})"),
+          regex("capturedBoundaryOnlyAlternativeBeforeCluster", "(\\b{g})|(\\X)"),
+          regex("boundaryClusterAlternativeAfterLiteral", "b|\\b{g}\\X"),
+          regex("boundaryClusterAlternativeBeforeLiteral", "\\b{g}\\X|b"),
+          regex("groupedBoundaryClusterAlternativeAfterLiteral", "(?:b|\\b{g}\\X)"),
+          regex("groupedBoundaryClusterAlternativeBeforeLiteral", "(?:\\b{g}\\X|b)"),
+          regex("capturedBoundaryClusterAlternativeAfterLiteral", "(b)|(\\b{g}\\X)"),
+          regex("capturedBoundaryClusterAlternativeBeforeLiteral", "(\\b{g}\\X)|(b)"),
+          regex("boundaryClusterAlternativeAfterCluster", "\\X|\\b{g}\\X"),
+          regex("boundaryClusterAlternativeBeforeCluster", "\\b{g}\\X|\\X"),
+          regex("groupedBoundaryClusterAlternativeAfterCluster", "(?:\\X|\\b{g}\\X)"),
+          regex("groupedBoundaryClusterAlternativeBeforeCluster", "(?:\\b{g}\\X|\\X)"),
+          regex("boundaryClusterAlternativeAfterAscii", "a|\\b{g}\\X"),
+          regex("boundaryClusterAlternativeBeforeAscii", "\\b{g}\\X|a"),
+          regex("nestedBoundaryClusterAlternativeAfterLiteral", "(?:a|(?:\\b{g}\\X))"),
+          regex("nestedBoundaryClusterAlternativeBeforeLiteral", "(?:(?:\\b{g}\\X)|a)"));
 
   private static final InputSpace INPUT_SPACE = buildInputSpace();
   private static final long INPUT_CASES = INPUT_SPACE.size();
@@ -133,11 +171,30 @@ public final class GraphemeClusterDivergenceSweep {
           fixedRegion("emptyInsideSupplementaryPrefix", "\uD83D", "\uDE00", 1, 1),
           fixedRegion("lowSurrogateOnlyPrefix", "\uD83D\uDE00", "", 1, 2),
           region("startAtLowSurrogatePrefix", "\uD83D", "", 0, 0),
+          region("startAtLowSurrogateBeforeExtend", "\uD83D", "\u0301", 0, 0),
+          region("startAtLowSurrogateBeforeZwj", "\uD83D", "\u200D", 0, 0),
+          region("startAtLowSurrogateBeforeSpacingMark", "\uD83D", "\u0903", 0, 0),
+          region("startAtLowSurrogateBeforeEmojiModifier", "\uD83D", "\uD83C\uDFFD", 0, 0),
+          region("startAtLowSurrogateBeforeLowSurrogate", "\uD83D", "\uDE00", 0, 0),
+          region("endBeforeSuffixExtend", "", "\u0301", 0, 0),
+          region("endBeforeSuffixZwj", "", "\u200D", 0, 0),
+          region("endBeforeSuffixSpacingMark", "", "\u0903", 0, 0),
+          region("endBeforeSuffixEmojiModifier", "", "\uD83C\uDFFD", 0, 0),
+          region("endBeforeSuffixRegionalIndicator", "", "\uD83C\uDDFA", 0, 0),
+          region("endBeforeSuffixHangulL", "", "\u1100", 0, 0),
+          region("endBeforeSuffixHangulV", "", "\u1161", 0, 0),
+          region("endBeforeSuffixHangulT", "", "\u11A8", 0, 0),
+          region("endBeforeSuffixLf", "", "\n", 0, 0),
+          region("endBeforeSuffixExtendedPictographic", "", "\uD83D\uDC69", 0, 0),
           region("endBeforeSuffixLowSurrogate", "", "\uDE00", 0, 0),
           region("bothEndsSplitSurrogates", "\uD83D", "\uDE00", 0, 0));
 
   private static final List<BoundsMode> BOUNDS_MODES =
-      List.of(bounds("opaqueAnchoring", false, true), bounds("opaqueNonAnchoring", false, false));
+      List.of(
+          bounds("opaqueAnchoring", false, true),
+          bounds("opaqueNonAnchoring", false, false),
+          bounds("transparentAnchoring", true, true),
+          bounds("transparentNonAnchoring", true, false));
 
   private static final List<OperationMode> OPERATION_MODES =
       // Matcher.find() is specified in terms of the first find in a region and previous successful
@@ -153,85 +210,173 @@ public final class GraphemeClusterDivergenceSweep {
               GraphemeClusterDivergenceSweep::resetRegionReuseTrace,
               GraphemeClusterDivergenceSweep::resetRegionReuseTrace));
 
+  private static final List<TargetedRegionInput> TARGETED_REGION_INPUTS =
+      List.of(
+          targetedRegion("splitTrailingRegionalBeforeRegional", "\uD83C\uDDE6\uD83C\uDDE6", 0, 1),
+          targetedRegion("splitLeadingRegionalBeforeRegional", "\uD83C\uDDE6\uD83C\uDDE6", 1, 3),
+          targetedRegion(
+              "splitLeadingRegionalBeforeRegionalFullSecond", "\uD83C\uDDE6\uD83C\uDDE6", 1, 4),
+          targetedRegion(
+              "splitTrailingRegionalTriple", "\uD83C\uDDE6\uD83C\uDDE6\uD83C\uDDE6", 0, 1),
+          targetedRegion(
+              "splitLeadingRegionalTriple", "\uD83C\uDDE6\uD83C\uDDE6\uD83C\uDDE6", 1, 5),
+          targetedRegion("splitTrailingZwjEmoji", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 1),
+          targetedRegion("splitLeadingZwjEmoji", "\uD83D\uDC69\u200D\uD83D\uDC69", 1, 5),
+          targetedRegion("splitLeadingZwjEmojiSplitSecond", "\uD83D\uDC69\u200D\uD83D\uDC69", 1, 4),
+          targetedRegion("splitTrailingEmojiModifier", "\uD83D\uDC4D\uD83C\uDFFB", 0, 1),
+          targetedRegion("splitLeadingEmojiModifier", "\uD83D\uDC4D\uD83C\uDFFB", 1, 3),
+          targetedRegion("splitLeadingEmojiModifierFullModifier", "\uD83D\uDC4D\uD83C\uDFFB", 1, 4),
+          targetedRegion("splitTrailingSupplementaryBeforeExtend", "\uD83D\uDE00\u0301", 0, 1),
+          targetedRegion("splitLeadingSupplementaryBeforeExtend", "\uD83D\uDE00\u0301", 1, 3),
+          targetedRegion(
+              "splitTrailingSupplementaryBeforeZwjEmoji", "\uD83D\uDE00\u200D\uD83D\uDE00", 0, 1),
+          targetedRegion(
+              "splitLeadingSupplementaryBeforeZwjEmoji", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 5),
+          targetedRegion(
+              "splitLeadingSupplementaryBeforeZwjEmojiSplitSecond",
+              "\uD83D\uDE00\u200D\uD83D\uDE00",
+              1,
+              4),
+          targetedRegion("indicConjunctFullRegion", "\u0915\u094D\u0937", 0, 3),
+          targetedRegion("indicConjunctAfterFirstConsonant", "\u0915\u094D\u0937", 1, 3));
+
+  private static final List<String> GRAPHEME_CANDIDATE_START_REGEX_LABELS =
+      List.of(
+          "twoClusters",
+          "twoClusterRepeat",
+          "nonCapturingTwoClusters",
+          "oneRepeatThenCluster",
+          "nonCapturingClusterRepeat",
+          "capturedTwoClusters");
+
+  private static final List<CaseSpec> TARGETED_REGION_CASES = buildTargetedRegionCases();
+
   private GraphemeClusterDivergenceSweep() {}
 
   public static void main(String[] args) throws IOException {
-    SweepOptions options =
-        SweepOptions.parse(
-            args,
-            Path.of("target", "exhaustive-reports", "grapheme-cluster-sweep"),
-            "grapheme-cluster-divergences.jsonl",
-            1_000_000);
-    Files.createDirectories(options.outputDir());
-    Files.deleteIfExists(options.jsonlPath());
-    options.printStartup("grapheme-cluster");
+    GraphemeSweepOptions options = parseOptions(args);
+    Files.createDirectories(options.sweep().outputDir());
+    Files.deleteIfExists(options.sweep().jsonlPath());
+    options.printStartup();
 
-    if (options.replayFile() != null) {
+    if (options.sweep().replayFile() != null) {
       runReplay(options);
       return;
     }
 
-    SweepRunState state = runSweep(options);
+    GraphemeRunResult result = runSweep(options);
 
-    System.out.println("checked=" + state.checked.sum());
-    System.out.println("generated=" + state.generated);
+    result.summary().writeReports(options.sweep().outputDir());
+    System.out.println("checked=" + result.checked());
+    System.out.println("generated=" + result.generated());
     System.out.println("totalCases=" + totalCases());
     System.out.println("inputCases=" + INPUT_CASES);
     System.out.println("inputFamilies=" + INPUT_SPACE.familySummary());
-    System.out.println("divergences=" + state.divergences.sum());
-    System.out.println("threads=" + options.threads());
-    System.out.println("jsonl=" + options.jsonlPath());
+    System.out.println("divergences=" + result.divergences());
+    System.out.println("actionableDivergences=" + result.summary().actionableCount());
+    System.out.println("unknownDivergences=" + result.summary().count(DivergenceClass.UNKNOWN));
+    System.out.println("threads=" + options.sweep().threads());
+    System.out.println("jsonl=" + options.sweep().jsonlPath());
   }
 
-  private static SweepRunState runSweep(SweepOptions options) throws IOException {
-    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
+  private static GraphemeSweepOptions parseOptions(String[] args) {
+    List<String> sweepArgs = new ArrayList<>();
+    int unknownStratifiedSamples = UNKNOWN_STRATIFIED_SAMPLE_LIMIT;
+    for (String arg : args) {
+      if (arg.startsWith("--unknown-stratified-samples=")) {
+        unknownStratifiedSamples =
+            Integer.parseInt(arg.substring("--unknown-stratified-samples=".length()));
+      } else {
+        sweepArgs.add(arg);
+      }
+    }
+    if (unknownStratifiedSamples < 0) {
+      throw new IllegalArgumentException("--unknown-stratified-samples must be non-negative");
+    }
+    SweepOptions sweepOptions =
+        SweepOptions.parse(
+            sweepArgs.toArray(String[]::new),
+            Path.of("target", "exhaustive-reports", "grapheme-cluster-sweep"),
+            "grapheme-cluster-divergences.jsonl",
+            DEFAULT_PROGRESS_INTERVAL);
+    return new GraphemeSweepOptions(sweepOptions, unknownStratifiedSamples);
+  }
+
+  private static GraphemeRunResult runSweep(GraphemeSweepOptions options) throws IOException {
+    SweepOptions sweepOptions = options.sweep();
+    long selectedCaseCount = sweepOptions.totalChecks(totalCases());
+    StratifiedUnknownSampler unknownSampler =
+        new StratifiedUnknownSampler(
+            sweepOptions.rangeStartInclusive(),
+            selectedCaseCount,
+            options.unknownStratifiedSamples());
+    GraphemeDivergenceSummary[] workerSummaries =
+        new GraphemeDivergenceSummary[sweepOptions.threads()];
+    try (SweepRunState runState = new SweepRunState(sweepOptions, selectedCaseCount)) {
       SweepWorkers.run(
-          options.threads(),
+          sweepOptions.threads(),
           "grapheme-cluster-sweep-",
           workerIndex -> {
-            SweepState worker = new SweepState(runState, workerIndex);
+            GraphemeDivergenceSummary workerSummary = new GraphemeDivergenceSummary(unknownSampler);
+            SweepState worker = new SweepState(runState, workerSummary, workerIndex);
             worker.run();
             worker.finish();
+            workerSummaries[workerIndex] = workerSummary;
           });
-      return runState;
+      GraphemeDivergenceSummary summary = new GraphemeDivergenceSummary(unknownSampler);
+      for (GraphemeDivergenceSummary workerSummary : workerSummaries) {
+        summary.merge(workerSummary);
+      }
+      return new GraphemeRunResult(
+          runState.checked.sum(), runState.generated, runState.divergences.sum(), summary);
     }
   }
 
-  private static void runReplay(SweepOptions options) throws IOException {
+  private static void runReplay(GraphemeSweepOptions options) throws IOException {
+    SweepOptions sweepOptions = options.sweep();
+    StratifiedUnknownSampler unknownSampler =
+        new StratifiedUnknownSampler(
+            0, Math.max(1, options.unknownStratifiedSamples()), options.unknownStratifiedSamples());
+    GraphemeDivergenceSummary summary = new GraphemeDivergenceSummary(unknownSampler);
+    AtomicLong replayCaseIndex = new AtomicLong();
     try (BufferedReader reader =
-            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
-        SweepRunState runState = new SweepRunState(options, 0)) {
+            Files.newBufferedReader(sweepOptions.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(sweepOptions, 0)) {
       long generated =
           SweepWorkers.runStreamingLines(
-              options.threads(),
+              sweepOptions.threads(),
               "grapheme-cluster-replay-",
               reader,
               line -> {
                 runState.checked.increment();
-                evaluateCase(runState, replayCase(line));
+                evaluateCase(
+                    runState, summary, replayCase(line), replayCaseIndex.getAndIncrement());
               });
       runState.recordGenerated(generated);
+      summary.writeReports(sweepOptions.outputDir());
       System.out.println("checked=" + runState.checked.sum());
       System.out.println("generated=" + runState.generated);
       System.out.println("divergences=" + runState.divergences.sum());
-      System.out.println("threads=" + options.threads());
-      System.out.println("jsonl=" + options.jsonlPath());
-      if (runState.divergences.sum() > 0) {
+      System.out.println("actionableDivergences=" + summary.actionableCount());
+      System.out.println("unknownDivergences=" + summary.count(DivergenceClass.UNKNOWN));
+      System.out.println("threads=" + sweepOptions.threads());
+      System.out.println("jsonl=" + sweepOptions.jsonlPath());
+      if (summary.actionableCount() > 0) {
         throw new IllegalStateException(
-            "replay found " + runState.divergences.sum() + " behavioral divergences");
+            "replay found " + summary.actionableCount() + " actionable behavioral divergences");
       }
     }
   }
 
   private static long totalCases() {
-    return (long) REGEX_TEMPLATES.size()
-        * INPUT_CASES
-        * REGION_MODES.size()
-        * BOUNDS_MODES.size()
-        * OPERATION_MODES.size();
+    return cartesianCases() + TARGETED_REGION_CASES.size();
   }
 
   private static CaseSpec caseAt(long index) {
+    long cartesianCases = cartesianCases();
+    if (index >= cartesianCases) {
+      return TARGETED_REGION_CASES.get(Math.toIntExact(index - cartesianCases));
+    }
     int operationIndex = (int) (index % OPERATION_MODES.size());
     index /= OPERATION_MODES.size();
     int boundsIndex = (int) (index % BOUNDS_MODES.size());
@@ -247,6 +392,14 @@ public final class GraphemeClusterDivergenceSweep {
         REGION_MODES.get(regionIndex),
         BOUNDS_MODES.get(boundsIndex),
         OPERATION_MODES.get(operationIndex));
+  }
+
+  private static long cartesianCases() {
+    return (long) REGEX_TEMPLATES.size()
+        * INPUT_CASES
+        * REGION_MODES.size()
+        * BOUNDS_MODES.size()
+        * OPERATION_MODES.size();
   }
 
   private static Outcome jdkOutcome(CaseSpec spec) {
@@ -470,6 +623,47 @@ public final class GraphemeClusterDivergenceSweep {
     return !left.accepted() || left.trace().equals(right.trace());
   }
 
+  private static DivergenceClass classifyDivergence(CaseSpec spec, Outcome jdk, Outcome safere) {
+    String regexLabel = spec.regexTemplate().label();
+    if (isNonAnchoringDollarRegionEnd(spec)) {
+      return DivergenceClass.NON_ANCHORING_DOLLAR_REGION_END;
+    }
+    if (isGraphemeCandidateStartDedup(spec)) {
+      return DivergenceClass.GRAPHEME_CANDIDATE_START_DEDUP;
+    }
+    if (regexLabel.equals("boundaryClusterBoundary")
+        || regexLabel.equals("anchoredBoundaryClusterBoundary")) {
+      return DivergenceClass.BOUNDARY_CLUSTER_BOUNDARY_COMPOSITION;
+    }
+    if (regexLabel.contains("BoundaryOnlyAlternative")
+        || regexLabel.contains("boundaryOnlyAlternative")) {
+      return DivergenceClass.BOUNDARY_ONLY_ALTERNATIVE_FIND_CURSOR;
+    }
+    if (regexLabel.contains("BoundaryClusterAlternative")
+        || regexLabel.contains("boundaryClusterAlternative")) {
+      return DivergenceClass.BOUNDARY_CLUSTER_ALTERNATIVE_FIND_CURSOR;
+    }
+    if (regexLabel.equals("clusterThenBoundary")
+        || regexLabel.equals("anchoredClusterThenBoundary")) {
+      return DivergenceClass.REGION_LOCAL_CONTINUATION_CLUSTER;
+    }
+    if (regexLabel.equals("boundary") || regexLabel.equals("capturedBoundary")) {
+      return DivergenceClass.TRANSPARENT_BOUNDARY_JDK_DETAIL;
+    }
+    return DivergenceClass.UNKNOWN;
+  }
+
+  private static boolean isNonAnchoringDollarRegionEnd(CaseSpec spec) {
+    return !spec.boundsMode().anchoringBounds()
+        && spec.regex().endsWith("$")
+        && spec.regionEnd() < spec.text().length();
+  }
+
+  private static boolean isGraphemeCandidateStartDedup(CaseSpec spec) {
+    return GRAPHEME_CANDIDATE_START_REGEX_LABELS.contains(spec.regexTemplate().label())
+        && spec.inputTemplate().label().startsWith("indicConjunctLinkerZwj");
+  }
+
   private static String escape(String value) {
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < value.length(); i++) {
@@ -523,6 +717,28 @@ public final class GraphemeClusterDivergenceSweep {
     return new OperationMode(label, jdkTrace, safeReTrace);
   }
 
+  private static TargetedRegionInput targetedRegion(
+      String label, String text, int regionStart, int regionEnd) {
+    return new TargetedRegionInput(label, text, regionStart, regionEnd);
+  }
+
+  private static List<CaseSpec> buildTargetedRegionCases() {
+    List<CaseSpec> cases = new ArrayList<>();
+    for (RegexTemplate regex : REGEX_TEMPLATES) {
+      for (TargetedRegionInput input : TARGETED_REGION_INPUTS) {
+        InputTemplate inputTemplate = input(input.label(), input.text());
+        RegionMode region =
+            fixedRegion(input.label(), "", "", input.regionStart(), input.regionEnd());
+        for (BoundsMode bounds : BOUNDS_MODES) {
+          for (OperationMode operation : OPERATION_MODES) {
+            cases.add(new CaseSpec(regex, inputTemplate, region, bounds, operation));
+          }
+        }
+      }
+    }
+    return List.copyOf(cases);
+  }
+
   private static BoundsMode boundsMode(String label) {
     return BOUNDS_MODES.stream()
         .filter(mode -> mode.label().equals(label))
@@ -558,6 +774,8 @@ public final class GraphemeClusterDivergenceSweep {
         new SequenceInputFamily(
             "highRiskLongGcbClassLength6", HIGH_RISK_LONG_GRAPHEME_CLASS_ATOMS, 6));
     families.add(new ExplicitInputFamily("targetedLong", buildTargetedLongInputs()));
+    families.add(
+        new ExplicitInputFamily("indicConjunctLinkerZwj", buildIndicConjunctLinkerZwjInputs()));
     return new InputSpace(families);
   }
 
@@ -699,6 +917,33 @@ public final class GraphemeClusterDivergenceSweep {
     return List.copyOf(inputs.values());
   }
 
+  private static List<InputTemplate> buildIndicConjunctLinkerZwjInputs() {
+    Map<String, InputTemplate> inputs = new LinkedHashMap<>();
+    addIndicConjunctLinkerZwjInputs(inputs, "Devanagari", "\u0915", "\u094D");
+    addIndicConjunctLinkerZwjInputs(inputs, "Bengali", "\u0995", "\u09CD");
+    addIndicConjunctLinkerZwjInputs(inputs, "Gujarati", "\u0A95", "\u0ACD");
+    addIndicConjunctLinkerZwjInputs(inputs, "Odia", "\u0B15", "\u0B4D");
+    addIndicConjunctLinkerZwjInputs(inputs, "Telugu", "\u0C15", "\u0C4D");
+    addIndicConjunctLinkerZwjInputs(inputs, "Malayalam", "\u0D15", "\u0D4D");
+    return List.copyOf(inputs.values());
+  }
+
+  private static void addIndicConjunctLinkerZwjInputs(
+      Map<String, InputTemplate> inputs, String script, String consonant, String linker) {
+    String prefix = "indicConjunctLinkerZwj" + script;
+    String conjunct = consonant + linker + "\u200D" + consonant;
+    addInput(inputs, input(prefix, conjunct));
+    addInput(inputs, input(prefix + "Extend", conjunct + "\u0301"));
+    addInput(inputs, input(prefix + "Ascii", conjunct + "a"));
+    addInput(inputs, input(prefix + "Chain", conjunct + linker + "\u200D" + consonant));
+    addInput(inputs, input(prefix + "LeadingLinker", linker + "\u200D" + consonant));
+    addInput(inputs, input(prefix + "TrailingLinker", consonant + linker + "\u200D"));
+    addInput(
+        inputs, input(prefix + "LinkerExtendZwj", consonant + linker + "\u0301\u200D" + consonant));
+    addInput(
+        inputs, input(prefix + "LinkerZwjExtend", consonant + linker + "\u200D\u0301" + consonant));
+  }
+
   private static String emojiZwjChain(int chainLength, String suffixAfterEachPictographic) {
     StringBuilder result = new StringBuilder("\uD83D\uDC69").append(suffixAfterEachPictographic);
     for (int i = 1; i < chainLength; i++) {
@@ -728,6 +973,8 @@ public final class GraphemeClusterDivergenceSweep {
   private record GraphemeAtom(String label, String input) {}
 
   private record InputTemplate(String label, String input) {}
+
+  private record TargetedRegionInput(String label, String text, int regionStart, int regionEnd) {}
 
   private interface InputFamily {
     String label();
@@ -886,11 +1133,80 @@ public final class GraphemeClusterDivergenceSweep {
 
   private record Outcome(boolean accepted, String trace, String error) {}
 
-  private record Divergence(CaseSpec spec, Outcome jdk, Outcome safere, String bucket) {
+  private record GraphemeRunResult(
+      long checked, long generated, long divergences, GraphemeDivergenceSummary summary) {}
+
+  private record GraphemeSweepOptions(SweepOptions sweep, int unknownStratifiedSamples) {
+    void printStartup() {
+      sweep.printStartup("grapheme-cluster");
+      System.out.println("unknownStratifiedSamples=" + unknownStratifiedSamples);
+    }
+  }
+
+  private enum DivergenceStatus {
+    KNOWN_INTENTIONAL,
+    EXPECTED_ZERO,
+    UNKNOWN
+  }
+
+  private enum DivergenceClass {
+    BOUNDARY_CLUSTER_BOUNDARY_COMPOSITION(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "SafeRE composes explicit \\b{g}, primitive \\X, and trailing \\b{g};"
+            + " observed JDK repeated-find traces skip some candidate starts."),
+    BOUNDARY_ONLY_ALTERNATIVE_FIND_CURSOR(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "Observed JDK repeated-find cursor behavior for alternatives involving a bare"
+            + " explicit \\b{g} is not part of SafeRE's compositional grapheme model."),
+    BOUNDARY_CLUSTER_ALTERNATIVE_FIND_CURSOR(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "Observed JDK traces for alternatives involving \\b{g}\\X expose matcher cursor and"
+            + " transparent-boundary implementation details that SafeRE does not copy."),
+    REGION_LOCAL_CONTINUATION_CLUSTER(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "SafeRE keeps opaque region-local continuation clusters compositional instead of"
+            + " copying selected JDK region-edge traces."),
+    TRANSPARENT_BOUNDARY_JDK_DETAIL(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "Observed JDK transparent-boundary traces expose implementation details that SafeRE"
+            + " does not target when they conflict with the documented grapheme model."),
+    NON_ANCHORING_DOLLAR_REGION_END(
+        DivergenceStatus.EXPECTED_ZERO,
+        "Non-anchoring bounds require $ to use full-input trailing-line context, not the"
+            + " region-local end."),
+    GRAPHEME_CANDIDATE_START_DEDUP(
+        DivergenceStatus.EXPECTED_ZERO,
+        "Unanchored search must preserve concurrent consuming \\X candidates with different"
+            + " starts."),
+    UNKNOWN(DivergenceStatus.UNKNOWN, "Unclassified SafeRE/JDK grapheme divergence.");
+
+    private final DivergenceStatus status;
+    private final String rationale;
+
+    DivergenceClass(DivergenceStatus status, String rationale) {
+      this.status = status;
+      this.rationale = rationale;
+    }
+
+    boolean actionable() {
+      return status == DivergenceStatus.EXPECTED_ZERO;
+    }
+  }
+
+  private record Divergence(
+      long caseIndex,
+      CaseSpec spec,
+      Outcome jdk,
+      Outcome safere,
+      String bucket,
+      DivergenceClass classification) {
     String toJson() {
       var object = SweepJson.object();
+      object.addProperty("caseIndex", caseIndex);
       object.add("case", caseJson(spec));
       object.addProperty("bucket", bucket);
+      object.addProperty("classification", classification.name());
+      object.addProperty("classificationStatus", classification.status.name());
       object.addProperty("labels", spec.labels());
       object.addProperty("regex", spec.regex());
       object.addProperty("input", spec.input());
@@ -926,15 +1242,208 @@ public final class GraphemeClusterDivergenceSweep {
     }
   }
 
+  private static final class GraphemeDivergenceSummary {
+    private final EnumMap<DivergenceClass, LongAdder> counts = new EnumMap<>(DivergenceClass.class);
+    private final List<DivergenceExample> firstUnknownExamples = new ArrayList<>();
+    private final List<DivergenceExample> actionableExamples = new ArrayList<>();
+    private final StratifiedUnknownSampler unknownSampler;
+
+    GraphemeDivergenceSummary(StratifiedUnknownSampler unknownSampler) {
+      this.unknownSampler = unknownSampler;
+      for (DivergenceClass divergenceClass : DivergenceClass.values()) {
+        counts.put(divergenceClass, new LongAdder());
+      }
+    }
+
+    void record(Divergence divergence, long caseIndex) {
+      DivergenceClass divergenceClass = divergence.classification();
+      counts.get(divergenceClass).increment();
+      if (divergenceClass == DivergenceClass.UNKNOWN) {
+        recordUnknown(divergence, caseIndex);
+      } else if (divergenceClass.actionable()) {
+        recordActionable(divergence, caseIndex);
+      }
+    }
+
+    void merge(GraphemeDivergenceSummary other) {
+      if (other == null) {
+        return;
+      }
+      for (DivergenceClass divergenceClass : DivergenceClass.values()) {
+        counts.get(divergenceClass).add(other.count(divergenceClass));
+      }
+      firstUnknownExamples.addAll(other.firstUnknownExamples);
+      firstUnknownExamples.sort(Comparator.comparingLong(DivergenceExample::caseIndex));
+      truncate(firstUnknownExamples, FIRST_UNKNOWN_LIMIT);
+
+      actionableExamples.addAll(other.actionableExamples);
+      actionableExamples.sort(Comparator.comparingLong(DivergenceExample::caseIndex));
+      truncate(actionableExamples, ACTIONABLE_SAMPLE_LIMIT);
+    }
+
+    long count(DivergenceClass divergenceClass) {
+      return counts.get(divergenceClass).sum();
+    }
+
+    long actionableCount() {
+      long total = 0;
+      for (DivergenceClass divergenceClass : DivergenceClass.values()) {
+        if (divergenceClass.actionable()) {
+          total += count(divergenceClass);
+        }
+      }
+      return total;
+    }
+
+    void writeReports(Path outputDir) throws IOException {
+      writeClassCounts(outputDir.resolve("grapheme-cluster-class-counts.tsv"));
+      writeExamples(
+          outputDir.resolve("grapheme-cluster-unknown-first.jsonl"), firstUnknownExamples);
+      writeStratifiedSamples(outputDir.resolve("grapheme-cluster-unknown-stratified.jsonl"));
+      writeExamples(
+          outputDir.resolve("grapheme-cluster-actionable-examples.jsonl"), actionableExamples);
+    }
+
+    private void recordUnknown(Divergence divergence, long caseIndex) {
+      recordExample(
+          firstUnknownExamples, new DivergenceExample(caseIndex, divergence), FIRST_UNKNOWN_LIMIT);
+      unknownSampler.record(divergence, caseIndex);
+    }
+
+    private void recordActionable(Divergence divergence, long caseIndex) {
+      recordExample(
+          actionableExamples,
+          new DivergenceExample(caseIndex, divergence),
+          ACTIONABLE_SAMPLE_LIMIT);
+    }
+
+    private static void recordExample(
+        List<DivergenceExample> examples, DivergenceExample example, int limit) {
+      synchronized (examples) {
+        if (examples.size() < limit) {
+          examples.add(example);
+        }
+      }
+    }
+
+    private void writeClassCounts(Path path) throws IOException {
+      try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+        writer.write("class\tstatus\tcount\trationale");
+        writer.newLine();
+        for (DivergenceClass divergenceClass : DivergenceClass.values()) {
+          writer.write(divergenceClass.name());
+          writer.write('\t');
+          writer.write(divergenceClass.status.name());
+          writer.write('\t');
+          writer.write(Long.toString(count(divergenceClass)));
+          writer.write('\t');
+          writer.write(divergenceClass.rationale);
+          writer.newLine();
+        }
+      }
+    }
+
+    private static void writeExamples(Path path, List<DivergenceExample> examples)
+        throws IOException {
+      try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+        for (DivergenceExample example : examples) {
+          writer.write(example.divergence().toJson());
+          writer.newLine();
+        }
+      }
+    }
+
+    private void writeStratifiedSamples(Path path) throws IOException {
+      unknownSampler.write(path);
+    }
+
+    private static void truncate(List<?> list, int limit) {
+      while (list.size() > limit) {
+        list.remove(list.size() - 1);
+      }
+    }
+  }
+
+  private record DivergenceExample(long caseIndex, Divergence divergence) {}
+
+  private static final class StratifiedUnknownSampler {
+    private final AtomicReferenceArray<StratifiedSampleEntry> samples;
+    private final long rangeStartInclusive;
+    private final long selectedCaseCount;
+
+    StratifiedUnknownSampler(
+        long rangeStartInclusive, long selectedCaseCount, int unknownStratifiedSampleLimit) {
+      this.rangeStartInclusive = rangeStartInclusive;
+      this.selectedCaseCount = selectedCaseCount;
+      int sampleSlots = (int) Math.min(unknownStratifiedSampleLimit, selectedCaseCount);
+      this.samples = new AtomicReferenceArray<>(sampleSlots);
+    }
+
+    void record(Divergence divergence, long caseIndex) {
+      int slot = stratifiedSlot(caseIndex);
+      if (slot < 0) {
+        return;
+      }
+      long distance = stratifiedDistance(slot, caseIndex);
+      while (true) {
+        StratifiedSampleEntry current = samples.get(slot);
+        if (current != null
+            && (current.distance() < distance
+                || (current.distance() == distance && current.caseIndex() <= caseIndex))) {
+          return;
+        }
+        StratifiedSampleEntry candidate =
+            new StratifiedSampleEntry(caseIndex, distance, divergence.toJson());
+        if (samples.compareAndSet(slot, current, candidate)) {
+          return;
+        }
+      }
+    }
+
+    private int stratifiedSlot(long caseIndex) {
+      if (samples.length() == 0
+          || caseIndex < rangeStartInclusive
+          || caseIndex - rangeStartInclusive >= selectedCaseCount) {
+        return -1;
+      }
+      long relative = caseIndex - rangeStartInclusive;
+      long slot = relative * samples.length() / selectedCaseCount;
+      return (int) Math.min(slot, samples.length() - 1L);
+    }
+
+    private long stratifiedDistance(int slot, long caseIndex) {
+      long slotStart = rangeStartInclusive + (long) slot * selectedCaseCount / samples.length();
+      long slotEnd = rangeStartInclusive + (long) (slot + 1) * selectedCaseCount / samples.length();
+      long midpoint = slotStart + (slotEnd - slotStart) / 2;
+      return Math.abs(caseIndex - midpoint);
+    }
+
+    void write(Path path) throws IOException {
+      try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+        for (int slot = 0; slot < samples.length(); slot++) {
+          StratifiedSampleEntry sample = samples.get(slot);
+          if (sample != null) {
+            writer.write(sample.json());
+            writer.newLine();
+          }
+        }
+      }
+    }
+  }
+
+  private record StratifiedSampleEntry(long caseIndex, long distance, String json) {}
+
   private static final class SweepState {
     final SweepRunState runState;
+    final GraphemeDivergenceSummary summary;
     final SweepOptions options;
     final SweepWorkers.ProgressReporter progressReporter;
     final int workerIndex;
     long generated;
 
-    SweepState(SweepRunState runState, int workerIndex) {
+    SweepState(SweepRunState runState, GraphemeDivergenceSummary summary, int workerIndex) {
       this.runState = runState;
+      this.summary = summary;
       this.options = runState.options;
       this.progressReporter = new SweepWorkers.ProgressReporter(runState);
       this.workerIndex = workerIndex;
@@ -947,7 +1456,7 @@ public final class GraphemeClusterDivergenceSweep {
         long caseIndex = generated;
         generated += options.threads();
         progressReporter.checked();
-        evaluateCase(caseAt(caseIndex));
+        evaluateCase(caseIndex, caseAt(caseIndex));
       }
     }
 
@@ -958,8 +1467,8 @@ public final class GraphemeClusterDivergenceSweep {
       return start + delta;
     }
 
-    void evaluateCase(CaseSpec spec) {
-      GraphemeClusterDivergenceSweep.evaluateCase(runState, spec);
+    void evaluateCase(long caseIndex, CaseSpec spec) {
+      GraphemeClusterDivergenceSweep.evaluateCase(runState, summary, spec, caseIndex);
       reportProgressIfNeeded();
     }
 
@@ -972,14 +1481,21 @@ public final class GraphemeClusterDivergenceSweep {
     }
   }
 
-  private static void evaluateCase(SweepRunState runState, CaseSpec spec) {
+  private static void evaluateCase(
+      SweepRunState runState, GraphemeDivergenceSummary summary, CaseSpec spec, long caseIndex) {
     Outcome jdk = jdkOutcome(spec);
     Outcome safere = safeReOutcome(spec);
     if (semanticallyEqual(jdk, safere)) {
       return;
     }
     String bucketName = bucketFor(spec, jdk, safere);
+    DivergenceClass classification = classifyDivergence(spec, jdk, safere);
+    Divergence divergence =
+        new Divergence(caseIndex, spec, jdk, safere, bucketName, classification);
     runState.recordDivergence();
-    runState.appendJsonl(new Divergence(spec, jdk, safere, bucketName).toJson());
+    summary.record(divergence, caseIndex);
+    if (classification.actionable()) {
+      runState.appendJsonl(divergence.toJson());
+    }
   }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -35,6 +35,9 @@ class SweepCliSmokeTest {
     GraphemeClusterDivergenceSweep.main(args(outputDir));
 
     assertThat(Files.exists(outputDir.resolve("grapheme-cluster-divergences.jsonl"))).isTrue();
+    assertThat(Files.exists(outputDir.resolve("grapheme-cluster-class-counts.tsv"))).isTrue();
+    assertThat(Files.exists(outputDir.resolve("grapheme-cluster-unknown-stratified.jsonl")))
+        .isTrue();
   }
 
   @Test
@@ -125,12 +128,89 @@ class SweepCliSmokeTest {
     assertThat(output).doesNotContain("threads=1");
   }
 
+  @Test
+  void graphemeClusterReplaySuppressesKnownIntentionalDivergences() throws Exception {
+    Path replayFile = tempDir.resolve("grapheme-known-replay.jsonl");
+    Path outputDir = tempDir.resolve("grapheme-known-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"regexLabel":"boundaryClusterBoundary","regex":"\\\\b{g}\\\\X\\\\b{g}","inputLabel":"twoAscii","input":"ab","region":"full","prefix":"","suffix":"","regionStart":0,"regionEnd":2,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        {"case":{"regexLabel":"boundaryClusterAlternativeAfterLiteral","regex":"b|\\\\b{g}\\\\X","inputLabel":"crlfTrace","input":"\\r\\r\\n\\r","region":"wrapped","prefix":"#","suffix":"$","regionStart":1,"regionEnd":5,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        {"case":{"regexLabel":"boundaryClusterAlternativeAfterLiteral","regex":"b|\\\\b{g}\\\\X","inputLabel":"transparentPrependTrace","input":"\\r؀a","region":"wrapped","prefix":"#","suffix":"$","regionStart":1,"regionEnd":4,"bounds":"transparentAnchoring","operation":"freshTrace"}}
+        """);
+
+    String output =
+        captureOutput(() -> GraphemeClusterDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("divergences=3", "actionableDivergences=0", "unknownDivergences=0");
+    assertThat(Files.size(outputDir.resolve("grapheme-cluster-divergences.jsonl"))).isZero();
+    assertThat(Files.readString(outputDir.resolve("grapheme-cluster-class-counts.tsv")))
+        .contains(
+            "BOUNDARY_CLUSTER_BOUNDARY_COMPOSITION\tKNOWN_INTENTIONAL\t1",
+            "BOUNDARY_CLUSTER_ALTERNATIVE_FIND_CURSOR\tKNOWN_INTENTIONAL\t2");
+  }
+
+  @Test
+  void graphemeClusterReplaySamplesUnknownDivergencesWithoutRawOutput() throws Exception {
+    Path replayFile = tempDir.resolve("grapheme-unknown-replay.jsonl");
+    Path outputDir = tempDir.resolve("grapheme-unknown-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"regexLabel":"unclassifiedGraphemeAlternative","regex":"b|\\\\b{g}\\\\X","inputLabel":"crlfTrace","input":"\\r\\r\\n\\r","region":"wrapped","prefix":"#","suffix":"$","regionStart":1,"regionEnd":5,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        """);
+
+    String output =
+        captureOutput(() -> GraphemeClusterDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("divergences=1", "actionableDivergences=0", "unknownDivergences=1");
+    assertThat(Files.size(outputDir.resolve("grapheme-cluster-divergences.jsonl"))).isZero();
+    assertThat(Files.readString(outputDir.resolve("grapheme-cluster-unknown-first.jsonl")))
+        .contains("\"classification\":\"UNKNOWN\"");
+    assertThat(Files.readString(outputDir.resolve("grapheme-cluster-unknown-stratified.jsonl")))
+        .contains("\"classification\":\"UNKNOWN\"");
+  }
+
+  @Test
+  void graphemeClusterReplayHonorsUnknownStratifiedSampleLimit() throws Exception {
+    Path replayFile = tempDir.resolve("grapheme-unknown-limit-replay.jsonl");
+    Path outputDir = tempDir.resolve("grapheme-unknown-limit-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"regexLabel":"unclassifiedGraphemeAlternative","regex":"b|\\\\b{g}\\\\X","inputLabel":"crlfTrace0","input":"\\r\\r\\n\\r","region":"wrapped","prefix":"#","suffix":"$","regionStart":1,"regionEnd":5,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        {"case":{"regexLabel":"unclassifiedGraphemeAlternative","regex":"b|\\\\b{g}\\\\X","inputLabel":"crlfTrace1","input":"\\r\\r\\n\\r","region":"wrapped","prefix":"#","suffix":"$","regionStart":1,"regionEnd":5,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        {"case":{"regexLabel":"unclassifiedGraphemeAlternative","regex":"b|\\\\b{g}\\\\X","inputLabel":"crlfTrace2","input":"\\r\\r\\n\\r","region":"wrapped","prefix":"#","suffix":"$","regionStart":1,"regionEnd":5,"bounds":"opaqueAnchoring","operation":"freshTrace"}}
+        """);
+
+    String output =
+        captureOutput(
+            () ->
+                GraphemeClusterDivergenceSweep.main(
+                    replayArgs(outputDir, replayFile, "--unknown-stratified-samples=2")));
+
+    assertThat(output)
+        .contains("unknownStratifiedSamples=2", "unknownDivergences=3", "actionableDivergences=0");
+    assertThat(Files.readAllLines(outputDir.resolve("grapheme-cluster-unknown-stratified.jsonl")))
+        .hasSize(2);
+  }
+
   private static String[] args(Path outputDir) {
     return new String[] {"--range=:10", "--threads=1", "--output-dir=" + outputDir};
   }
 
   private static String[] replayArgs(Path outputDir, Path replayFile) {
-    return new String[] {"--threads=2", "--output-dir=" + outputDir, "--replay-file=" + replayFile};
+    return replayArgs(outputDir, replayFile, new String[0]);
+  }
+
+  private static String[] replayArgs(Path outputDir, Path replayFile, String... extraArgs) {
+    String[] args = new String[3 + extraArgs.length];
+    args[0] = "--threads=2";
+    args[1] = "--output-dir=" + outputDir;
+    args[2] = "--replay-file=" + replayFile;
+    System.arraycopy(extraArgs, 0, args, 3, extraArgs.length);
+    return args;
   }
 
   private static String captureOutput(ThrowingRunnable runnable) throws Exception {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
@@ -7,11 +7,57 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.ArrayList;
+import java.util.List;
 
 final class RegionBoundsFuzzer {
+  private record GraphemeRegion(String input, int start, int end) {}
+
+  private record SafeReModelCase(
+      String regex, String input, int start, int end, List<String> expectedFinds) {}
+
+  private static final List<GraphemeRegion> GRAPHEME_REGIONS =
+      List.of(
+          new GraphemeRegion("\uD83C\uDDE6".repeat(3), 2, 6),
+          new GraphemeRegion("\uD83D\uDE00", 0, 1),
+          new GraphemeRegion("e\u0301", 1, 2),
+          new GraphemeRegion("a\u0301b", 1, 2),
+          new GraphemeRegion("\u1100\u1161", 1, 2),
+          new GraphemeRegion("\u0915\u094D\u0937", 0, 3));
+
+  private static final List<String> GRAPHEME_REGION_REGEXES =
+      List.of("\\X", "^\\X$", "\\b{g}", "\\b{g}\\X", "\\X\\b{g}", "\\b{g}\\X\\b{g}");
+
+  private static final List<GraphemeRegion> SPLIT_REGIONAL_GRAPHEME_REGIONS =
+      List.of(
+          new GraphemeRegion("\uD83C\uDDE6\uD83C\uDDE6", 0, 1),
+          new GraphemeRegion("\uD83C\uDDE6\uD83C\uDDE6", 1, 3));
+
+  private static final List<String> SPLIT_REGIONAL_GRAPHEME_REGEXES =
+      List.of("\\X", "\\b{g}", "\\X\\b{g}");
+
+  private static final List<GraphemeRegion> TRANSPARENT_GRAPHEME_CONTEXT_REGIONS =
+      List.of(new GraphemeRegion("\uD83D\uDC4D\uD83C\uDFFB", 1, 3));
+
+  private static final List<String> TRANSPARENT_GRAPHEME_CONTEXT_REGEXES = List.of("\\X\\b{g}");
+
+  private static final List<GraphemeRegion> NON_ANCHORING_FINAL_CRLF_GRAPHEME_REGIONS =
+      List.of(new GraphemeRegion("\r\r\r\n", 0, 3));
+
+  private static final List<String> NON_ANCHORING_FINAL_CRLF_GRAPHEME_REGEXES =
+      List.of("^\\X\\X$", "\\X\\X$", "^(?:\\X){2}$", "^\\X{2}$");
+
+  private static final List<SafeReModelCase> SAFE_RE_GRAPHEME_MODEL_CASES =
+      List.of(
+          new SafeReModelCase("\\b{g}\\X\\b{g}", "ab", 0, 2, List.of("0-1", "1-2")),
+          new SafeReModelCase(
+              "\\X\\b{g}", "\uD83D\uDC69\u200D\uD83D\uDC69", 2, 5, List.of("2-3", "3-5")),
+          new SafeReModelCase("\\X\\X", "\u0915\u094D\u0937", 0, 3, List.of("1-3")));
 
   @FuzzTest(maxDuration = "30s")
   void regionBounds(FuzzedDataProvider data) {
+    compareGraphemeRegions();
+
     String regex = data.consumeString(256);
     int flags = FuzzSupport.consumeFlags(data);
     String input = data.consumeString(2048);
@@ -35,6 +81,115 @@ final class RegionBoundsFuzzer {
     matcher.matches();
     matcher.reset();
     matcher.region(region[0], region[1]);
+    matcher.lookingAt();
+  }
+
+  private static void compareGraphemeRegions() {
+    compareSafeReGraphemeModelCases();
+    for (String regex : GRAPHEME_REGION_REGEXES) {
+      FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, 0);
+      if (pattern == null) {
+        continue;
+      }
+      for (GraphemeRegion region : GRAPHEME_REGIONS) {
+        compareGraphemeRegion(pattern, region, false);
+        compareGraphemeRegion(pattern, region, true);
+      }
+    }
+    for (String regex : SPLIT_REGIONAL_GRAPHEME_REGEXES) {
+      FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, 0);
+      if (pattern == null) {
+        continue;
+      }
+      for (GraphemeRegion region : SPLIT_REGIONAL_GRAPHEME_REGIONS) {
+        compareGraphemeRegion(pattern, region, false);
+        compareGraphemeRegion(pattern, region, true);
+      }
+    }
+    for (String regex : TRANSPARENT_GRAPHEME_CONTEXT_REGEXES) {
+      FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, 0);
+      if (pattern == null) {
+        continue;
+      }
+      for (GraphemeRegion region : TRANSPARENT_GRAPHEME_CONTEXT_REGIONS) {
+        compareGraphemeRegion(pattern, region, false);
+        compareGraphemeRegion(pattern, region, true);
+      }
+    }
+    for (String regex : NON_ANCHORING_FINAL_CRLF_GRAPHEME_REGEXES) {
+      FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, 0);
+      if (pattern == null) {
+        continue;
+      }
+      for (GraphemeRegion region : NON_ANCHORING_FINAL_CRLF_GRAPHEME_REGIONS) {
+        compareNonAnchoringGraphemeRegion(pattern, region, false);
+        compareNonAnchoringGraphemeRegion(pattern, region, true);
+      }
+    }
+  }
+
+  private static void compareSafeReGraphemeModelCases() {
+    for (SafeReModelCase testCase : SAFE_RE_GRAPHEME_MODEL_CASES) {
+      org.safere.Matcher matcher =
+          org.safere.Pattern.compile(testCase.regex())
+              .matcher(testCase.input())
+              .region(testCase.start(), testCase.end());
+      List<String> actual = new ArrayList<>();
+      while (matcher.find()) {
+        actual.add(matcher.start() + "-" + matcher.end());
+      }
+      if (!actual.equals(testCase.expectedFinds())) {
+        throw new AssertionError(
+            "SafeRE grapheme model mismatch"
+                + "\nRegex: "
+                + testCase.regex()
+                + "\nRegion: ["
+                + testCase.start()
+                + ","
+                + testCase.end()
+                + "]"
+                + "\nExpected: "
+                + testCase.expectedFinds()
+                + "\nActual: "
+                + actual);
+      }
+    }
+  }
+
+  private static void compareGraphemeRegion(
+      FuzzSupport.CompiledPattern pattern, GraphemeRegion region, boolean transparentBounds) {
+    FuzzSupport.MatcherPair matcher = pattern.matcher(region.input());
+    matcher.region(region.start(), region.end()).useTransparentBounds(transparentBounds);
+    while (matcher.find()) {
+      // Walk the whole sequence so extra or missing zero-width boundaries are compared.
+    }
+    matcher.reset().region(region.start(), region.end()).useTransparentBounds(transparentBounds);
+    matcher.matches();
+    matcher.reset().region(region.start(), region.end()).useTransparentBounds(transparentBounds);
+    matcher.lookingAt();
+  }
+
+  private static void compareNonAnchoringGraphemeRegion(
+      FuzzSupport.CompiledPattern pattern, GraphemeRegion region, boolean transparentBounds) {
+    FuzzSupport.MatcherPair matcher = pattern.matcher(region.input());
+    matcher
+        .region(region.start(), region.end())
+        .useAnchoringBounds(false)
+        .useTransparentBounds(transparentBounds);
+    while (matcher.find()) {
+      // Walk the whole sequence so extra or missing zero-width boundaries are compared.
+    }
+    matcher
+        .reset()
+        .region(region.start(), region.end())
+        .useAnchoringBounds(false)
+        .useTransparentBounds(transparentBounds);
+    matcher.matches();
+    matcher
+        .reset()
+        .region(region.start(), region.end())
+        .useAnchoringBounds(false)
+        .useTransparentBounds(transparentBounds);
     matcher.lookingAt();
   }
 }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
@@ -11,11 +11,25 @@ import java.util.List;
 
 final class UnicodeFuzzer {
 
-  private static final List<String> GRAPHEME_CLUSTER_REGEXES = List.of("\\X", "^\\^?\\X\\X");
+  private static final List<String> GRAPHEME_CLUSTER_REGEXES =
+      List.of(
+          "\\X",
+          "\\X+",
+          "\\Xz",
+          "\\X\\X",
+          "\\X\\X\\X",
+          "\\X{2}",
+          "\\X{3}",
+          "(\\X)(\\X)",
+          "a|\\X",
+          "(a)|(\\X)",
+          "^\\^?\\X\\X");
 
   private static final List<String> GRAPHEME_CLUSTER_INPUTS =
       List.of(
           "a",
+          "ab",
+          "a\u0301b",
           "e\u0301",
           "\u0301\u0301a",
           "\u0301".repeat(44) + "a".repeat(8),
@@ -24,11 +38,23 @@ final class UnicodeFuzzer {
           "\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8",
           "\uD83D\uDC4D\uD83C\uDFFD",
           "\uD83D\uDC69\u200D\uD83D\uDCBB",
+          "a\uD83D\uDC69\u200D\uD83D\uDC69",
           "\uD83D\uDC69\uD83C\uDFFD\u200D\uD83D\uDCBB",
           "a\u200D",
           "\u1100\u1161",
           "\uAC00\u11A8",
           "\u0600a");
+
+  private static final List<String> INDIC_CONJUNCT_REGEXES =
+      List.of("\\X", "\\X+", "\\X\\b{g}", "\\X\\X", "\\X{2}", "(?:\\X){2}", "(\\X)(\\X)");
+
+  private static final List<String> INDIC_CONJUNCT_INPUTS =
+      List.of(
+          "\u0915\u094D\u0937",
+          "\u0915\u094D\u0937\u093F",
+          "\u0915\u094D\u200D\u0915",
+          "\u0915\u094D\u0301\u200D\u0915",
+          "\u0995\u09CD\u200D\u0995");
 
   @FuzzTest(maxDuration = "30s")
   void unicode(FuzzedDataProvider data) {
@@ -41,6 +67,18 @@ final class UnicodeFuzzer {
         }
       }
     }
+    for (String regex : INDIC_CONJUNCT_REGEXES) {
+      FuzzSupport.CompiledPattern graphemePattern = FuzzSupport.compileOrSkip(regex, 0);
+      for (String input : INDIC_CONJUNCT_INPUTS) {
+        FuzzSupport.MatcherPair matcher = graphemePattern.matcher(input);
+        while (matcher.find()) {
+          // Continue through the sequence so group boundaries are compared at every cluster.
+        }
+      }
+    }
+    FuzzSupport.MatcherPair anchoredSuffix =
+        FuzzSupport.compileOrSkip("\\Xz$", 0).matcher("a".repeat(2_048) + "z");
+    anchoredSuffix.find();
 
     String regex = data.consumeString(256);
     int flags = FuzzSupport.consumeFlags(data);

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -839,6 +839,15 @@ final class Compiler extends Walker<Compiler.Frag> {
     return new Frag(id, PatchList.mk(id << 1), false);
   }
 
+  private Frag graphemeCluster() {
+    int id = allocInst();
+    if (id < 0) {
+      return Frag.NO_MATCH;
+    }
+    prog.mutableInst(id).initGraphemeCluster(0);
+    return new Frag(id, PatchList.mk(id << 1), false);
+  }
+
   private Frag nop() {
     int id = allocInst();
     if (id < 0) {
@@ -1029,6 +1038,8 @@ final class Compiler extends Walker<Compiler.Frag> {
 
       case ANY_CHAR -> anyCodePoint();
 
+      case GRAPHEME_CLUSTER -> graphemeCluster();
+
       case CHAR_CLASS -> compileCharClass(re);
 
       case CAPTURE -> {
@@ -1066,12 +1077,7 @@ final class Compiler extends Walker<Compiler.Frag> {
         yield emptyWidth(EmptyOp.NON_WORD_BOUNDARY);
       }
 
-      case GRAPHEME_CLUSTER_BOUNDARY -> {
-        if ((re.flags & ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY) != 0) {
-          yield emptyWidth(EmptyOp.GRAPHEME_CLUSTER_BOUNDARY);
-        }
-        yield emptyWidth(EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY);
-      }
+      case GRAPHEME_CLUSTER_BOUNDARY -> emptyWidth(EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY);
 
       default -> {
         failed = true;

--- a/safere/src/main/java/org/safere/Inst.java
+++ b/safere/src/main/java/org/safere/Inst.java
@@ -25,6 +25,7 @@ package org.safere;
  *   <li>{@link InstOp#NOP}: No-op, continue to {@code out}
  *   <li>{@link InstOp#FAIL}: Unconditional failure
  *   <li>{@link InstOp#CHAR_CLASS}: Match a code point against a multi-range character class
+ *   <li>{@link InstOp#GRAPHEME_CLUSTER}: Match one Unicode extended grapheme cluster
  * </ul>
  */
 final class Inst {
@@ -212,6 +213,13 @@ final class Inst {
     this.bitmap1 = b1;
   }
 
+  /** Initializes as a GRAPHEME_CLUSTER instruction. */
+  public void initGraphemeCluster(int out) {
+    this.op = InstOp.GRAPHEME_CLUSTER;
+    this.opCode = InstOp.OP_GRAPHEME_CLUSTER;
+    this.out = out;
+  }
+
   /**
    * Returns true if the given code point matches this CHAR_CLASS instruction. Uses the precomputed
    * ASCII bitmap for code points 0–127, falls back to binary search for non-ASCII.
@@ -308,6 +316,7 @@ final class Inst {
       case MATCH -> String.format("match %d", arg);
       case NOP -> String.format("nop -> %d", out);
       case FAIL -> "fail";
+      case GRAPHEME_CLUSTER -> String.format("grapheme_cluster -> %d", out);
       case PROGRESS_CHECK ->
           String.format(
               "progress_check reg=%d body=%d exit=%d %s",

--- a/safere/src/main/java/org/safere/InstOp.java
+++ b/safere/src/main/java/org/safere/InstOp.java
@@ -51,6 +51,9 @@ enum InstOp {
    */
   CHAR_CLASS,
 
+  /** Match one Unicode extended grapheme cluster. */
+  GRAPHEME_CLUSTER,
+
   /**
    * Loop progress check for zero-width repetition breaking. Emitted at the entry point of each loop
    * iteration for {@code *}/{@code +} with nullable bodies. On first visit (saved == -1), saves the
@@ -64,7 +67,7 @@ enum InstOp {
   PROGRESS_CHECK;
 
   // Int constants for hot-loop switches, avoiding Enum.ordinal() + synthetic switch-map overhead.
-  // Values must match enum declaration order (ALT=0, ALT_MATCH=1, ..., PROGRESS_CHECK=9).
+  // Values must match enum declaration order (ALT=0, ALT_MATCH=1, ..., PROGRESS_CHECK=10).
   static final int OP_ALT = 0;
   static final int OP_ALT_MATCH = 1;
   static final int OP_CHAR_RANGE = 2;
@@ -74,5 +77,6 @@ enum InstOp {
   static final int OP_NOP = 6;
   static final int OP_FAIL = 7;
   static final int OP_CHAR_CLASS = 8;
-  static final int OP_PROGRESS_CHECK = 9;
+  static final int OP_GRAPHEME_CLUSTER = 9;
+  static final int OP_PROGRESS_CHECK = 10;
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -5,7 +5,6 @@
 
 package org.safere;
 
-import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -110,10 +109,8 @@ public final class Matcher implements MatchResult {
   private boolean anchoringBounds = true;
   private int regionStart;
   private int regionEnd;
-  private boolean regionStartInsideSurrogatePairContext;
-  private boolean opaqueGraphemeRegionContext;
+  private boolean fullTextRegionContext;
   private boolean findExhaustedAfterTerminalEmptyMatch;
-  private boolean boundaryStartedRepeatedFindAdvance;
   private int modCount;
 
   /**
@@ -641,14 +638,10 @@ public final class Matcher implements MatchResult {
     boolean regionSubstituted = false;
 
     try {
-      if (regionActive) {
-        regionStartInsideSurrogatePairContext = regionStartsInsideSurrogatePair();
-        opaqueGraphemeRegionContext = !transparentBounds && needsFullTextGraphemeRegion();
-      }
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
         return applyEngineResult(new NoMatchResult());
       }
-      if (regionActive && (transparentBounds || needsFullTextGraphemeRegion())) {
+      if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return matchesTransparentRegion();
       }
       if (regionActive) {
@@ -671,8 +664,7 @@ public final class Matcher implements MatchResult {
           deferredMatchEnd += regionStart;
         }
       }
-      regionStartInsideSurrogatePairContext = false;
-      opaqueGraphemeRegionContext = false;
+      fullTextRegionContext = false;
     }
   }
 
@@ -730,7 +722,7 @@ public final class Matcher implements MatchResult {
     }
 
     // Medium path: use DFA to check if a full match exists.
-    if (enginePathOptions().dfa() && !prog.hasGraphemeClusterBoundary()) {
+    if (enginePathOptions().dfa() && dfaSupportsProgram(prog)) {
       Dfa.SearchResult dfaResult = dfa().doSearch(text, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
         return applyEngineResult(new NoMatchResult());
@@ -788,14 +780,10 @@ public final class Matcher implements MatchResult {
     boolean regionSubstituted = false;
 
     try {
-      if (regionActive) {
-        regionStartInsideSurrogatePairContext = regionStartsInsideSurrogatePair();
-        opaqueGraphemeRegionContext = !transparentBounds && needsFullTextGraphemeRegion();
-      }
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
         return applyEngineResult(new NoMatchResult());
       }
-      if (regionActive && (transparentBounds || needsFullTextGraphemeRegion())) {
+      if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return lookingAtTransparentRegion();
       }
       if (regionActive) {
@@ -818,8 +806,7 @@ public final class Matcher implements MatchResult {
           deferredMatchEnd += regionStart;
         }
       }
-      regionStartInsideSurrogatePairContext = false;
-      opaqueGraphemeRegionContext = false;
+      fullTextRegionContext = false;
     }
   }
 
@@ -863,7 +850,7 @@ public final class Matcher implements MatchResult {
     }
 
     // Medium path: use DFA to check if an anchored match exists.
-    if (enginePathOptions().dfa() && !prog.hasGraphemeClusterBoundary()) {
+    if (enginePathOptions().dfa() && dfaSupportsProgram(prog)) {
       Dfa.SearchResult dfaResult = dfa().doSearch(text, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
         return applyEngineResult(new NoMatchResult());
@@ -916,9 +903,6 @@ public final class Matcher implements MatchResult {
           return false;
         }
         searchFrom++;
-      } else if (parentPattern.startsWithGraphemeClusterBoundary() && searchFrom < regionEnd) {
-        searchFrom = nextGraphemeClusterBoundary(searchFrom);
-        boundaryStartedRepeatedFindAdvance = true;
       } else if (parentPattern.hasInternalGraphemeClusterBoundary()
           && searchFrom < regionEnd
           && endedAfterCrLf(searchFrom)) {
@@ -932,15 +916,6 @@ public final class Matcher implements MatchResult {
     return pos >= 2 && text.charAt(pos - 2) == '\r' && text.charAt(pos - 1) == '\n';
   }
 
-  private int nextGraphemeClusterBoundary(int start) {
-    int pos = Math.min(start + 1, regionEnd);
-    Nfa.GraphemeContext context = graphemeContext();
-    while (pos < regionEnd && !Nfa.isGraphemeClusterBoundary(text, pos, context)) {
-      pos++;
-    }
-    return pos;
-  }
-
   private Nfa.GraphemeContext graphemeContext() {
     if (graphemeContext == null || !Objects.equals(graphemeContextText, text)) {
       graphemeContextText = text;
@@ -952,6 +927,13 @@ public final class Matcher implements MatchResult {
 
   private Nfa.GraphemeContext graphemeContextFor(Prog prog) {
     return prog.hasGraphemeClusterBoundary() ? graphemeContext() : null;
+  }
+
+  /**
+   * Returns whether DFA paths implement every instruction and boundary predicate in {@code prog}.
+   */
+  private static boolean dfaSupportsProgram(Prog prog) {
+    return !prog.hasGraphemeClusterBoundary();
   }
 
   /**
@@ -1011,14 +993,10 @@ public final class Matcher implements MatchResult {
     boolean regionSubstituted = false;
 
     try {
-      if (regionActive) {
-        regionStartInsideSurrogatePairContext = regionStartsInsideSurrogatePair();
-        opaqueGraphemeRegionContext = !transparentBounds && needsFullTextGraphemeRegion();
-      }
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
         return applyEngineResult(new NoMatchResult());
       }
-      if (regionActive && (transparentBounds || needsFullTextGraphemeRegion())) {
+      if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return doFindTransparentRegion();
       }
       if (regionActive) {
@@ -1043,10 +1021,15 @@ public final class Matcher implements MatchResult {
           deferredMatchEnd += regionStart;
         }
       }
-      regionStartInsideSurrogatePairContext = false;
-      opaqueGraphemeRegionContext = false;
-      boundaryStartedRepeatedFindAdvance = false;
+      fullTextRegionContext = false;
     }
+  }
+
+  private boolean needsFullTextRegionContext(boolean regionActive, Prog prog) {
+    return regionActive
+        && (transparentBounds
+            || prog.hasGraphemeClusterBoundary()
+            || (!anchoringBounds && prog.anchorEnd()));
   }
 
   /**
@@ -1068,32 +1051,11 @@ public final class Matcher implements MatchResult {
     if (prog.hasGraphemeClusterBoundary() && regionEndsInsideSurrogatePair()) {
       return true;
     }
-    return prog.dollarAnchorEnd()
-        && Nfa.isAtTrailingLineTerminator(text, regionEnd, prog.unixLines());
-  }
-
-  private boolean needsFullTextGraphemeRegion() {
-    return parentPattern.hasInternalGraphemeClusterBoundary()
-        || regionStartsInsideSurrogatePair()
-        || regionStartsAtZwjAfterPairedLowSurrogate()
-        || regionEndsInsideSurrogatePair();
-  }
-
-  private boolean regionStartsAtZwjAfterPairedLowSurrogate() {
-    return parentPattern.prog().hasGraphemeClusterBoundary()
-        && regionStart > 1
-        && regionStart < text.length()
-        && text.charAt(regionStart) == 0x200D
-        && Character.isLowSurrogate(text.charAt(regionStart - 1))
-        && Character.isHighSurrogate(text.charAt(regionStart - 2));
-  }
-
-  private boolean regionStartsInsideSurrogatePair() {
-    return parentPattern.prog().hasGraphemeClusterBoundary()
-        && regionStart > 0
-        && regionStart < text.length()
-        && Character.isHighSurrogate(text.charAt(regionStart - 1))
-        && Character.isLowSurrogate(text.charAt(regionStart));
+    if (!prog.dollarAnchorEnd()) {
+      return false;
+    }
+    int dollarEndPos = Nfa.trailingLineTerminatorStart(text, prog.unixLines());
+    return dollarEndPos >= regionStart && dollarEndPos <= regionEnd;
   }
 
   private boolean regionEndsInsideSurrogatePair() {
@@ -1104,10 +1066,25 @@ public final class Matcher implements MatchResult {
         && Character.isLowSurrogate(text.charAt(regionEnd));
   }
 
+  private int graphemeConsumeEndPos(Prog prog, int endPos) {
+    if (!prog.hasGraphemeClusterInstruction()
+        || endPos <= 0
+        || endPos >= text.length()
+        || !Character.isHighSurrogate(text.charAt(endPos - 1))
+        || !Character.isLowSurrogate(text.charAt(endPos))) {
+      return endPos;
+    }
+    // \X may complete the scalar that starts inside the region; ordinary atoms and full-match
+    // checks still use endPos.
+    return endPos + 1;
+  }
+
   private boolean matchesTransparentRegion() {
     capturesResolved = true;
     groupZeroResolved = true;
+    fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
+    int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
     return applyEngineResult(
         new FullMatchResult(
             searchWithBitStateOrNfa(
@@ -1116,6 +1093,7 @@ public final class Matcher implements MatchResult {
                 regionStart,
                 regionStart,
                 regionEnd,
+                graphemeConsumeEndPos,
                 true,
                 false,
                 true,
@@ -1125,8 +1103,9 @@ public final class Matcher implements MatchResult {
   private boolean lookingAtTransparentRegion() {
     capturesResolved = true;
     groupZeroResolved = true;
+    fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
-    int endPos = anchoredGraphemeSearchEndPos(prog);
+    int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
     return applyEngineResult(
         new FullMatchResult(
             searchWithBitStateOrNfa(
@@ -1134,7 +1113,8 @@ public final class Matcher implements MatchResult {
                 text,
                 regionStart,
                 regionStart,
-                endPos,
+                regionEnd,
+                graphemeConsumeEndPos,
                 true,
                 false,
                 false,
@@ -1147,63 +1127,25 @@ public final class Matcher implements MatchResult {
     }
     capturesResolved = true;
     groupZeroResolved = true;
+    fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     if (prog.anchorStart() && searchFrom > regionStart) {
       return applyEngineResult(new NoMatchResult());
     }
-    int endPos = anchoredGraphemeSearchEndPos(prog);
+    int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
     int[] result =
         searchWithBitStateOrNfa(
-            prog, text, searchFrom, regionEnd, endPos, false, false, false, prog.numCaptures());
-    if (prog.hasGraphemeClusterBoundary() && !prog.anchorStart()) {
-      result =
-          nextValidGraphemeCandidate(
-              result, text, searchFrom, regionEnd, endPos, prog.numCaptures(), regionStart);
-      if (result == null && !parentPattern.startsWithGraphemeClusterBoundary()) {
-        result = searchLowSurrogateStarts(text, searchFrom, regionEnd, endPos, prog.numCaptures());
-      }
-    }
+            prog,
+            text,
+            searchFrom,
+            regionEnd,
+            regionEnd,
+            graphemeConsumeEndPos,
+            false,
+            false,
+            false,
+            prog.numCaptures());
     return applyEngineResult(new FullMatchResult(result));
-  }
-
-  private int anchoredGraphemeSearchEndPos(Prog prog) {
-    return prog.anchorEnd() && regionEndsInsideSurrogatePair() ? regionEnd + 1 : regionEnd;
-  }
-
-  private boolean startsAtRegionStartSplitLowSurrogateZwjBoundaryWrappedMatch(int start) {
-    return hasBoundaryWrappedConsumingBody(parentPattern.ast())
-        && regionStartsInsideSurrogatePair()
-        && startsAtRegionStartSplitLowSurrogateZwj(start);
-  }
-
-  private boolean startsAtRegionStartSplitLowSurrogateZwj(int start) {
-    return start == regionStart + 1 && start < text.length() && text.charAt(start) == 0x200D;
-  }
-
-  private static boolean hasBoundaryWrappedConsumingBody(Regexp re) {
-    Regexp node = unwrapCaptures(re);
-    if (node.op != RegexpOp.CONCAT || node.nsub() < 3) {
-      return false;
-    }
-    if (unwrapCaptures(node.subs.getFirst()).op != RegexpOp.GRAPHEME_CLUSTER_BOUNDARY
-        || unwrapCaptures(node.subs.getLast()).op != RegexpOp.GRAPHEME_CLUSTER_BOUNDARY) {
-      return false;
-    }
-    for (int i = 1; i < node.nsub() - 1; i++) {
-      Regexp sub = unwrapCaptures(node.subs.get(i));
-      if (sub.op != RegexpOp.GRAPHEME_CLUSTER_BOUNDARY) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static Regexp unwrapCaptures(Regexp re) {
-    Regexp node = re;
-    while (node.op == RegexpOp.CAPTURE) {
-      node = node.sub();
-    }
-    return node;
   }
 
   /**
@@ -1362,6 +1304,7 @@ public final class Matcher implements MatchResult {
     // must fall through to the normal forward DFA path rather than returning false.
     if (options.dfa()
         && options.reverseDfa()
+        && dfaSupportsProgram(prog)
         && !regionActive
         && prog.anchorEnd()
         && !prog.anchorStart()
@@ -1460,7 +1403,7 @@ public final class Matcher implements MatchResult {
     // precheck cannot produce reusable bounds and would fall through to the complete fallback
     // search anyway.
     Dfa.SearchResult fwdResult;
-    if (!options.dfa() || directFallback || prog.hasGraphemeClusterBoundary()) {
+    if (!options.dfa() || directFallback || !dfaSupportsProgram(prog)) {
       fwdResult = null;
     } else {
       fwdResult = dfa().doSearch(text, effectiveStart, false, false);
@@ -1606,6 +1549,7 @@ public final class Matcher implements MatchResult {
     boolean lazyFallbackCaptures =
         !regionActive
             && !eagerFallbackCaptures
+            && !prog.hasGraphemeClusterBoundary()
             && options.lazyCaptureExtraction()
             && prog.numCaptures() <= MAX_LAZY_FALLBACK_SUBMATCHES;
     int nsubmatch = lazyFallbackCaptures ? 1 : prog.numCaptures();
@@ -1620,276 +1564,15 @@ public final class Matcher implements MatchResult {
             false,
             false,
             nsubmatch);
-    boolean fullCapturesFromGraphemeFallback = false;
-    if (prog.hasGraphemeClusterBoundary() && !prog.anchorStart()) {
-      int candidateRegionStart = regionActive ? 0 : regionStart;
-      result =
-          nextValidGraphemeCandidate(
-              result,
-              text,
-              effectiveStart,
-              text.length(),
-              text.length(),
-              nsubmatch,
-              candidateRegionStart);
-      if (result == null && !parentPattern.startsWithGraphemeClusterBoundary()) {
-        result =
-            searchLowSurrogateStarts(
-                text, effectiveStart, text.length(), text.length(), prog.numCaptures());
-        fullCapturesFromGraphemeFallback = result != null;
-      }
-    }
     if (result == null) {
       return applyEngineResult(new NoMatchResult());
     }
-    if (!lazyFallbackCaptures || prog.numCaptures() <= 1 || fullCapturesFromGraphemeFallback) {
+    if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
       return applyEngineResult(new FullMatchResult(result));
     } else {
       return applyEngineResult(
           new DeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false));
     }
-  }
-
-  private int[] searchLowSurrogateStarts(
-      String text, int effectiveStart, int searchLimit, int endPos, int nsubmatch) {
-    Nfa.SearchResult result =
-        Nfa.searchLowSurrogateStarts(
-            parentPattern.prog(),
-            text,
-            effectiveStart,
-            searchLimit,
-            endPos,
-            nsubmatch,
-            graphemeContext());
-    return result.groups();
-  }
-
-  private int[] nextValidGraphemeCandidate(
-      int[] result,
-      String text,
-      int start,
-      int searchLimit,
-      int endPos,
-      int nsubmatch,
-      int candidateRegionStart) {
-    Prog prog = parentPattern.prog();
-    int retryStart = start;
-    while (result != null
-        && result[0] != result[1]
-        && (!isAnchoredCandidate(result, text, searchLimit)
-            || startsAtNonRegionLowSurrogateAfterExplicitGraphemeBoundary(
-                text, result[0], candidateRegionStart)
-            || startsAtExtenderAfterRegionStartSplitLowSurrogate(
-                text, result[0], candidateRegionStart)
-            || startsAtSupplementaryAfterRegionStartSplitLowSurrogateZwj(
-                text, result[0], candidateRegionStart)
-            || startsAtRegionStartSplitLowSurrogateZwjBoundaryWrappedMatch(result[0])
-            || startsInsideRegionStartSplitLowSurrogateZwjPictographicContinuation(
-                text, result[0], candidateRegionStart)
-            || startsInsidePairedSupplementaryClusterAfterRepeatedBoundaryFind(text, result[0])
-            || (hasExplicitGraphemeClusterBoundary(parentPattern.ast())
-                && endsInsideFullTextPictographicZwjSequence(
-                    text, result[0], result[1], candidateRegionStart)))) {
-      retryStart = Math.max(result[0] + 1, retryStart + 1);
-      if (retryStart > searchLimit) {
-        return null;
-      }
-      result =
-          searchWithBitStateOrNfa(
-              prog, text, retryStart, searchLimit, endPos, false, false, false, nsubmatch);
-    }
-    if (result != null && result[0] != result[1] && result[0] > start) {
-      int[] earlier =
-          searchAnchoredGraphemeCandidates(
-              text, start, result[0], searchLimit, nsubmatch, candidateRegionStart);
-      if (earlier != null) {
-        return earlier;
-      }
-    }
-    return result;
-  }
-
-  private boolean endsInsideFullTextPictographicZwjSequence(
-      String text, int pos, int end, int candidateRegionStart) {
-    if (pos <= candidateRegionStart
-        || candidateRegionStart < 0
-        || candidateRegionStart >= text.length()
-        || !Character.isLowSurrogate(text.charAt(candidateRegionStart))
-        || candidateRegionStart == 0
-        || !Character.isHighSurrogate(text.charAt(candidateRegionStart - 1))
-        || !Nfa.isExtendedPictographicAt(text, end)) {
-      return false;
-    }
-    int lastZwj = -1;
-    int scan = pos;
-    while (scan < end) {
-      if (!Nfa.hasGraphemeExtendAt(text, scan)) {
-        return false;
-      }
-      if (text.charAt(scan) == 0x200D) {
-        lastZwj = scan;
-      }
-      scan += Character.charCount(text.codePointAt(scan));
-    }
-    return lastZwj == end - 1 && Nfa.hasExtendedPictographicBeforeZwj(text, lastZwj, 0);
-  }
-
-  private boolean startsAtNonRegionLowSurrogateAfterExplicitGraphemeBoundary(
-      String text, int pos, int candidateRegionStart) {
-    return parentPattern.startsWithGraphemeClusterBoundary()
-        && pos != candidateRegionStart
-        && pos > 0
-        && pos < text.length()
-        && Character.isHighSurrogate(text.charAt(pos - 1))
-        && Character.isLowSurrogate(text.charAt(pos));
-  }
-
-  private boolean startsAtExtenderAfterRegionStartSplitLowSurrogate(
-      String text, int pos, int candidateRegionStart) {
-    if (!parentPattern.startsWithGraphemeClusterBoundary()
-        || pos <= candidateRegionStart
-        || candidateRegionStart <= 0
-        || candidateRegionStart >= text.length()
-        || !Character.isLowSurrogate(text.charAt(candidateRegionStart))
-        || !Character.isHighSurrogate(text.charAt(candidateRegionStart - 1))
-        || !Nfa.hasGraphemeExtendAt(text, pos)) {
-      return false;
-    }
-    int scan = pos;
-    while (scan > candidateRegionStart + 1) {
-      int previous = text.codePointBefore(scan);
-      int previousPos = scan - Character.charCount(previous);
-      if (!Nfa.hasGraphemeExtendAt(text, previousPos)) {
-        return false;
-      }
-      scan = previousPos;
-    }
-    return scan == candidateRegionStart + 1;
-  }
-
-  private boolean startsAtSupplementaryAfterRegionStartSplitLowSurrogateZwj(
-      String text, int pos, int candidateRegionStart) {
-    return parentPattern.startsWithGraphemeClusterBoundary()
-        && pos > candidateRegionStart + 1
-        && pos < text.length()
-        && Nfa.isExtendedPictographicAt(text, pos)
-        && text.charAt(pos - 1) == 0x200D
-        && startsAtExtenderAfterRegionStartSplitLowSurrogate(text, pos - 1, candidateRegionStart);
-  }
-
-  private boolean startsInsideRegionStartSplitLowSurrogateZwjPictographicContinuation(
-      String text, int pos, int candidateRegionStart) {
-    if (!parentPattern.startsWithGraphemeClusterBoundary()
-        || candidateRegionStart <= 0
-        || !Character.isLowSurrogate(text.charAt(candidateRegionStart))
-        || !Character.isHighSurrogate(text.charAt(candidateRegionStart - 1))) {
-      return false;
-    }
-    int firstPictographic = -1;
-    boolean sawZwj = false;
-    int scan = candidateRegionStart + 1;
-    while (scan < pos && scan < text.length()) {
-      if (Nfa.isExtendedPictographicAt(text, scan)) {
-        firstPictographic = scan;
-        break;
-      }
-      if (!Nfa.hasGraphemeExtendAt(text, scan)) {
-        return false;
-      }
-      sawZwj |= text.codePointAt(scan) == 0x200D;
-      scan += Character.charCount(text.codePointAt(scan));
-    }
-    if (firstPictographic < 0 || !sawZwj || pos <= firstPictographic) {
-      return false;
-    }
-    scan = firstPictographic + Character.charCount(text.codePointAt(firstPictographic));
-    while (scan < pos) {
-      if (!Nfa.hasGraphemeExtendAt(text, scan)) {
-        return false;
-      }
-      scan += Character.charCount(text.codePointAt(scan));
-    }
-    if (scan != pos) {
-      return false;
-    }
-    if (Nfa.hasGraphemeExtendAt(text, pos)) {
-      return true;
-    }
-    return Nfa.isExtendedPictographicAt(text, pos)
-        && pos > 0
-        && text.codePointBefore(pos) == 0x200D;
-  }
-
-  private boolean startsInsidePairedSupplementaryClusterAfterRepeatedBoundaryFind(
-      String text, int pos) {
-    if (!boundaryStartedRepeatedFindAdvance || !Nfa.hasGraphemeExtendAt(text, pos)) {
-      return false;
-    }
-    int scan = pos;
-    while (scan > 0) {
-      int previous = text.codePointBefore(scan);
-      int previousPos = scan - Character.charCount(previous);
-      if (Character.charCount(previous) == 2) {
-        return true;
-      }
-      if (!Nfa.hasGraphemeExtendAt(text, previousPos)) {
-        return false;
-      }
-      scan = previousPos;
-    }
-    return false;
-  }
-
-  private int[] searchAnchoredGraphemeCandidates(
-      String text,
-      int start,
-      int endExclusive,
-      int searchLimit,
-      int nsubmatch,
-      int candidateRegionStart) {
-    for (int pos = Math.max(0, start); pos < endExclusive; pos++) {
-      Matcher verifier = parentPattern.matcher(text).region(pos, searchLimit);
-      if (verifier.lookingAt()
-          && !startsAtNonRegionLowSurrogateAfterExplicitGraphemeBoundary(
-              text, pos, candidateRegionStart)
-          && !startsAtExtenderAfterRegionStartSplitLowSurrogate(text, pos, candidateRegionStart)
-          && !startsAtSupplementaryAfterRegionStartSplitLowSurrogateZwj(
-              text, pos, candidateRegionStart)
-          && !startsAtRegionStartSplitLowSurrogateZwjBoundaryWrappedMatch(pos)
-          && !startsInsideRegionStartSplitLowSurrogateZwjPictographicContinuation(
-              text, pos, candidateRegionStart)
-          && !startsInsidePairedSupplementaryClusterAfterRepeatedBoundaryFind(text, pos)
-          && (!hasExplicitGraphemeClusterBoundary(parentPattern.ast())
-              || !endsInsideFullTextPictographicZwjSequence(
-                  text, pos, verifier.end(), candidateRegionStart))) {
-        int ncap = 2 * Math.max(nsubmatch, 1);
-        return Arrays.copyOf(verifier.groups, ncap);
-      }
-    }
-    return null;
-  }
-
-  private static boolean hasExplicitGraphemeClusterBoundary(Regexp re) {
-    ArrayDeque<Regexp> stack = new ArrayDeque<>();
-    stack.push(re);
-    while (!stack.isEmpty()) {
-      Regexp node = stack.pop();
-      if (node.op == RegexpOp.GRAPHEME_CLUSTER_BOUNDARY
-          && (node.flags & ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY) == 0) {
-        return true;
-      }
-      if (node.subs != null) {
-        for (Regexp sub : node.subs) {
-          stack.push(sub);
-        }
-      }
-    }
-    return false;
-  }
-
-  private boolean isAnchoredCandidate(int[] result, String text, int searchLimit) {
-    Matcher verifier = parentPattern.matcher(text).region(result[0], searchLimit);
-    return verifier.lookingAt() && verifier.start() == result[0] && verifier.end() == result[1];
   }
 
   private boolean findKeywordAlternation(
@@ -2022,10 +1705,10 @@ public final class Matcher implements MatchResult {
    * @param prog the compiled program
    * @param text the full input text
    * @param startPos the char index at which to begin searching
-   * @param searchLimit upper bound on match end position; the capture engines only try start
-   *     positions up to this index. Use {@code text.length()} for unbounded search.
-   * @param endPos upper bound on character consumption; engines will not read past this position.
-   *     Use {@code text.length()} for unbounded search.
+   * @param searchLimit upper bound on positions where new candidate starts are tried. Use {@code
+   *     text.length()} for unbounded search.
+   * @param endPos logical match end and ordinary-atom consumption limit. Use {@code text.length()}
+   *     for unbounded search.
    * @param anchored whether the search is anchored at {@code startPos}
    * @param longest whether to find the longest match
    * @param endMatch whether the match must extend to {@code endPos}
@@ -2042,12 +1725,28 @@ public final class Matcher implements MatchResult {
       boolean longest,
       boolean endMatch,
       int nsubmatch) {
+    return searchWithBitStateOrNfa(
+        prog, text, startPos, searchLimit, endPos, endPos, anchored, longest, endMatch, nsubmatch);
+  }
+
+  private int[] searchWithBitStateOrNfa(
+      Prog prog,
+      String text,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int graphemeConsumeEndPos,
+      boolean anchored,
+      boolean longest,
+      boolean endMatch,
+      int nsubmatch) {
     // Try BitState if the full text is small enough for the visited bitmap. BitState is an
     // optimization; if capture-priority backtracking exceeds its work budget, fall back to the
     // Pike NFA below.
     int maxBitStateLen = BitState.maxTextSize(prog);
     boolean canUseBitState =
         enginePathOptions().bitState()
+            && !fullTextRegionContext
             && !(prog.hasGraphemeClusterBoundary() && !anchored)
             && !prog.hasGraphemeClusterBoundary()
             && (!enginePathOptions().semanticGuards()
@@ -2090,8 +1789,12 @@ public final class Matcher implements MatchResult {
     } else {
       nfaKind = Nfa.MatchKind.FIRST_MATCH;
     }
-    int nfaRegionStart =
-        (regionStartInsideSurrogatePairContext || opaqueGraphemeRegionContext) ? regionStart : 0;
+    boolean graphemeRegionContext = fullTextRegionContext && prog.hasGraphemeClusterBoundary();
+    int consumeRegionStart = graphemeRegionContext && !transparentBounds ? regionStart : 0;
+    int boundaryRegionStart = fullTextRegionContext && !transparentBounds ? regionStart : 0;
+    int boundaryEndPos = fullTextRegionContext && !transparentBounds ? endPos : text.length();
+    int anchorEndPos =
+        fullTextRegionContext && !anchoringBounds && prog.anchorEnd() ? text.length() : endPos;
     Nfa.SearchResult nfaResult =
         Nfa.search(
             prog,
@@ -2099,7 +1802,11 @@ public final class Matcher implements MatchResult {
             startPos,
             searchLimit,
             endPos,
-            nfaRegionStart,
+            graphemeConsumeEndPos,
+            consumeRegionStart,
+            boundaryRegionStart,
+            boundaryEndPos,
+            anchorEndPos,
             nfaAnchor,
             nfaKind,
             nsubmatch,

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -7,8 +7,10 @@ package org.safere;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -53,7 +55,28 @@ final class Nfa {
   /** A thread in the NFA: an instruction index paired with capture metadata. */
   // TODO(#98): Replace int[] with Guava ImmutableIntArray to get proper value semantics.
   @SuppressWarnings("ArrayRecordComponent")
-  private record NfaThread(int id, int[] capture, boolean consumedInput) {}
+  private record NfaThread(int id, int[] capture, boolean consumedInput, int graphemeStart) {}
+
+  private static final int VISIT_KEY_VARIANT_BITS = 5;
+  private static final int GRAPHEME_LOW_SURROGATE_PAIR_VISIBLE = 1;
+  private static final int GRAPHEME_EXTENDED_PICTOGRAPHIC_VISIBLE = 1 << 1;
+  private static final int GRAPHEME_REGIONAL_INDICATOR_ODD = 1 << 2;
+  private static final int GRAPHEME_INDIC_CONJUNCT_LINKER_VISIBLE = 1 << 3;
+  private static final int GRAPHEME_INDIC_CONJUNCT_SEQUENCE_VISIBLE = 1 << 4;
+
+  private static final class QueueState {
+    final List<NfaThread> threads = new ArrayList<>();
+    final Set<Long> visited = new HashSet<>();
+
+    boolean isEmpty() {
+      return threads.isEmpty();
+    }
+
+    void clear() {
+      threads.clear();
+      visited.clear();
+    }
+  }
 
   @SuppressWarnings("ArrayRecordComponent")
   record SearchResult(int[] groups) {}
@@ -68,7 +91,12 @@ final class Nfa {
     private static final GraphemeContext EMPTY = new GraphemeContext(null);
 
     private final String text;
-    private boolean[] computedOddRegionalIndicatorsBefore;
+    private int[] regionalIndicatorStartsBefore;
+    private int[] regionalIndicatorRunStartBefore;
+    private int[] extendedPictographicStartBefore;
+    private int[] extendedPictographicPrependBefore;
+    private int[] indicConjunctSequenceStartBefore;
+    private int[] indicConjunctLinkerStartBefore;
 
     private GraphemeContext(String text) {
       this.text = text;
@@ -81,36 +109,155 @@ final class Nfa {
       return new GraphemeContext(text);
     }
 
-    boolean hasEvenRegionalIndicatorsBefore(int pos) {
+    boolean hasEvenRegionalIndicatorsBefore(int pos, int regionStart) {
       if (text == null) {
         return true;
       }
-      boolean[] oddRegionalIndicatorsBefore = oddRegionalIndicatorsBefore();
-      return pos < 0
-          || pos >= oddRegionalIndicatorsBefore.length
-          || !oddRegionalIndicatorsBefore[pos];
-    }
-
-    private boolean[] oddRegionalIndicatorsBefore() {
-      if (computedOddRegionalIndicatorsBefore != null) {
-        return computedOddRegionalIndicatorsBefore;
+      int start = Math.max(0, Math.min(regionStart, text.length()));
+      if (pos <= start || pos > text.length()) {
+        return true;
       }
-      computedOddRegionalIndicatorsBefore = computeOddRegionalIndicatorsBefore(text);
-      return computedOddRegionalIndicatorsBefore;
+      ensureRegionalIndicatorRunData();
+      int runStart = regionalIndicatorRunStartBefore[pos];
+      int countStart = Math.max(start, runStart);
+      int regionalIndicatorsBefore =
+          regionalIndicatorStartsBefore[pos] - regionalIndicatorStartsBefore[countStart];
+      return (regionalIndicatorsBefore & 1) == 0;
     }
 
-    private static boolean[] computeOddRegionalIndicatorsBefore(String text) {
-      boolean[] oddRegionalIndicatorsBefore = new boolean[text.length() + 1];
+    boolean hasExtendedPictographicBefore(int pos, int regionStart) {
+      if (text == null) {
+        return false;
+      }
+      int start = Math.max(0, Math.min(regionStart, text.length()));
+      if (pos <= start || pos > text.length()) {
+        return false;
+      }
+      ensureExtendedPictographicData();
+      int pictographicStart = extendedPictographicStartBefore[pos];
+      if (pictographicStart < start) {
+        return false;
+      }
+      int prependStart = extendedPictographicPrependBefore[pos];
+      return prependStart < start;
+    }
+
+    boolean hasIndicConjunctLinkerBefore(int pos, int regionStart) {
+      if (text == null) {
+        return false;
+      }
+      int start = Math.max(0, Math.min(regionStart, text.length()));
+      if (pos <= start || pos > text.length()) {
+        return false;
+      }
+      ensureIndicConjunctData();
+      return indicConjunctLinkerStartBefore[pos] >= start;
+    }
+
+    boolean hasIndicConjunctSequenceBefore(int pos, int regionStart) {
+      if (text == null) {
+        return false;
+      }
+      int start = Math.max(0, Math.min(regionStart, text.length()));
+      if (pos <= start || pos > text.length()) {
+        return false;
+      }
+      ensureIndicConjunctData();
+      return indicConjunctSequenceStartBefore[pos] >= start;
+    }
+
+    private void ensureRegionalIndicatorRunData() {
+      if (regionalIndicatorStartsBefore != null) {
+        return;
+      }
+      regionalIndicatorStartsBefore = new int[text.length() + 1];
+      regionalIndicatorRunStartBefore = new int[text.length() + 1];
+      int runStart = 0;
       int runLength = 0;
       int pos = 0;
       while (pos < text.length()) {
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
-        runLength = isRegionalIndicator(cp) ? runLength + 1 : 0;
-        oddRegionalIndicatorsBefore[next] = (runLength & 1) != 0;
+        if (isRegionalIndicator(cp)) {
+          if (runLength == 0) {
+            runStart = pos;
+          }
+          runLength++;
+          for (int i = pos + 1; i <= next; i++) {
+            regionalIndicatorStartsBefore[i] = runLength;
+            regionalIndicatorRunStartBefore[i] = runStart;
+          }
+        } else {
+          runLength = 0;
+        }
         pos = next;
       }
-      return oddRegionalIndicatorsBefore;
+    }
+
+    private void ensureIndicConjunctData() {
+      if (indicConjunctLinkerStartBefore != null) {
+        return;
+      }
+      indicConjunctSequenceStartBefore = new int[text.length() + 1];
+      indicConjunctLinkerStartBefore = new int[text.length() + 1];
+      Arrays.fill(indicConjunctSequenceStartBefore, -1);
+      Arrays.fill(indicConjunctLinkerStartBefore, -1);
+
+      int sequenceStart = -1;
+      boolean linkerSeen = false;
+      int pos = 0;
+      while (pos < text.length()) {
+        int cp = text.codePointAt(pos);
+        int next = pos + Character.charCount(cp);
+        if (isIndicConjunctConsonant(cp)) {
+          sequenceStart = pos;
+          linkerSeen = false;
+        } else if (isIndicConjunctLinker(cp)) {
+          if (sequenceStart >= 0) {
+            linkerSeen = true;
+          }
+        } else if (!isIndicConjunctExtend(cp)) {
+          sequenceStart = -1;
+          linkerSeen = false;
+        }
+        int activeSequenceStart = sequenceStart;
+        int linkerStart = linkerSeen ? sequenceStart : -1;
+        for (int i = pos + 1; i <= next; i++) {
+          indicConjunctSequenceStartBefore[i] = activeSequenceStart;
+          indicConjunctLinkerStartBefore[i] = linkerStart;
+        }
+        pos = next;
+      }
+    }
+
+    private void ensureExtendedPictographicData() {
+      if (extendedPictographicStartBefore != null) {
+        return;
+      }
+      extendedPictographicStartBefore = new int[text.length() + 1];
+      extendedPictographicPrependBefore = new int[text.length() + 1];
+      Arrays.fill(extendedPictographicStartBefore, -1);
+      Arrays.fill(extendedPictographicPrependBefore, -1);
+
+      int visiblePictographicStart = -1;
+      int visiblePrependStart = -1;
+      int pos = 0;
+      while (pos < text.length()) {
+        int cp = text.codePointAt(pos);
+        int next = pos + Character.charCount(cp);
+        if (containsCodePoint(EXTENDED_PICTOGRAPHIC, cp)) {
+          visiblePictographicStart = pos;
+          visiblePrependStart = immediatePrependStartBefore(text, pos);
+        } else if (!isGraphemeExtend(cp)) {
+          visiblePictographicStart = -1;
+          visiblePrependStart = -1;
+        }
+        for (int i = pos + 1; i <= next; i++) {
+          extendedPictographicStartBefore[i] = visiblePictographicStart;
+          extendedPictographicPrependBefore[i] = visiblePrependStart;
+        }
+        pos = next;
+      }
     }
   }
 
@@ -123,17 +270,15 @@ final class Nfa {
   private final boolean longest;
   private final boolean endmatch;
   private final int endPos;
-  private final int regionStart;
+  private final int anchorEndPos;
+  private final int graphemeConsumeEndPos;
+  private final int consumeRegionStart;
+  private final int boundaryRegionStart;
+  private final int boundaryEndPos;
   private final GraphemeContext graphemeContext;
-  private final boolean useMatchStartAsRegionStart;
-  private final boolean lowSurrogateStartsOnly;
 
   private boolean matched;
   private int[] bestMatch;
-
-  // NfaThread queues: ordered lists of threads. The order is the thread priority.
-  private List<NfaThread> runq;
-  private List<NfaThread> nextq;
 
   private Nfa(
       Prog prog,
@@ -142,21 +287,23 @@ final class Nfa {
       boolean longest,
       boolean endmatch,
       int endPos,
-      int regionStart,
-      boolean useMatchStartAsRegionStart,
-      boolean lowSurrogateStartsOnly) {
+      int anchorEndPos,
+      int graphemeConsumeEndPos,
+      int consumeRegionStart,
+      int boundaryRegionStart,
+      int boundaryEndPos) {
     this.prog = prog;
     this.ncapture = ncapture;
     this.threadArraySize = ncapture + prog.numLoopRegs();
     this.longest = longest;
     this.endmatch = endmatch;
     this.endPos = endPos;
-    this.regionStart = regionStart;
+    this.anchorEndPos = anchorEndPos;
+    this.graphemeConsumeEndPos = graphemeConsumeEndPos;
+    this.consumeRegionStart = consumeRegionStart;
+    this.boundaryRegionStart = boundaryRegionStart;
+    this.boundaryEndPos = boundaryEndPos;
     this.graphemeContext = graphemeContext;
-    this.useMatchStartAsRegionStart = useMatchStartAsRegionStart;
-    this.lowSurrogateStartsOnly = lowSurrogateStartsOnly;
-    this.runq = new ArrayList<>();
-    this.nextq = new ArrayList<>();
     this.bestMatch = new int[ncapture];
     Arrays.fill(bestMatch, -1);
   }
@@ -257,6 +404,68 @@ final class Nfa {
       MatchKind kind,
       int nsubmatch,
       GraphemeContext graphemeContext) {
+    return search(
+        prog,
+        text,
+        startPos,
+        searchLimit,
+        endPos,
+        endPos,
+        regionStart,
+        regionStart,
+        endPos,
+        endPos,
+        anchor,
+        kind,
+        nsubmatch,
+        graphemeContext);
+  }
+
+  static SearchResult search(
+      Prog prog,
+      String text,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int consumeRegionStart,
+      int boundaryRegionStart,
+      int boundaryEndPos,
+      Anchor anchor,
+      MatchKind kind,
+      int nsubmatch,
+      GraphemeContext graphemeContext) {
+    return search(
+        prog,
+        text,
+        startPos,
+        searchLimit,
+        endPos,
+        endPos,
+        consumeRegionStart,
+        boundaryRegionStart,
+        boundaryEndPos,
+        endPos,
+        anchor,
+        kind,
+        nsubmatch,
+        graphemeContext);
+  }
+
+  static SearchResult search(
+      Prog prog,
+      String text,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int graphemeConsumeEndPos,
+      int consumeRegionStart,
+      int boundaryRegionStart,
+      int boundaryEndPos,
+      int anchorEndPos,
+      Anchor anchor,
+      MatchKind kind,
+      int nsubmatch,
+      GraphemeContext graphemeContext) {
     if (prog.start() == 0) {
       return new SearchResult(null);
     }
@@ -281,9 +490,20 @@ final class Nfa {
             ? graphemeContext
             : GraphemeContext.create(text, prog.hasGraphemeClusterBoundary());
     Nfa nfa =
-        new Nfa(prog, context, ncapture, longestMode, endmatch, endPos, regionStart, false, false);
-    if (!anchored && prog.hasGraphemeClusterBoundary()) {
-      nfa.doSearchEveryCharPosition(text, startPos, searchLimit);
+        new Nfa(
+            prog,
+            context,
+            ncapture,
+            longestMode,
+            endmatch,
+            endPos,
+            anchorEndPos,
+            graphemeConsumeEndPos,
+            consumeRegionStart,
+            boundaryRegionStart,
+            boundaryEndPos);
+    if (prog.hasGraphemeClusterBoundary()) {
+      nfa.doSearchEveryCharPosition(text, startPos, searchLimit, anchored);
     } else {
       nfa.doSearch(text, startPos, searchLimit, anchored);
     }
@@ -304,32 +524,6 @@ final class Nfa {
     return new SearchResult(result);
   }
 
-  static SearchResult searchLowSurrogateStarts(
-      Prog prog, String text, int startPos, int searchLimit, int endPos, int nsubmatch) {
-    return searchLowSurrogateStarts(prog, text, startPos, searchLimit, endPos, nsubmatch, null);
-  }
-
-  static SearchResult searchLowSurrogateStarts(
-      Prog prog,
-      String text,
-      int startPos,
-      int searchLimit,
-      int endPos,
-      int nsubmatch,
-      GraphemeContext graphemeContext) {
-    if (prog.start() == 0) {
-      return new SearchResult(null);
-    }
-    int ncapture = 2 * Math.max(nsubmatch, 1);
-    GraphemeContext context =
-        graphemeContext != null
-            ? graphemeContext
-            : GraphemeContext.create(text, prog.hasGraphemeClusterBoundary());
-    Nfa nfa = new Nfa(prog, context, ncapture, false, prog.anchorEnd(), endPos, 0, true, true);
-    nfa.doSearchEveryCharPosition(text, startPos, searchLimit);
-    return new SearchResult(nfa.matched ? nfa.bestMatch : null);
-  }
-
   /**
    * Main search loop. Iterates over each position in the text starting from {@code startPos} (plus
    * one past the end), stepping the NFA. At each position, starts a new thread if appropriate, then
@@ -342,9 +536,8 @@ final class Nfa {
    * @param anchored whether to anchor the search at {@code startPos}
    */
   private void doSearch(String text, int startPos, int searchLimit, boolean anchored) {
-    // The set of instruction IDs in each queue, for deduplication in addToThreadq.
-    Set<Integer> runqSet = new HashSet<>();
-    Set<Integer> nextqSet = new HashSet<>();
+    QueueState runq = new QueueState();
+    QueueState nextq = new QueueState();
 
     int pos = startPos;
     while (true) {
@@ -355,17 +548,14 @@ final class Nfa {
       // (no point starting new threads to the right of an existing match).
       // Also don't start threads past searchLimit — the DFA has already determined
       // there's no match starting beyond that position.
-      if (!matched
-          && pos <= searchLimit
-          && (!anchored || pos == startPos)
-          && canStartAt(text, pos)) {
+      if (!matched && pos <= searchLimit && (!anchored || pos == startPos)) {
         int[] cap = new int[threadArraySize];
         Arrays.fill(cap, -1);
         cap[0] = pos;
         // Always use prog.start() (anchored start). Unanchored matching is achieved
         // by starting a new thread at each position. The startUnanchored() entry point
         // (which includes a .*? prefix) is only for the DFA engine.
-        addToThreadq(runq, runqSet, prog.start(), text, pos, cap, false);
+        addToThreadq(runq.threads, runq.visited, prog.start(), text, pos, cap, false);
       }
 
       // If all threads have died, stop if anchored or we already have a match.
@@ -374,28 +564,21 @@ final class Nfa {
         if (anchored || matched) {
           break;
         }
-        // In unanchored mode with no match yet, advance to the next position
-        // and try again. Clear the visited set so instructions can be re-added.
+        // In unanchored mode with no match yet, advance to the next position and try again.
         if (pos >= endPos) {
           break;
         }
-        runqSet.clear();
+        runq.clear();
         pos = nextPos;
         continue;
       }
 
-      boolean done = step(runq, runqSet, nextq, nextqSet, cp, text, pos, nextPos);
+      boolean done = stepCodePoint(runq, nextq, cp, text, pos, nextPos);
 
-      // Swap queues.
-      List<NfaThread> tmpQ = runq;
+      QueueState tmp = runq;
       runq = nextq;
-      nextq = tmpQ;
+      nextq = tmp;
       nextq.clear();
-
-      Set<Integer> tmpS = runqSet;
-      runqSet = nextqSet;
-      nextqSet = tmpS;
-      nextqSet.clear();
 
       if (done) {
         break;
@@ -417,50 +600,170 @@ final class Nfa {
    * search contract for grapheme constructs without changing the code-point stepping used by
    * ordinary SafeRE programs.
    */
-  private void doSearchEveryCharPosition(String text, int startPos, int searchLimit) {
+  private void doSearchEveryCharPosition(
+      String text, int startPos, int searchLimit, boolean anchored) {
     int start = Math.max(0, startPos);
-    Set<Integer> runqSet = new HashSet<>();
-    Set<Integer> nextqSet = new HashSet<>();
-    List<NfaThread> secondq = new ArrayList<>();
-    Set<Integer> secondqSet = new HashSet<>();
+    QueueState runq = new QueueState();
+    Map<Integer, QueueState> delayed = new HashMap<>();
 
-    for (int pos = start; pos < endPos + 2; pos++) {
-      if (!matched && pos <= searchLimit && canStartAt(text, pos)) {
+    int engineEndPos = Math.max(endPos, graphemeConsumeEndPos);
+    for (int pos = start; pos < engineEndPos + 2; pos++) {
+      mergeDelayedQueue(delayed, pos, runq);
+      if (!matched && pos <= searchLimit && (!anchored || pos == startPos)) {
         int[] cap = new int[threadArraySize];
         Arrays.fill(cap, -1);
         cap[0] = pos;
-        addToThreadq(runq, runqSet, prog.start(), text, pos, cap, false);
+        addToThreadq(runq.threads, runq.visited, prog.start(), text, pos, cap, false);
       }
 
       if (!runq.isEmpty()) {
-        int cp = (pos < endPos) ? text.codePointAt(pos) : -1;
-        int nextPos = (pos < endPos) ? pos + Character.charCount(cp) : endPos + 1;
-        List<NfaThread> destinationQueue = (nextPos == pos + 1) ? nextq : secondq;
-        Set<Integer> destinationSet = (nextPos == pos + 1) ? nextqSet : secondqSet;
-        step(runq, runqSet, destinationQueue, destinationSet, cp, text, pos, nextPos, false);
+        int cp = inputCodePointAt(text, pos);
+        int nextPos = inputNextPos(text, pos);
+        step(runq, delayed, cp, text, pos, nextPos);
+      } else {
+        runq.clear();
       }
-
-      if (matched && runq.isEmpty() && nextq.isEmpty() && secondq.isEmpty()) {
+      if (matched && runq.isEmpty() && delayed.isEmpty()) {
         break;
       }
-
-      List<NfaThread> oldRunq = runq;
-      runq = nextq;
-      nextq = secondq;
-      secondq = oldRunq;
-      secondq.clear();
-
-      Set<Integer> oldRunqSet = runqSet;
-      runqSet = nextqSet;
-      nextqSet = secondqSet;
-      secondqSet = oldRunqSet;
-      secondqSet.clear();
     }
   }
 
-  private boolean canStartAt(String text, int pos) {
-    return !lowSurrogateStartsOnly
-        || (pos >= 0 && pos < text.length() && Character.isLowSurrogate(text.charAt(pos)));
+  private void mergeDelayedQueue(
+      Map<Integer, QueueState> delayed, int pos, QueueState destination) {
+    QueueState source = delayed.remove(pos);
+    if (source == null) {
+      return;
+    }
+    destination.threads.addAll(source.threads);
+    destination.visited.addAll(source.visited);
+  }
+
+  private QueueState delayedQueueAt(Map<Integer, QueueState> delayed, int pos) {
+    int engineEndPos = Math.max(endPos, graphemeConsumeEndPos);
+    if (pos < 0 || pos > engineEndPos + 1) {
+      return null;
+    }
+    return delayed.computeIfAbsent(pos, unused -> new QueueState());
+  }
+
+  private long visitKey(Inst ip, int id, String text, int pos, int graphemeStart) {
+    long instructionKey = ((long) id) << VISIT_KEY_VARIANT_BITS;
+    if (ip.op != InstOp.GRAPHEME_CLUSTER) {
+      return instructionKey;
+    }
+    return instructionKey | graphemeVisitVariant(text, pos, graphemeStart);
+  }
+
+  private int graphemeVisitVariant(String text, int pos, int graphemeStart) {
+    int start = Math.max(consumeRegionStart, graphemeStart);
+    if (pos < 0 || pos >= graphemeConsumeEndPos || pos >= text.length()) {
+      return 0;
+    }
+
+    int variant = 0;
+    char ch = text.charAt(pos);
+    if (Character.isLowSurrogate(ch)
+        && hasHighSurrogateBeforeLowSurrogateInRegion(text, pos, start)) {
+      variant |= GRAPHEME_LOW_SURROGATE_PAIR_VISIBLE;
+    }
+    if (graphemeContext.hasExtendedPictographicBefore(pos, start)) {
+      variant |= GRAPHEME_EXTENDED_PICTOGRAPHIC_VISIBLE;
+    }
+    int cp = graphemeCodePointAt(text, pos);
+    int scalarEnd = nextRegionLocalScalarEnd(text, pos, graphemeConsumeEndPos);
+    int nextCp = graphemeCodePointAt(text, scalarEnd);
+    // Candidate starts inside a pending Indic conjunct sequence are not equivalent to starts
+    // before that sequence; future linker+consonant boundaries can diverge.
+    if (graphemeContext.hasIndicConjunctSequenceBefore(pos, start)) {
+      variant |= GRAPHEME_INDIC_CONJUNCT_SEQUENCE_VISIBLE;
+    }
+    if ((isIndicConjunctConsonant(cp) && graphemeContext.hasIndicConjunctLinkerBefore(pos, start))
+        || (isIndicConjunctConsonant(nextCp)
+            && graphemeContext.hasIndicConjunctLinkerBefore(scalarEnd, start))) {
+      variant |= GRAPHEME_INDIC_CONJUNCT_LINKER_VISIBLE;
+    }
+    if (isRegionalIndicator(cp)) {
+      if (!graphemeContext.hasEvenRegionalIndicatorsBefore(scalarEnd, start)) {
+        variant |= GRAPHEME_REGIONAL_INDICATOR_ODD;
+      }
+    }
+    return variant;
+  }
+
+  private int inputCodePointAt(String text, int pos) {
+    if (pos < 0 || pos >= endPos || pos >= text.length()) {
+      return -1;
+    }
+    if (!prog.hasGraphemeClusterBoundary()) {
+      return text.codePointAt(pos);
+    }
+    char ch = text.charAt(pos);
+    if (Character.isHighSurrogate(ch)
+        && pos + 1 < endPos
+        && pos + 1 < text.length()
+        && Character.isLowSurrogate(text.charAt(pos + 1))) {
+      return Character.toCodePoint(ch, text.charAt(pos + 1));
+    }
+    if (Character.isHighSurrogate(ch)
+        && pos + 1 < text.length()
+        && Character.isLowSurrogate(text.charAt(pos + 1))) {
+      // The scalar is only partially inside the region, so ordinary atoms cannot consume it.
+      return -1;
+    }
+    return ch;
+  }
+
+  private int inputNextPos(String text, int pos) {
+    if (pos < 0 || pos >= endPos || pos >= text.length()) {
+      return endPos + 1;
+    }
+    if (!prog.hasGraphemeClusterBoundary()) {
+      return pos + Character.charCount(text.codePointAt(pos));
+    }
+    int cp = inputCodePointAt(text, pos);
+    if (cp < 0) {
+      return endPos + 1;
+    }
+    if (Character.isSupplementaryCodePoint(cp)) {
+      return pos + 2;
+    }
+    return pos + 1;
+  }
+
+  private int graphemeCodePointAt(String text, int pos) {
+    if (pos < 0 || pos >= graphemeConsumeEndPos || pos >= text.length()) {
+      return -1;
+    }
+    char ch = text.charAt(pos);
+    if (Character.isHighSurrogate(ch)
+        && pos + 1 < graphemeConsumeEndPos
+        && pos + 1 < text.length()
+        && Character.isLowSurrogate(text.charAt(pos + 1))) {
+      return Character.toCodePoint(ch, text.charAt(pos + 1));
+    }
+    return ch;
+  }
+
+  private int graphemeNextPos(String text, int pos) {
+    if (pos < 0 || pos >= graphemeConsumeEndPos || pos >= text.length()) {
+      return graphemeConsumeEndPos + 1;
+    }
+    return nextRegionLocalScalarEnd(text, pos, graphemeConsumeEndPos);
+  }
+
+  private static int nextRegionLocalScalarEnd(String text, int pos, int endPos) {
+    if (pos < 0 || pos >= endPos || pos >= text.length()) {
+      return endPos + 1;
+    }
+    char ch = text.charAt(pos);
+    if (Character.isHighSurrogate(ch)
+        && pos + 1 < endPos
+        && pos + 1 < text.length()
+        && Character.isLowSurrogate(text.charAt(pos + 1))) {
+      return pos + 2;
+    }
+    return pos + 1;
   }
 
   /**
@@ -471,7 +774,7 @@ final class Nfa {
    * already in the queue.
    *
    * @param q the thread queue to add to
-   * @param visited set of instruction IDs already visited/enqueued
+   * @param visited set of instruction keys already visited/enqueued
    * @param id0 starting instruction ID
    * @param text the input text
    * @param pos the current position in the text
@@ -479,7 +782,7 @@ final class Nfa {
    */
   private void addToThreadq(
       List<NfaThread> q,
-      Set<Integer> visited,
+      Set<Long> visited,
       int id0,
       String text,
       int pos,
@@ -514,7 +817,7 @@ final class Nfa {
         t0 = entryCap;
       }
 
-      if (id == 0 || visited.contains(id)) {
+      if (id == 0) {
         continue;
       }
       // PROGRESS_CHECK is excluded from the visited set: it manages its own re-entry
@@ -526,7 +829,10 @@ final class Nfa {
       // registers. The later zero-width iteration is JDK-visible and must not be discarded.
       Inst ip = prog.inst(id);
       if (ip.op != InstOp.PROGRESS_CHECK && ip.op != InstOp.ALT && ip.op != InstOp.CAPTURE) {
-        visited.add(id);
+        long visitKey = visitKey(ip, id, text, pos, pos);
+        if (!visited.add(visitKey)) {
+          continue;
+        }
       }
       switch (ip.op) {
         case FAIL -> {}
@@ -543,7 +849,7 @@ final class Nfa {
 
         case ALT_MATCH -> {
           // Enqueue this state and also explore the next alt branch.
-          q.add(new NfaThread(id, t0, consumedInput));
+          q.add(new NfaThread(id, t0, consumedInput, -1));
           // Explore the next instruction after this one (the other alt branch).
           stack.add(new int[] {ip.out, -1});
           captureStack.add(t0);
@@ -576,7 +882,10 @@ final class Nfa {
         }
 
         case EMPTY_WIDTH -> {
-          int effectiveRegionStart = useMatchStartAsRegionStart ? t0[0] : regionStart;
+          int effectiveBoundaryEndPos =
+              consumedInput && graphemeConsumeEndPos > boundaryEndPos
+                  ? graphemeConsumeEndPos
+                  : boundaryEndPos;
           int flags =
               emptyFlags(
                   text,
@@ -585,9 +894,10 @@ final class Nfa {
                   prog.hasGraphemeClusterBoundary(),
                   graphemeContext,
                   t0[0],
-                  effectiveRegionStart,
+                  boundaryRegionStart,
                   consumedInput,
-                  endPos);
+                  anchorEndPos,
+                  effectiveBoundaryEndPos);
           if ((ip.arg & ~flags) == 0) {
             stack.add(new int[] {ip.out, -1});
             captureStack.add(null);
@@ -636,10 +946,11 @@ final class Nfa {
           }
         }
 
-        case CHAR_RANGE, CHAR_CLASS, MATCH ->
+        case CHAR_RANGE, CHAR_CLASS, GRAPHEME_CLUSTER, MATCH ->
             // These are "real" states. Capture arrays are immutable from this point
             // until a later CAPTURE or PROGRESS_CHECK transition clones them.
-            q.add(new NfaThread(id, t0, consumedInput));
+            q.add(
+                new NfaThread(id, t0, consumedInput, ip.op == InstOp.GRAPHEME_CLUSTER ? pos : -1));
 
         default -> {}
       }
@@ -648,39 +959,20 @@ final class Nfa {
 
   /**
    * Processes all threads in {@code rq} for the current input character. Threads at CHAR_RANGE
-   * instructions that match the character are advanced to {@code nq}. Threads at MATCH instructions
-   * record the match.
+   * instructions that match the character are advanced to the delayed queues. Threads at MATCH
+   * instructions record the match.
    *
    * @return true if the search should stop (first-match found and remaining threads cut off)
    */
   private boolean step(
-      List<NfaThread> rq,
-      Set<Integer> rqSet,
-      List<NfaThread> nq,
-      Set<Integer> nqSet,
+      QueueState rq,
+      Map<Integer, QueueState> delayed,
       int cp,
       String text,
       int matchPos,
       int nextPos) {
-    return step(rq, rqSet, nq, nqSet, cp, text, matchPos, nextPos, true);
-  }
-
-  private boolean step(
-      List<NfaThread> rq,
-      Set<Integer> rqSet,
-      List<NfaThread> nq,
-      Set<Integer> nqSet,
-      int cp,
-      String text,
-      int matchPos,
-      int nextPos,
-      boolean clearDestination) {
-    if (clearDestination) {
-      nq.clear();
-      nqSet.clear();
-    }
-
-    for (NfaThread t : rq) {
+    for (int threadIndex = 0; threadIndex < rq.threads.size(); threadIndex++) {
+      NfaThread t = rq.threads.get(threadIndex);
       int id = t.id();
       int[] capture = t.capture();
 
@@ -696,22 +988,51 @@ final class Nfa {
       switch (ip.op) {
         case CHAR_RANGE -> {
           if (cp >= 0 && ip.matchesChar(cp)) {
-            addToThreadq(nq, nqSet, ip.out, text, nextPos, capture, true);
+            QueueState destination = delayedQueueAt(delayed, nextPos);
+            if (destination != null) {
+              addToThreadq(
+                  destination.threads, destination.visited, ip.out, text, nextPos, capture, true);
+            }
           }
         }
 
         case CHAR_CLASS -> {
           if (cp >= 0 && ip.matchesCharClass(cp)) {
-            addToThreadq(nq, nqSet, ip.out, text, nextPos, capture, true);
+            QueueState destination = delayedQueueAt(delayed, nextPos);
+            if (destination != null) {
+              addToThreadq(
+                  destination.threads, destination.visited, ip.out, text, nextPos, capture, true);
+            }
+          }
+        }
+
+        case GRAPHEME_CLUSTER -> {
+          if (matchPos < endPos) {
+            int graphemeStart =
+                Math.max(consumeRegionStart, t.graphemeStart() >= 0 ? t.graphemeStart() : matchPos);
+            int scalarEnd = graphemeNextPos(text, matchPos);
+            QueueState destination = delayedQueueAt(delayed, scalarEnd);
+            if (destination != null) {
+              if (scalarEnd == graphemeConsumeEndPos
+                  || isGraphemeClusterBoundary(text, scalarEnd, graphemeStart, graphemeContext)) {
+                addToThreadq(
+                    destination.threads,
+                    destination.visited,
+                    ip.out,
+                    text,
+                    scalarEnd,
+                    capture,
+                    true);
+              } else if (destination.visited.add(
+                  visitKey(ip, id, text, scalarEnd, graphemeStart))) {
+                destination.threads.add(new NfaThread(id, capture, true, graphemeStart));
+              }
+            }
           }
         }
 
         case MATCH -> {
-          boolean skip =
-              endmatch
-                  && matchPos != endPos
-                  && (!prog.dollarAnchorEnd()
-                      || !isAtTrailingLineTerminator(text, matchPos, prog.unixLines(), endPos));
+          boolean skip = endmatch && !matchesEndPosition(text, matchPos);
           if (!skip) {
             if (longest) {
               if (!matched
@@ -724,12 +1045,12 @@ final class Nfa {
             } else {
               // First match mode: this is the best match (leftmost, due to priority).
               // Cut off threads that can only find worse matches (remaining runq),
-              // but do NOT stop the main loop — threads already in nextq continue.
+              // but do not stop the main loop: threads already queued for later positions continue.
               System.arraycopy(capture, 0, bestMatch, 0, ncapture);
               bestMatch[1] = matchPos;
               matched = true;
-              // Clear remaining runq entries (they can only find worse matches).
-              // We break out of the for-each loop; rq will be cleared after the loop.
+              // Clear remaining runq entries; they can only find worse matches.
+              rq.clear();
               return false;
             }
           }
@@ -737,7 +1058,7 @@ final class Nfa {
 
         case ALT_MATCH -> {
           // Optimization: if this is the first thread and we want the match, take it.
-          if (longest || rq.indexOf(t) == 0) {
+          if (longest || threadIndex == 0) {
             System.arraycopy(capture, 0, bestMatch, 0, ncapture);
             matched = true;
           }
@@ -747,8 +1068,90 @@ final class Nfa {
       }
     }
     rq.clear();
-    rqSet.clear();
     return false;
+  }
+
+  private boolean stepCodePoint(
+      QueueState rq, QueueState nq, int cp, String text, int matchPos, int nextPos) {
+    nq.clear();
+
+    for (int threadIndex = 0; threadIndex < rq.threads.size(); threadIndex++) {
+      NfaThread t = rq.threads.get(threadIndex);
+      int id = t.id();
+      int[] capture = t.capture();
+
+      if (longest
+          && matched
+          && bestMatch[0] != -1
+          && capture[0] != -1
+          && bestMatch[0] < capture[0]) {
+        continue;
+      }
+
+      Inst ip = prog.inst(id);
+      switch (ip.op) {
+        case CHAR_RANGE -> {
+          if (cp >= 0 && ip.matchesChar(cp)) {
+            addToThreadq(nq.threads, nq.visited, ip.out, text, nextPos, capture, true);
+          }
+        }
+
+        case CHAR_CLASS -> {
+          if (cp >= 0 && ip.matchesCharClass(cp)) {
+            addToThreadq(nq.threads, nq.visited, ip.out, text, nextPos, capture, true);
+          }
+        }
+
+        case MATCH -> {
+          boolean skip = endmatch && !matchesEndPosition(text, matchPos);
+          if (!skip) {
+            if (longest) {
+              if (!matched
+                  || capture[0] < bestMatch[0]
+                  || (capture[0] == bestMatch[0] && matchPos > bestMatch[1])) {
+                System.arraycopy(capture, 0, bestMatch, 0, ncapture);
+                bestMatch[1] = matchPos;
+                matched = true;
+              }
+            } else {
+              // First match mode: this is the best match (leftmost, due to priority).
+              // Cut off threads that can only find worse matches (remaining runq),
+              // but do not stop the main loop: threads already in nextq continue.
+              System.arraycopy(capture, 0, bestMatch, 0, ncapture);
+              bestMatch[1] = matchPos;
+              matched = true;
+              rq.clear();
+              return false;
+            }
+          }
+        }
+
+        case ALT_MATCH -> {
+          // Optimization: if this is the first thread and we want the match, take it.
+          if (longest || threadIndex == 0) {
+            System.arraycopy(capture, 0, bestMatch, 0, ncapture);
+            matched = true;
+          }
+        }
+
+        default -> {}
+      }
+    }
+    rq.clear();
+    return false;
+  }
+
+  private boolean matchesEndPosition(String text, int matchPos) {
+    if (matchPos == anchorEndPos) {
+      return true;
+    }
+    if (matchPos == graphemeConsumeEndPos
+        && graphemeConsumeEndPos != endPos
+        && anchorEndPos == endPos) {
+      return true;
+    }
+    return prog.dollarAnchorEnd()
+        && isAtTrailingLineTerminator(text, matchPos, prog.unixLines(), anchorEndPos);
   }
 
   // ---------------------------------------------------------------------------
@@ -774,26 +1177,32 @@ final class Nfa {
     return isAtTrailingLineTerminator(text, pos, unixLines, text.length());
   }
 
+  static int trailingLineTerminatorStart(String text, boolean unixLines) {
+    return trailingLineTerminatorStart(text, unixLines, text.length());
+  }
+
   private static boolean isAtTrailingLineTerminator(
       String text, int pos, boolean unixLines, int logicalEndPos) {
+    return pos == trailingLineTerminatorStart(text, unixLines, logicalEndPos);
+  }
+
+  private static int trailingLineTerminatorStart(
+      String text, boolean unixLines, int logicalEndPos) {
     int len = logicalEndPos;
-    if (pos < 0 || pos >= len) {
-      return false;
+    if (len <= 0 || len > text.length()) {
+      return -1;
     }
-    char ch = text.charAt(pos);
+    char ch = text.charAt(len - 1);
     if (unixLines) {
-      return ch == '\n' && pos + 1 == len;
+      return ch == '\n' ? len - 1 : -1;
     }
-    if (ch == '\n' && pos + 1 == len) {
-      // Don't treat the \n of an atomic \r\n as a standalone trailing line terminator.
-      // The trailing terminator is the \r\n pair starting at pos-1.
-      return pos == 0 || text.charAt(pos - 1) != '\r';
+    if (ch == '\n') {
+      return len >= 2 && text.charAt(len - 2) == '\r' ? len - 2 : len - 1;
     }
-    if (ch == '\r') {
-      return pos + 1 == len
-          || (pos + 2 == len && pos + 1 < text.length() && text.charAt(pos + 1) == '\n');
+    if (ch == '\r' || ch == '\u0085' || ch == '\u2028' || ch == '\u2029') {
+      return len - 1;
     }
-    return (ch == '\u0085' || ch == '\u2028' || ch == '\u2029') && pos + 1 == len;
+    return -1;
   }
 
   /**
@@ -871,6 +1280,7 @@ final class Nfa {
         matchStart,
         regionStart,
         consumedInput,
+        text.length(),
         text.length());
   }
 
@@ -883,7 +1293,8 @@ final class Nfa {
       int matchStart,
       int regionStart,
       boolean consumedInput,
-      int logicalEndPos) {
+      int anchorEndPos,
+      int boundaryEndPos) {
     int flags = 0;
 
     // ^ and \A
@@ -921,14 +1332,14 @@ final class Nfa {
     // END_TEXT is set only at end of text (used by \z).
     // DOLLAR_END is set at end of text and also before the trailing line terminator at end of
     // text (used by $ without MULTILINE — JDK's default $ behavior).
-    if (pos == logicalEndPos) {
+    if (pos == anchorEndPos) {
       flags |= EmptyOp.END_TEXT | EmptyOp.END_LINE | EmptyOp.DOLLAR_END;
     } else if (pos < text.length()) {
       char ch = text.charAt(pos);
       if (unixLines) {
         if (ch == '\n') {
           flags |= EmptyOp.END_LINE;
-          if (pos + 1 == text.length()) {
+          if (pos + 1 == anchorEndPos) {
             flags |= EmptyOp.DOLLAR_END;
           }
         }
@@ -939,7 +1350,7 @@ final class Nfa {
         boolean isAtomicLF = (ch == '\n' && pos > 0 && text.charAt(pos - 1) == '\r');
         if (!isAtomicLF) {
           flags |= EmptyOp.END_LINE;
-          if (isAtTrailingLineTerminator(text, pos, false, logicalEndPos)) {
+          if (isAtTrailingLineTerminator(text, pos, false, anchorEndPos)) {
             flags |= EmptyOp.DOLLAR_END;
           }
         }
@@ -947,8 +1358,8 @@ final class Nfa {
     }
 
     // \b and \B
-    boolean prevWord = pos > 0 && isWordChar(text.codePointBefore(pos));
-    boolean nextWord = pos < text.length() && isWordChar(text.codePointAt(pos));
+    boolean prevWord = pos > regionStart && isWordChar(text.codePointBefore(pos));
+    boolean nextWord = pos < boundaryEndPos && isWordChar(text.codePointAt(pos));
     if (prevWord != nextWord) {
       flags |= EmptyOp.WORD_BOUNDARY;
     } else {
@@ -956,8 +1367,8 @@ final class Nfa {
     }
 
     // Unicode \b and \B
-    boolean prevUnicodeWord = pos > 0 && isUnicodeWordChar(text.codePointBefore(pos));
-    boolean nextUnicodeWord = pos < text.length() && isUnicodeWordChar(text.codePointAt(pos));
+    boolean prevUnicodeWord = pos > regionStart && isUnicodeWordChar(text.codePointBefore(pos));
+    boolean nextUnicodeWord = pos < boundaryEndPos && isUnicodeWordChar(text.codePointAt(pos));
     if (prevUnicodeWord != nextUnicodeWord) {
       flags |= EmptyOp.UNICODE_WORD_BOUNDARY;
     } else {
@@ -965,29 +1376,38 @@ final class Nfa {
     }
 
     if (includeGraphemeClusterBoundary) {
-      if (isRegionStartSplitSurrogateBoundary(text, pos, regionStart)
-          || isRegionEndSplitSurrogateBoundary(text, pos, logicalEndPos)) {
+      if (isGraphemeBoundaryContextEdge(pos, regionStart, boundaryEndPos)) {
+        flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
+      } else if (isRegionStartSplitSurrogateBoundary(text, pos, regionStart)
+          || isRegionEndSplitSurrogateBoundary(text, pos, boundaryEndPos)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
       } else if (isAfterRegionStartSplitLowSurrogateBoundary(text, pos, regionStart)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-        if (!(consumedInput && pos < logicalEndPos && hasGraphemeExtendAt(text, pos))) {
+        if (!suppressesConsumedSplitLowSurrogateExplicitBoundary(
+            text, pos, boundaryEndPos, consumedInput)) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
       } else if (consumedInput
-          && isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
+          && isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart, graphemeContext)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-        if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart)) {
+        if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart, graphemeContext)) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
       } else if (isGraphemeClusterBoundary(text, pos, regionStart, graphemeContext)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-        if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart)
-            || !isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
+        if (!isAfterPairedExtendedPictographicZwj(text, pos, regionStart, graphemeContext)
+            || !isStandaloneZwjBeforePictographicBoundary(
+                text, pos, regionStart, graphemeContext)) {
           flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
         }
-      } else if (isLowHighSurrogateBoundary(text, pos) && matchStart > 0 && pos > matchStart) {
+      } else if (isLowHighSurrogateBoundary(text, pos)
+          && matchStart > 0
+          && pos > matchStart
+          && !hasHighSurrogateBeforeLowSurrogateInRegion(text, pos - 1, regionStart)) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
-      } else if (startsAtLowSurrogate(text, matchStart) && pos == matchStart + 1) {
+      } else if (startsAtLowSurrogate(text, matchStart)
+          && !hasHighSurrogateBeforeLowSurrogateInRegion(text, matchStart, regionStart)
+          && pos == matchStart + 1) {
         flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
         if (!hasGraphemeExtendAt(text, pos)
             && !suppressesRegionStartSplitExplicitBoundary(
@@ -1010,7 +1430,7 @@ final class Nfa {
           && !hasGraphemeExtendAt(text, pos)) {
         flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
       } else if (!consumedInput
-          && isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart)) {
+          && isStandaloneZwjBeforePictographicBoundary(text, pos, regionStart, graphemeContext)) {
         flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
       } else if (isExplicitGraphemeClusterBoundary(text, pos, matchStart, regionStart)) {
         flags |= EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
@@ -1018,6 +1438,11 @@ final class Nfa {
     }
 
     return flags;
+  }
+
+  private static boolean isGraphemeBoundaryContextEdge(
+      int pos, int boundaryStart, int boundaryEnd) {
+    return pos == boundaryStart || pos == boundaryEnd;
   }
 
   /**
@@ -1032,7 +1457,7 @@ final class Nfa {
     return isGraphemeClusterBoundary(text, pos, 0, graphemeContext);
   }
 
-  private static boolean isGraphemeClusterBoundary(
+  static boolean isGraphemeClusterBoundary(
       String text, int pos, int regionStart, GraphemeContext graphemeContext) {
     if (pos < 0 || pos > text.length()) {
       return false;
@@ -1069,15 +1494,18 @@ final class Nfa {
     if (isHangulGraphemeContinuation(prev, next)) {
       return false;
     }
+    GraphemeContext context =
+        graphemeContext != null ? graphemeContext : GraphemeContext.create(text, true);
+    if (isIndicConjunctConsonant(next) && context.hasIndicConjunctLinkerBefore(pos, regionStart)) {
+      return false;
+    }
     if (prev == 0x200D
         && containsCodePoint(EXTENDED_PICTOGRAPHIC, next)
-        && hasExtendedPictographicBeforeZwj(text, pos - 1, regionStart)) {
+        && context.hasExtendedPictographicBefore(pos - 1, regionStart)) {
       return false;
     }
     if (isRegionalIndicator(prev) && isRegionalIndicator(next)) {
-      GraphemeContext context =
-          graphemeContext != null ? graphemeContext : GraphemeContext.create(text, true);
-      return context.hasEvenRegionalIndicatorsBefore(pos);
+      return context.hasEvenRegionalIndicatorsBefore(pos, regionStart);
     }
     return true;
   }
@@ -1090,7 +1518,7 @@ final class Nfa {
     char prevChar = text.charAt(pos - 1);
     char nextChar = text.charAt(pos);
     if (Character.isLowSurrogate(prevChar) && Character.isHighSurrogate(nextChar)) {
-      return true;
+      return !hasHighSurrogateBeforeLowSurrogateInRegion(text, pos - 1, regionStart);
     }
     if (prevChar == '\r' && nextChar == '\n') {
       return true;
@@ -1135,6 +1563,31 @@ final class Nfa {
         && Character.isLowSurrogate(text.charAt(regionEnd));
   }
 
+  private static boolean suppressesConsumedSplitLowSurrogateExplicitBoundary(
+      String text, int pos, int boundaryEndPos, boolean consumedInput) {
+    if (!consumedInput || pos >= boundaryEndPos) {
+      return false;
+    }
+    if (hasGraphemeExtendAt(text, pos)) {
+      return true;
+    }
+    return isRegionalIndicator(regionLocalCodePointAt(text, pos, boundaryEndPos));
+  }
+
+  private static int regionLocalCodePointAt(String text, int pos, int endPos) {
+    if (pos < 0 || pos >= endPos || pos >= text.length()) {
+      return -1;
+    }
+    char ch = text.charAt(pos);
+    if (Character.isHighSurrogate(ch)
+        && pos + 1 < endPos
+        && pos + 1 < text.length()
+        && Character.isLowSurrogate(text.charAt(pos + 1))) {
+      return Character.toCodePoint(ch, text.charAt(pos + 1));
+    }
+    return ch;
+  }
+
   private static boolean isLowSurrogateBeforeZwjBoundary(
       String text, int pos, int matchStart, int regionStart) {
     return pos == matchStart
@@ -1163,17 +1616,21 @@ final class Nfa {
   }
 
   private static boolean isStandaloneZwjBeforePictographicBoundary(
-      String text, int pos, int regionStart) {
+      String text, int pos, int regionStart, GraphemeContext graphemeContext) {
+    GraphemeContext context =
+        graphemeContext != null ? graphemeContext : GraphemeContext.create(text, true);
     return pos > 0
         && pos < text.length()
         && text.charAt(pos - 1) == 0x200D
         && containsCodePoint(EXTENDED_PICTOGRAPHIC, text.codePointAt(pos))
         && !isAfterRegionStartSplitLowSurrogate(text, pos - 1, regionStart)
-        && !hasExtendedPictographicBeforeZwj(text, pos - 1, regionStart);
+        && !context.hasExtendedPictographicBefore(pos - 1, regionStart);
   }
 
   private static boolean isAfterPairedExtendedPictographicZwj(
-      String text, int pos, int regionStart) {
+      String text, int pos, int regionStart, GraphemeContext graphemeContext) {
+    GraphemeContext context =
+        graphemeContext != null ? graphemeContext : GraphemeContext.create(text, true);
     int lowSurrogatePos = pos - 2;
     if (regionStart <= lowSurrogatePos && regionStart > 0) {
       return false;
@@ -1182,7 +1639,7 @@ final class Nfa {
         && text.charAt(pos - 1) == 0x200D
         && Character.isLowSurrogate(text.charAt(lowSurrogatePos))
         && Character.isHighSurrogate(text.charAt(pos - 3))
-        && hasExtendedPictographicBeforeZwj(text, pos - 1, 0);
+        && context.hasExtendedPictographicBefore(pos - 1, regionStart);
   }
 
   private static boolean isAfterRegionStartSplitLowSurrogate(
@@ -1191,30 +1648,15 @@ final class Nfa {
         && isRegionStartSplitSurrogateBoundary(text, regionStart, regionStart);
   }
 
-  static boolean hasExtendedPictographicBeforeZwj(String text, int zwjPos, int regionStart) {
-    int pos = zwjPos;
-    while (pos > regionStart && pos > 0) {
-      int previous = text.codePointBefore(pos);
-      int previousPos = pos - Character.charCount(previous);
-      if (previousPos < regionStart) {
-        return false;
-      }
-      if (containsCodePoint(EXTENDED_PICTOGRAPHIC, previous)) {
-        return !hasPrependImmediatelyBefore(text, previousPos, regionStart);
-      }
-      if (!isGraphemeExtend(previous)) {
-        return false;
-      }
-      pos = previousPos;
+  private static int immediatePrependStartBefore(String text, int pos) {
+    if (pos <= 0) {
+      return -1;
     }
-    return false;
-  }
-
-  private static boolean hasPrependImmediatelyBefore(String text, int pos, int regionStart) {
-    if (pos <= regionStart || pos <= 0) {
-      return false;
+    int previous = text.codePointBefore(pos);
+    if (!isGraphemePrepend(previous)) {
+      return -1;
     }
-    return isGraphemePrepend(text.codePointBefore(pos));
+    return pos - Character.charCount(previous);
   }
 
   private static boolean hasHighSurrogateBeforeLowSurrogateInRegion(
@@ -1320,6 +1762,43 @@ final class Nfa {
 
   private static boolean isRegionalIndicator(int c) {
     return 0x1F1E6 <= c && c <= 0x1F1FF;
+  }
+
+  private static boolean isIndicConjunctConsonant(int c) {
+    return (0x0915 <= c && c <= 0x0939)
+        || (0x0958 <= c && c <= 0x095F)
+        || (0x0978 <= c && c <= 0x097F)
+        || (0x0995 <= c && c <= 0x09A8)
+        || (0x09AA <= c && c <= 0x09B0)
+        || c == 0x09B2
+        || (0x09B6 <= c && c <= 0x09B9)
+        || (0x09DC <= c && c <= 0x09DD)
+        || c == 0x09DF
+        || (0x09F0 <= c && c <= 0x09F1)
+        || (0x0A95 <= c && c <= 0x0AA8)
+        || (0x0AAA <= c && c <= 0x0AB0)
+        || (0x0AB2 <= c && c <= 0x0AB3)
+        || (0x0AB5 <= c && c <= 0x0AB9)
+        || c == 0x0AF9
+        || (0x0B15 <= c && c <= 0x0B28)
+        || (0x0B2A <= c && c <= 0x0B30)
+        || (0x0B32 <= c && c <= 0x0B33)
+        || (0x0B35 <= c && c <= 0x0B39)
+        || (0x0B5C <= c && c <= 0x0B5D)
+        || c == 0x0B5F
+        || c == 0x0B71
+        || (0x0C15 <= c && c <= 0x0C28)
+        || (0x0C2A <= c && c <= 0x0C39)
+        || (0x0C58 <= c && c <= 0x0C5A)
+        || (0x0D15 <= c && c <= 0x0D3A);
+  }
+
+  private static boolean isIndicConjunctLinker(int c) {
+    return c == 0x094D || c == 0x09CD || c == 0x0ACD || c == 0x0B4D || c == 0x0C4D || c == 0x0D4D;
+  }
+
+  private static boolean isIndicConjunctExtend(int c) {
+    return isGraphemeExtend(c) || (0xE0020 <= c && c <= 0xE007F);
   }
 
   private static boolean containsCodePoint(int[][] ranges, int c) {

--- a/safere/src/main/java/org/safere/ParseFlags.java
+++ b/safere/src/main/java/org/safere/ParseFlags.java
@@ -104,13 +104,8 @@ final class ParseFlags {
   /** Use Unicode-aware case folding when {@link #FOLD_CASE} is active. */
   public static final int UNICODE_CASE = 1 << 17;
 
-  /**
-   * Internal flag: marks the synthetic grapheme boundary that terminates a {@code \X} expansion.
-   */
-  public static final int SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY = 1 << 18;
-
   /** Mask of all valid parse flags. */
-  public static final int ALL_FLAGS = (1 << 19) - 1;
+  public static final int ALL_FLAGS = (1 << 18) - 1;
 
   private ParseFlags() {} // Non-instantiable.
 }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -414,11 +414,10 @@ final class Parser {
       return false;
     }
 
-    // \X: Extended grapheme cluster (simplified).
-    // Equivalent to (?:\r\n|\P{M}\p{M}*|<any>), which handles base+combining-marks.
+    // \X: Extended grapheme cluster.
     if (pos + 1 < pattern.length() && pattern.charAt(pos + 1) == 'X') {
       pos += 2; // '\\', 'X'
-      pushRegexp(buildGraphemeClusterRegexp());
+      pushRegexp(Regexp.graphemeCluster(flags));
       return false;
     }
 
@@ -634,6 +633,7 @@ final class Parser {
           case WORD_BOUNDARY -> Regexp.wordBoundary(flags);
           case NO_WORD_BOUNDARY -> Regexp.noWordBoundary(flags);
           case GRAPHEME_CLUSTER_BOUNDARY -> Regexp.graphemeClusterBoundary(flags);
+          case GRAPHEME_CLUSTER -> Regexp.graphemeCluster(flags);
           default -> Regexp.emptyMatch(flags);
         };
     pushRegexp(re);
@@ -4676,7 +4676,7 @@ final class Parser {
     return Regexp.charClass(ccb.build(), flags & ~ParseFlags.FOLD_CASE);
   }
 
-  // ---- \R and \X expansion helpers ----
+  // ---- \R expansion helper ----
 
   /**
    * Builds a Regexp equivalent to {@code (?:\r\n|[\n\x0B\f\r\x{85}\x{2028}\x{2029}])}, which
@@ -4699,182 +4699,5 @@ final class Parser {
     Regexp singleLinebreak = Regexp.charClass(ccb.build(), flags);
 
     return Regexp.alternate(List.of(crLf, singleLinebreak), flags);
-  }
-
-  /** Builds a regular approximation of JDK {@code \X} extended grapheme cluster matching. */
-  private Regexp buildGraphemeClusterRegexp() {
-    // Alternative 1: \r\n (CRLF as a single unit)
-    Regexp crLf = Regexp.literalString(new int[] {'\r', '\n'}, flags);
-
-    Regexp extend = buildGraphemeExtendClass(true);
-    Regexp extendStar = Regexp.star(extend, flags);
-    Regexp connectorExtends = Regexp.star(extend, flags | ParseFlags.NON_GREEDY);
-
-    // Extended pictographic sequences joined by ZWJ, e.g. emoji presentation chains.
-    Regexp pictographic =
-        charClassFromTable(UnicodeProperties.lookupBinaryProperty("Extended_Pictographic"));
-    Regexp pictographicWithExtends = Regexp.concat(List.of(pictographic, connectorExtends), flags);
-    Regexp zwjPictographicSegment =
-        Regexp.concat(
-            List.of(Regexp.literal(0x200D, flags), pictographic, connectorExtends), flags);
-    Regexp zwjSequence =
-        Regexp.concat(
-            List.of(pictographicWithExtends, Regexp.plus(zwjPictographicSegment, flags)), flags);
-
-    // Regional indicators pair into flag clusters.
-    Regexp regionalIndicator = charClassFromRange(0x1F1E6, 0x1F1FF);
-    Regexp regionalIndicatorPair =
-        Regexp.concat(List.of(regionalIndicator, regionalIndicator, extendStar), flags);
-    Regexp regionalIndicatorWithExtends =
-        Regexp.concat(List.of(regionalIndicator, extendStar), flags);
-
-    Regexp hangulCluster = Regexp.concat(List.of(buildHangulGraphemeCluster(), extendStar), flags);
-
-    // \P{M} plus grapheme-extending code points keeps the historical base+mark behavior and
-    // covers emoji modifier sequences such as thumbs-up plus skin tone.
-    CharClassBuilder nonMarkCcb = new CharClassBuilder();
-    addTable(nonMarkCcb, UnicodeTables.UNICODE_GROUPS.get("M"));
-    nonMarkCcb.negate(); // \P{M}
-    removeGraphemeControlCodePoints(nonMarkCcb);
-    nonMarkCcb.removeRange(0xD800, 0xDFFF);
-    nonMarkCcb.removeRange(0x1F1E6, 0x1F1FF);
-    Regexp nonMark = Regexp.charClass(nonMarkCcb.build(), flags);
-
-    Regexp lowSurrogate = charClassFromRange(0xDC00, 0xDFFF);
-    Regexp baseWithExtends = Regexp.concat(List.of(nonMark, extendStar), flags);
-    Regexp leadingExtends = Regexp.plus(extend, flags);
-    Regexp prependCluster =
-        Regexp.concat(
-            List.of(
-                Regexp.plus(buildGraphemePrependClass(), flags),
-                Regexp.alternate(
-                    List.of(
-                        regionalIndicatorPair,
-                        regionalIndicatorWithExtends,
-                        hangulCluster,
-                        baseWithExtends,
-                        leadingExtends),
-                    flags)),
-            flags);
-
-    // Alternative 3: any single character (fallback for standalone combining marks, controls, etc.)
-    // Use ANY_CHAR with DOT_NL to match all characters including newlines.
-    Regexp anyOne = Regexp.anyChar(flags | ParseFlags.DOT_NL);
-
-    Regexp clusterBody =
-        Regexp.alternate(
-            List.of(
-                crLf,
-                zwjSequence,
-                regionalIndicatorPair,
-                regionalIndicatorWithExtends,
-                hangulCluster,
-                prependCluster,
-                lowSurrogate,
-                baseWithExtends,
-                leadingExtends,
-                anyOne),
-            flags);
-    return Regexp.concat(
-        List.of(
-            clusterBody,
-            Regexp.graphemeClusterBoundary(flags | ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY)),
-        flags);
-  }
-
-  private Regexp buildGraphemeExtendClass(boolean includeZwj) {
-    CharClassBuilder ccb = new CharClassBuilder();
-    addTable(ccb, UnicodeTables.UNICODE_GROUPS.get("M"));
-    addTable(ccb, UnicodeProperties.lookupBinaryProperty("Emoji_Modifier"));
-    if (includeZwj) {
-      ccb.addRune(0x200D);
-    }
-    return Regexp.charClass(ccb.build(), flags);
-  }
-
-  private static void removeGraphemeControlCodePoints(CharClassBuilder ccb) {
-    ccb.removeRange(0x0000, 0x001F);
-    ccb.removeRange(0x007F, 0x009F);
-    ccb.removeRange(0x2028, 0x2029);
-  }
-
-  private Regexp buildGraphemePrependClass() {
-    CharClassBuilder ccb = new CharClassBuilder();
-    ccb.addRange(0x0600, 0x0605);
-    ccb.addRune(0x06DD);
-    ccb.addRune(0x070F);
-    ccb.addRange(0x0890, 0x0891);
-    ccb.addRune(0x08E2);
-    ccb.addRune(0x110BD);
-    ccb.addRune(0x110CD);
-    return Regexp.charClass(ccb.build(), flags);
-  }
-
-  private Regexp buildHangulGraphemeCluster() {
-    Regexp l = buildHangulLClass();
-    Regexp v = charClassFromRanges(new int[][] {{0x1160, 0x11A7}, {0xD7B0, 0xD7C6}});
-    Regexp t = charClassFromRanges(new int[][] {{0x11A8, 0x11FF}, {0xD7CB, 0xD7FB}});
-    Regexp lv = buildHangulSyllableClass(true);
-    Regexp lvt = buildHangulSyllableClass(false);
-    Regexp tStar = Regexp.star(t, flags);
-
-    Regexp lTail =
-        Regexp.alternate(
-            List.of(
-                Regexp.concat(List.of(Regexp.plus(v, flags), tStar), flags),
-                Regexp.concat(List.of(lv, Regexp.star(v, flags), tStar), flags),
-                Regexp.concat(List.of(lvt, tStar), flags)),
-            flags);
-    Regexp lSequence =
-        Regexp.concat(List.of(Regexp.plus(l, flags), Regexp.quest(lTail, flags)), flags);
-    Regexp lvOrVSequence =
-        Regexp.concat(
-            List.of(Regexp.alternate(List.of(lv, v), flags), Regexp.star(v, flags), tStar), flags);
-    Regexp lvtOrTSequence =
-        Regexp.concat(List.of(Regexp.alternate(List.of(lvt, t), flags), tStar), flags);
-    return Regexp.alternate(List.of(lSequence, lvOrVSequence, lvtOrTSequence), flags);
-  }
-
-  private Regexp buildHangulLClass() {
-    return charClassFromRanges(new int[][] {{0x1100, 0x115F}, {0xA960, 0xA97C}});
-  }
-
-  private Regexp buildHangulSyllableClass(boolean lv) {
-    CharClassBuilder ccb = new CharClassBuilder();
-    for (int cp = 0xAC00; cp <= 0xD7A3; cp += 28) {
-      if (lv) {
-        ccb.addRune(cp);
-      } else {
-        int hi = Math.min(cp + 27, 0xD7A3);
-        if (cp + 1 <= hi) {
-          ccb.addRange(cp + 1, hi);
-        }
-      }
-    }
-    return Regexp.charClass(ccb.build(), flags);
-  }
-
-  private Regexp charClassFromRange(int lo, int hi) {
-    CharClassBuilder ccb = new CharClassBuilder();
-    ccb.addRange(lo, hi);
-    return Regexp.charClass(ccb.build(), flags);
-  }
-
-  private Regexp charClassFromRanges(int[][] ranges) {
-    CharClassBuilder ccb = new CharClassBuilder();
-    addTable(ccb, ranges);
-    return Regexp.charClass(ccb.build(), flags);
-  }
-
-  private Regexp charClassFromTable(int[][] table) {
-    CharClassBuilder ccb = new CharClassBuilder();
-    addTable(ccb, table);
-    return Regexp.charClass(ccb.build(), flags);
-  }
-
-  private void addTable(CharClassBuilder ccb, int[][] table) {
-    for (int[] row : table) {
-      ccb.addRange(row[0], row[1]);
-    }
   }
 }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -303,7 +303,6 @@ public final class Pattern implements Serializable {
     if (compiled == null) {
       throw new PatternSyntaxException("compiled program too large", regex, -1);
     }
-    compiled.setCharOffsetGraphemeSearch(needsCharOffsetGraphemeSearch(re));
     compiled.setUnixLines((effectiveFlags & UNIX_LINES) != 0);
     // Language-shape accelerators should see through source-only grouping. Correctness guards
     // below still inspect the source AST because source quantifiers carry matching semantics that
@@ -982,10 +981,6 @@ public final class Pattern implements Serializable {
     return hasInternalGraphemeClusterBoundary;
   }
 
-  boolean charOffsetGraphemeSearch() {
-    return prog.hasMultipleGraphemeClusterBoundaries();
-  }
-
   /** Returns the parsed AST. */
   Regexp ast() {
     return ast;
@@ -1263,10 +1258,6 @@ public final class Pattern implements Serializable {
     return first != null && first.op == RegexpOp.GRAPHEME_CLUSTER_BOUNDARY;
   }
 
-  private static boolean needsCharOffsetGraphemeSearch(Regexp re) {
-    return new SyntheticGraphemeCapacityWalker().walk(re, 0) >= 2;
-  }
-
   private static boolean hasInternalExplicitGraphemeBoundary(Regexp re) {
     return new GraphemeBoundaryContextWalker()
         .walk(re, GraphemeBoundaryContext.noMatch())
@@ -1325,12 +1316,9 @@ public final class Pattern implements Serializable {
             NO_WORD_BOUNDARY,
             HAVE_MATCH ->
             GraphemeBoundaryContext.empty();
-        case LITERAL, LITERAL_STRING, ANY_CHAR, ANY_BYTE, CHAR_CLASS ->
+        case LITERAL, LITERAL_STRING, ANY_CHAR, ANY_BYTE, CHAR_CLASS, GRAPHEME_CLUSTER ->
             GraphemeBoundaryContext.consuming();
-        case GRAPHEME_CLUSTER_BOUNDARY ->
-            (re.flags & ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY) == 0
-                ? GraphemeBoundaryContext.explicitBoundary()
-                : GraphemeBoundaryContext.empty();
+        case GRAPHEME_CLUSTER_BOUNDARY -> GraphemeBoundaryContext.explicitBoundary();
         case CONCAT -> concatBoundaryContext(childArgs);
         case ALTERNATE -> alternateBoundaryContext(childArgs);
         case STAR, QUEST -> optionalBoundaryContext(childArgs);
@@ -1436,74 +1424,6 @@ public final class Pattern implements Serializable {
     private static GraphemeBoundaryContext childBoundaryContext(
         List<GraphemeBoundaryContext> childArgs) {
       return childArgs.isEmpty() ? GraphemeBoundaryContext.noMatch() : childArgs.getFirst();
-    }
-  }
-
-  private static final class SyntheticGraphemeCapacityWalker extends Walker<Integer> {
-    private static final int TWO_OR_MORE = 2;
-
-    @Override
-    protected Integer shortVisit(Regexp re, Integer parentArg) {
-      return 0;
-    }
-
-    @Override
-    protected Integer copy(Integer arg) {
-      return arg;
-    }
-
-    @Override
-    protected Integer postVisit(
-        Regexp re, Integer parentArg, Integer preArg, List<Integer> childArgs) {
-      return switch (re.op) {
-        case GRAPHEME_CLUSTER_BOUNDARY ->
-            (re.flags & ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY) != 0 ? 1 : 0;
-        case CONCAT -> sumCapacity(childArgs);
-        case ALTERNATE -> maxCapacity(childArgs);
-        case STAR, PLUS -> repeatsCapacity(childArgs);
-        case QUEST, NON_CAPTURE, CAPTURE -> childCapacity(childArgs);
-        case REPEAT -> repeatCapacity(re, childArgs);
-        default -> 0;
-      };
-    }
-
-    private static int sumCapacity(List<Integer> childArgs) {
-      int total = 0;
-      for (int childCapacity : childArgs) {
-        total += childCapacity;
-        if (total >= TWO_OR_MORE) {
-          return TWO_OR_MORE;
-        }
-      }
-      return total;
-    }
-
-    private static int maxCapacity(List<Integer> childArgs) {
-      int max = 0;
-      for (int childCapacity : childArgs) {
-        max = Math.max(max, childCapacity);
-      }
-      return Math.min(max, TWO_OR_MORE);
-    }
-
-    private static int repeatsCapacity(List<Integer> childArgs) {
-      int childCapacity = childCapacity(childArgs);
-      return childCapacity == 0 ? 0 : TWO_OR_MORE;
-    }
-
-    private static int repeatCapacity(Regexp re, List<Integer> childArgs) {
-      int childCapacity = childCapacity(childArgs);
-      if (childCapacity == 0 || re.max == 0) {
-        return 0;
-      }
-      if (childCapacity >= TWO_OR_MORE || re.max == -1 || re.max >= 2) {
-        return TWO_OR_MORE;
-      }
-      return childCapacity;
-    }
-
-    private static int childCapacity(List<Integer> childArgs) {
-      return childArgs.isEmpty() ? 0 : childArgs.getFirst();
     }
   }
 

--- a/safere/src/main/java/org/safere/PatternSet.java
+++ b/safere/src/main/java/org/safere/PatternSet.java
@@ -53,6 +53,7 @@ public final class PatternSet {
   private final Prog prog;
   private final int size;
   private final List<String> patterns;
+  private final List<Pattern> fallbackPatterns;
   private final int maxDfaStates;
 
   /** Parse flags for pattern set patterns: Perl-compatible without captures. */
@@ -61,11 +62,18 @@ public final class PatternSet {
   /** Default maximum number of DFA states before falling back to NFA. */
   static final int DEFAULT_MAX_DFA_STATES = 10_000;
 
-  private PatternSet(Anchor anchor, Prog prog, int size, List<String> patterns, int maxDfaStates) {
+  private PatternSet(
+      Anchor anchor,
+      Prog prog,
+      int size,
+      List<String> patterns,
+      List<Pattern> fallbackPatterns,
+      int maxDfaStates) {
     this.anchor = anchor;
     this.prog = prog;
     this.size = size;
     this.patterns = patterns;
+    this.fallbackPatterns = fallbackPatterns;
     this.maxDfaStates = maxDfaStates;
   }
 
@@ -112,6 +120,10 @@ public final class PatternSet {
   public List<Integer> match(String text) {
     boolean anchored = (anchor != Anchor.UNANCHORED);
 
+    if (prog.hasGraphemeClusterInstruction()) {
+      return matchFallback(text);
+    }
+
     // Try DFA multi-match first.
     Dfa.ManyMatchResult dfaResult = Dfa.searchMany(prog, text, anchored, maxDfaStates);
     if (dfaResult != null) {
@@ -137,7 +149,7 @@ public final class PatternSet {
   private List<Integer> matchFallback(String text) {
     List<Integer> result = new ArrayList<>();
     for (int i = 0; i < size; i++) {
-      Pattern p = Pattern.compile(patterns.get(i));
+      Pattern p = fallbackPatterns.get(i);
       Matcher m = p.matcher(text);
       boolean matched =
           switch (anchor) {
@@ -200,45 +212,7 @@ public final class PatternSet {
      * @throws IllegalStateException if no patterns have been added or if already compiled
      */
     public PatternSet compile() {
-      if (compiled) {
-        throw new IllegalStateException("compile() has already been called");
-      }
-      if (patterns.isEmpty()) {
-        throw new IllegalStateException("No patterns have been added");
-      }
-      compiled = true;
-
-      int parseFlags = SET_PARSE_FLAGS;
-      int size = patterns.size();
-
-      // Build tagged regexps: each pattern is concatenated with a HAVE_MATCH marker.
-      List<Regexp> tagged = new ArrayList<>(size);
-      for (int i = 0; i < size; i++) {
-        Regexp re = Parser.parse(patterns.get(i), parseFlags);
-        Regexp haveMatch = Regexp.haveMatch(i, parseFlags);
-        tagged.add(Regexp.concat(List.of(re, haveMatch), parseFlags));
-      }
-
-      // Combine all tagged patterns into a single alternation.
-      Regexp combined;
-      if (size == 1) {
-        combined = tagged.getFirst();
-      } else {
-        combined = Regexp.alternate(tagged, parseFlags);
-      }
-
-      // Compile the combined regexp.
-      Prog prog = Compiler.compile(combined);
-
-      // Adjust anchoring based on the requested anchor mode.
-      if (anchor == Anchor.ANCHOR_START || anchor == Anchor.ANCHOR_BOTH) {
-        prog.setAnchorStart(true);
-      }
-      if (anchor == Anchor.ANCHOR_BOTH) {
-        prog.setAnchorEnd(true);
-      }
-
-      return new PatternSet(anchor, prog, size, List.copyOf(patterns), DEFAULT_MAX_DFA_STATES);
+      return compile(DEFAULT_MAX_DFA_STATES);
     }
 
     /**
@@ -260,8 +234,11 @@ public final class PatternSet {
       int size = patterns.size();
 
       List<Regexp> tagged = new ArrayList<>(size);
+      List<Pattern> fallbackPatterns = new ArrayList<>(size);
       for (int i = 0; i < size; i++) {
-        Regexp re = Parser.parse(patterns.get(i), parseFlags);
+        String pattern = patterns.get(i);
+        Regexp re = Parser.parse(pattern, parseFlags);
+        fallbackPatterns.add(Pattern.compile(pattern));
         Regexp haveMatch = Regexp.haveMatch(i, parseFlags);
         tagged.add(Regexp.concat(List.of(re, haveMatch), parseFlags));
       }
@@ -282,7 +259,8 @@ public final class PatternSet {
         prog.setAnchorEnd(true);
       }
 
-      return new PatternSet(anchor, prog, size, List.copyOf(patterns), maxDfaStates);
+      return new PatternSet(
+          anchor, prog, size, List.copyOf(patterns), List.copyOf(fallbackPatterns), maxDfaStates);
     }
   }
 }

--- a/safere/src/main/java/org/safere/Prog.java
+++ b/safere/src/main/java/org/safere/Prog.java
@@ -40,7 +40,7 @@ final class Prog {
   private int numLoopRegs;
   private boolean requiresPikeNfaCaptureSemantics;
   private boolean hasGraphemeClusterBoundary;
-  private boolean charOffsetGraphemeSearch;
+  private boolean hasGraphemeClusterInstruction;
 
   /** Creates an empty program. */
   public Prog() {}
@@ -83,6 +83,7 @@ final class Prog {
   public void freeze() {
     instArray = instructions.toArray(new Inst[0]);
     hasGraphemeClusterBoundary = computeHasGraphemeClusterBoundary();
+    hasGraphemeClusterInstruction = computeHasGraphemeClusterInstruction();
   }
 
   /** Returns the start instruction index for anchored matching. */
@@ -215,28 +216,36 @@ final class Prog {
     return false;
   }
 
-  /** Returns true if this program contains a {@code \b{g}} assertion. */
+  /** Returns true if this program contains grapheme-sensitive matching. */
   boolean hasGraphemeClusterBoundary() {
     return hasGraphemeClusterBoundary;
   }
 
-  boolean hasMultipleGraphemeClusterBoundaries() {
-    return charOffsetGraphemeSearch;
-  }
-
-  void setCharOffsetGraphemeSearch(boolean charOffsetGraphemeSearch) {
-    this.charOffsetGraphemeSearch = charOffsetGraphemeSearch;
+  /** Returns true if this program contains a consuming {@code \X} instruction. */
+  boolean hasGraphemeClusterInstruction() {
+    return hasGraphemeClusterInstruction;
   }
 
   private boolean computeHasGraphemeClusterBoundary() {
     int n = instArray.length;
     for (int i = 0; i < n; i++) {
       Inst ip = instArray[i];
-      if (ip.op == InstOp.EMPTY_WIDTH
-          && (ip.arg
-                  & (EmptyOp.GRAPHEME_CLUSTER_BOUNDARY
-                      | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY))
-              != 0) {
+      if (ip.op == InstOp.GRAPHEME_CLUSTER
+          || (ip.op == InstOp.EMPTY_WIDTH
+              && (ip.arg
+                      & (EmptyOp.GRAPHEME_CLUSTER_BOUNDARY
+                          | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY))
+                  != 0)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean computeHasGraphemeClusterInstruction() {
+    int n = instArray.length;
+    for (int i = 0; i < n; i++) {
+      if (instArray[i].op == InstOp.GRAPHEME_CLUSTER) {
         return true;
       }
     }

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -26,6 +26,7 @@ import java.util.List;
  *   <tr><td>{@link RegexpOp#LITERAL}</td><td>{@link #rune}, {@link #flags}</td></tr>
  *   <tr><td>{@link RegexpOp#LITERAL_STRING}</td><td>{@link #runes}, {@link #flags}</td></tr>
  *   <tr><td>{@link RegexpOp#CHAR_CLASS}</td><td>{@link #charClass}</td></tr>
+ *   <tr><td>{@link RegexpOp#GRAPHEME_CLUSTER}</td><td>{@link #flags}</td></tr>
  *   <tr><td>{@link RegexpOp#CONCAT}, {@link RegexpOp#ALTERNATE}</td><td>{@link #subs}</td></tr>
  *   <tr><td>{@link RegexpOp#STAR}, {@link RegexpOp#PLUS}, {@link RegexpOp#QUEST}</td>
  *       <td>{@link #subs} (length 1), {@link #flags}</td></tr>
@@ -232,6 +233,11 @@ final class Regexp {
     return new Regexp(RegexpOp.GRAPHEME_CLUSTER_BOUNDARY, flags);
   }
 
+  /** Creates a GRAPHEME_CLUSTER node. */
+  public static Regexp graphemeCluster(int flags) {
+    return new Regexp(RegexpOp.GRAPHEME_CLUSTER, flags);
+  }
+
   /** Creates a BEGIN_TEXT node. */
   public static Regexp beginText(int flags) {
     return new Regexp(RegexpOp.BEGIN_TEXT, flags);
@@ -333,6 +339,7 @@ final class Regexp {
                 WORD_BOUNDARY,
                 NO_WORD_BOUNDARY,
                 GRAPHEME_CLUSTER_BOUNDARY,
+                GRAPHEME_CLUSTER,
                 CHAR_CLASS,
                 HAVE_MATCH ->
                 PREC_ATOM;
@@ -464,6 +471,7 @@ final class Regexp {
         case WORD_BOUNDARY -> sb.append("\\b");
         case NO_WORD_BOUNDARY -> sb.append("\\B");
         case GRAPHEME_CLUSTER_BOUNDARY -> sb.append("\\b{g}");
+        case GRAPHEME_CLUSTER -> sb.append("\\X");
         case CHAR_CLASS -> appendCharClass(sb, re.charClass);
         case NON_CAPTURE -> sb.append(')');
         case CAPTURE -> sb.append(')');

--- a/safere/src/main/java/org/safere/RegexpOp.java
+++ b/safere/src/main/java/org/safere/RegexpOp.java
@@ -74,6 +74,9 @@ enum RegexpOp {
   /** Matches a Unicode extended grapheme cluster boundary ({@code \b{g}}). */
   GRAPHEME_CLUSTER_BOUNDARY,
 
+  /** Matches a single Unicode extended grapheme cluster ({@code \X}). */
+  GRAPHEME_CLUSTER,
+
   /** Matches empty string at beginning of text ({@code \A}). */
   BEGIN_TEXT,
 

--- a/safere/src/test/java/org/safere/BoundaryMatcherTest.java
+++ b/safere/src/test/java/org/safere/BoundaryMatcherTest.java
@@ -227,9 +227,16 @@ class BoundaryMatcherTest {
 
       jdkMatcher.reset(input).region(start, end);
       safeMatcher.reset(input).region(start, end);
-      assertThat(safeMatcher.lookingAt())
+      boolean jdkLookingAt = jdkMatcher.lookingAt();
+      boolean safeLookingAt = safeMatcher.lookingAt();
+      assertThat(safeLookingAt)
           .as("lookingAt() for /%s/ on %s region [%s,%s]", regex, input, start, end)
-          .isEqualTo(jdkMatcher.lookingAt());
+          .isEqualTo(jdkLookingAt);
+      if (jdkLookingAt) {
+        assertThat(new int[] {safeMatcher.start(), safeMatcher.end()})
+            .as("lookingAt() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
+            .containsExactly(jdkMatcher.start(), jdkMatcher.end());
+      }
 
       jdkMatcher.reset(input).region(start, end);
       safeMatcher.reset(input).region(start, end);
@@ -246,6 +253,114 @@ class BoundaryMatcherTest {
       assertThat(safeMatches)
           .as("find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
           .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
+    private void assertSafeReFindBounds(
+        String regex, String input, int start, int end, List<String> expected) {
+      Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
+      List<String> safeMatches = new ArrayList<>();
+      while (safeMatcher.find()) {
+        safeMatches.add(safeMatcher.start() + "-" + safeMatcher.end());
+      }
+      assertThat(safeMatches)
+          .as("SafeRE find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .containsExactlyElementsOf(expected);
+    }
+
+    private void assertTransparentTraceSameAsJdk(String regex, String input, int start, int end) {
+      java.util.regex.Matcher jdkMatcher =
+          java.util.regex.Pattern.compile(regex)
+              .matcher(input)
+              .region(start, end)
+              .useTransparentBounds(true);
+      Matcher safeMatcher =
+          Pattern.compile(regex).matcher(input).region(start, end).useTransparentBounds(true);
+
+      assertThat(safeMatcher.matches())
+          .as("transparent matches() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .isEqualTo(jdkMatcher.matches());
+
+      jdkMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      safeMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      boolean jdkLookingAt = jdkMatcher.lookingAt();
+      boolean safeLookingAt = safeMatcher.lookingAt();
+      assertThat(safeLookingAt)
+          .as("transparent lookingAt() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .isEqualTo(jdkLookingAt);
+      if (jdkLookingAt) {
+        assertThat(new int[] {safeMatcher.start(), safeMatcher.end()})
+            .as(
+                "transparent lookingAt() positions for /%s/ on %s region [%s,%s]",
+                regex, input, start, end)
+            .containsExactly(jdkMatcher.start(), jdkMatcher.end());
+      }
+
+      jdkMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      safeMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      List<int[]> jdkMatches = new ArrayList<>();
+      while (jdkMatcher.find()) {
+        jdkMatches.add(new int[] {jdkMatcher.start(), jdkMatcher.end()});
+      }
+
+      List<int[]> safeMatches = new ArrayList<>();
+      while (safeMatcher.find()) {
+        safeMatches.add(new int[] {safeMatcher.start(), safeMatcher.end()});
+      }
+
+      assertThat(safeMatches)
+          .as(
+              "transparent find() positions for /%s/ on %s region [%s,%s]",
+              regex, input, start, end)
+          .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
+    private void assertCapturedFindTraceSameAsJdk(String regex, String input, int start, int end) {
+      java.util.regex.Matcher jdkMatcher =
+          java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
+      Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
+
+      List<String> jdkMatches = capturedFindTrace(jdkMatcher);
+      List<String> safeMatches = capturedFindTrace(safeMatcher);
+
+      assertThat(safeMatches)
+          .as("captured find() trace for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .containsExactlyElementsOf(jdkMatches);
+    }
+
+    private List<String> capturedFindTrace(java.util.regex.Matcher matcher) {
+      List<String> trace = new ArrayList<>();
+      while (matcher.find()) {
+        trace.add(capturedMatchTrace(matcher));
+      }
+      return trace;
+    }
+
+    private List<String> capturedFindTrace(Matcher matcher) {
+      List<String> trace = new ArrayList<>();
+      while (matcher.find()) {
+        trace.add(capturedMatchTrace(matcher));
+      }
+      return trace;
+    }
+
+    private String capturedMatchTrace(java.util.regex.Matcher matcher) {
+      StringBuilder builder = new StringBuilder();
+      builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
+      builder.append(matcher.group());
+      for (int i = 1; i <= matcher.groupCount(); i++) {
+        builder.append(':').append(matcher.group(i));
+      }
+      return builder.toString();
+    }
+
+    private String capturedMatchTrace(Matcher matcher) {
+      StringBuilder builder = new StringBuilder();
+      builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
+      builder.append(matcher.group());
+      for (int i = 1; i <= matcher.groupCount(); i++) {
+        builder.append(':').append(matcher.group(i));
+      }
+      return builder.toString();
     }
 
     @Test
@@ -287,6 +402,10 @@ class BoundaryMatcherTest {
     @Test
     @DisplayName("\\b{g} respects opaque region bounds for base-plus-mark clusters")
     void respectsOpaqueRegionBoundsForBaseMarkClusters() {
+      assertTraceSameAsJdk("\\b{g}", "e\u0301", 1, 2);
+      assertTraceSameAsJdk("(\\b{g})", "e\u0301", 1, 2);
+      assertTraceSameAsJdk("\\b{g}\\X", "e\u0301", 1, 2);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "e\u0301", 1, 2);
       assertTraceSameAsJdk("a\\b{g}\\u0300", "#a\u0300$", 1, 3);
       assertTraceSameAsJdk("(?:a)\\b{g}\\u0300", "#a\u0300$", 1, 3);
       assertTraceSameAsJdk("(a)\\b{g}\\u0300", "#a\u0300$", 1, 3);
@@ -300,12 +419,52 @@ class BoundaryMatcherTest {
     }
 
     @Test
-    @DisplayName("\\b{g}\\X\\b{g} find() follows JDK repeated-search positions")
-    void boundaryClusterBoundaryFindFollowsJdkPositions() {
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "ab", 0, 2);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "e\u0301a", 0, 3);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\u0301a", 0, 2);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8", 0, 6);
+    @DisplayName("\\b{g} treats opaque region edges inside non-surrogate clusters as boundaries")
+    void treatsOpaqueRegionEdgesInsideNonSurrogateClustersAsBoundaries() {
+      assertTraceSameAsJdk("\\b{g}", "a\u0301b", 1, 2);
+      assertTraceSameAsJdk("\\b{g}\\X", "a\u0301b", 1, 2);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "a\u0301b", 1, 2);
+
+      String hangulCluster = "\u1100\u1161";
+      assertTraceSameAsJdk("\\b{g}", hangulCluster, 1, 2);
+      assertTraceSameAsJdk("\\b{g}\\X", hangulCluster, 1, 2);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", hangulCluster, 1, 2);
+    }
+
+    @Test
+    @DisabledForCrosscheck(
+        "SafeRE's region-local grapheme model intentionally composes this JDK edge trace")
+    @DisplayName("\\b{g} composes across opaque region edges inside ZWJ sequences")
+    void composesAcrossOpaqueRegionEdgesInsideZwjSequences() {
+      String zwjSequence = "\uD83D\uDC69\u200D\uD83D\uDC69";
+      assertSafeReFindBounds("\\b{g}\\X", zwjSequence, 2, 5, List.of("2-3", "3-5"));
+    }
+
+    @Test
+    @DisplayName("bare \\b{g} alternatives preserve priority after empty find() matches")
+    void boundaryOnlyAlternativesPreserveEmptyMatchPriorityOnRepeatedFind() {
+      assertTraceSameAsJdk("\\b{g}|a", "aa", 0, 2);
+      assertTraceSameAsJdk("(?:\\b{g}|a)", "aa", 0, 2);
+      assertTraceSameAsJdk("(?:(?:\\b{g})|a)", "aa", 0, 2);
+      assertCapturedFindTraceSameAsJdk("(\\b{g})|(a)", "aa", 0, 2);
+      assertTraceSameAsJdk("\\b{g}|\\X", "aa", 0, 2);
+      assertTraceSameAsJdk("(?:\\b{g}|\\X)", "aa", 0, 2);
+      assertCapturedFindTraceSameAsJdk("(\\b{g})|(\\X)", "aa", 0, 2);
+    }
+
+    @Test
+    @DisplayName("transparent trailing \\b{g} sees contextual characters beyond region end")
+    void transparentTrailingGraphemeBoundaryUsesFullTextContext() {
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "a\u0301", 0, 1);
+      assertTransparentTraceSameAsJdk("^\\X\\b{g}", "a\u0301", 0, 1);
+      assertTransparentTraceSameAsJdk("\\b{g}\\X\\b{g}", "a\u0301", 0, 1);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "\r\n", 0, 1);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "a\u200D", 0, 1);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "a\u0903", 0, 1);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDC4D\uD83C\uDFFD", 0, 2);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "\uD83C\uDDFA\uD83C\uDDF8", 0, 2);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "\u1100\u1161", 0, 1);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "\uAC00\u11A8", 0, 1);
     }
 
     @Test
@@ -313,12 +472,55 @@ class BoundaryMatcherTest {
     void graphemeBoundariesRespectRegionsSplitInsideSurrogatePairs() {
       String splitBeforeZwj = "\uD83D\uDC69\u200D\uD83D\uDCBB";
       assertTraceSameAsJdk("\\b{g}", splitBeforeZwj, 1, 5);
-      assertTraceSameAsJdk("\\X\\b{g}", splitBeforeZwj, 1, 5);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", splitBeforeZwj, 1, 5);
+      assertTransparentTraceSameAsJdk("\\b{g}", "\uD83D\uDE00", 1, 1);
+      assertTransparentTraceSameAsJdk("(\\b{g})", "\uD83D\uDE00", 1, 1);
+      assertTransparentTraceSameAsJdk("\\b{g}", "\uD83D\uDE00\u0301\u0301", 2, 4);
+      assertTransparentTraceSameAsJdk("(\\b{g})", "\uD83D\uDE00\u0301\u0301", 2, 4);
+      assertTransparentTraceSameAsJdk("\\b{g}", "\uD83D\uD83C\uDDFA\uD83C\uDDF8\u200D", 1, 5);
+      assertTransparentTraceSameAsJdk(
+          "\\b{g}", "a\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8\u0300", 1, 7);
 
       String lowSurrogateThenZwj = "\uD83D\uDE00\u200D";
       assertTraceSameAsJdk("\\b{g}", lowSurrogateThenZwj, 1, 3);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", lowSurrogateThenZwj, 1, 3);
+
+      String splitLowSurrogateBeforeModifier = "\uD83D\uDC4D\uD83C\uDFFB";
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", splitLowSurrogateBeforeModifier, 1, 3);
+      assertTransparentTraceSameAsJdk("\\b{g}\\X\\b{g}", splitLowSurrogateBeforeModifier, 1, 3);
+
+      String splitBeforeExtender = "\uD83D\uDE00\uD83D\u0301";
+      assertTraceSameAsJdk("\\b{g}", splitBeforeExtender, 1, 3);
+      assertTraceSameAsJdk("(\\b{g})", splitBeforeExtender, 1, 3);
+      assertTraceSameAsJdk("\\X\\b{g}", splitBeforeExtender, 1, 3);
+    }
+
+    @Test
+    @DisplayName(
+        "\\X preserves full code points when an opaque region ends inside a surrogate pair")
+    void graphemeClustersPreserveCodePointsAtOpaqueRegionEnd() {
+      String emoji = "\uD83D\uDE00";
+      assertTraceSameAsJdk("\\X", emoji, 0, 1);
+      assertTraceSameAsJdk("^\\X$", emoji, 0, 1);
+      assertTraceSameAsJdk("\\b{g}\\X", emoji, 0, 1);
+      assertTraceSameAsJdk("\\X\\b{g}", emoji, 0, 1);
+      assertCapturedFindTraceSameAsJdk("(.)|(\\X)", emoji, 0, 1);
+      assertCapturedFindTraceSameAsJdk("(\\X)|(.)", emoji, 0, 1);
+    }
+
+    @Test
+    @DisplayName("chained \\X find() preserves leftmost starts inside Indic conjunct clusters")
+    void chainedGraphemeClustersPreserveLeftmostStartsInsideIndicConjuncts() {
+      String devanagariConjunct = "\u0915\u094D\u200D\u0915";
+      assertTraceSameAsJdk("\\X\\X", devanagariConjunct, 0, devanagariConjunct.length());
+      assertTraceSameAsJdk("(?:\\X)(?:\\X)", devanagariConjunct, 0, devanagariConjunct.length());
+      assertTraceSameAsJdk("(?:\\X){2}", devanagariConjunct, 0, devanagariConjunct.length());
+      assertTraceSameAsJdk("\\X{1}\\X", devanagariConjunct, 0, devanagariConjunct.length());
+      assertCapturedFindTraceSameAsJdk(
+          "(\\X)(\\X)", devanagariConjunct, 0, devanagariConjunct.length());
+
+      String bengaliConjunct = "\u0995\u09CD\u200D\u0995";
+      assertTraceSameAsJdk("\\X\\X", bengaliConjunct, 0, bengaliConjunct.length());
+      assertTraceSameAsJdk("(?:\\X){2}", bengaliConjunct, 0, bengaliConjunct.length());
+      assertCapturedFindTraceSameAsJdk("(\\X)(\\X)", bengaliConjunct, 0, bengaliConjunct.length());
     }
 
     @Test

--- a/safere/src/test/java/org/safere/EndAnchorRegionCompatibilityMatrixTest.java
+++ b/safere/src/test/java/org/safere/EndAnchorRegionCompatibilityMatrixTest.java
@@ -1,0 +1,303 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Focused differential matrix for end anchors under matcher regions and bounds. */
+@DisabledForCrosscheck("differential matrix already compares SafeRE with java.util.regex")
+class EndAnchorRegionCompatibilityMatrixTest {
+  private static final int FIND_LIMIT = 16;
+
+  @ParameterizedTest(name = "[{index}] {0} /{1}/")
+  @MethodSource("endAnchorRegionCases")
+  @DisplayName("end-anchor region behavior matches java.util.regex")
+  void endAnchorRegionBehaviorMatchesJdk(Scenario scenario, RegexCase regexCase) {
+    Trace safeTrace = safeTrace(regexCase, scenario);
+    Trace jdkTrace = jdkTrace(regexCase, scenario);
+
+    assertThat(safeTrace)
+        .as(
+            "%s%nInput length=%s region=[%s,%s] transparent=%s anchoring=%s flags=%s",
+            scenario.name(),
+            scenario.input().length(),
+            scenario.start(),
+            scenario.end(),
+            scenario.transparentBounds(),
+            scenario.anchoringBounds(),
+            regexCase.flags())
+        .isEqualTo(jdkTrace);
+  }
+
+  private static Stream<Arguments> endAnchorRegionCases() {
+    return scenarios().stream()
+        .flatMap(
+            scenario -> regexCases().stream().map(regexCase -> Arguments.of(scenario, regexCase)));
+  }
+
+  private static List<Scenario> scenarios() {
+    List<Scenario> scenarios = new ArrayList<>();
+    for (InputRegion inputRegion : inputRegions()) {
+      for (BoundsCase boundsCase : boundsCases()) {
+        scenarios.add(
+            new Scenario(
+                inputRegion.name() + " " + boundsCase.name(),
+                inputRegion.input(),
+                inputRegion.start(),
+                inputRegion.end(),
+                boundsCase.transparentBounds(),
+                boundsCase.anchoringBounds()));
+      }
+    }
+    return scenarios;
+  }
+
+  private static List<InputRegion> inputRegions() {
+    return List.of(
+        new InputRegion("before final lf", "ab\n", 0, 2),
+        new InputRegion("including final lf", "ab\n", 0, 3),
+        new InputRegion("before final cr", "ab\r", 0, 2),
+        new InputRegion("including final cr", "ab\r", 0, 3),
+        new InputRegion("before final nel", "ab\u0085", 0, 2),
+        new InputRegion("before final ls", "ab\u2028", 0, 2),
+        new InputRegion("before final ps", "ab\u2029", 0, 2),
+        new InputRegion("before final crlf", "ab\r\n", 0, 2),
+        new InputRegion("split final crlf", "ab\r\n", 0, 3),
+        new InputRegion("including final crlf", "ab\r\n", 0, 4),
+        new InputRegion("interior lf before suffix", "ab\nx", 0, 3),
+        new InputRegion("region end before full-text final lf", "a\u0000\n\n", 0, 3));
+  }
+
+  private static List<BoundsCase> boundsCases() {
+    return List.of(
+        new BoundsCase("opaque anchoring", false, true),
+        new BoundsCase("opaque non-anchoring", false, false),
+        new BoundsCase("transparent anchoring", true, true),
+        new BoundsCase("transparent non-anchoring", true, false));
+  }
+
+  private static List<RegexCase> regexCases() {
+    return List.of(
+        regex("dollar only", "$", 0),
+        regex("Z only", "\\Z", 0),
+        regex("z only", "\\z", 0),
+        regex("two chars dollar", "[\\s\\S][\\s\\S]$", 0),
+        regex("anchored two chars dollar", "^[\\s\\S][\\s\\S]$", 0),
+        regex("captured two chars dollar", "([\\s\\S])([\\s\\S])$", 0),
+        regex("two chars Z", "[\\s\\S][\\s\\S]\\Z", 0),
+        regex("anchored two chars Z", "^[\\s\\S][\\s\\S]\\Z", 0),
+        regex("two chars z", "[\\s\\S][\\s\\S]\\z", 0),
+        regex("anchored two chars z", "^[\\s\\S][\\s\\S]\\z", 0),
+        regex("greedy chars dollar", "[\\s\\S]+$", 0),
+        regex("dotall two chars dollar", "..$", Pattern.DOTALL),
+        regex("unix lines dollar", "[\\s\\S][\\s\\S]$", Pattern.UNIX_LINES),
+        regex("unix lines Z", "[\\s\\S][\\s\\S]\\Z", Pattern.UNIX_LINES),
+        regex("multiline dollar", "[\\s\\S][\\s\\S]$", Pattern.MULTILINE),
+        regex("multiline anchored dollar", "^[\\s\\S][\\s\\S]$", Pattern.MULTILINE));
+  }
+
+  private static RegexCase regex(String name, String regex, int flags) {
+    return new RegexCase(name, regex, flags);
+  }
+
+  private static Trace safeTrace(RegexCase regexCase, Scenario scenario) {
+    Pattern pattern = Pattern.compile(regexCase.regex(), regexCase.flags());
+    Matcher matcher = configure(pattern.matcher(scenario.input()), scenario);
+    int groupCount = matcher.groupCount();
+
+    String matches =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.MATCHES);
+    String lookingAt =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.LOOKING_AT);
+    List<String> finds = findTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> results = resultsTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> resultsAfterFind =
+        resultsAfterFindTrace(configure(pattern.matcher(scenario.input()), scenario));
+
+    return new Trace(groupCount, matches, lookingAt, finds, results, resultsAfterFind);
+  }
+
+  private static Trace jdkTrace(RegexCase regexCase, Scenario scenario) {
+    java.util.regex.Pattern pattern =
+        java.util.regex.Pattern.compile(regexCase.regex(), regexCase.flags());
+    java.util.regex.Matcher matcher = configure(pattern.matcher(scenario.input()), scenario);
+    int groupCount = matcher.groupCount();
+
+    String matches =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.MATCHES);
+    String lookingAt =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.LOOKING_AT);
+    List<String> finds = findTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> results = resultsTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> resultsAfterFind =
+        resultsAfterFindTrace(configure(pattern.matcher(scenario.input()), scenario));
+
+    return new Trace(groupCount, matches, lookingAt, finds, results, resultsAfterFind);
+  }
+
+  private static Matcher configure(Matcher matcher, Scenario scenario) {
+    return matcher
+        .region(scenario.start(), scenario.end())
+        .useTransparentBounds(scenario.transparentBounds())
+        .useAnchoringBounds(scenario.anchoringBounds());
+  }
+
+  private static java.util.regex.Matcher configure(
+      java.util.regex.Matcher matcher, Scenario scenario) {
+    return matcher
+        .region(scenario.start(), scenario.end())
+        .useTransparentBounds(scenario.transparentBounds())
+        .useAnchoringBounds(scenario.anchoringBounds());
+  }
+
+  private static String matchTrace(Matcher matcher, Operation operation) {
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+        };
+    return matched ? capturedMatchTrace(matcher) : "NO_MATCH";
+  }
+
+  private static String matchTrace(java.util.regex.Matcher matcher, Operation operation) {
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+        };
+    return matched ? capturedMatchTrace(matcher) : "NO_MATCH";
+  }
+
+  private static List<String> findTrace(Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      trace.add(capturedMatchTrace(matcher));
+      if (trace.size() > FIND_LIMIT) {
+        throw new AssertionError("find() trace exceeded " + FIND_LIMIT + " matches");
+      }
+    }
+    return trace;
+  }
+
+  private static List<String> findTrace(java.util.regex.Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      trace.add(capturedMatchTrace(matcher));
+      if (trace.size() > FIND_LIMIT) {
+        throw new AssertionError("find() trace exceeded " + FIND_LIMIT + " matches");
+      }
+    }
+    return trace;
+  }
+
+  private static List<String> resultsTrace(Matcher matcher) {
+    return matcher.results().map(EndAnchorRegionCompatibilityMatrixTest::matchResultTrace).toList();
+  }
+
+  private static List<String> resultsTrace(java.util.regex.Matcher matcher) {
+    return matcher.results().map(EndAnchorRegionCompatibilityMatrixTest::matchResultTrace).toList();
+  }
+
+  private static List<String> resultsAfterFindTrace(Matcher matcher) {
+    if (!matcher.find()) {
+      return List.of();
+    }
+    return resultsTrace(matcher);
+  }
+
+  private static List<String> resultsAfterFindTrace(java.util.regex.Matcher matcher) {
+    if (!matcher.find()) {
+      return List.of();
+    }
+    return resultsTrace(matcher);
+  }
+
+  private static String capturedMatchTrace(Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(matcher.start()).append('-').append(matcher.end());
+    for (int group = 0; group <= matcher.groupCount(); group++) {
+      appendGroup(builder, group, matcher.start(group), matcher.end(group), matcher.group(group));
+    }
+    return builder.toString();
+  }
+
+  private static String capturedMatchTrace(java.util.regex.Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(matcher.start()).append('-').append(matcher.end());
+    for (int group = 0; group <= matcher.groupCount(); group++) {
+      appendGroup(builder, group, matcher.start(group), matcher.end(group), matcher.group(group));
+    }
+    return builder.toString();
+  }
+
+  private static String matchResultTrace(MatchResult result) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(result.start()).append('-').append(result.end());
+    for (int group = 0; group <= result.groupCount(); group++) {
+      appendGroup(builder, group, result.start(group), result.end(group), result.group(group));
+    }
+    return builder.toString();
+  }
+
+  private static void appendGroup(
+      StringBuilder builder, int group, int start, int end, String value) {
+    builder
+        .append(";g")
+        .append(group)
+        .append('=')
+        .append(start)
+        .append('-')
+        .append(end)
+        .append(':')
+        .append(value == null ? "<null>" : value);
+  }
+
+  private record InputRegion(String name, String input, int start, int end) {}
+
+  private record BoundsCase(String name, boolean transparentBounds, boolean anchoringBounds) {}
+
+  private record Scenario(
+      String name,
+      String input,
+      int start,
+      int end,
+      boolean transparentBounds,
+      boolean anchoringBounds) {
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record RegexCase(String name, String regex, int flags) {
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record Trace(
+      int groupCount,
+      String matches,
+      String lookingAt,
+      List<String> finds,
+      List<String> results,
+      List<String> resultsAfterFind) {}
+
+  private enum Operation {
+    MATCHES,
+    LOOKING_AT
+  }
+}

--- a/safere/src/test/java/org/safere/GraphemeJdkImplementationDetailTest.java
+++ b/safere/src/test/java/org/safere/GraphemeJdkImplementationDetailTest.java
@@ -1,0 +1,324 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Inventory of observed JDK grapheme-region behavior that appears to depend on {@code
+ * java.util.regex} implementation details rather than on specified regex semantics.
+ *
+ * <p>These cases are intentionally not active SafeRE compatibility requirements. If one of these
+ * behaviors is reclassified as a principled SafeRE target, move it into the focused grapheme tests
+ * with an explicit model-based expectation instead of relying on exact JDK trace equality.
+ */
+@Disabled("Observed JDK grapheme-region implementation details; not a SafeRE compatibility target")
+@DisplayName("JDK grapheme implementation-detail inventory")
+class GraphemeJdkImplementationDetailTest {
+
+  @Test
+  @DisplayName("boundary-starting grapheme alternatives advance repeated find like JDK")
+  void boundaryStartingGraphemeAlternativesAdvanceRepeatedFindLikeJdk() {
+    assertTraceSameAsJdk("\\b{g}\\X|b", "abc", 0, 3);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "abc", 0, 3);
+    assertTraceSameAsJdk("(?:\\b{g}\\X|b)", "abc", 0, 3);
+    assertTraceSameAsJdk("(\\b{g}\\X)|(b)", "abc", 0, 3);
+    assertTraceSameAsJdk("\\b{g}\\X|\\X", "abc", 0, 3);
+    assertTraceSameAsJdk("\\b{g}\\X|b", "#\r\r\n\r$", 1, 5);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "#\r\r\n\r$", 1, 5);
+    assertTraceSameAsJdk("\\X|\\b{g}\\X", "\r\r\n", 0, 3);
+    assertTraceSameAsJdk("\\X|\\b{g}\\X", "\n\r\n", 0, 3);
+    assertTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X|a", "\r\u0600a\u0301", 0, 4);
+    assertTraceSameAsJdk("\\b{g}\\X|a", "\uD83D\uDE00\u0600a\u0301", 1, 5);
+    assertTraceSameAsJdk("a|\\b{g}\\X", "\uD83D\uDE00\u0600a\r", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X|a", "#\ra\u200D\u0600a$", 1, 6);
+    assertTraceSameAsJdk("\\b{g}\\X|a", "#\ra\u0301\u0600a$", 1, 6);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\uD83D\uDE00\u0301\u200D\uD83D\uDC69\n", 1, 7);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\uD83D\uDE00\u0301\u200D\uD83D\uDC69\uD83C\uDDFAa", 1, 9);
+    assertTransparentTraceSameAsJdk("a|\\b{g}\\X", "#\r\u0600a$", 1, 4);
+    assertTransparentCapturedFindTraceSameAsJdk("(\\b{g}\\X)|(b)", "#ab$", 1, 3);
+    assertTraceSameAsJdk("\\b{g}\\X|b", "\u11A8\r\n\u0000\u0301", 0, 5);
+    assertTraceSameAsJdk("\\b{g}\\X|b", "\u1100\u200Da\u0903\uDE00", 0, 5);
+  }
+
+  @Test
+  @DisplayName("boundary-starting grapheme alternatives handle low-surrogate searches like JDK")
+  void boundaryStartingGraphemeAlternativesHandleLowSurrogateSearchesLikeJdk() {
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\r\uDE00", 0, 2);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\n\uDE00", 0, 2);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "a\uDE00", 0, 2);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\uD83D\uDE00\u200D\uD83D\uDC69", 1, 5);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 5);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 5);
+    assertTraceSameAsJdk("b|\\b{g}\\X", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
+    assertTraceSameAsJdk("a|\\b{g}\\X", "\uD83D\uDE00\u200D\uD83D\uDC69\u0600a", 1, 7);
+    assertTraceSameAsJdk("a|\\b{g}\\X", "\uD83D\uDE00\u0600a\u0600\uD83C\uDDFA", 1, 7);
+
+    assertTransparentTraceSameAsJdk("b|\\b{g}\\X", "#\u0301\uDE00$", 1, 3);
+    assertTransparentTraceSameAsJdk("b|\\b{g}\\X", "#\u200D\uDE00$", 1, 3);
+    assertTransparentTraceSameAsJdk("b|\\b{g}\\X", "#\uD83C\uDFFD\uDE00$", 1, 4);
+    assertTransparentTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\u200D\uD83D\uDCBB\uDE00", 1, 5);
+    assertTransparentTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\u0301", 1, 3);
+    assertTransparentTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\uD83C\uDFFD", 1, 4);
+    assertTransparentTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\u0301\r", 1, 4);
+    assertTransparentTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\u200D\u0301\uD83C\uDDFA", 1, 6);
+    assertTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDE00\u200D\uD83D\uDC69\r", 1, 6);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X|\\X", "\uD83D\uDE00\u0301\r", 1, 4);
+    assertTransparentTraceSameAsJdk("(?:\\X)|(?:\\b{g}\\X)", "\uD83D\uDE00\u0301\r", 1, 4);
+  }
+
+  @Test
+  @DisplayName("explicit grapheme boundaries treat selected region edges like JDK")
+  void explicitGraphemeBoundariesTreatSelectedRegionEdgesLikeJdk() {
+    assertTransparentTraceSameAsJdk("\\X\\b{g}", "aa\u0300", 1, 2);
+    assertTransparentTraceSameAsJdk("^\\X\\b{g}", "aa\u0300", 1, 2);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X\\b{g}", "aa\u0300", 1, 2);
+    assertTransparentTraceSameAsJdk("^\\b{g}\\X\\b{g}", "aa\u0300", 1, 2);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X|b", "zz\u0301\u0301", 2, 4);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X|\\X", "#\u0301\u0600\u0327\u200D", 1, 5);
+    assertTransparentTraceSameAsJdk("\\b{g}a\\u0300\\b{g}", "\uD83Da\u0300\u200D", 1, 3);
+    assertTransparentTraceSameAsJdk("\\X\\b{g}", "a\u0301\u0300", 1, 2);
+    assertTransparentTraceSameAsJdk("\\X\\b{g}", "#\u0600$", 1, 2);
+    assertTransparentTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u0301", 1, 2);
+    assertTransparentTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00a", 1, 2);
+    assertTransparentTraceSameAsJdk("\\X\\b{g}", "\uD83D\u0301\u200D", 1, 2);
+    assertTransparentTraceSameAsJdk("^\\X\\b{g}", "a\u0301\u0300", 1, 2);
+    assertTransparentTraceSameAsJdk("^\\X\\b{g}", "\uD83D\uDE00\u0301", 1, 2);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X\\b{g}", "a\u0301a\u0300", 1, 3);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\u0301\u0600$", 1, 3);
+    assertTransparentTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\r\r\u0301\u0300", 1, 4);
+    assertTransparentTraceSameAsJdk("^\\b{g}\\X\\b{g}", "\uD83D\uDE00", 1, 2);
+    assertTransparentTraceSameAsJdk("^\\b{g}\\X\\b{g}", "\uD83D\uDE00\uD83D\uDE00", 1, 2);
+    assertTransparentTraceSameAsJdk(
+        "b|\\b{g}\\X", "\uD83D\uDC69\u200D\uD83D\uDC69\uD83C\uDFFD", 0, 7);
+    assertTransparentTraceSameAsJdk(
+        "b|\\b{g}\\X", "#\uD83D\uDC69\u200D\uD83D\uDE00\uD83C\uDFFD$", 1, 8);
+  }
+
+  @Test
+  @DisplayName("boundary-starting alternatives continue after contextual grapheme characters")
+  void boundaryStartingAlternativesContinueAfterContextualGraphemeCharacters() {
+    assertTraceSameAsJdk("\\b{g}\\X|\\X", "\uD83D\uDC69\u200D\uD83D\uDCBB\u0301", 1, 5);
+    assertTraceSameAsJdk("\\X|\\b{g}\\X", "\uD83D\uDC69\u200D\uD83D\uDCBB\u0301", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X|a", "#\r\u0600a$", 1, 4);
+    assertTraceSameAsJdk("a|\\b{g}\\X", "#\r\u0600a$", 1, 4);
+    assertTraceSameAsJdk("(?:(?:\\b{g}\\X)|a)", "#\r\u0600a$", 1, 4);
+    assertCapturedFindTraceSameAsJdk("(\\b{g}\\X)|(b)", "ab", 0, 2);
+  }
+
+  @Test
+  @DisplayName("repeated \\X find positions expose JDK candidate-start details")
+  void repeatedGraphemeFindPositionsExposeJdkCandidateStartDetails() {
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "ab", 0, 2);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "e\u0301a", 0, 3);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\u0301a", 0, 2);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8", 0, 6);
+    assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 5);
+    assertTraceSameAsJdk("\\X", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
+    assertTransparentTraceSameAsJdk("\\X\\X", "\uD83C\uDDFA\uD83C\uDDF8", 0, 4);
+    assertTransparentTraceSameAsJdk("\\X\\X", "\uD83D\uDC4D\uD83C\uDFFD", 0, 4);
+    assertTransparentTraceSameAsJdk("\\X\\X", "\uD83D\uDC69\u200D\uD83D\uDCBB", 0, 5);
+    assertTraceSameAsJdk("\\X\\X", "#\r\r\uD83C\uDDFA\uD83C\uDDFA\u0301$", 1, 8);
+    assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
+    assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u200D\uD83D\uDE00", 1, 6);
+    assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\uD83C\uDFFD\u200D\uD83D\uDE00", 1, 7);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uAC01\uD83C\uDDFA\uD83C\uDDFA\r", 0, 6);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "a\uD83C\uDDFA\u200D\uD83C\uDDFA", 0, 6);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\r\u0903\u0903\u0903\u1100", 0, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D", 1, 3);
+    assertTransparentTraceSameAsJdk("\\X\\X", "\uD83D\uDE00\u0600\u0600\uD83D\uDE00", 1, 5);
+    assertTransparentTraceSameAsJdk("\\X\\X", "\uD83D\uDE00\uD83D\uDC69\u200D\uD83D\uDE00", 1, 6);
+    assertTransparentTraceSameAsJdk("\\X\\X", "\uD83D\uDE00\uD83D\uDE00\u200D\uD83D\uDE00", 1, 6);
+    assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDC69\u200D\uD83D\uDCBB\uDE00", 1, 5);
+    assertTraceSameAsJdk("\\X\\X", "#\r\r\uD83C\uDDFA\uD83C\uDDFA$", 1, 7);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\r\r\u200D", 1, 4);
+    assertTransparentTraceSameAsJdk("\\X{2}", "\u0903\u11A8\uD83D\uDC69\u200D\uD83D\uDC69", 0, 7);
+    assertTransparentTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDCBB", 0, 5);
+    assertTransparentTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 5);
+    assertTransparentCapturedFindTraceSameAsJdk(
+        "(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDCBB", 0, 5);
+    assertTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 5);
+    assertCapturedFindTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8$", 1, 7);
+    assertTransparentTraceSameAsJdk("\\X+", "\uD83D\uDC69\u200D\uD83D\uDCBB\uDE00", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\r\uD83C\uDDFA$", 1, 4);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\u200D\uD83D\uDC69$", 1, 4);
+    assertTransparentTraceSameAsJdk(
+        "\\b{g}\\X\\b{g}", "zz\uD83D\uDC69\u200D\uD83D\uDC69\uD83C\uDFFD", 2, 9);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\r\r\uDE00", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\r\r", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\r\n", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uDE00\uDE00", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u0301\r", 1, 7);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u200D\uDE00a", 1, 8);
+    assertTraceSameAsJdk(
+        "\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u200D\uD83D\uDC69", 1, 8);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDC69\u0301a", 1, 8);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\u200D\uD83D\uDC69\u200Da", 1, 8);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83C\uDDFA", 1, 6);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D", 1, 5);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83C\uDDE6\uD83C\uDDE6", 1, 3);
+    assertTraceSameAsJdk("\\b{g}\\X\\b{g}$", "\uD83C\uDDE6".repeat(1001), 0, 2002);
+    assertTraceSameAsJdk(
+        "\\X\\X",
+        "#\uD83D\uDC69\uD83C\uDFFD\u200D\uD83D\uDC69\uD83C\uDFFD"
+            + "\u200D\uD83D\uDC69\uD83C\uDFFD$",
+        1,
+        15);
+    assertTraceSameAsJdk("\\X\\X", "\uD83C\uDDFA\uD83C\uDDF8", 0, 4);
+    assertTraceSameAsJdk("\\X{2}", "\uD83D\uDC4D\uD83C\uDFFD", 0, 4);
+    assertTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDCBB", 0, 5);
+    assertTraceSameAsJdk("\\X\\X", "\u0915\u094D\u0937", 0, 3);
+    assertTraceSameAsJdk("\\X{2}", "\u0915\u094D\u0937", 0, 3);
+    assertTraceSameAsJdk("(\\X)(\\X)", "\u0915\u094D\u0937", 0, 3);
+    assertTraceSameAsJdk("(?:\\X)(?:\\X)", "\uD83C\uDDFA\uD83C\uDDF8", 0, 4);
+    assertTraceSameAsJdk("\\X{1}\\X", "\uD83C\uDDFA\uD83C\uDDF8", 0, 4);
+    assertTraceSameAsJdk("(?:\\X){2}", "\uD83C\uDDFA\uD83C\uDDF8", 0, 4);
+
+    String regionEndsInsidePair = "\uDE00\uD83D\uDE00";
+    assertTraceSameAsJdk("^\\X\\X$", regionEndsInsidePair, 0, 2);
+    assertTraceSameAsJdk("\\X{2}", regionEndsInsidePair, 0, 2);
+
+    String regionStartsInsidePair = "\uD83D\uDE00\uD83D\uDE01";
+    assertTraceSameAsJdk("\\X{2}", regionStartsInsidePair, 1, 4);
+  }
+
+  private void assertTraceSameAsJdk(String regex, String input, int start, int end) {
+    java.util.regex.Matcher jdkMatcher =
+        java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
+    Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
+
+    assertThat(safeMatcher.matches())
+        .as("matches() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .isEqualTo(jdkMatcher.matches());
+
+    jdkMatcher.reset(input).region(start, end);
+    safeMatcher.reset(input).region(start, end);
+    assertThat(safeMatcher.lookingAt())
+        .as("lookingAt() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .isEqualTo(jdkMatcher.lookingAt());
+
+    jdkMatcher.reset(input).region(start, end);
+    safeMatcher.reset(input).region(start, end);
+    assertThat(findBounds(safeMatcher))
+        .as("find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .containsExactly(findBounds(jdkMatcher).toArray(int[][]::new));
+  }
+
+  private void assertTransparentTraceSameAsJdk(String regex, String input, int start, int end) {
+    java.util.regex.Matcher jdkMatcher =
+        java.util.regex.Pattern.compile(regex)
+            .matcher(input)
+            .region(start, end)
+            .useTransparentBounds(true);
+    Matcher safeMatcher =
+        Pattern.compile(regex).matcher(input).region(start, end).useTransparentBounds(true);
+
+    assertThat(safeMatcher.matches())
+        .as("transparent matches() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .isEqualTo(jdkMatcher.matches());
+
+    jdkMatcher.reset(input).region(start, end).useTransparentBounds(true);
+    safeMatcher.reset(input).region(start, end).useTransparentBounds(true);
+    assertThat(safeMatcher.lookingAt())
+        .as("transparent lookingAt() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .isEqualTo(jdkMatcher.lookingAt());
+
+    jdkMatcher.reset(input).region(start, end).useTransparentBounds(true);
+    safeMatcher.reset(input).region(start, end).useTransparentBounds(true);
+    assertThat(findBounds(safeMatcher))
+        .as("transparent find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .containsExactly(findBounds(jdkMatcher).toArray(int[][]::new));
+  }
+
+  private void assertCapturedFindTraceSameAsJdk(String regex, String input, int start, int end) {
+    java.util.regex.Matcher jdkMatcher =
+        java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
+    Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
+
+    assertThat(capturedFindTrace(safeMatcher))
+        .as("captured find() trace for /%s/ on %s region [%s,%s]", regex, input, start, end)
+        .containsExactlyElementsOf(capturedFindTrace(jdkMatcher));
+  }
+
+  private void assertTransparentCapturedFindTraceSameAsJdk(
+      String regex, String input, int start, int end) {
+    java.util.regex.Matcher jdkMatcher =
+        java.util.regex.Pattern.compile(regex)
+            .matcher(input)
+            .region(start, end)
+            .useTransparentBounds(true);
+    Matcher safeMatcher =
+        Pattern.compile(regex).matcher(input).region(start, end).useTransparentBounds(true);
+
+    assertThat(capturedFindTrace(safeMatcher))
+        .as(
+            "transparent captured find() trace for /%s/ on %s region [%s,%s]",
+            regex, input, start, end)
+        .containsExactlyElementsOf(capturedFindTrace(jdkMatcher));
+  }
+
+  private List<int[]> findBounds(java.util.regex.Matcher matcher) {
+    List<int[]> matches = new ArrayList<>();
+    while (matcher.find()) {
+      matches.add(new int[] {matcher.start(), matcher.end()});
+    }
+    return matches;
+  }
+
+  private List<int[]> findBounds(Matcher matcher) {
+    List<int[]> matches = new ArrayList<>();
+    while (matcher.find()) {
+      matches.add(new int[] {matcher.start(), matcher.end()});
+    }
+    return matches;
+  }
+
+  private List<String> capturedFindTrace(java.util.regex.Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      trace.add(capturedMatchTrace(matcher));
+    }
+    return trace;
+  }
+
+  private List<String> capturedFindTrace(Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      trace.add(capturedMatchTrace(matcher));
+    }
+    return trace;
+  }
+
+  private String capturedMatchTrace(java.util.regex.Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
+    builder.append(matcher.group());
+    for (int i = 1; i <= matcher.groupCount(); i++) {
+      builder.append(':').append(matcher.group(i));
+    }
+    return builder.toString();
+  }
+
+  private String capturedMatchTrace(Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
+    builder.append(matcher.group());
+    for (int i = 1; i <= matcher.groupCount(); i++) {
+      builder.append(':').append(matcher.group(i));
+    }
+    return builder.toString();
+  }
+}

--- a/safere/src/test/java/org/safere/GraphemeRegionCompatibilityMatrixTest.java
+++ b/safere/src/test/java/org/safere/GraphemeRegionCompatibilityMatrixTest.java
@@ -1,0 +1,512 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Focused differential matrix for SafeRE's supported grapheme-region contract. */
+@DisabledForCrosscheck("differential matrix already compares SafeRE with java.util.regex")
+class GraphemeRegionCompatibilityMatrixTest {
+
+  @ParameterizedTest(name = "[{index}] {0} /{1}/")
+  @MethodSource("supportedContractCases")
+  @DisplayName("supported grapheme-region contract matches java.util.regex")
+  void supportedGraphemeRegionContractMatchesJdk(Scenario scenario, String regex) {
+    Trace safeTrace = safeTrace(regex, scenario);
+    Trace jdkTrace = jdkTrace(regex, scenario);
+
+    assertThat(safeTrace)
+        .as(
+            "%s%nInvariant: %s%nInput length=%s region=[%s,%s] transparent=%s anchoring=%s",
+            scenario.name(),
+            scenario.invariant(),
+            scenario.input().length(),
+            scenario.start(),
+            scenario.end(),
+            scenario.transparentBounds(),
+            scenario.anchoringBounds())
+        .isEqualTo(jdkTrace);
+  }
+
+  private static Stream<Arguments> supportedContractCases() {
+    return scenarios().stream()
+        .flatMap(
+            scenario -> scenario.regexes().stream().map(regex -> Arguments.of(scenario, regex)));
+  }
+
+  private static List<Scenario> scenarios() {
+    return List.of(
+        new Scenario(
+            "split trailing surrogate scalar completion",
+            "\\X may complete the scalar for lookingAt/find, while matches() remains region-end"
+                + " strict and ordinary atoms do not report half-code-point bounds.",
+            "\uD83D\uDE00",
+            0,
+            1,
+            false,
+            true,
+            List.of("\\X", "^\\X$", "\\X\\b{g}", "\\b{g}\\X", "(.)|(\\X)", "(\\X)|(.)")),
+        new Scenario(
+            "split trailing regional indicator uses completed boundary edge",
+            "A trailing \\b{g} after \\X sees the effective grapheme consume end when an opaque"
+                + " region ends inside a regional-indicator surrogate pair.",
+            "\uD83C\uDDE6\uD83C\uDDE6",
+            0,
+            1,
+            false,
+            true,
+            List.of("\\X\\b{g}", "\\b{g}\\X\\b{g}", "^\\X\\b{g}$")),
+        new Scenario(
+            "split trailing surrogate with non-anchoring bounds",
+            "Non-anchoring bounds do not make region edges anchors, but text anchors can still"
+                + " match when scalar completion reaches the real input end.",
+            "\uD83D\uDE00",
+            0,
+            1,
+            false,
+            false,
+            List.of("^\\X$", "\\X$", "\\A\\X\\z")),
+        new Scenario(
+            "interior non-anchoring bounds do not satisfy anchors",
+            "With non-anchoring bounds, region edges are not anchor positions for ^ or $ even when"
+                + " the consuming atom is a valid grapheme cluster.",
+            "#a\u0301$",
+            1,
+            3,
+            false,
+            false,
+            List.of("^\\X$", "\\X$")),
+        new Scenario(
+            "non-anchoring grapheme matches remain region bounded",
+            "matches() still checks the logical matcher region when no end anchor needs full-text"
+                + " context.",
+            "#a$",
+            1,
+            2,
+            false,
+            false,
+            List.of("\\X", "\\X+", "(\\X)", "\\b{g}?")),
+        new Scenario(
+            "non-anchoring bounds do not expose region-local line terminator anchors",
+            "With non-anchoring bounds, $ must not accept a position before a line terminator"
+                + " merely because that line terminator is inside the region.",
+            "\r\u0000\n\n",
+            0,
+            3,
+            false,
+            false,
+            List.of("^\\X\\X$", "\\X\\X$", "^(?:\\X){2}$", "^\\X{2}$")),
+        new Scenario(
+            "non-anchoring dollar sees final crlf across region edge",
+            "With non-anchoring bounds, $ uses full-input trailing-line context, including a"
+                + " final CRLF terminator split by the matcher region end.",
+            "\r\r\r\n",
+            0,
+            3,
+            false,
+            false,
+            List.of("^\\X\\X$", "\\X\\X$", "^(?:\\X){2}$", "^\\X{2}$")),
+        new Scenario(
+            "transparent non-anchoring dollar sees final crlf across region edge",
+            "Transparent bounds do not change $ anchor context: with non-anchoring bounds, the"
+                + " final CRLF terminator can still be split by the matcher region end.",
+            "\r\r\r\n",
+            0,
+            3,
+            true,
+            false,
+            List.of("^\\X\\X$", "\\X\\X$", "^(?:\\X){2}$", "^\\X{2}$")),
+        new Scenario(
+            "transparent low surrogate sees preceding high surrogate",
+            "Transparent grapheme context may inspect outside the region, while candidate starts"
+                + " remain inside the region.",
+            "\uD83D\uDC4D\uD83C\uDFFB",
+            1,
+            3,
+            true,
+            true,
+            List.of("\\X\\b{g}", "\\b{g}", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "opaque low surrogate is region local",
+            "Opaque bounds make the region edge a local grapheme context edge without adopting the"
+                + " full-text cluster.",
+            "\uD83D\uDC4D\uD83C\uDFFB",
+            1,
+            3,
+            false,
+            true,
+            List.of("\\X", "\\X\\b{g}", "\\b{g}")),
+        new Scenario(
+            "opaque low surrogate before regional indicator keeps contextual boundary rules",
+            "A region-local low surrogate can start consumption, but the following boundary must"
+                + " still obey regional-indicator parity instead of becoming unconditional.",
+            "\uD83C\uDDE6\uD83C\uDDE6",
+            1,
+            3,
+            false,
+            true,
+            List.of("\\X\\b{g}")),
+        new Scenario(
+            "opaque non-surrogate cluster edge",
+            "Opaque region edges are grapheme-boundary context edges even when they split a"
+                + " base-plus-mark cluster.",
+            "a\u0301b",
+            1,
+            2,
+            false,
+            true,
+            List.of("\\b{g}", "\\b{g}\\X", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "empty opaque region inside base-plus-mark cluster",
+            "An empty opaque region inside a grapheme cluster is still a local boundary context for"
+                + " zero-width grapheme predicates.",
+            "a\u0301",
+            1,
+            1,
+            false,
+            true,
+            List.of("\\b{g}", "(\\b{g})", "\\b{g}|a", "\\b{g}\\X?")),
+        new Scenario(
+            "empty transparent region inside base-plus-mark cluster",
+            "An empty transparent region inside a grapheme cluster lets \\b{g} inspect the hidden"
+                + " base and extender context.",
+            "a\u0301",
+            1,
+            1,
+            true,
+            true,
+            List.of("\\b{g}", "(\\b{g})", "\\b{g}|a", "\\b{g}\\X?")),
+        new Scenario(
+            "empty transparent region inside surrogate pair",
+            "An empty transparent region inside a valid surrogate pair lets grapheme-boundary"
+                + " predicates inspect both halves.",
+            "\uD83D\uDE00",
+            1,
+            1,
+            true,
+            true,
+            List.of("\\b{g}", "(\\b{g})", "\\b{g}|a")),
+        new Scenario(
+            "transparent trailing boundary sees hidden extender",
+            "Transparent bounds let trailing grapheme-boundary predicates see a combining mark just"
+                + " outside the region.",
+            "a\u0301",
+            0,
+            1,
+            true,
+            true,
+            List.of("\\X\\b{g}", "^\\X\\b{g}", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "opaque regional-indicator parity starts at region",
+            "Regional-indicator parity is relative to the active opaque grapheme context, not the"
+                + " full input.",
+            "\uD83C\uDDE6\uD83C\uDDE6\uD83C\uDDE6",
+            2,
+            6,
+            false,
+            true,
+            List.of("\\X", "\\b{g}", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "opaque crlf remains atomic at region edge",
+            "CRLF segmentation remains atomic inside an opaque grapheme context.",
+            "#\r\n$",
+            1,
+            3,
+            false,
+            true,
+            List.of("\\r\\b{g}\\n", "\\X", "\\X\\b{g}")),
+        new Scenario(
+            "control characters remain standalone before extenders",
+            "Control characters force grapheme boundaries before following combining marks.",
+            "a\u0000\u0301",
+            1,
+            3,
+            false,
+            true,
+            List.of("\\X", "\\X\\b{g}")),
+        new Scenario(
+            "transparent crlf boundary sees hidden line feed",
+            "Transparent bounds let trailing grapheme-boundary predicates keep CRLF atomic across"
+                + " the region edge.",
+            "\r\n\u0301",
+            0,
+            1,
+            true,
+            true,
+            List.of("\\X\\b{g}", "\\r\\b{g}\\n?")),
+        new Scenario(
+            "transparent hangul continuation sees suffix",
+            "Transparent grapheme context lets \\X and \\b{g} see Hangul continuation state outside"
+                + " the consumption range.",
+            "\u1100\u1161",
+            0,
+            1,
+            true,
+            true,
+            List.of("\\X\\b{g}")),
+        new Scenario(
+            "opaque region inside zwj sequence starts at edge",
+            "Opaque bounds treat a region start inside a ZWJ sequence as a local grapheme"
+                + " boundary.",
+            "\uD83D\uDC69\u200D\uD83D\uDC69",
+            2,
+            5,
+            false,
+            true,
+            List.of("\\b{g}")),
+        new Scenario(
+            "transparent prepend sees following cluster",
+            "Transparent grapheme context lets a Prepend character stay attached to the following"
+                + " hidden cluster.",
+            "\u0600a",
+            0,
+            1,
+            true,
+            true,
+            List.of("\\X\\b{g}", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "opaque prepend edge is region local",
+            "Opaque bounds let a region ending after a Prepend character form a local grapheme"
+                + " cluster.",
+            "\u0600a",
+            0,
+            1,
+            false,
+            true,
+            List.of("\\X", "\\X\\b{g}", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "transparent spacing mark sees preceding base",
+            "Transparent grapheme context lets a SpacingMark stay attached to the hidden preceding"
+                + " base.",
+            "a\u0903",
+            1,
+            2,
+            true,
+            true,
+            List.of("\\b{g}", "\\b{g}\\X", "\\X\\b{g}")),
+        new Scenario(
+            "indic conjunct remains one extended cluster",
+            "Indic conjunct segmentation follows the extended grapheme cluster rules rather than"
+                + " splitting at the virama linker.",
+            "\u0915\u094D\u0937",
+            0,
+            3,
+            false,
+            true,
+            List.of("\\X", "\\X+", "(\\X)+", "\\X\\b{g}", "\\b{g}\\X\\b{g}")),
+        new Scenario(
+            "greedy grapheme quantifiers preserve priority",
+            "Repeated and quantified \\X atoms remain leftmost-first and greedy while preserving"
+                + " capture bounds.",
+            "a\u0301b",
+            0,
+            3,
+            false,
+            true,
+            List.of("(\\X)+", "(\\X)+?", "(\\X)(\\X)", "\\X{2}", "a|\\X", "\\X|a")),
+        new Scenario(
+            "long end-anchored base-plus-mark input uses grapheme engine semantics",
+            "Long inputs exercise optimized engine selection while preserving grapheme-aware end"
+                + " anchors.",
+            ("a\u0301").repeat(1000) + "z",
+            0,
+            2001,
+            false,
+            true,
+            List.of("\\Xz$", "\\X\\b{g}z$")),
+        new Scenario(
+            "long regional-indicator parity remains context relative",
+            "Long regional-indicator runs keep bounded parity state across engine paths.",
+            "\uD83C\uDDE6".repeat(1001),
+            0,
+            2002,
+            false,
+            true,
+            List.of("\\X$")));
+  }
+
+  private static Trace safeTrace(String regex, Scenario scenario) {
+    Pattern pattern = Pattern.compile(regex);
+    Matcher matcher = configure(pattern.matcher(scenario.input()), scenario);
+    int groupCount = matcher.groupCount();
+
+    String matches =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.MATCHES);
+    String lookingAt =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.LOOKING_AT);
+    List<String> finds = findTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> results = resultsTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> resultsAfterFind =
+        resultsAfterFindTrace(configure(pattern.matcher(scenario.input()), scenario));
+
+    return new Trace(groupCount, matches, lookingAt, finds, results, resultsAfterFind);
+  }
+
+  private static Trace jdkTrace(String regex, Scenario scenario) {
+    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regex);
+    java.util.regex.Matcher matcher = configure(pattern.matcher(scenario.input()), scenario);
+    int groupCount = matcher.groupCount();
+
+    String matches =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.MATCHES);
+    String lookingAt =
+        matchTrace(configure(pattern.matcher(scenario.input()), scenario), Operation.LOOKING_AT);
+    List<String> finds = findTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> results = resultsTrace(configure(pattern.matcher(scenario.input()), scenario));
+    List<String> resultsAfterFind =
+        resultsAfterFindTrace(configure(pattern.matcher(scenario.input()), scenario));
+
+    return new Trace(groupCount, matches, lookingAt, finds, results, resultsAfterFind);
+  }
+
+  private static Matcher configure(Matcher matcher, Scenario scenario) {
+    return matcher
+        .region(scenario.start(), scenario.end())
+        .useTransparentBounds(scenario.transparentBounds())
+        .useAnchoringBounds(scenario.anchoringBounds());
+  }
+
+  private static java.util.regex.Matcher configure(
+      java.util.regex.Matcher matcher, Scenario scenario) {
+    return matcher
+        .region(scenario.start(), scenario.end())
+        .useTransparentBounds(scenario.transparentBounds())
+        .useAnchoringBounds(scenario.anchoringBounds());
+  }
+
+  private static String matchTrace(Matcher matcher, Operation operation) {
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+        };
+    return matched ? capturedMatchTrace(matcher) : "NO_MATCH";
+  }
+
+  private static String matchTrace(java.util.regex.Matcher matcher, Operation operation) {
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+        };
+    return matched ? capturedMatchTrace(matcher) : "NO_MATCH";
+  }
+
+  private static List<String> findTrace(Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      trace.add(capturedMatchTrace(matcher));
+    }
+    return trace;
+  }
+
+  private static List<String> findTrace(java.util.regex.Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      trace.add(capturedMatchTrace(matcher));
+    }
+    return trace;
+  }
+
+  private static List<String> resultsTrace(Matcher matcher) {
+    return matcher.results().map(GraphemeRegionCompatibilityMatrixTest::matchResultTrace).toList();
+  }
+
+  private static List<String> resultsTrace(java.util.regex.Matcher matcher) {
+    return matcher.results().map(GraphemeRegionCompatibilityMatrixTest::matchResultTrace).toList();
+  }
+
+  private static List<String> resultsAfterFindTrace(Matcher matcher) {
+    if (!matcher.find()) {
+      return List.of();
+    }
+    return resultsTrace(matcher);
+  }
+
+  private static List<String> resultsAfterFindTrace(java.util.regex.Matcher matcher) {
+    if (!matcher.find()) {
+      return List.of();
+    }
+    return resultsTrace(matcher);
+  }
+
+  private static String capturedMatchTrace(Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(matcher.start()).append('-').append(matcher.end());
+    for (int group = 0; group <= matcher.groupCount(); group++) {
+      appendGroup(builder, group, matcher.start(group), matcher.end(group), matcher.group(group));
+    }
+    return builder.toString();
+  }
+
+  private static String matchResultTrace(MatchResult result) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(result.start()).append('-').append(result.end());
+    for (int group = 0; group <= result.groupCount(); group++) {
+      appendGroup(builder, group, result.start(group), result.end(group), result.group(group));
+    }
+    return builder.toString();
+  }
+
+  private static String capturedMatchTrace(java.util.regex.Matcher matcher) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(matcher.start()).append('-').append(matcher.end());
+    for (int group = 0; group <= matcher.groupCount(); group++) {
+      appendGroup(builder, group, matcher.start(group), matcher.end(group), matcher.group(group));
+    }
+    return builder.toString();
+  }
+
+  private static void appendGroup(
+      StringBuilder builder, int group, int start, int end, String value) {
+    builder
+        .append(";g")
+        .append(group)
+        .append('=')
+        .append(start)
+        .append('-')
+        .append(end)
+        .append(':')
+        .append(value == null ? "<null>" : value);
+  }
+
+  private record Scenario(
+      String name,
+      String invariant,
+      String input,
+      int start,
+      int end,
+      boolean transparentBounds,
+      boolean anchoringBounds,
+      List<String> regexes) {
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record Trace(
+      int groupCount,
+      String matches,
+      String lookingAt,
+      List<String> finds,
+      List<String> results,
+      List<String> resultsAfterFind) {}
+
+  private enum Operation {
+    MATCHES,
+    LOOKING_AT
+  }
+}

--- a/safere/src/test/java/org/safere/GraphemeRegionModelTest.java
+++ b/safere/src/test/java/org/safere/GraphemeRegionModelTest.java
@@ -1,0 +1,156 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Tests for SafeRE's documented grapheme-region model where it intentionally diverges from JDK. */
+@DisabledForCrosscheck(
+    "SafeRE's documented grapheme-region model intentionally diverges from selected JDK traces")
+class GraphemeRegionModelTest {
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("regionLocalCases")
+  @DisplayName("opaque region-local grapheme behavior is compositional")
+  void opaqueRegionLocalGraphemeBehaviorIsCompositional(Case testCase) {
+    Matcher matcher =
+        Pattern.compile(testCase.regex())
+            .matcher(testCase.input())
+            .region(testCase.start(), testCase.end());
+
+    assertThat(findTrace(matcher)).containsExactlyElementsOf(testCase.expectedFinds());
+  }
+
+  private static Stream<Arguments> regionLocalCases() {
+    return Stream.of(
+        Arguments.of(
+            new Case(
+                "explicit boundaries compose across ordinary characters",
+                "\\b{g}\\X\\b{g}",
+                "ab",
+                0,
+                2,
+                List.of("0-1;g0=U+0061", "1-2;g0=U+0062"))),
+        Arguments.of(
+            new Case(
+                "standalone ZWJ at opaque region start has a trailing boundary",
+                "\\X\\b{g}",
+                "\uD83D\uDC69\u200D\uD83D\uDC69",
+                2,
+                5,
+                List.of("2-3;g0=U+200D", "3-5;g0=U+1F469"))),
+        Arguments.of(
+            new Case(
+                "explicit leading boundary composes at opaque low-surrogate region start",
+                "\\b{g}\\X",
+                "\uD83D\uDC4D\uD83C\uDFFB",
+                1,
+                3,
+                List.of("1-2;g0=U+DC4D", "2-4;g0=U+1F3FB"))),
+        Arguments.of(
+            new Case(
+                "explicit leading boundary composes at opaque ZWJ region start",
+                "\\b{g}\\X",
+                "\uD83D\uDC69\u200D\uD83D\uDC69",
+                2,
+                5,
+                List.of("2-3;g0=U+200D", "3-5;g0=U+1F469"))),
+        Arguments.of(
+            new Case(
+                "explicit boundaries compose around standalone ZWJ at opaque region start",
+                "\\b{g}\\X\\b{g}",
+                "\uD83D\uDC69\u200D\uD83D\uDC69",
+                2,
+                5,
+                List.of("2-3;g0=U+200D", "3-5;g0=U+1F469"))),
+        Arguments.of(
+            new Case(
+                "explicit boundaries compose after a control before an extender",
+                "\\b{g}\\X\\b{g}",
+                "a\u0000\u0301",
+                1,
+                3,
+                List.of("1-2;g0=U+0000", "2-3;g0=U+0301"))),
+        Arguments.of(
+            new Case(
+                "explicit boundaries compose around an Indic suffix region",
+                "\\b{g}\\X\\b{g}",
+                "\u0915\u094D\u0937",
+                1,
+                3,
+                List.of("1-2;g0=U+094D", "2-3;g0=U+0937"))),
+        Arguments.of(
+            new Case(
+                "unanchored chained clusters can start at an Indic suffix",
+                "\\X\\X",
+                "\u0915\u094D\u0937",
+                0,
+                3,
+                List.of("1-3;g0=U+094D U+0937"))),
+        Arguments.of(
+            new Case(
+                "quantified clusters can start at an Indic suffix",
+                "\\X{2}",
+                "\u0915\u094D\u0937",
+                0,
+                3,
+                List.of("1-3;g0=U+094D U+0937"))),
+        Arguments.of(
+            new Case(
+                "captured chained clusters preserve suffix-local captures",
+                "(\\X)(\\X)",
+                "\u0915\u094D\u0937",
+                0,
+                3,
+                List.of("1-3;g0=U+094D U+0937;g1=U+094D;g2=U+0937"))));
+  }
+
+  private static List<String> findTrace(Matcher matcher) {
+    List<String> trace = new ArrayList<>();
+    while (matcher.find()) {
+      StringBuilder builder = new StringBuilder();
+      builder.append(matcher.start()).append('-').append(matcher.end());
+      for (int group = 0; group <= matcher.groupCount(); group++) {
+        builder.append(";g").append(group).append('=').append(codePoints(matcher.group(group)));
+      }
+      trace.add(builder.toString());
+    }
+    return trace;
+  }
+
+  private static String codePoints(String value) {
+    if (value == null) {
+      return "<null>";
+    }
+    StringBuilder builder = new StringBuilder();
+    value
+        .codePoints()
+        .forEach(
+            cp -> {
+              if (!builder.isEmpty()) {
+                builder.append(' ');
+              }
+              builder.append(String.format("U+%04X", cp));
+            });
+    return builder.toString();
+  }
+
+  private record Case(
+      String name, String regex, String input, int start, int end, List<String> expectedFinds) {
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/InstOpTest.java
+++ b/safere/src/test/java/org/safere/InstOpTest.java
@@ -15,8 +15,7 @@ class InstOpTest {
 
   @Test
   void allOpsAreDefined() {
-    // 8 opcodes as defined in RE2's prog.h
-    assertThat(InstOp.values().length).isEqualTo(10);
+    assertThat(InstOp.values().length).isEqualTo(11);
   }
 
   @Test
@@ -29,5 +28,8 @@ class InstOpTest {
     assertThat(InstOp.MATCH.ordinal()).isEqualTo(5);
     assertThat(InstOp.NOP.ordinal()).isEqualTo(6);
     assertThat(InstOp.FAIL.ordinal()).isEqualTo(7);
+    assertThat(InstOp.CHAR_CLASS.ordinal()).isEqualTo(8);
+    assertThat(InstOp.GRAPHEME_CLUSTER.ordinal()).isEqualTo(9);
+    assertThat(InstOp.PROGRESS_CHECK.ordinal()).isEqualTo(10);
   }
 }

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -280,10 +280,22 @@ class LinebreakGraphemeTest {
       assertTraceSameAsJdk("\\X", "\u0301\u0301\u200D", 0, 3);
       assertTraceSameAsJdk("\\X", "\u0301\u200Da", 0, 3);
       assertTraceSameAsJdk("\\X", "a\u0301\u200D\uD83D\uDE00\u0300", 1, 5);
-      assertTraceSameAsJdk("\\X", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
       assertTraceSameAsJdk("\\X\\X", "\u0301\u200Da", 0, 3);
       assertTraceSameAsJdk("\\X\\b{g}", "\u200D\uD83D\uDC69", 0, 3);
       assertTraceSameAsJdk("\\X\\b{g}", "\uDE00\u200D\uD83D\uDC69", 0, 4);
+    }
+
+    @Test
+    @DisplayName("\\X repeated find respects region-local transparent bounds")
+    void repeatedFindRespectsRegionLocalTransparentBounds() {
+      assertTransparentTraceSameAsJdk("\\X", "aa\u0300", 1, 2);
+      assertTransparentTraceSameAsJdk("\\X", "\uD83Da\u0301", 1, 2);
+      assertTransparentTraceSameAsJdk("\\X", "\uD83Dab\u0301", 1, 3);
+      assertTransparentTraceSameAsJdk("\\X", "\uD83D\uDE00", 1, 1);
+      assertTransparentTraceSameAsJdk("\\X", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 5);
+      assertTransparentTraceSameAsJdk("\\X", "\uD83D\uDE00\u0301\uD83D\uDC69", 1, 5);
+      assertTransparentTraceSameAsJdk("^\\X\\X", "\uD83D\uDE00\u200D\uD83D\uDC69", 1, 5);
+      assertTransparentTraceSameAsJdk("^\\X\\X", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 5);
     }
 
     @Test
@@ -305,7 +317,6 @@ class LinebreakGraphemeTest {
       assertTraceSameAsJdk("\\X", "\uD83C\uDDFA\uD83C\uDDFA\u0301", 0, 5);
       assertTraceSameAsJdk("\\X", "\uD83C\uDDFA\uD83C\uDDFA\u200D", 0, 5);
       assertTraceSameAsJdk("\\X", "\uD83C\uDDFA\uD83C\uDDFA\uD83C\uDFFD", 0, 6);
-      assertTraceSameAsJdk("\\X\\X", "#\r\r\uD83C\uDDFA\uD83C\uDDFA\u0301$", 1, 8);
       assertTraceSameAsJdk("\\X", "\u1100\u1161\u0301", 0, 3);
       assertTraceSameAsJdk("\\X", "\uAC00\u11A8\u0301", 0, 3);
     }
@@ -354,53 +365,27 @@ class LinebreakGraphemeTest {
       assertTraceSameAsJdk("\\b{g}", "#\uDE00\u200D\u0301$", 1, 4);
       assertTraceSameAsJdk("\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
       assertFindGroupsSameAsJdk("(\\b{g})", "\uD83D\uDE00\u200D\uD83D\uDE00", 1, 4);
-      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
-      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u200D\uD83D\uDE00", 1, 6);
       assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u0301\uDE00", 1, 4);
       assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\uD83C\uDDFA", 1, 5);
       assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83C\uDDFA", 1, 6);
       assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\u200D\u0301\uD83C\uDDFA", 1, 6);
       assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\uD83C\uDFFD\uD83D\uDE00", 1, 6);
-      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDE00\uD83C\uDFFD\u200D\uD83D\uDE00", 1, 7);
-      assertTraceSameAsJdk("\\X\\b{g}", "\uD83D\uDC69\u200D\uD83D\uDCBB\uDE00", 1, 5);
-      assertTraceSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 5);
-      assertFindGroupsSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDC69", 0, 5);
+      assertTransparentTraceSameAsJdk("\\X\\b{g}", "#\u0301$", 1, 2);
+      assertTransparentTraceSameAsJdk(
+          "\\X\\b{g}", "\uD83D\u0000\u200D\u1100\u0600\uD83D\uDC69\u0903", 1, 7);
       assertTraceSameAsJdk("\\X\\X", "\r\uDE00\u0301", 0, 3);
       assertTraceSameAsJdk("\\X\\X", "\uDE00\uDE00\u0301", 0, 3);
       assertTraceSameAsJdk("\\X\\X", "#\uDE00\uD83D\uDC69\u200D\uD83D\uDC69\u0301$", 1, 8);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDE8$", 1, 7);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\r\uD83C\uDDFA$", 1, 4);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "#\u200D\uD83D\uDC69$", 1, 4);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\r\r\uDE00", 1, 5);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\r\r", 1, 5);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\r\n", 1, 5);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uDE00\uDE00", 1, 5);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u0301\r", 1, 7);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u200D\uDE00a", 1, 8);
-      assertTraceSameAsJdk(
-          "\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\uD83D\uDC69\u200D\uD83D\uDC69", 1, 8);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDC69\u0301a", 1, 8);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u200D\u200D\uD83D\uDC69\u200Da", 1, 8);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D\uDE00", 1, 6);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83C\uDDFA", 1, 6);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uD83D\uDE00\u0301\u200D\uD83D", 1, 5);
       assertTraceSameAsJdk("^\\X\\X$", "\uD83D\uDE00\r\r\uDE00", 1, 4);
       assertTraceSameAsJdk("^\\X\\X$", "\uD83D\uDE00a\u0903\r\n\uDE00", 1, 6);
-      assertTraceSameAsJdk(
-          "\\X\\X",
-          "#\uD83D\uDC69\uD83C\uDFFD\u200D\uD83D\uDC69\uD83C\uDFFD"
-              + "\u200D\uD83D\uDC69\uD83C\uDFFD$",
-          1,
-          15);
+      assertTransparentTraceSameAsJdk("\\b{g}a\\u0300\\b{g}", "aa\u0300\u0300", 1, 3);
     }
 
     @Test
-    @DisplayName("repeated find does not split regional-indicator pairs after controls")
-    void repeatedFindDoesNotSplitRegionalIndicatorPairsAfterControls() {
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\uAC01\uD83C\uDDFA\uD83C\uDDFA\r", 0, 6);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "a\uD83C\uDDFA\u200D\uD83C\uDDFA", 0, 6);
-      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", "\r\u0903\u0903\u0903\u1100", 0, 5);
-      assertTraceSameAsJdk("\\X\\X", "#\r\r\uD83C\uDDFA\uD83C\uDDFA$", 1, 7);
+    @DisplayName("\\X repeated find keeps valid split-surrogate region-local candidates")
+    void repeatedFindKeepsValidSplitSurrogateRegionLocalCandidates() {
+      assertTraceSameAsJdk("\\X", "\uD83D\uDE00\u200D\u0301", 1, 3);
+      assertTraceSameAsJdk("\\X", "\uD83D\uDE00a\u0301", 1, 3);
     }
 
     @Test
@@ -455,6 +440,40 @@ class LinebreakGraphemeTest {
     }
 
     @Test
+    @DisplayName("greedy \\X+ find consumes all adjacent clusters")
+    void greedyPlusFindConsumesAllAdjacentClusters() {
+      Matcher ascii = Pattern.compile("\\X+").matcher("ab");
+      assertThat(ascii.find()).isTrue();
+      assertThat(ascii.start()).isZero();
+      assertThat(ascii.end()).isEqualTo(2);
+      assertThat(ascii.find()).isFalse();
+
+      Matcher combining = Pattern.compile("\\X+").matcher("a\u0301b");
+      assertThat(combining.find()).isTrue();
+      assertThat(combining.start()).isZero();
+      assertThat(combining.end()).isEqualTo(3);
+      assertThat(combining.group()).isEqualTo("a\u0301b");
+      assertThat(combining.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("ordered alternation preserves earlier branches before \\X")
+    void orderedAlternationPreservesEarlierBranchesBeforeGraphemeCluster() {
+      assertTraceSameAsJdk("a|\\X", "a\u0301b", 0, 3);
+      assertFindGroupsSameAsJdk("(a)|(\\X)", "a\u0301b", 0, 3);
+    }
+
+    @Test
+    @DisabledForCrosscheck(
+        "SafeRE's region-local grapheme model intentionally diverges from selected JDK traces")
+    @DisplayName("repeated find resumes after leading grapheme-boundary clusters")
+    void repeatedFindResumesAfterLeadingGraphemeBoundaryClusters() {
+      assertSafeReFindBounds("\\b{g}\\X", "ab", 0, 2, List.of("0-1", "1-2"));
+      assertSafeReFindBounds("\\b{g}\\X", "a\u0301b", 0, 3, List.of("0-2", "2-3"));
+      assertSafeReFindBounds("(\\b{g})(\\X)", "ab", 0, 2, List.of("0-1", "1-2"));
+    }
+
+    @Test
     @DisplayName("\\X inside [...] is rejected")
     void rejectedInsideCharClass() {
       assertThatThrownBy(() -> Pattern.compile("[\\X]")).isInstanceOf(PatternSyntaxException.class);
@@ -472,15 +491,21 @@ class LinebreakGraphemeTest {
     }
 
     @Test
-    @DisplayName("unanchored consecutive \\X atoms follow JDK search positions")
-    void unanchoredConsecutiveAtomsFollowJdkSearchPositions() {
-      assertFindBoundsSameAsJdk("\\X\\X", "\uD83C\uDDFA\uD83C\uDDF8");
-      assertFindBoundsSameAsJdk("\\X{2}", "\uD83D\uDC4D\uD83C\uDFFD");
-      assertFindBoundsSameAsJdk("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDCBB");
-      assertFindBoundsSameAsJdk("(?:\\X)(?:\\X)", "\uD83C\uDDFA\uD83C\uDDF8");
-      assertFindBoundsSameAsJdk("\\X{1}\\X", "\uD83C\uDDFA\uD83C\uDDF8");
-      assertFindBoundsSameAsJdk("(?:\\X){2}", "\uD83C\uDDFA\uD83C\uDDF8");
-      assertFindBoundsSameAsJdk("\\X+", "ab");
+    @DisplayName("unanchored \\X chains can start at UTF-16 low-surrogate offsets")
+    void unanchoredChainsCanStartAtLowSurrogateOffsets() {
+      assertFirstFindBounds("\\X\\X", "\uD83C\uDDFA\uD83C\uDDF8", 1, 4);
+      assertFirstFindBounds("\\X{2}", "\uD83C\uDDFA\uD83C\uDDF8", 1, 4);
+      assertFirstFindBounds("(?:\\X)(?:\\X)", "\uD83D\uDC4D\uD83C\uDFFD", 1, 4);
+      assertFirstFindBounds("(\\X)(\\X)", "\uD83D\uDC69\u200D\uD83D\uDCBB", 1, 3);
+      assertTraceSameAsJdk("\\X\\X\\X", "a\uD83D\uDC69\u200D\uD83D\uDC69", 0, 6);
+      assertTraceSameAsJdk("\\X{3}", "a\uD83D\uDC69\u200D\uD83D\uDC69", 0, 6);
+      assertTraceSameAsJdk("(?:\\X)(?:\\X)(?:\\X)", "a\uD83D\uDC69\u200D\uD83D\uDC69", 0, 6);
+    }
+
+    @Test
+    @DisplayName("end-anchored \\X searches keep correct long-input bounds")
+    void endAnchoredGraphemeSearchesKeepCorrectLongInputBounds() {
+      assertFirstFindBounds("\\Xz$", "a".repeat(2_000) + "z", 1_999, 2_001);
     }
 
     @Test
@@ -549,6 +574,20 @@ class LinebreakGraphemeTest {
     }
 
     @Test
+    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
+    @DisplayName("failed unanchored \\X suffix misses stay near-linear")
+    void failedUnanchoredGraphemeSuffixMissesStayNearLinear() {
+      Pattern pattern = Pattern.compile("\\Xz");
+
+      assertFourXInputStaysNearLinear(
+          "failed unanchored \\X suffix miss",
+          length -> assertThat(pattern.matcher("a" + "\u0301".repeat(length)).find()).isFalse());
+      assertFourXInputStaysNearLinear(
+          "failed unanchored regional-indicator \\X suffix miss",
+          length -> assertThat(pattern.matcher("\uD83C\uDDE6".repeat(length)).find()).isFalse());
+    }
+
+    @Test
     @DisplayName("consecutive \\X atoms do not split a single grapheme cluster")
     void consecutiveAtomsDoNotSplitSingleCluster() {
       Pattern p = Pattern.compile("^\\X\\X$");
@@ -559,17 +598,6 @@ class LinebreakGraphemeTest {
       assertThat(p.matcher("\u0600a").matches()).isFalse();
       assertThat(p.matcher("\u1100\u1161").matches()).isFalse();
       assertThat(p.matcher("e\u0301a").matches()).isTrue();
-    }
-
-    @Test
-    @DisplayName("consecutive \\X atoms respect regions split inside surrogate pairs")
-    void consecutiveAtomsRespectRegionsSplitInsideSurrogatePairs() {
-      String regionEndsInsidePair = "\uDE00\uD83D\uDE00";
-      assertTraceSameAsJdk("^\\X\\X$", regionEndsInsidePair, 0, 2);
-      assertTraceSameAsJdk("\\X{2}", regionEndsInsidePair, 0, 2);
-
-      String regionStartsInsidePair = "\uD83D\uDE00\uD83D\uDE01";
-      assertTraceSameAsJdk("\\X{2}", regionStartsInsidePair, 1, 4);
     }
 
     @Test
@@ -624,6 +652,26 @@ class LinebreakGraphemeTest {
       assertThat(m.group()).isEqualTo("\uD83C\uDDE8");
 
       assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("opaque regions reset regional-indicator grapheme parity")
+    void opaqueRegionsResetRegionalIndicatorGraphemeParity() {
+      String regionalIndicators = "\uD83C\uDDE6".repeat(3);
+
+      assertTraceSameAsJdk("\\X", regionalIndicators, 2, 6);
+      assertTraceSameAsJdk("\\b{g}", regionalIndicators, 2, 6);
+      assertTraceSameAsJdk("\\b{g}\\X", regionalIndicators, 2, 6);
+      assertTraceSameAsJdk("\\b{g}\\X\\b{g}", regionalIndicators, 2, 6);
+    }
+
+    @Test
+    @DisplayName("transparent boundaries keep full-input regional-indicator parity")
+    void transparentBoundariesKeepFullInputRegionalIndicatorParity() {
+      String regionalIndicators = "\uD83C\uDDE6".repeat(3);
+
+      assertTransparentTraceSameAsJdk("\\b{g}", regionalIndicators, 2, 6);
+      assertTransparentTraceSameAsJdk("\\b{g}\\X", regionalIndicators, 2, 6);
     }
 
     @Test
@@ -736,6 +784,16 @@ class LinebreakGraphemeTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
+    private void assertFirstFindBounds(String regex, String input, int start, int end) {
+      Matcher matcher = Pattern.compile(regex).matcher(input);
+      assertThat(matcher.find()).as("first find() for /%s/ on %s", regex, input).isTrue();
+      assertThat(matcher.start())
+          .as("first find() start for /%s/ on %s", regex, input)
+          .isEqualTo(start);
+      assertThat(matcher.end()).as("first find() end for /%s/ on %s", regex, input).isEqualTo(end);
+      assertThat(matcher.find()).as("second find() for /%s/ on %s", regex, input).isFalse();
+    }
+
     private void assertFindGroupsSameAsJdk(String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
@@ -746,6 +804,27 @@ class LinebreakGraphemeTest {
       for (int group = 0; group <= jdkMatcher.groupCount(); group++) {
         assertThat(safeMatcher.group(group))
             .as("group %s for /%s/ on %s region [%s,%s]", group, regex, input, start, end)
+            .isEqualTo(jdkMatcher.group(group));
+      }
+    }
+
+    private void assertTransparentFindGroupsSameAsJdk(
+        String regex, String input, int start, int end) {
+      java.util.regex.Matcher jdkMatcher =
+          java.util.regex.Pattern.compile(regex)
+              .matcher(input)
+              .region(start, end)
+              .useTransparentBounds(true);
+      Matcher safeMatcher =
+          Pattern.compile(regex).matcher(input).region(start, end).useTransparentBounds(true);
+
+      assertThat(safeMatcher.find()).as("SafeRE find() should match").isEqualTo(jdkMatcher.find());
+      assertThat(safeMatcher.groupCount()).isEqualTo(jdkMatcher.groupCount());
+      for (int group = 0; group <= jdkMatcher.groupCount(); group++) {
+        assertThat(safeMatcher.group(group))
+            .as(
+                "group %s for transparent /%s/ on %s region [%s,%s]",
+                group, regex, input, start, end)
             .isEqualTo(jdkMatcher.group(group));
       }
     }
@@ -782,6 +861,56 @@ class LinebreakGraphemeTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
+    private void assertSafeReFindBounds(
+        String regex, String input, int start, int end, List<String> expected) {
+      Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
+      List<String> safeMatches = new ArrayList<>();
+      while (safeMatcher.find()) {
+        safeMatches.add(safeMatcher.start() + "-" + safeMatcher.end());
+      }
+      assertThat(safeMatches)
+          .as("SafeRE find() positions for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .containsExactlyElementsOf(expected);
+    }
+
+    private void assertTransparentTraceSameAsJdk(String regex, String input, int start, int end) {
+      java.util.regex.Matcher jdkMatcher =
+          java.util.regex.Pattern.compile(regex)
+              .matcher(input)
+              .region(start, end)
+              .useTransparentBounds(true);
+      Matcher safeMatcher =
+          Pattern.compile(regex).matcher(input).region(start, end).useTransparentBounds(true);
+
+      assertThat(safeMatcher.matches())
+          .as("transparent matches() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .isEqualTo(jdkMatcher.matches());
+
+      jdkMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      safeMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      assertThat(safeMatcher.lookingAt())
+          .as("transparent lookingAt() for /%s/ on %s region [%s,%s]", regex, input, start, end)
+          .isEqualTo(jdkMatcher.lookingAt());
+
+      jdkMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      safeMatcher.reset(input).region(start, end).useTransparentBounds(true);
+      List<int[]> jdkMatches = new ArrayList<>();
+      while (jdkMatcher.find()) {
+        jdkMatches.add(new int[] {jdkMatcher.start(), jdkMatcher.end()});
+      }
+
+      List<int[]> safeMatches = new ArrayList<>();
+      while (safeMatcher.find()) {
+        safeMatches.add(new int[] {safeMatcher.start(), safeMatcher.end()});
+      }
+
+      assertThat(safeMatches)
+          .as(
+              "transparent find() positions for /%s/ on %s region [%s,%s]",
+              regex, input, start, end)
+          .containsExactly(jdkMatches.toArray(int[][]::new));
+    }
+
     private long allocatedForImmediateTwoClusterFind(
         AllocationTracker allocationTracker, long threadId, Pattern pattern, String text) {
       long before = allocationTracker.allocatedBytes(threadId);
@@ -797,9 +926,9 @@ class LinebreakGraphemeTest {
     }
 
     private void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
-      task.accept(100);
-      long smallerNanos = bestRuntimeNanos(() -> task.accept(1_000));
-      long largerNanos = bestRuntimeNanos(() -> task.accept(4_000));
+      task.accept(1_000);
+      long smallerNanos = bestRuntimeNanos(() -> task.accept(5_000));
+      long largerNanos = bestRuntimeNanos(() -> task.accept(20_000));
 
       assertThat(largerNanos)
           .as(

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1681,6 +1681,21 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("grapheme matches() stays bounded to region without anchoring bounds")
+    void graphemeMatchesStaysRegionBoundedWithoutAnchoringBounds() {
+      java.util.regex.Matcher jdk =
+          java.util.regex.Pattern.compile("\\X").matcher("#a$").region(1, 2);
+      jdk.useAnchoringBounds(false);
+      assertThat(jdk.matches()).isTrue();
+
+      Matcher m = Pattern.compile("\\X").matcher("#a$").region(1, 2);
+      m.useAnchoringBounds(false);
+      assertThat(m.matches()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.end()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("matches() fails if region doesn't fully match")
     void matchesFailsPartialRegion() {
       Pattern p = Pattern.compile("\\d+");
@@ -1787,6 +1802,24 @@ class MatcherTest {
       m.region(3, 6); // "123"
       m.useAnchoringBounds(false);
       assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("$ uses full-text trailing terminator context without anchoring bounds")
+    void dollarUsesFullTextTrailingTerminatorContextWithoutAnchoringBounds() {
+      Pattern anchored = Pattern.compile("^[\\s\\S][\\s\\S]$");
+      Matcher anchoredMatcher = anchored.matcher("a\u0000\n\n");
+      anchoredMatcher.region(0, 3);
+      anchoredMatcher.useAnchoringBounds(false);
+      assertThat(anchoredMatcher.find()).isFalse();
+
+      Pattern unanchored = Pattern.compile("[\\s\\S][\\s\\S]$");
+      Matcher unanchoredMatcher = unanchored.matcher("a\u0000\n\n");
+      unanchoredMatcher.region(0, 3);
+      unanchoredMatcher.useAnchoringBounds(false);
+      assertThat(unanchoredMatcher.find()).isTrue();
+      assertThat(unanchoredMatcher.start()).isEqualTo(1);
+      assertThat(unanchoredMatcher.end()).isEqualTo(3);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/ParseFlagsTest.java
+++ b/safere/src/test/java/org/safere/ParseFlagsTest.java
@@ -34,7 +34,6 @@ class ParseFlagsTest {
     assertThat(ParseFlags.WAS_DOLLAR).isEqualTo(32768);
     assertThat(ParseFlags.UNIX_LINES).isEqualTo(65536);
     assertThat(ParseFlags.UNICODE_CASE).isEqualTo(131072);
-    assertThat(ParseFlags.SYNTHETIC_GRAPHEME_CLUSTER_BOUNDARY).isEqualTo(262144);
   }
 
   @Test
@@ -56,7 +55,7 @@ class ParseFlagsTest {
 
   @Test
   void allFlagsCoversAllBits() {
-    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 19) - 1);
+    assertThat(ParseFlags.ALL_FLAGS).isEqualTo((1 << 18) - 1);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/PatternSetTest.java
+++ b/safere/src/test/java/org/safere/PatternSetTest.java
@@ -9,10 +9,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntConsumer;
 import java.util.regex.PatternSyntaxException;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -157,6 +161,59 @@ class PatternSetTest {
           "PatternSet regional-indicator boundary miss",
           length -> assertThat(set.match("\uD83C\uDDE6".repeat(length))).isEmpty());
     }
+
+    @Test
+    void graphemeClusterPatternMatches() {
+      PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.UNANCHORED);
+      b.add("\\X");
+      b.add("z");
+      PatternSet set = b.compile();
+
+      assertThat(set.match("a")).containsExactly(0);
+      assertThat(set.match("e\u0301")).containsExactly(0);
+      assertThat(set.match("z")).containsExactly(0, 1);
+    }
+
+    @Test
+    void graphemeFallbackDoesNotRecompileMembersPerMatch() {
+      PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.UNANCHORED);
+      List<String> patterns = new ArrayList<>();
+      patterns.add("\\X");
+      b.add(patterns.getFirst());
+      for (int i = 0; i < 64; i++) {
+        String pattern = "literal" + i;
+        patterns.add(pattern);
+        b.add(pattern);
+      }
+      PatternSet set = b.compile();
+      AllocationTracker allocationTracker = allocationTracker();
+      long threadId = Thread.currentThread().threadId();
+
+      set.match("a");
+      compileAndMatchEachPattern(patterns, "a");
+      long compileEachTimeAllocated =
+          allocatedFor(
+              allocationTracker,
+              threadId,
+              () -> {
+                for (int i = 0; i < 50; i++) {
+                  compileAndMatchEachPattern(patterns, "a");
+                }
+              });
+      long cachedSetAllocated =
+          allocatedFor(
+              allocationTracker,
+              threadId,
+              () -> {
+                for (int i = 0; i < 50; i++) {
+                  assertThat(set.match("a")).containsExactly(0);
+                }
+              });
+
+      assertThat(cachedSetAllocated)
+          .as("grapheme PatternSet fallback should reuse compile-time member patterns")
+          .isLessThan(compileEachTimeAllocated / 2);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -222,6 +279,18 @@ class PatternSetTest {
       assertThat(set.match("abc")).containsExactly(0, 1, 2);
       assertThat(set.match("xyz")).containsExactly(1, 2);
       assertThat(set.match("abcd")).containsExactly(1);
+    }
+
+    @Test
+    void graphemeClusterPatternMatchesWholeText() {
+      PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.ANCHOR_BOTH);
+      b.add("\\X");
+      b.add("\\X+");
+      PatternSet set = b.compile();
+
+      assertThat(set.match("a")).containsExactly(0, 1);
+      assertThat(set.match("e\u0301")).containsExactly(0, 1);
+      assertThat(set.match("ab")).containsExactly(1);
     }
   }
 
@@ -552,9 +621,9 @@ class PatternSetTest {
   }
 
   private static void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
-    task.accept(100);
-    long smallerNanos = bestRuntimeNanos(() -> task.accept(1_000));
-    long largerNanos = bestRuntimeNanos(() -> task.accept(4_000));
+    task.accept(1_000);
+    long smallerNanos = bestRuntimeNanos(() -> task.accept(5_000));
+    long largerNanos = bestRuntimeNanos(() -> task.accept(20_000));
 
     assertThat(largerNanos)
         .as(
@@ -579,5 +648,55 @@ class PatternSetTest {
           task.run();
           return System.nanoTime() - start;
         });
+  }
+
+  private static long allocatedFor(
+      AllocationTracker allocationTracker, long threadId, Runnable task) {
+    long before = allocationTracker.allocatedBytes(threadId);
+    task.run();
+    return allocationTracker.allocatedBytes(threadId) - before;
+  }
+
+  private static void compileAndMatchEachPattern(List<String> patterns, String text) {
+    for (String pattern : patterns) {
+      Pattern.compile(pattern).matcher(text).find();
+    }
+  }
+
+  private static AllocationTracker allocationTracker() {
+    try {
+      Class<?> managementFactoryClass = Class.forName("java.lang.management.ManagementFactory");
+      Object threadBean = managementFactoryClass.getMethod("getThreadMXBean").invoke(null);
+      Class<?> allocationBeanClass = Class.forName("com.sun.management.ThreadMXBean");
+      Assumptions.assumeTrue(allocationBeanClass.isInstance(threadBean));
+
+      Method supportedMethod = allocationBeanClass.getMethod("isThreadAllocatedMemorySupported");
+      Method enabledMethod = allocationBeanClass.getMethod("isThreadAllocatedMemoryEnabled");
+      Method setEnabledMethod =
+          allocationBeanClass.getMethod("setThreadAllocatedMemoryEnabled", boolean.class);
+      Method allocatedBytesMethod =
+          allocationBeanClass.getMethod("getThreadAllocatedBytes", long.class);
+
+      Assumptions.assumeTrue((Boolean) supportedMethod.invoke(threadBean));
+      if (!(Boolean) enabledMethod.invoke(threadBean)) {
+        setEnabledMethod.invoke(threadBean, true);
+      }
+      return new AllocationTracker(threadBean, allocatedBytesMethod);
+    } catch (ReflectiveOperationException e) {
+      Assumptions.abort("thread allocation tracking is unavailable: " + e);
+      throw new AssertionError("unreachable");
+    }
+  }
+
+  private record AllocationTracker(Object threadBean, Method allocatedBytesMethod) {
+    long allocatedBytes(long threadId) {
+      try {
+        return (Long) allocatedBytesMethod.invoke(threadBean, threadId);
+      } catch (IllegalAccessException e) {
+        throw new AssertionError(e);
+      } catch (InvocationTargetException e) {
+        throw new AssertionError(e.getCause());
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Replace grapheme compatibility patchwork with native `\X` compilation and NFA execution.
- Make grapheme-region matching explicit around UTF-16 search positions, region-local scalar consumption, transparent/opaque bounds, and anchor context.
- Add focused grapheme-region compatibility/model matrices, quarantine JDK implementation-detail traces, and expand the exhaustive grapheme sweep classification/output workflow.
- Add replay/fuzz coverage for the grapheme candidate-start and region-edge cases found during review.

Fixes #414 

## Follow-up

- Refs #448 for no-behavior-change refactoring of the engine context and grapheme segmentation structure.

## Verification

Current rebased HEAD:

- `git diff --check origin/main..HEAD`
- `mvn -pl safere -Dtest=BoundaryMatcherTest,GraphemeRegionCompatibilityMatrixTest,EndAnchorRegionCompatibilityMatrixTest test -q`

Development verification before the final rebase:

- `mvn -pl safere -Dtest=BoundaryMatcherTest,GraphemeRegionCompatibilityMatrixTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=UnicodeFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- replayed 33,120 grapheme divergence rows from the targeted range outputs: `divergences=0`
- `mvn -pl safere test -q`
- `mvn -pl safere,safere-fuzz,safere-exhaustive spotless:check -q`
- `mvn -pl safere-exhaustive -Dtest=SweepCliSmokeTest test -q`

Not run:

- Full `mvn -pl safere test -q` after the final rebase.
- Full public API crosscheck profile: `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`.
