### PR TITLE
Fix Unicode case-folding class closure

### DIFF
--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -176,3 +176,32 @@ compile acceptance and full-match membership between SafeRE and
 Use this sweep before review when changing control-escape parsing behavior. The
 full matrix is bounded and has roughly 36 million generated cases. Range bounds
 and replay files use the same conventions as the character-class sweep.
+
+## Case-Folding Character-Class Sweep
+
+Run through the dispatcher script:
+
+```bash
+./run-exhaustive-sweep.sh CaseFoldingCharacterClassDivergenceSweep \
+  --output-dir=target/exhaustive-reports/case-folding-character-class-sweep-full
+```
+
+For a smaller ad hoc local check, run a generated-case index range:
+
+```bash
+./run-exhaustive-sweep.sh CaseFoldingCharacterClassDivergenceSweep --range=:100000 \
+  --output-dir=target/exhaustive-reports/case-folding-character-class-sweep-smoke
+```
+
+The case-folding character-class sweep compares SafeRE with `java.util.regex`
+for case-insensitive membership across every Unicode code point. It focuses on
+explicit cased literals, singleton classes, high-risk ASCII ranges such as
+`[h-j]`, Unicode general categories such as `\p{Lu}`, `\p{Ll}`, and `\p{Lt}`,
+their common spelling variants, negated category/range forms, and a quantified
+titlecase-category case. Flag axes include `CASE_INSENSITIVE`,
+`CASE_INSENSITIVE | UNICODE_CASE`, and
+`CASE_INSENSITIVE | UNICODE_CHARACTER_CLASS`.
+
+Use this sweep before review when changing case-folding, Unicode category, or
+character-class expansion behavior. Range bounds and replay files use the same
+conventions as the other exhaustive sweeps.

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CaseFoldingCharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CaseFoldingCharacterClassDivergenceSweep.java
@@ -1,0 +1,388 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.exhaustive;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.PatternSyntaxException;
+
+/** Offline differential sweep for case-insensitive character-class closure bugs. */
+public final class CaseFoldingCharacterClassDivergenceSweep {
+  private static final int INPUT_COUNT = Character.MAX_CODE_POINT + 1;
+
+  private static final List<FlagMode> FLAG_MODES =
+      List.of(
+          new FlagMode("caseInsensitive", java.util.regex.Pattern.CASE_INSENSITIVE),
+          new FlagMode(
+              "unicodeCase",
+              java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.UNICODE_CASE),
+          new FlagMode(
+              "unicodeCharacterClass",
+              java.util.regex.Pattern.CASE_INSENSITIVE
+                  | java.util.regex.Pattern.UNICODE_CHARACTER_CLASS));
+
+  private static final List<PatternSpec> PATTERNS =
+      List.of(
+          pattern("literalLowerI", "\\x{69}"),
+          pattern("literalUpperI", "\\x{49}"),
+          pattern("literalLowerK", "\\x{6B}"),
+          pattern("literalUpperK", "\\x{4B}"),
+          pattern("literalLongS", "\\x{17F}"),
+          pattern("literalGreekSigma", "\\x{3A3}"),
+          pattern("literalGreekFinalSigma", "\\x{3C2}"),
+          pattern("classLowerI", "[\\x{69}]"),
+          pattern("classUpperI", "[\\x{49}]"),
+          pattern("classLowerK", "[\\x{6B}]"),
+          pattern("classUpperK", "[\\x{4B}]"),
+          pattern("classLongS", "[\\x{17F}]"),
+          pattern("rangeLowerAZ", "[a-z]"),
+          pattern("rangeUpperAZ", "[A-Z]"),
+          pattern("rangeLowerHJ", "[h-j]"),
+          pattern("rangeUpperHJ", "[H-J]"),
+          pattern("negatedRangeLowerHJ", "[^h-j]"),
+          pattern("negatedRangeUpperHJ", "[^H-J]"),
+          pattern("categoryUpper", "\\p{Lu}"),
+          pattern("categoryLower", "\\p{Ll}"),
+          pattern("categoryTitle", "\\p{Lt}"),
+          pattern("categoryLetter", "\\p{L}"),
+          pattern("categoryIsUpper", "\\p{IsLu}"),
+          pattern("categoryIsLower", "\\p{IsLl}"),
+          pattern("categoryIsTitle", "\\p{IsLt}"),
+          pattern("categoryGeneralUpper", "\\p{gc=Lu}"),
+          pattern("categoryGeneralLower", "\\p{gc=Ll}"),
+          pattern("categoryGeneralTitle", "\\p{gc=Lt}"),
+          pattern("classCategoryUpper", "[\\p{Lu}]"),
+          pattern("classCategoryLower", "[\\p{Ll}]"),
+          pattern("classCategoryTitle", "[\\p{Lt}]"),
+          pattern("negatedCategoryUpper", "\\P{Lu}"),
+          pattern("negatedCategoryLower", "\\P{Ll}"),
+          pattern("negatedCategoryTitle", "\\P{Lt}"),
+          pattern("classNegatedCategoryUpper", "[^\\p{Lu}]"),
+          pattern("classNegatedCategoryLower", "[^\\p{Ll}]"),
+          pattern("classNegatedCategoryTitle", "[^\\p{Lt}]"),
+          pattern("javaLower", "\\p{javaLowerCase}"),
+          pattern("javaUpper", "\\p{javaUpperCase}"),
+          pattern("titleRepeat4", "\\p{Lt}{4}", 4));
+
+  private CaseFoldingCharacterClassDivergenceSweep() {}
+
+  public static void main(String[] args) throws IOException {
+    SweepOptions options =
+        SweepOptions.parse(
+            args,
+            Path.of("target", "exhaustive-reports", "case-folding-character-class-sweep"),
+            "case-folding-character-class-divergences.jsonl",
+            1_000_000);
+    Files.createDirectories(options.outputDir());
+    Files.deleteIfExists(options.jsonlPath());
+    options.printStartup("case-folding-character-class");
+
+    if (options.replayFile() != null) {
+      runReplay(options);
+      return;
+    }
+
+    SweepRunState state = runSweep(options);
+
+    System.out.println("checked=" + state.checked.sum());
+    System.out.println("generated=" + state.generated);
+    System.out.println("totalCases=" + totalCases());
+    System.out.println("divergences=" + state.divergences.sum());
+    System.out.println("threads=" + options.threads());
+    System.out.println("jsonl=" + options.jsonlPath());
+  }
+
+  private static SweepRunState runSweep(SweepOptions options) throws IOException {
+    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
+      SweepWorkers.run(
+          options.threads(),
+          "case-folding-character-class-sweep-",
+          workerIndex -> {
+            SweepState worker = new SweepState(runState, workerIndex);
+            worker.run();
+            worker.finish();
+          });
+      return runState;
+    }
+  }
+
+  private static void runReplay(SweepOptions options) throws IOException {
+    try (BufferedReader reader =
+            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(options, 0)) {
+      long generated =
+          SweepWorkers.runStreamingLines(
+              options.threads(),
+              "case-folding-character-class-replay-",
+              reader,
+              line -> {
+                runState.checked.increment();
+                evaluateCase(runState, replayCase(line));
+              });
+      runState.recordGenerated(generated);
+      System.out.println("checked=" + runState.checked.sum());
+      System.out.println("generated=" + runState.generated);
+      System.out.println("divergences=" + runState.divergences.sum());
+      System.out.println("threads=" + options.threads());
+      System.out.println("jsonl=" + options.jsonlPath());
+      if (runState.divergences.sum() > 0) {
+        throw new IllegalStateException(
+            "replay found " + runState.divergences.sum() + " behavioral divergences");
+      }
+    }
+  }
+
+  private static CaseSpec replayCase(String line) {
+    var object = SweepJson.parseObject(line);
+    var caseObject = SweepJson.object(object, "case");
+    return new CaseSpec(
+        new PatternSpec(
+            SweepJson.string(caseObject, "patternLabel"),
+            SweepJson.string(caseObject, "regex"),
+            SweepJson.integer(caseObject, "inputRepeat")),
+        new FlagMode(
+            SweepJson.string(caseObject, "flagLabel"), SweepJson.integer(caseObject, "flags")),
+        SweepJson.integer(caseObject, "inputCodePoint"));
+  }
+
+  private static long totalCases() {
+    return (long) INPUT_COUNT * PATTERNS.size() * FLAG_MODES.size();
+  }
+
+  private static CaseSpec caseAt(long index) {
+    int flagIndex = (int) (index % FLAG_MODES.size());
+    index /= FLAG_MODES.size();
+    int patternIndex = (int) (index % PATTERNS.size());
+    index /= PATTERNS.size();
+    int inputCodePoint = (int) index;
+    return new CaseSpec(PATTERNS.get(patternIndex), FLAG_MODES.get(flagIndex), inputCodePoint);
+  }
+
+  private static Outcome jdkOutcome(String regex, int flags, String input) {
+    try {
+      return new Outcome(
+          true, java.util.regex.Pattern.compile(regex, flags).matcher(input).matches(), "");
+    } catch (PatternSyntaxException e) {
+      return new Outcome(false, false, e.getDescription());
+    } catch (RuntimeException e) {
+      return new Outcome(false, false, e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+  }
+
+  private static Outcome safeReOutcome(String regex, int flags, String input) {
+    try {
+      return new Outcome(
+          true, org.safere.Pattern.compile(regex, flags).matcher(input).matches(), "");
+    } catch (PatternSyntaxException e) {
+      return new Outcome(false, false, e.getDescription());
+    } catch (RuntimeException e) {
+      return new Outcome(false, false, e.getClass().getSimpleName() + ": " + e.getMessage());
+    }
+  }
+
+  private static String stringForCodePoint(int codePoint) {
+    if (codePoint <= Character.MAX_VALUE) {
+      return Character.toString((char) codePoint);
+    }
+    return new String(Character.toChars(codePoint));
+  }
+
+  private static String inputFor(CaseSpec spec) {
+    return stringForCodePoint(spec.inputCodePoint()).repeat(spec.pattern().inputRepeat());
+  }
+
+  private static String escape(String value) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\' -> result.append("\\\\");
+        case '\n' -> result.append("\\n");
+        case '\t' -> result.append("\\t");
+        case '\r' -> result.append("\\r");
+        case '"' -> result.append("\\\"");
+        default -> {
+          if (Character.isISOControl(c)
+              || Character.isSurrogate(c)
+              || Character.getType(c) == Character.PRIVATE_USE) {
+            result.append(String.format("\\u%04X", (int) c));
+          } else {
+            result.append(c);
+          }
+        }
+      }
+    }
+    return result.toString();
+  }
+
+  private static String bucketFor(CaseSpec spec, Outcome jdk, Outcome safere) {
+    String kind = jdk.accepted() != safere.accepted() ? "compile" : "membership";
+    return String.join(
+        "|",
+        "kind=" + kind,
+        "direction=" + direction(jdk, safere),
+        "pattern=" + spec.pattern().label(),
+        "flags=" + spec.flagMode().label(),
+        "inputClass=" + inputClass(spec.inputCodePoint()));
+  }
+
+  private static String direction(Outcome jdk, Outcome safere) {
+    if (jdk.accepted() && !safere.accepted()) {
+      return "jdk-accepts";
+    }
+    if (!jdk.accepted() && safere.accepted()) {
+      return "safere-accepts";
+    }
+    if (jdk.matches()) {
+      return "jdk-matches";
+    }
+    return "safere-matches";
+  }
+
+  private static String inputClass(int codePoint) {
+    if (codePoint <= Character.MAX_VALUE && Character.isHighSurrogate((char) codePoint)) {
+      return "high-surrogate";
+    }
+    if (codePoint <= Character.MAX_VALUE && Character.isLowSurrogate((char) codePoint)) {
+      return "low-surrogate";
+    }
+    int type = Character.getType(codePoint);
+    return switch (type) {
+      case Character.UPPERCASE_LETTER -> "uppercase-letter";
+      case Character.LOWERCASE_LETTER -> "lowercase-letter";
+      case Character.TITLECASE_LETTER -> "titlecase-letter";
+      case Character.MODIFIER_LETTER -> "modifier-letter";
+      case Character.OTHER_LETTER -> "other-letter";
+      default -> "type-" + type;
+    };
+  }
+
+  private static boolean semanticallyEqual(Outcome left, Outcome right) {
+    if (left.accepted() != right.accepted()) {
+      return false;
+    }
+    return !left.accepted() || left.matches() == right.matches();
+  }
+
+  private static PatternSpec pattern(String label, String regex) {
+    return new PatternSpec(label, regex, 1);
+  }
+
+  private static PatternSpec pattern(String label, String regex, int inputRepeat) {
+    return new PatternSpec(label, regex, inputRepeat);
+  }
+
+  private record PatternSpec(String label, String regex, int inputRepeat) {}
+
+  private record FlagMode(String label, int flags) {}
+
+  private record CaseSpec(PatternSpec pattern, FlagMode flagMode, int inputCodePoint) {
+    String labels() {
+      return "pattern="
+          + pattern.label()
+          + ",flags="
+          + flagMode.label()
+          + ",input="
+          + String.format("U+%04X", inputCodePoint)
+          + ",inputClass="
+          + inputClass(inputCodePoint);
+    }
+  }
+
+  private record Outcome(boolean accepted, boolean matches, String error) {}
+
+  private record Divergence(
+      CaseSpec spec, String input, Outcome jdk, Outcome safere, String bucket) {
+    String toJson() {
+      var object = SweepJson.object();
+      object.add("case", caseJson(spec));
+      object.addProperty("bucket", bucket);
+      object.addProperty("labels", spec.labels());
+      object.addProperty("regex", spec.pattern().regex());
+      object.addProperty("flags", spec.flagMode().label());
+      object.addProperty("inputCodePoint", spec.inputCodePoint());
+      object.addProperty("input", escape(input));
+      object.addProperty("jdkAccepted", jdk.accepted());
+      object.addProperty("safeReAccepted", safere.accepted());
+      object.addProperty("jdkMatches", jdk.matches());
+      object.addProperty("safeReMatches", safere.matches());
+      object.addProperty("jdkError", jdk.error());
+      object.addProperty("safeReError", safere.error());
+      return SweepJson.toJson(object);
+    }
+
+    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+      var object = SweepJson.object();
+      object.addProperty("patternLabel", spec.pattern().label());
+      object.addProperty("regex", spec.pattern().regex());
+      object.addProperty("inputRepeat", spec.pattern().inputRepeat());
+      object.addProperty("flagLabel", spec.flagMode().label());
+      object.addProperty("flags", spec.flagMode().flags());
+      object.addProperty("inputCodePoint", spec.inputCodePoint());
+      return object;
+    }
+  }
+
+  private static final class SweepState {
+    final SweepRunState runState;
+    final SweepOptions options;
+    final SweepWorkers.ProgressReporter progressReporter;
+    final int workerIndex;
+    long generated;
+
+    SweepState(SweepRunState runState, int workerIndex) {
+      this.runState = runState;
+      this.options = runState.options;
+      this.progressReporter = new SweepWorkers.ProgressReporter(runState);
+      this.workerIndex = workerIndex;
+    }
+
+    void run() {
+      long end = Math.min(options.rangeEndExclusive(), totalCases());
+      while (generated < end) {
+        long caseIndex = generated++;
+        if (caseIndex < options.rangeStartInclusive()) {
+          reportProgressIfNeeded();
+          continue;
+        }
+        if (caseIndex % options.threads() != workerIndex) {
+          continue;
+        }
+        progressReporter.checked();
+        evaluateCase(caseAt(caseIndex));
+      }
+    }
+
+    void evaluateCase(CaseSpec spec) {
+      CaseFoldingCharacterClassDivergenceSweep.evaluateCase(runState, spec);
+      reportProgressIfNeeded();
+    }
+
+    void finish() {
+      runState.recordGenerated(generated);
+    }
+
+    void reportProgressIfNeeded() {
+      progressReporter.reportIfNeeded(generated);
+    }
+  }
+
+  private static void evaluateCase(SweepRunState runState, CaseSpec spec) {
+    String input = inputFor(spec);
+    Outcome jdk = jdkOutcome(spec.pattern().regex(), spec.flagMode().flags(), input);
+    Outcome safere = safeReOutcome(spec.pattern().regex(), spec.flagMode().flags(), input);
+    if (semanticallyEqual(jdk, safere)) {
+      return;
+    }
+    String bucketName = bucketFor(spec, jdk, safere);
+    runState.recordDivergence();
+    runState.appendJsonl(new Divergence(spec, input, jdk, safere, bucketName).toJson());
+  }
+}

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -60,6 +60,16 @@ class SweepCliSmokeTest {
   }
 
   @Test
+  void caseFoldingCharacterClassSweepRunsTinyRange() throws Exception {
+    Path outputDir = tempDir.resolve("case-folding");
+
+    CaseFoldingCharacterClassDivergenceSweep.main(args(outputDir));
+
+    assertThat(Files.exists(outputDir.resolve("case-folding-character-class-divergences.jsonl")))
+        .isTrue();
+  }
+
+  @Test
   void characterClassReplayUsesConfiguredThreads() throws Exception {
     Path replayFile = tempDir.resolve("character-replay.jsonl");
     Path outputDir = tempDir.resolve("character-replay");
@@ -106,6 +116,24 @@ class SweepCliSmokeTest {
     String output =
         captureOutput(
             () -> UnicodeCharacterClassDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
+    assertThat(output).doesNotContain("threads=1");
+  }
+
+  @Test
+  void caseFoldingCharacterClassReplayUsesConfiguredThreads() throws Exception {
+    Path replayFile = tempDir.resolve("case-folding-replay.jsonl");
+    Path outputDir = tempDir.resolve("case-folding-replay");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"patternLabel":"rangeLowerHJ","regex":"[h-j]","inputRepeat":1,"flagLabel":"unicodeCase","flags":66,"inputCodePoint":104}}
+        """);
+
+    String output =
+        captureOutput(
+            () -> CaseFoldingCharacterClassDivergenceSweep.main(replayArgs(outputDir, replayFile)));
 
     assertThat(output).contains("mode=replay", "checked=1", "generated=1", "threads=2");
     assertThat(output).doesNotContain("threads=1");

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -7,11 +7,47 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
 
 final class MatchFuzzer {
+  private static final int CI = org.safere.Pattern.CASE_INSENSITIVE;
+  private static final int CI_U =
+      org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CASE;
+  private static final int CI_UCC =
+      org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CHARACTER_CLASS;
+
+  private static final List<RegressionCase> CASE_FOLDING_REGRESSIONS =
+      List.of(
+          new RegressionCase("\\p{Lt}{4}", CI, List.of("abcd", "AAAA", "\u01C4".repeat(4))),
+          new RegressionCase("\\p{javaUpperCase}", CI, List.of("\u00AA", "\u02B0", "A", "a", "1")),
+          new RegressionCase("[h-j]+", CI_U, List.of("\u0130\u0131", "HIJ", "abc")),
+          new RegressionCase("[^h-j]", CI_U, List.of("\u0130", "\u0131", "x")),
+          new RegressionCase("[\\x{17F}]", CI_U, List.of("\u017F", "S", "s")),
+          new RegressionCase("[K]", CI, List.of("\u212A", "K", "k")),
+          new RegressionCase("\\p{L}", CI_U, List.of("\u0345", "\u0399", "A", "a")),
+          new RegressionCase("\\P{L}", CI_U, List.of("\u0345", "\u0399", "A", "a")),
+          new RegressionCase("[A-Z]", CI_U, List.of("\u017F", "K", "k")),
+          new RegressionCase("[K-K]", CI_U, List.of("K", "k")),
+          new RegressionCase("\\p{Lower}", CI_U, List.of("\u212A", "A", "a")),
+          new RegressionCase("\\p{Lower}", CI_UCC, List.of("\u0345", "\u212A", "A", "a")),
+          new RegressionCase("\\x{49}", CI_U, List.of("\u0130", "\u0131", "I", "i")),
+          new RegressionCase("\\x{69}", CI_U, List.of("\u0130", "\u0131", "I", "i")));
+
+  private static final List<RegressionCase> CASE_FOLDING_MODEL_REGRESSIONS =
+      List.of(
+          new RegressionCase("[A-Z]", CI_U, List.of("\u0130", "\u212A")),
+          new RegressionCase("[I-I]", CI_U, List.of("\u0130")),
+          new RegressionCase("[K-K]", CI_U, List.of("\u212A")));
 
   @FuzzTest(maxDuration = "30s")
   void match(FuzzedDataProvider data) {
+    for (RegressionCase regression : CASE_FOLDING_REGRESSIONS) {
+      FuzzSupport.assertFullMatchesJdk(regression.regex(), regression.flags(), regression.inputs());
+    }
+    for (RegressionCase regression : CASE_FOLDING_MODEL_REGRESSIONS) {
+      assertFullMatchesSafeRe(regression.regex(), regression.flags(), regression.inputs());
+    }
+
     String regex;
     int flags;
     String input;
@@ -48,4 +84,22 @@ final class MatchFuzzer {
     }
     return pattern.toString();
   }
+
+  private static void assertFullMatchesSafeRe(String regex, int flags, List<String> inputs) {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(regex, flags);
+    for (String input : inputs) {
+      if (!pattern.matcher(input).matches()) {
+        throw new AssertionError(
+            "SafeRE model regression"
+                + "\nRegex: "
+                + regex
+                + "\nFlags: "
+                + flags
+                + "\nInput: "
+                + input);
+      }
+    }
+  }
+
+  private record RegressionCase(String regex, int flags, List<String> inputs) {}
 }

--- a/safere/src/main/java/org/safere/CharClassExpander.java
+++ b/safere/src/main/java/org/safere/CharClassExpander.java
@@ -1,0 +1,263 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Locale;
+
+/**
+ * Expands parsed character-class atoms according to SafeRE's regex flags and Unicode property
+ * semantics.
+ */
+final class CharClassExpander {
+  private CharClassExpander() {}
+
+  enum CaseFoldPolicy {
+    NONE,
+    ASCII_POSIX,
+    UNICODE_CASED_LETTER_CATEGORY,
+    JAVA_CASED_PROPERTY
+  }
+
+  static final class Group {
+    private final int[][] table;
+    private final CaseFoldPolicy caseFoldPolicy;
+
+    Group(int[][] table, CaseFoldPolicy caseFoldPolicy) {
+      this.table = table;
+      this.caseFoldPolicy = caseFoldPolicy;
+    }
+
+    int[][] table() {
+      return table;
+    }
+
+    CaseFoldPolicy caseFoldPolicy() {
+      return caseFoldPolicy;
+    }
+  }
+
+  static Group lookupPerlGroup(String name, boolean unicodeCharacterClass) {
+    int[][] table =
+        unicodeCharacterClass
+            ? UnicodeTables.unicodePerlGroups().get(name)
+            : UnicodeTables.PERL_GROUPS.get(name);
+    return table == null ? null : new Group(table, CaseFoldPolicy.NONE);
+  }
+
+  static Group lookupUnicodeGroup(String name, boolean unicodeCharacterClass) {
+    int[][] table = JavaCharacterClasses.lookup(name);
+    if (table != null) {
+      return new Group(table, javaClassCaseFoldPolicy(name));
+    }
+    table =
+        unicodeCharacterClass
+            ? UnicodeTables.unicodePosixPropertyGroups().get(name)
+            : UnicodeTables.POSIX_PROPERTY_GROUPS.get(name);
+    if (table != null) {
+      return new Group(table, posixPropertyCaseFoldPolicy(name, unicodeCharacterClass));
+    }
+
+    int eq = name.indexOf('=');
+    if (eq >= 0) {
+      return lookupKeywordProperty(name.substring(0, eq), name.substring(eq + 1));
+    }
+
+    if (name.startsWith("Is") && name.length() > 2) {
+      String stripped = name.substring(2);
+      table = UnicodeProperties.lookupScriptOrCategory(stripped);
+      if (table != null) {
+        return new Group(table, scriptOrCategoryCaseFoldPolicy(stripped));
+      }
+      table = UnicodeProperties.lookupBinaryProperty(stripped);
+      return table == null ? null : new Group(table, binaryPropertyCaseFoldPolicy(stripped));
+    }
+
+    if (name.startsWith("In") && name.length() > 2) {
+      table = UnicodeProperties.lookupBlock(name.substring(2));
+      return table == null ? null : new Group(table, CaseFoldPolicy.NONE);
+    }
+
+    table = UnicodeProperties.lookupCategory(name);
+    return table == null ? null : new Group(table, categoryCaseFoldPolicy(name));
+  }
+
+  static void addPositiveGroup(CharClassBuilder ccb, Group group, int parseFlags) {
+    if ((parseFlags & ParseFlags.FOLD_CASE) == 0) {
+      addPropertyTableWithoutCaseFolding(ccb, group.table(), parseFlags);
+      return;
+    }
+    switch (group.caseFoldPolicy()) {
+      case ASCII_POSIX -> addAsciiFoldedPropertyTable(ccb, group.table(), parseFlags);
+      case UNICODE_CASED_LETTER_CATEGORY -> addCasedLetterCategoryClosure(ccb);
+      case JAVA_CASED_PROPERTY -> ccb.addTable(JavaCasedPropertyClosureHolder.TABLE);
+      case NONE -> addPropertyTableWithoutCaseFolding(ccb, group.table(), parseFlags);
+    }
+  }
+
+  static void addNegatedGroup(CharClassBuilder ccb, Group group, int parseFlags) {
+    if ((parseFlags & ParseFlags.FOLD_CASE) != 0) {
+      CharClassBuilder positive = new CharClassBuilder();
+      addPositiveGroup(positive, group, parseFlags);
+      boolean cutnl =
+          (parseFlags & ParseFlags.CLASS_NL) == 0 || (parseFlags & ParseFlags.NEVER_NL) != 0;
+      if (cutnl) {
+        positive.addRune('\n');
+      }
+      positive.negate();
+      ccb.addCharClass(positive);
+      return;
+    }
+    int next = 0;
+    for (int[] row : group.table()) {
+      if (next < row[0]) {
+        addRange(ccb, next, row[0] - 1, parseFlags);
+      }
+      next = row[1] + 1;
+    }
+    if (next <= Utils.MAX_RUNE) {
+      addRange(ccb, next, Utils.MAX_RUNE, parseFlags);
+    }
+  }
+
+  static void addRange(CharClassBuilder ccb, int lo, int hi, int parseFlags) {
+    boolean cutnl =
+        (parseFlags & ParseFlags.CLASS_NL) == 0 || (parseFlags & ParseFlags.NEVER_NL) != 0;
+    if (cutnl && lo <= '\n' && '\n' <= hi) {
+      if (lo < '\n') {
+        addRange(ccb, lo, '\n' - 1, parseFlags);
+      }
+      if (hi > '\n') {
+        addRange(ccb, '\n' + 1, hi, parseFlags);
+      }
+      return;
+    }
+
+    if ((parseFlags & ParseFlags.FOLD_CASE) != 0) {
+      if ((parseFlags & ParseFlags.UNICODE_CASE) == 0) {
+        UnicodeCaseFolding.addAsciiFoldedRange(ccb, lo, hi);
+        return;
+      }
+      UnicodeCaseFolding.addUnicodeFoldedRange(ccb, lo, hi);
+    } else {
+      ccb.addRange(lo, hi);
+    }
+  }
+
+  private static Group lookupKeywordProperty(String key, String value) {
+    String normalizedKey = normalizePropertyName(key);
+    return switch (normalizedKey) {
+      case "SCRIPT", "SC" -> {
+        int[][] table = UnicodeProperties.lookupScript(value);
+        yield table == null ? null : new Group(table, CaseFoldPolicy.NONE);
+      }
+      case "BLOCK", "BLK" -> {
+        int[][] table = UnicodeProperties.lookupBlock(value);
+        yield table == null ? null : new Group(table, CaseFoldPolicy.NONE);
+      }
+      case "GENERALCATEGORY", "GC" -> {
+        int[][] table = UnicodeProperties.lookupCategory(value);
+        yield table == null ? null : new Group(table, categoryCaseFoldPolicy(value));
+      }
+      default -> null;
+    };
+  }
+
+  private static void addPropertyTableWithoutCaseFolding(
+      CharClassBuilder ccb, int[][] table, int parseFlags) {
+    int noFoldFlags = parseFlags & ~ParseFlags.FOLD_CASE;
+    if ((noFoldFlags & ParseFlags.CLASS_NL) != 0 && (noFoldFlags & ParseFlags.NEVER_NL) == 0) {
+      ccb.addTable(table);
+      return;
+    }
+    for (int[] row : table) {
+      addRange(ccb, row[0], row[1], noFoldFlags);
+    }
+  }
+
+  private static void addAsciiFoldedPropertyTable(
+      CharClassBuilder ccb, int[][] table, int parseFlags) {
+    int asciiFoldFlags = parseFlags & ~ParseFlags.UNICODE_CASE;
+    for (int[] row : table) {
+      addRange(ccb, row[0], row[1], asciiFoldFlags);
+    }
+  }
+
+  private static void addCasedLetterCategoryClosure(CharClassBuilder ccb) {
+    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Lu"));
+    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Ll"));
+    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Lt"));
+  }
+
+  private static CaseFoldPolicy posixPropertyCaseFoldPolicy(
+      String name, boolean unicodeCharacterClass) {
+    if (unicodeCharacterClass) {
+      return switch (name) {
+        case "Lower", "Upper" -> CaseFoldPolicy.JAVA_CASED_PROPERTY;
+        default -> CaseFoldPolicy.NONE;
+      };
+    }
+    return CaseFoldPolicy.ASCII_POSIX;
+  }
+
+  private static CaseFoldPolicy javaClassCaseFoldPolicy(String name) {
+    return switch (name) {
+      case "javaUpperCase", "javaLowerCase", "javaTitleCase" -> CaseFoldPolicy.JAVA_CASED_PROPERTY;
+      default -> CaseFoldPolicy.NONE;
+    };
+  }
+
+  private static CaseFoldPolicy scriptOrCategoryCaseFoldPolicy(String name) {
+    return isCasedLetterCategoryName(name)
+        ? CaseFoldPolicy.UNICODE_CASED_LETTER_CATEGORY
+        : CaseFoldPolicy.NONE;
+  }
+
+  private static CaseFoldPolicy categoryCaseFoldPolicy(String name) {
+    return switch (name) {
+      case "Lu", "Ll", "Lt" -> CaseFoldPolicy.UNICODE_CASED_LETTER_CATEGORY;
+      default -> CaseFoldPolicy.NONE;
+    };
+  }
+
+  private static CaseFoldPolicy binaryPropertyCaseFoldPolicy(String name) {
+    String normalized = normalizePropertyName(name);
+    return switch (normalized) {
+      case "UPPERCASE", "LOWERCASE", "TITLECASE" -> CaseFoldPolicy.JAVA_CASED_PROPERTY;
+      default -> CaseFoldPolicy.NONE;
+    };
+  }
+
+  private static boolean isCasedLetterCategoryName(String name) {
+    return switch (normalizePropertyName(name)) {
+      case "LU", "LL", "LT" -> true;
+      default -> false;
+    };
+  }
+
+  private static String normalizePropertyName(String name) {
+    return name.toUpperCase(Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
+  }
+
+  private static final class JavaCasedPropertyClosureHolder {
+    static final int[][] TABLE = buildTable();
+
+    private static int[][] buildTable() {
+      CharClassBuilder ccb = new CharClassBuilder();
+      for (int cp = 0; cp <= Utils.MAX_RUNE; cp++) {
+        if (Character.isUpperCase(cp) || Character.isLowerCase(cp) || Character.isTitleCase(cp)) {
+          ccb.addRune(cp);
+        }
+      }
+      CharClass cc = ccb.build();
+      int[][] table = new int[cc.numRanges()][2];
+      for (int i = 0; i < cc.numRanges(); i++) {
+        table[i][0] = cc.lo(i);
+        table[i][1] = cc.hi(i);
+      }
+      return table;
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -944,9 +944,33 @@ final class Compiler extends Walker<Compiler.Frag> {
     return true;
   }
 
-  private Frag literal(int rune, boolean foldCase) {
+  private Frag literal(int rune, int flags) {
+    boolean foldCase = (flags & ParseFlags.FOLD_CASE) != 0;
+    if (foldCase && (flags & ParseFlags.UNICODE_CASE) == 0) {
+      if (isAsciiLetter(rune)) {
+        // Parser keeps these as folded literals so literal/prefix accelerators can see them.
+        // Lower to an explicit ASCII class here to avoid Unicode simple-fold matching.
+        return asciiFoldedLiteral(rune);
+      }
+      foldCase = false;
+    }
     // In our code-point model, a literal is just a single CHAR_RANGE.
     return charRange(rune, rune, foldCase);
+  }
+
+  private Frag asciiFoldedLiteral(int rune) {
+    int lower = UnicodeCaseFolding.asciiFoldRune(rune);
+    int upper = lower - ('a' - 'A');
+    int id = allocInst();
+    if (id < 0) {
+      return Frag.NO_MATCH;
+    }
+    prog.mutableInst(id).initCharClass(0, new int[] {upper, upper, lower, lower});
+    return new Frag(id, PatchList.mk(id << 1), false);
+  }
+
+  private static boolean isAsciiLetter(int rune) {
+    return ('A' <= rune && rune <= 'Z') || ('a' <= rune && rune <= 'z');
   }
 
   /** Compiles an "any code point" fragment. */
@@ -1023,15 +1047,15 @@ final class Compiler extends Walker<Compiler.Frag> {
 
       case QUEST -> quest(childArgs.get(0), re.nonGreedy());
 
-      case LITERAL -> literal(re.rune, re.foldCase());
+      case LITERAL -> literal(re.rune, re.flags);
 
       case LITERAL_STRING -> {
         if (re.runes == null || re.runes.length == 0) {
           yield nop();
         }
-        Frag f = literal(re.runes[0], re.foldCase());
+        Frag f = literal(re.runes[0], re.flags);
         for (int i = 1; i < re.runes.length; i++) {
-          f = cat(f, literal(re.runes[i], re.foldCase()));
+          f = cat(f, literal(re.runes[i], re.flags));
         }
         yield f;
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -438,7 +438,14 @@ public final class Matcher implements MatchResult {
     if (remainingLen >= literal.length()) {
       return false;
     }
-    return text.regionMatches(parentPattern.prefixFoldCase(), offset, literal, 0, remainingLen);
+    return literalRegionMatches(literal, offset, remainingLen);
+  }
+
+  private boolean literalRegionMatches(String literal, int offset, int length) {
+    if (parentPattern.prefixFoldCase()) {
+      return regionMatchesAsciiIgnoreCase(text, offset, literal, 0, length);
+    }
+    return text.regionMatches(false, offset, literal, 0, length);
   }
 
   private static boolean charClassContains(int[] ranges, long b0, long b1, int cp) {
@@ -681,8 +688,7 @@ public final class Matcher implements MatchResult {
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched =
-            text.length() == literal.length()
-                && text.regionMatches(true, 0, literal, 0, literal.length());
+            text.length() == literal.length() && literalRegionMatches(literal, 0, literal.length());
       } else {
         matched = text.equals(literal);
       }
@@ -823,8 +829,7 @@ public final class Matcher implements MatchResult {
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched =
-            text.length() >= literal.length()
-                && text.regionMatches(true, 0, literal, 0, literal.length());
+            text.length() >= literal.length() && literalRegionMatches(literal, 0, literal.length());
       } else {
         matched = text.startsWith(literal);
       }
@@ -1248,8 +1253,7 @@ public final class Matcher implements MatchResult {
         } else {
           int remainingLen = text.length() - searchFrom;
           if (remainingLen < prefix.length()
-              && text.regionMatches(
-                  parentPattern.prefixFoldCase(), searchFrom, prefix, 0, remainingLen)) {}
+              && literalRegionMatches(prefix, searchFrom, remainingLen)) {}
         }
         return applyEngineResult(new NoMatchResult());
       }
@@ -1622,16 +1626,33 @@ public final class Matcher implements MatchResult {
     return ('A' <= ch && ch <= 'Z') ? ch + ('a' - 'A') : ch;
   }
 
-  /** Case-insensitive indexOf using Unicode case folding. */
+  /** ASCII case-insensitive indexOf for Java's default CASE_INSENSITIVE semantics. */
   private static int indexOfIgnoreCase(String text, String prefix, int fromIndex) {
     int prefixLen = prefix.length();
     int limit = text.length() - prefixLen;
     for (int i = fromIndex; i <= limit; i++) {
-      if (text.regionMatches(true, i, prefix, 0, prefixLen)) {
+      if (regionMatchesAsciiIgnoreCase(text, i, prefix, 0, prefixLen)) {
         return i;
       }
     }
     return -1;
+  }
+
+  private static boolean regionMatchesAsciiIgnoreCase(
+      String text, int textOffset, String prefix, int prefixOffset, int length) {
+    if (textOffset < 0
+        || prefixOffset < 0
+        || length < 0
+        || textOffset + length > text.length()
+        || prefixOffset + length > prefix.length()) {
+      return false;
+    }
+    for (int i = 0; i < length; i++) {
+      if (asciiLower(text.charAt(textOffset + i)) != asciiLower(prefix.charAt(prefixOffset + i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -521,16 +521,8 @@ final class Parser {
 
   private void pushLiteral(int r) {
     // Do case folding if needed.
-    if ((flags & ParseFlags.FOLD_CASE) != 0) {
-      if ((flags & ParseFlags.UNICODE_CASE) == 0) {
-        if (('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z')) {
-          CharClassBuilder ccb = new CharClassBuilder();
-          UnicodeCaseFolding.addAsciiFoldedRange(ccb, r, r);
-          pushRegexp(finishCharClassBuilder(ccb));
-          return;
-        }
-      } else if (UnicodeCaseFolding.hasUnicodeCaseVariant(r)
-          || UnicodeCaseFolding.cycleFoldRune(r) != r) {
+    if ((flags & ParseFlags.FOLD_CASE) != 0 && (flags & ParseFlags.UNICODE_CASE) != 0) {
+      if (UnicodeCaseFolding.hasUnicodeCaseVariant(r) || UnicodeCaseFolding.cycleFoldRune(r) != r) {
         CharClassBuilder ccb = new CharClassBuilder();
         UnicodeCaseFolding.addUnicodeFoldedRange(ccb, r, r);
         Regexp re = finishCharClassBuilder(ccb);

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -9,7 +9,6 @@ package org.safere;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -113,31 +112,6 @@ final class Parser {
       }
       int totalCost = multiplySaturated(multiplier, subCost, limit);
       return new RepeatCount(totalCost, re.op == RegexpOp.REPEAT || subHasRepeat);
-    }
-  }
-
-  private enum GroupCaseFoldPolicy {
-    NONE,
-    ASCII_POSIX,
-    UNICODE_CASED_LETTER_CATEGORY,
-    JAVA_CASED_PROPERTY
-  }
-
-  private static final class CharacterGroup {
-    private final int[][] table;
-    private final GroupCaseFoldPolicy caseFoldPolicy;
-
-    CharacterGroup(int[][] table, GroupCaseFoldPolicy caseFoldPolicy) {
-      this.table = table;
-      this.caseFoldPolicy = caseFoldPolicy;
-    }
-
-    int[][] table() {
-      return table;
-    }
-
-    GroupCaseFoldPolicy caseFoldPolicy() {
-      return caseFoldPolicy;
     }
   }
 
@@ -551,13 +525,14 @@ final class Parser {
       if ((flags & ParseFlags.UNICODE_CASE) == 0) {
         if (('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z')) {
           CharClassBuilder ccb = new CharClassBuilder();
-          addAsciiFoldedRange(ccb, r, r);
+          UnicodeCaseFolding.addAsciiFoldedRange(ccb, r, r);
           pushRegexp(finishCharClassBuilder(ccb));
           return;
         }
-      } else if (hasUnicodeCaseVariant(r) || cycleFoldRune(r) != r) {
+      } else if (UnicodeCaseFolding.hasUnicodeCaseVariant(r)
+          || UnicodeCaseFolding.cycleFoldRune(r) != r) {
         CharClassBuilder ccb = new CharClassBuilder();
-        addUnicodeFoldedRange(ccb, r, r);
+        UnicodeCaseFolding.addUnicodeFoldedRange(ccb, r, r);
         Regexp re = finishCharClassBuilder(ccb);
         pushRegexp(re);
         return;
@@ -574,7 +549,7 @@ final class Parser {
     int literalFlags = flags;
     if ((flags & ParseFlags.FOLD_CASE) != 0
         && (flags & ParseFlags.UNICODE_CASE) == 0
-        && asciiFoldRune(r) == r
+        && UnicodeCaseFolding.asciiFoldRune(r) == r
         && !('a' <= r && r <= 'z')) {
       literalFlags &= ~ParseFlags.FOLD_CASE;
     }
@@ -4115,26 +4090,19 @@ final class Parser {
     }
 
     pos += 2; // '\\', letter
-    // Use Unicode-aware tables when UNICODE_CHAR_CLASS is active.
-    int[][] table = lookupPerlGroup(posName, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
-    if (table == null) {
+    CharClassExpander.Group group =
+        CharClassExpander.lookupPerlGroup(posName, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
+    if (group == null) {
       return null;
     }
-    CharacterGroup group = new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
 
     CharClassBuilder ccb = new CharClassBuilder();
     if (negate) {
-      addGroupNegated(ccb, group);
+      CharClassExpander.addNegatedGroup(ccb, group, flags);
     } else {
-      addGroupPositive(ccb, group);
+      CharClassExpander.addPositiveGroup(ccb, group, flags);
     }
     return ccb;
-  }
-
-  private static int[][] lookupPerlGroup(String name, boolean unicodeCharacterClass) {
-    return unicodeCharacterClass
-        ? UnicodeTables.unicodePerlGroups().get(name)
-        : UnicodeTables.PERL_GROUPS.get(name);
   }
 
   // ---- Unicode group parsing (\p{...}, \P{...}) ----
@@ -4175,450 +4143,23 @@ final class Parser {
       pos = end + 1; // skip '}'
     }
 
-    CharacterGroup group = lookupUnicodeGroup(name, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
+    CharClassExpander.Group group =
+        CharClassExpander.lookupUnicodeGroup(name, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
     if (group == null) {
       throw new PatternSyntaxException("invalid Unicode group: " + name, pattern, seqStart);
     }
 
     if (sign > 0) {
-      addGroupPositive(ccb, group);
+      CharClassExpander.addPositiveGroup(ccb, group, flags);
     } else {
-      addGroupNegated(ccb, group);
+      CharClassExpander.addNegatedGroup(ccb, group, flags);
     }
     return PARSE_OK;
   }
 
-  private static CharacterGroup lookupUnicodeGroup(String name, boolean unicodeCharacterClass) {
-    int[][] table = JavaCharacterClasses.lookup(name);
-    if (table != null) {
-      return new CharacterGroup(table, javaClassCaseFoldPolicy(name));
-    }
-    table =
-        unicodeCharacterClass
-            ? UnicodeTables.unicodePosixPropertyGroups().get(name)
-            : UnicodeTables.POSIX_PROPERTY_GROUPS.get(name);
-    if (table != null) {
-      return new CharacterGroup(table, posixPropertyCaseFoldPolicy(name, unicodeCharacterClass));
-    }
-
-    // Keyword forms: script=, sc=, block=, blk=, general_category=, gc=.
-    int eq = name.indexOf('=');
-    if (eq >= 0) {
-      String key = name.substring(0, eq);
-      String value = name.substring(eq + 1);
-      return lookupKeywordProperty(key, value);
-    }
-
-    // "Is" prefix: try script/category (case-insensitive), then binary property.
-    // The prefix is case-sensitive ("Is" only, not "is" or "IS").
-    if (name.startsWith("Is") && name.length() > 2) {
-      String stripped = name.substring(2);
-      table = UnicodeProperties.lookupScriptOrCategory(stripped);
-      if (table != null) {
-        return new CharacterGroup(table, scriptOrCategoryCaseFoldPolicy(stripped));
-      }
-      table = UnicodeProperties.lookupBinaryProperty(stripped);
-      if (table != null) {
-        return new CharacterGroup(table, binaryPropertyCaseFoldPolicy(stripped));
-      }
-      return null;
-    }
-
-    // "In" prefix: Unicode block lookup.
-    if (name.startsWith("In") && name.length() > 2) {
-      table = UnicodeProperties.lookupBlock(name.substring(2));
-      return table == null ? null : new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
-    }
-
-    // Bare Unicode properties are valid only for general categories such as "L" or "Lu".
-    // JDK Pattern requires scripts to use Is/script=/sc= and blocks to use In/block=/blk=.
-    table = UnicodeProperties.lookupCategory(name);
-    return table == null ? null : new CharacterGroup(table, categoryCaseFoldPolicy(name));
-  }
-
-  private static CharacterGroup lookupKeywordProperty(String key, String value) {
-    // Keywords are case-insensitive per JDK behavior; remove underscores/hyphens/spaces.
-    String normalizedKey =
-        key.toUpperCase(java.util.Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
-    return switch (normalizedKey) {
-      case "SCRIPT", "SC" -> {
-        int[][] table = UnicodeProperties.lookupScript(value);
-        yield table == null ? null : new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
-      }
-      case "BLOCK", "BLK" -> {
-        int[][] table = UnicodeProperties.lookupBlock(value);
-        yield table == null ? null : new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
-      }
-      case "GENERALCATEGORY", "GC" -> {
-        int[][] table = UnicodeProperties.lookupCategory(value);
-        yield table == null ? null : new CharacterGroup(table, categoryCaseFoldPolicy(value));
-      }
-      default -> null;
-    };
-  }
-
-  private static GroupCaseFoldPolicy posixPropertyCaseFoldPolicy(
-      String name, boolean unicodeCharacterClass) {
-    if (unicodeCharacterClass) {
-      return switch (name) {
-        case "Lower", "Upper" -> GroupCaseFoldPolicy.JAVA_CASED_PROPERTY;
-        default -> GroupCaseFoldPolicy.NONE;
-      };
-    }
-    return GroupCaseFoldPolicy.ASCII_POSIX;
-  }
-
-  private static GroupCaseFoldPolicy javaClassCaseFoldPolicy(String name) {
-    return switch (name) {
-      case "javaUpperCase", "javaLowerCase", "javaTitleCase" ->
-          GroupCaseFoldPolicy.JAVA_CASED_PROPERTY;
-      default -> GroupCaseFoldPolicy.NONE;
-    };
-  }
-
-  private static GroupCaseFoldPolicy scriptOrCategoryCaseFoldPolicy(String name) {
-    return isCasedLetterCategoryName(name)
-        ? GroupCaseFoldPolicy.UNICODE_CASED_LETTER_CATEGORY
-        : GroupCaseFoldPolicy.NONE;
-  }
-
-  private static GroupCaseFoldPolicy categoryCaseFoldPolicy(String name) {
-    return switch (name) {
-      case "Lu", "Ll", "Lt" -> GroupCaseFoldPolicy.UNICODE_CASED_LETTER_CATEGORY;
-      default -> GroupCaseFoldPolicy.NONE;
-    };
-  }
-
-  private static GroupCaseFoldPolicy binaryPropertyCaseFoldPolicy(String name) {
-    String normalized = normalizePropertyName(name);
-    return switch (normalized) {
-      case "UPPERCASE", "LOWERCASE", "TITLECASE" -> GroupCaseFoldPolicy.JAVA_CASED_PROPERTY;
-      default -> GroupCaseFoldPolicy.NONE;
-    };
-  }
-
-  private static boolean isCasedLetterCategoryName(String name) {
-    return switch (normalizePropertyName(name)) {
-      case "LU", "LL", "LT" -> true;
-      default -> false;
-    };
-  }
-
-  private static String normalizePropertyName(String name) {
-    return name.toUpperCase(java.util.Locale.ROOT)
-        .replace("_", "")
-        .replace("-", "")
-        .replace(" ", "");
-  }
-
-  // ---- Group add helpers ----
-
-  private void addGroupPositive(CharClassBuilder ccb, CharacterGroup group) {
-    if ((flags & ParseFlags.FOLD_CASE) == 0) {
-      addPropertyTableWithoutCaseFolding(ccb, group.table());
-      return;
-    }
-    switch (group.caseFoldPolicy()) {
-      case ASCII_POSIX -> addAsciiFoldedPropertyTable(ccb, group.table());
-      case UNICODE_CASED_LETTER_CATEGORY -> addCasedLetterCategoryClosure(ccb);
-      case JAVA_CASED_PROPERTY -> ccb.addTable(JavaCasedPropertyClosureHolder.TABLE);
-      case NONE -> addPropertyTableWithoutCaseFolding(ccb, group.table());
-    }
-  }
-
-  private void addPropertyTableWithoutCaseFolding(CharClassBuilder ccb, int[][] table) {
-    int noFoldFlags = flags & ~ParseFlags.FOLD_CASE;
-    if ((noFoldFlags & ParseFlags.CLASS_NL) != 0 && (noFoldFlags & ParseFlags.NEVER_NL) == 0) {
-      ccb.addTable(table);
-      return;
-    }
-    for (int[] row : table) {
-      addRangeFlags(ccb, row[0], row[1], noFoldFlags);
-    }
-  }
-
-  private void addAsciiFoldedPropertyTable(CharClassBuilder ccb, int[][] table) {
-    int asciiFoldFlags = flags & ~ParseFlags.UNICODE_CASE;
-    for (int[] row : table) {
-      addRangeFlags(ccb, row[0], row[1], asciiFoldFlags);
-    }
-  }
-
-  private static void addCasedLetterCategoryClosure(CharClassBuilder ccb) {
-    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Lu"));
-    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Ll"));
-    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Lt"));
-  }
-
-  private static final class JavaCasedPropertyClosureHolder {
-    static final int[][] TABLE = buildTable();
-
-    private static int[][] buildTable() {
-      CharClassBuilder ccb = new CharClassBuilder();
-      for (int cp = 0; cp <= Utils.MAX_RUNE; cp++) {
-        if (Character.isUpperCase(cp) || Character.isLowerCase(cp) || Character.isTitleCase(cp)) {
-          ccb.addRune(cp);
-        }
-      }
-      CharClass cc = ccb.build();
-      int[][] table = new int[cc.numRanges()][2];
-      for (int i = 0; i < cc.numRanges(); i++) {
-        table[i][0] = cc.lo(i);
-        table[i][1] = cc.hi(i);
-      }
-      return table;
-    }
-  }
-
-  private void addGroupNegated(CharClassBuilder ccb, CharacterGroup group) {
-    if ((flags & ParseFlags.FOLD_CASE) != 0) {
-      // Build the positive set with folding, then negate, then merge.
-      CharClassBuilder ccb1 = new CharClassBuilder();
-      addGroupPositive(ccb1, group);
-      boolean cutnl = (flags & ParseFlags.CLASS_NL) == 0 || (flags & ParseFlags.NEVER_NL) != 0;
-      if (cutnl) {
-        ccb1.addRune('\n');
-      }
-      ccb1.negate();
-      ccb.addCharClass(ccb1);
-      return;
-    }
-    int next = 0;
-    for (int[] row : group.table()) {
-      if (next < row[0]) {
-        addRangeFlags(ccb, next, row[0] - 1, flags);
-      }
-      next = row[1] + 1;
-    }
-    if (next <= Utils.MAX_RUNE) {
-      addRangeFlags(ccb, next, Utils.MAX_RUNE, flags);
-    }
-  }
-
   /** Add a range to the character class, but exclude newline if asked. Also handle case folding. */
-  private void addRangeFlags(CharClassBuilder ccb, int lo, int hi, int parseFlags) {
-    // Take out \n if the flags say so.
-    boolean cutnl =
-        (parseFlags & ParseFlags.CLASS_NL) == 0 || (parseFlags & ParseFlags.NEVER_NL) != 0;
-    if (cutnl && lo <= '\n' && '\n' <= hi) {
-      if (lo < '\n') {
-        addRangeFlags(ccb, lo, '\n' - 1, parseFlags);
-      }
-      if (hi > '\n') {
-        addRangeFlags(ccb, '\n' + 1, hi, parseFlags);
-      }
-      return;
-    }
-
-    // If folding case, add fold-equivalent characters too.
-    if ((parseFlags & ParseFlags.FOLD_CASE) != 0) {
-      if ((parseFlags & ParseFlags.UNICODE_CASE) == 0) {
-        addAsciiFoldedRange(ccb, lo, hi);
-        return;
-      }
-      addUnicodeFoldedRange(ccb, lo, hi);
-    } else {
-      ccb.addRange(lo, hi);
-    }
-  }
-
-  // ---- Case folding ----
-
-  private static int asciiFoldRune(int r) {
-    if ('A' <= r && r <= 'Z') {
-      return r + ('a' - 'A');
-    }
-    if ('a' <= r && r <= 'z') {
-      return r;
-    }
-    return r;
-  }
-
-  private static void addAsciiFoldedRange(CharClassBuilder ccb, int lo, int hi) {
-    ccb.addRange(lo, hi);
-    int upperLo = Math.max(lo, 'A');
-    int upperHi = Math.min(hi, 'Z');
-    if (upperLo <= upperHi) {
-      ccb.addRange(upperLo + ('a' - 'A'), upperHi + ('a' - 'A'));
-    }
-    int lowerLo = Math.max(lo, 'a');
-    int lowerHi = Math.min(hi, 'z');
-    if (lowerLo <= lowerHi) {
-      ccb.addRange(lowerLo - ('a' - 'A'), lowerHi - ('a' - 'A'));
-    }
-  }
-
-  /**
-   * Look up the case fold entry containing r. Returns the index into CASE_FOLD, or -1 if none
-   * contains r. If r is between entries, returns the index of the next entry after r.
-   */
-  private static final int CASE_FOLD_NOT_FOUND = Integer.MIN_VALUE;
-
-  private static int lookupCaseFold(int r) {
-    int[][] cf = UnicodeTables.CASE_FOLD;
-    int lo = 0;
-    int hi = cf.length - 1;
-    while (lo <= hi) {
-      int mid = (lo + hi) >>> 1;
-      if (cf[mid][0] <= r && r <= cf[mid][1]) {
-        return mid;
-      }
-      if (r < cf[mid][0]) {
-        hi = mid - 1;
-      } else {
-        lo = mid + 1;
-      }
-    }
-    // r is not in any entry. lo points at the first entry after r.
-    if (lo < cf.length) {
-      return -(lo + 1); // negative to indicate "not found, but next is at lo"
-    }
-    return CASE_FOLD_NOT_FOUND;
-  }
-
-  /** Returns the result of applying the fold to rune r given the fold entry at index idx. */
-  private static int applyFold(int[] entry, int r) {
-    int delta = entry[2];
-    if (delta == UnicodeTables.EVEN_ODD_SKIP) {
-      if ((r - entry[0]) % 2 != 0) return r;
-      // fall through to EVEN_ODD
-      delta = UnicodeTables.EVEN_ODD;
-    }
-    if (delta == UnicodeTables.ODD_EVEN_SKIP) {
-      if ((r - entry[0]) % 2 != 0) return r;
-      // fall through to ODD_EVEN
-      delta = UnicodeTables.ODD_EVEN;
-    }
-    if (delta == UnicodeTables.EVEN_ODD) {
-      return (r % 2 == 0) ? r + 1 : r - 1;
-    }
-    if (delta == UnicodeTables.ODD_EVEN) {
-      return (r % 2 == 1) ? r + 1 : r - 1;
-    }
-    return r + delta;
-  }
-
-  /** Returns the next rune in r's folding cycle. */
-  static int cycleFoldRune(int r) {
-    int[][] cf = UnicodeTables.CASE_FOLD;
-    int idx = lookupCaseFold(r);
-    if (idx < 0) {
-      return r; // no fold for this rune
-    }
-    return applyFold(cf[idx], r);
-  }
-
-  private static void addUnicodeFoldedRange(CharClassBuilder ccb, int lo, int hi) {
-    ccb.addRange(lo, hi);
-    UnicodeCaseClosureIndex.addSourcesForTargetsInRange(ccb, lo, hi);
-  }
-
-  private static boolean hasUnicodeCaseVariant(int cp) {
-    return Character.toUpperCase(cp) != cp
-        || Character.toLowerCase(cp) != cp
-        || Character.toTitleCase(cp) != cp
-        || Character.toLowerCase(Character.toUpperCase(cp)) != cp
-        || Character.toUpperCase(Character.toLowerCase(cp)) != cp;
-  }
-
-  private static final class UnicodeCaseClosureIndex {
-    static final long[] TARGET_TO_SOURCE = buildTargetToSourcePairs();
-
-    private static void addSourcesForTargetsInRange(CharClassBuilder ccb, int lo, int hi) {
-      int index = lowerBoundTarget(lo);
-      while (index < TARGET_TO_SOURCE.length) {
-        long pair = TARGET_TO_SOURCE[index];
-        int target = target(pair);
-        if (target > hi) {
-          return;
-        }
-        ccb.addRune(source(pair));
-        index++;
-      }
-    }
-
-    private static int lowerBoundTarget(int target) {
-      long key = pack(target, 0);
-      int lo = 0;
-      int hi = TARGET_TO_SOURCE.length;
-      while (lo < hi) {
-        int mid = (lo + hi) >>> 1;
-        if (TARGET_TO_SOURCE[mid] < key) {
-          lo = mid + 1;
-        } else {
-          hi = mid;
-        }
-      }
-      return lo;
-    }
-
-    private static long[] buildTargetToSourcePairs() {
-      LongArrayBuilder pairs = new LongArrayBuilder();
-      for (int source = 0; source <= Utils.MAX_RUNE; source++) {
-        addPair(pairs, source, Character.toUpperCase(source));
-        addPair(pairs, source, Character.toLowerCase(source));
-        addPair(pairs, source, Character.toTitleCase(source));
-        addPair(pairs, source, Character.toLowerCase(Character.toUpperCase(source)));
-        addPair(pairs, source, Character.toUpperCase(Character.toLowerCase(source)));
-
-        int folded = cycleFoldRune(source);
-        while (folded != source) {
-          addPair(pairs, source, folded);
-          folded = cycleFoldRune(folded);
-        }
-      }
-
-      long[] sorted = pairs.toArray();
-      Arrays.sort(sorted);
-      return deduplicate(sorted);
-    }
-
-    private static void addPair(LongArrayBuilder pairs, int source, int target) {
-      if (source != target) {
-        pairs.add(pack(target, source));
-      }
-    }
-
-    private static long[] deduplicate(long[] sorted) {
-      if (sorted.length == 0) {
-        return sorted;
-      }
-      int size = 1;
-      for (int i = 1; i < sorted.length; i++) {
-        if (sorted[i] != sorted[size - 1]) {
-          sorted[size++] = sorted[i];
-        }
-      }
-      return Arrays.copyOf(sorted, size);
-    }
-
-    private static long pack(int target, int source) {
-      return ((long) target << Integer.SIZE) | Integer.toUnsignedLong(source);
-    }
-
-    private static int target(long pair) {
-      return (int) (pair >>> Integer.SIZE);
-    }
-
-    private static int source(long pair) {
-      return (int) pair;
-    }
-  }
-
-  private static final class LongArrayBuilder {
-    private long[] values = new long[4096];
-    private int size;
-
-    void add(long value) {
-      if (size == values.length) {
-        values = Arrays.copyOf(values, values.length * 2);
-      }
-      values[size++] = value;
-    }
-
-    long[] toArray() {
-      return Arrays.copyOf(values, size);
-    }
+  private static void addRangeFlags(CharClassBuilder ccb, int lo, int hi, int parseFlags) {
+    CharClassExpander.addRange(ccb, lo, hi, parseFlags);
   }
 
   // ---- Perl flags parsing ----

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -9,6 +9,7 @@ package org.safere;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -112,6 +113,31 @@ final class Parser {
       }
       int totalCost = multiplySaturated(multiplier, subCost, limit);
       return new RepeatCount(totalCost, re.op == RegexpOp.REPEAT || subHasRepeat);
+    }
+  }
+
+  private enum GroupCaseFoldPolicy {
+    NONE,
+    ASCII_POSIX,
+    UNICODE_CASED_LETTER_CATEGORY,
+    JAVA_CASED_PROPERTY
+  }
+
+  private static final class CharacterGroup {
+    private final int[][] table;
+    private final GroupCaseFoldPolicy caseFoldPolicy;
+
+    CharacterGroup(int[][] table, GroupCaseFoldPolicy caseFoldPolicy) {
+      this.table = table;
+      this.caseFoldPolicy = caseFoldPolicy;
+    }
+
+    int[][] table() {
+      return table;
+    }
+
+    GroupCaseFoldPolicy caseFoldPolicy() {
+      return caseFoldPolicy;
     }
   }
 
@@ -511,16 +537,6 @@ final class Parser {
       if (cc.numRanges() == 1 && cc.lo(0) == cc.hi(0)) {
         int r = cc.lo(0);
         re = Regexp.literal(r, re.flags);
-      } else if (cc.numRanges() == 2) {
-        int r = cc.lo(0);
-        if ('A' <= r
-            && r <= 'Z'
-            && cc.hi(0) == r
-            && cc.numRanges() == 2
-            && cc.lo(1) == r + ('a' - 'A')
-            && cc.hi(1) == r + ('a' - 'A')) {
-          re = Regexp.literal(r + ('a' - 'A'), flags | ParseFlags.FOLD_CASE);
-        }
       }
     }
 
@@ -533,20 +549,15 @@ final class Parser {
     // Do case folding if needed.
     if ((flags & ParseFlags.FOLD_CASE) != 0) {
       if ((flags & ParseFlags.UNICODE_CASE) == 0) {
-        int folded = asciiFoldRune(r);
-        if (folded != r) {
-          pushRegexp(Regexp.literal(folded, flags));
+        if (('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z')) {
+          CharClassBuilder ccb = new CharClassBuilder();
+          addAsciiFoldedRange(ccb, r, r);
+          pushRegexp(finishCharClassBuilder(ccb));
           return;
         }
-      } else if (cycleFoldRune(r) != r) {
+      } else if (hasUnicodeCaseVariant(r) || cycleFoldRune(r) != r) {
         CharClassBuilder ccb = new CharClassBuilder();
-        int r1 = r;
-        do {
-          if ((flags & ParseFlags.NEVER_NL) == 0 || r != '\n') {
-            ccb.addRune(r);
-          }
-          r = cycleFoldRune(r);
-        } while (r != r1);
+        addUnicodeFoldedRange(ccb, r, r);
         Regexp re = finishCharClassBuilder(ccb);
         pushRegexp(re);
         return;
@@ -4105,19 +4116,25 @@ final class Parser {
 
     pos += 2; // '\\', letter
     // Use Unicode-aware tables when UNICODE_CHAR_CLASS is active.
-    int[][] table =
-        (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0
-            ? UnicodeTables.unicodePerlGroups().get(posName)
-            : UnicodeTables.PERL_GROUPS.get(posName);
-    if (table == null) return null;
+    int[][] table = lookupPerlGroup(posName, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
+    if (table == null) {
+      return null;
+    }
+    CharacterGroup group = new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
 
     CharClassBuilder ccb = new CharClassBuilder();
     if (negate) {
-      addGroupNegated(ccb, table);
+      addGroupNegated(ccb, group);
     } else {
-      addGroupPositive(ccb, table);
+      addGroupPositive(ccb, group);
     }
     return ccb;
+  }
+
+  private static int[][] lookupPerlGroup(String name, boolean unicodeCharacterClass) {
+    return unicodeCharacterClass
+        ? UnicodeTables.unicodePerlGroups().get(name)
+        : UnicodeTables.PERL_GROUPS.get(name);
   }
 
   // ---- Unicode group parsing (\p{...}, \P{...}) ----
@@ -4158,30 +4175,30 @@ final class Parser {
       pos = end + 1; // skip '}'
     }
 
-    int[][] table = lookupUnicodeGroup(name, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
-    if (table == null) {
+    CharacterGroup group = lookupUnicodeGroup(name, (flags & ParseFlags.UNICODE_CHAR_CLASS) != 0);
+    if (group == null) {
       throw new PatternSyntaxException("invalid Unicode group: " + name, pattern, seqStart);
     }
 
     if (sign > 0) {
-      addGroupPositive(ccb, table);
+      addGroupPositive(ccb, group);
     } else {
-      addGroupNegated(ccb, table);
+      addGroupNegated(ccb, group);
     }
     return PARSE_OK;
   }
 
-  private static int[][] lookupUnicodeGroup(String name, boolean unicodeCharacterClass) {
+  private static CharacterGroup lookupUnicodeGroup(String name, boolean unicodeCharacterClass) {
     int[][] table = JavaCharacterClasses.lookup(name);
     if (table != null) {
-      return table;
+      return new CharacterGroup(table, javaClassCaseFoldPolicy(name));
     }
     table =
         unicodeCharacterClass
             ? UnicodeTables.unicodePosixPropertyGroups().get(name)
             : UnicodeTables.POSIX_PROPERTY_GROUPS.get(name);
     if (table != null) {
-      return table;
+      return new CharacterGroup(table, posixPropertyCaseFoldPolicy(name, unicodeCharacterClass));
     }
 
     // Keyword forms: script=, sc=, block=, blk=, general_category=, gc=.
@@ -4198,52 +4215,166 @@ final class Parser {
       String stripped = name.substring(2);
       table = UnicodeProperties.lookupScriptOrCategory(stripped);
       if (table != null) {
-        return table;
+        return new CharacterGroup(table, scriptOrCategoryCaseFoldPolicy(stripped));
       }
-      return UnicodeProperties.lookupBinaryProperty(stripped);
+      table = UnicodeProperties.lookupBinaryProperty(stripped);
+      if (table != null) {
+        return new CharacterGroup(table, binaryPropertyCaseFoldPolicy(stripped));
+      }
+      return null;
     }
 
     // "In" prefix: Unicode block lookup.
     if (name.startsWith("In") && name.length() > 2) {
-      return UnicodeProperties.lookupBlock(name.substring(2));
+      table = UnicodeProperties.lookupBlock(name.substring(2));
+      return table == null ? null : new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
     }
 
     // Bare Unicode properties are valid only for general categories such as "L" or "Lu".
     // JDK Pattern requires scripts to use Is/script=/sc= and blocks to use In/block=/blk=.
-    return UnicodeProperties.lookupCategory(name);
+    table = UnicodeProperties.lookupCategory(name);
+    return table == null ? null : new CharacterGroup(table, categoryCaseFoldPolicy(name));
   }
 
-  private static int[][] lookupKeywordProperty(String key, String value) {
+  private static CharacterGroup lookupKeywordProperty(String key, String value) {
     // Keywords are case-insensitive per JDK behavior; remove underscores/hyphens/spaces.
     String normalizedKey =
         key.toUpperCase(java.util.Locale.ROOT).replace("_", "").replace("-", "").replace(" ", "");
     return switch (normalizedKey) {
-      case "SCRIPT", "SC" -> UnicodeProperties.lookupScript(value);
-      case "BLOCK", "BLK" -> UnicodeProperties.lookupBlock(value);
-      case "GENERALCATEGORY", "GC" -> UnicodeProperties.lookupCategory(value);
+      case "SCRIPT", "SC" -> {
+        int[][] table = UnicodeProperties.lookupScript(value);
+        yield table == null ? null : new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
+      }
+      case "BLOCK", "BLK" -> {
+        int[][] table = UnicodeProperties.lookupBlock(value);
+        yield table == null ? null : new CharacterGroup(table, GroupCaseFoldPolicy.NONE);
+      }
+      case "GENERALCATEGORY", "GC" -> {
+        int[][] table = UnicodeProperties.lookupCategory(value);
+        yield table == null ? null : new CharacterGroup(table, categoryCaseFoldPolicy(value));
+      }
       default -> null;
     };
   }
 
+  private static GroupCaseFoldPolicy posixPropertyCaseFoldPolicy(
+      String name, boolean unicodeCharacterClass) {
+    if (unicodeCharacterClass) {
+      return switch (name) {
+        case "Lower", "Upper" -> GroupCaseFoldPolicy.JAVA_CASED_PROPERTY;
+        default -> GroupCaseFoldPolicy.NONE;
+      };
+    }
+    return GroupCaseFoldPolicy.ASCII_POSIX;
+  }
+
+  private static GroupCaseFoldPolicy javaClassCaseFoldPolicy(String name) {
+    return switch (name) {
+      case "javaUpperCase", "javaLowerCase", "javaTitleCase" ->
+          GroupCaseFoldPolicy.JAVA_CASED_PROPERTY;
+      default -> GroupCaseFoldPolicy.NONE;
+    };
+  }
+
+  private static GroupCaseFoldPolicy scriptOrCategoryCaseFoldPolicy(String name) {
+    return isCasedLetterCategoryName(name)
+        ? GroupCaseFoldPolicy.UNICODE_CASED_LETTER_CATEGORY
+        : GroupCaseFoldPolicy.NONE;
+  }
+
+  private static GroupCaseFoldPolicy categoryCaseFoldPolicy(String name) {
+    return switch (name) {
+      case "Lu", "Ll", "Lt" -> GroupCaseFoldPolicy.UNICODE_CASED_LETTER_CATEGORY;
+      default -> GroupCaseFoldPolicy.NONE;
+    };
+  }
+
+  private static GroupCaseFoldPolicy binaryPropertyCaseFoldPolicy(String name) {
+    String normalized = normalizePropertyName(name);
+    return switch (normalized) {
+      case "UPPERCASE", "LOWERCASE", "TITLECASE" -> GroupCaseFoldPolicy.JAVA_CASED_PROPERTY;
+      default -> GroupCaseFoldPolicy.NONE;
+    };
+  }
+
+  private static boolean isCasedLetterCategoryName(String name) {
+    return switch (normalizePropertyName(name)) {
+      case "LU", "LL", "LT" -> true;
+      default -> false;
+    };
+  }
+
+  private static String normalizePropertyName(String name) {
+    return name.toUpperCase(java.util.Locale.ROOT)
+        .replace("_", "")
+        .replace("-", "")
+        .replace(" ", "");
+  }
+
   // ---- Group add helpers ----
 
-  private void addGroupPositive(CharClassBuilder ccb, int[][] table) {
-    if ((flags & ParseFlags.FOLD_CASE) == 0
-        && (flags & ParseFlags.CLASS_NL) != 0
-        && (flags & ParseFlags.NEVER_NL) == 0) {
+  private void addGroupPositive(CharClassBuilder ccb, CharacterGroup group) {
+    if ((flags & ParseFlags.FOLD_CASE) == 0) {
+      addPropertyTableWithoutCaseFolding(ccb, group.table());
+      return;
+    }
+    switch (group.caseFoldPolicy()) {
+      case ASCII_POSIX -> addAsciiFoldedPropertyTable(ccb, group.table());
+      case UNICODE_CASED_LETTER_CATEGORY -> addCasedLetterCategoryClosure(ccb);
+      case JAVA_CASED_PROPERTY -> ccb.addTable(JavaCasedPropertyClosureHolder.TABLE);
+      case NONE -> addPropertyTableWithoutCaseFolding(ccb, group.table());
+    }
+  }
+
+  private void addPropertyTableWithoutCaseFolding(CharClassBuilder ccb, int[][] table) {
+    int noFoldFlags = flags & ~ParseFlags.FOLD_CASE;
+    if ((noFoldFlags & ParseFlags.CLASS_NL) != 0 && (noFoldFlags & ParseFlags.NEVER_NL) == 0) {
       ccb.addTable(table);
       return;
     }
     for (int[] row : table) {
-      addRangeFlags(ccb, row[0], row[1], flags);
+      addRangeFlags(ccb, row[0], row[1], noFoldFlags);
     }
   }
 
-  private void addGroupNegated(CharClassBuilder ccb, int[][] table) {
+  private void addAsciiFoldedPropertyTable(CharClassBuilder ccb, int[][] table) {
+    int asciiFoldFlags = flags & ~ParseFlags.UNICODE_CASE;
+    for (int[] row : table) {
+      addRangeFlags(ccb, row[0], row[1], asciiFoldFlags);
+    }
+  }
+
+  private static void addCasedLetterCategoryClosure(CharClassBuilder ccb) {
+    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Lu"));
+    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Ll"));
+    ccb.addTable(UnicodeTables.UNICODE_GROUPS.get("Lt"));
+  }
+
+  private static final class JavaCasedPropertyClosureHolder {
+    static final int[][] TABLE = buildTable();
+
+    private static int[][] buildTable() {
+      CharClassBuilder ccb = new CharClassBuilder();
+      for (int cp = 0; cp <= Utils.MAX_RUNE; cp++) {
+        if (Character.isUpperCase(cp) || Character.isLowerCase(cp) || Character.isTitleCase(cp)) {
+          ccb.addRune(cp);
+        }
+      }
+      CharClass cc = ccb.build();
+      int[][] table = new int[cc.numRanges()][2];
+      for (int i = 0; i < cc.numRanges(); i++) {
+        table[i][0] = cc.lo(i);
+        table[i][1] = cc.hi(i);
+      }
+      return table;
+    }
+  }
+
+  private void addGroupNegated(CharClassBuilder ccb, CharacterGroup group) {
     if ((flags & ParseFlags.FOLD_CASE) != 0) {
       // Build the positive set with folding, then negate, then merge.
       CharClassBuilder ccb1 = new CharClassBuilder();
-      addGroupPositive(ccb1, table);
+      addGroupPositive(ccb1, group);
       boolean cutnl = (flags & ParseFlags.CLASS_NL) == 0 || (flags & ParseFlags.NEVER_NL) != 0;
       if (cutnl) {
         ccb1.addRune('\n');
@@ -4253,7 +4384,7 @@ final class Parser {
       return;
     }
     int next = 0;
-    for (int[] row : table) {
+    for (int[] row : group.table()) {
       if (next < row[0]) {
         addRangeFlags(ccb, next, row[0] - 1, flags);
       }
@@ -4285,7 +4416,7 @@ final class Parser {
         addAsciiFoldedRange(ccb, lo, hi);
         return;
       }
-      addFoldedRange(ccb, lo, hi, 0);
+      addUnicodeFoldedRange(ccb, lo, hi);
     } else {
       ccb.addRange(lo, hi);
     }
@@ -4377,53 +4508,116 @@ final class Parser {
     return applyFold(cf[idx], r);
   }
 
-  /** Add lo-hi to the class, along with their fold-equivalent characters. */
-  private static void addFoldedRange(CharClassBuilder ccb, int lo, int hi, int depth) {
-    if (depth > 10) return;
-
-    // Track whether we actually added something new.
-    int oldRunes = ccb.numRunes();
+  private static void addUnicodeFoldedRange(CharClassBuilder ccb, int lo, int hi) {
     ccb.addRange(lo, hi);
-    if (ccb.numRunes() == oldRunes && depth > 0) {
-      // lo-hi was already there; assume fold-equivalents are too.
-      return;
+    UnicodeCaseClosureIndex.addSourcesForTargetsInRange(ccb, lo, hi);
+  }
+
+  private static boolean hasUnicodeCaseVariant(int cp) {
+    return Character.toUpperCase(cp) != cp
+        || Character.toLowerCase(cp) != cp
+        || Character.toTitleCase(cp) != cp
+        || Character.toLowerCase(Character.toUpperCase(cp)) != cp
+        || Character.toUpperCase(Character.toLowerCase(cp)) != cp;
+  }
+
+  private static final class UnicodeCaseClosureIndex {
+    static final long[] TARGET_TO_SOURCE = buildTargetToSourcePairs();
+
+    private static void addSourcesForTargetsInRange(CharClassBuilder ccb, int lo, int hi) {
+      int index = lowerBoundTarget(lo);
+      while (index < TARGET_TO_SOURCE.length) {
+        long pair = TARGET_TO_SOURCE[index];
+        int target = target(pair);
+        if (target > hi) {
+          return;
+        }
+        ccb.addRune(source(pair));
+        index++;
+      }
     }
 
-    int[][] cf = UnicodeTables.CASE_FOLD;
-    int r = lo;
-    while (r <= hi) {
-      int idx = lookupCaseFold(r);
-      if (idx < 0) {
-        if (idx == CASE_FOLD_NOT_FOUND) break; // no more entries
-        // -(lo+1) means entry at that index is above r
-        int nextIdx = -(idx + 1);
-        if (nextIdx >= cf.length) break;
-        r = cf[nextIdx][0];
-        continue;
+    private static int lowerBoundTarget(int target) {
+      long key = pack(target, 0);
+      int lo = 0;
+      int hi = TARGET_TO_SOURCE.length;
+      while (lo < hi) {
+        int mid = (lo + hi) >>> 1;
+        if (TARGET_TO_SOURCE[mid] < key) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
       }
-      if (r < cf[idx][0]) {
-        r = cf[idx][0];
-        continue;
+      return lo;
+    }
+
+    private static long[] buildTargetToSourcePairs() {
+      LongArrayBuilder pairs = new LongArrayBuilder();
+      for (int source = 0; source <= Utils.MAX_RUNE; source++) {
+        addPair(pairs, source, Character.toUpperCase(source));
+        addPair(pairs, source, Character.toLowerCase(source));
+        addPair(pairs, source, Character.toTitleCase(source));
+        addPair(pairs, source, Character.toLowerCase(Character.toUpperCase(source)));
+        addPair(pairs, source, Character.toUpperCase(Character.toLowerCase(source)));
+
+        int folded = cycleFoldRune(source);
+        while (folded != source) {
+          addPair(pairs, source, folded);
+          folded = cycleFoldRune(folded);
+        }
       }
 
-      // Add in the result of folding the range r to min(hi, cf[idx][1])
-      int lo1 = r;
-      int hi1 = Math.min(hi, cf[idx][1]);
-      int delta = cf[idx][2];
-      int flo, fhi;
-      if (delta == UnicodeTables.EVEN_ODD || delta == UnicodeTables.EVEN_ODD_SKIP) {
-        flo = (lo1 % 2 == 1) ? lo1 - 1 : lo1;
-        fhi = (hi1 % 2 == 0) ? hi1 + 1 : hi1;
-      } else if (delta == UnicodeTables.ODD_EVEN || delta == UnicodeTables.ODD_EVEN_SKIP) {
-        flo = (lo1 % 2 == 0) ? lo1 - 1 : lo1;
-        fhi = (hi1 % 2 == 1) ? hi1 + 1 : hi1;
-      } else {
-        flo = lo1 + delta;
-        fhi = hi1 + delta;
-      }
-      addFoldedRange(ccb, flo, fhi, depth + 1);
+      long[] sorted = pairs.toArray();
+      Arrays.sort(sorted);
+      return deduplicate(sorted);
+    }
 
-      r = cf[idx][1] + 1;
+    private static void addPair(LongArrayBuilder pairs, int source, int target) {
+      if (source != target) {
+        pairs.add(pack(target, source));
+      }
+    }
+
+    private static long[] deduplicate(long[] sorted) {
+      if (sorted.length == 0) {
+        return sorted;
+      }
+      int size = 1;
+      for (int i = 1; i < sorted.length; i++) {
+        if (sorted[i] != sorted[size - 1]) {
+          sorted[size++] = sorted[i];
+        }
+      }
+      return Arrays.copyOf(sorted, size);
+    }
+
+    private static long pack(int target, int source) {
+      return ((long) target << Integer.SIZE) | Integer.toUnsignedLong(source);
+    }
+
+    private static int target(long pair) {
+      return (int) (pair >>> Integer.SIZE);
+    }
+
+    private static int source(long pair) {
+      return (int) pair;
+    }
+  }
+
+  private static final class LongArrayBuilder {
+    private long[] values = new long[4096];
+    private int size;
+
+    void add(long value) {
+      if (size == values.length) {
+        values = Arrays.copyOf(values, values.length * 2);
+      }
+      values[size++] = value;
+    }
+
+    long[] toArray() {
+      return Arrays.copyOf(values, size);
     }
   }
 

--- a/safere/src/main/java/org/safere/UnicodeCaseFolding.java
+++ b/safere/src/main/java/org/safere/UnicodeCaseFolding.java
@@ -1,0 +1,198 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Arrays;
+
+/** Utilities for regex case-folded literal and range expansion. */
+final class UnicodeCaseFolding {
+  private static final int CASE_FOLD_NOT_FOUND = Integer.MIN_VALUE;
+
+  private UnicodeCaseFolding() {}
+
+  static int asciiFoldRune(int r) {
+    if ('A' <= r && r <= 'Z') {
+      return r + ('a' - 'A');
+    }
+    if ('a' <= r && r <= 'z') {
+      return r;
+    }
+    return r;
+  }
+
+  static void addAsciiFoldedRange(CharClassBuilder ccb, int lo, int hi) {
+    ccb.addRange(lo, hi);
+    int upperLo = Math.max(lo, 'A');
+    int upperHi = Math.min(hi, 'Z');
+    if (upperLo <= upperHi) {
+      ccb.addRange(upperLo + ('a' - 'A'), upperHi + ('a' - 'A'));
+    }
+    int lowerLo = Math.max(lo, 'a');
+    int lowerHi = Math.min(hi, 'z');
+    if (lowerLo <= lowerHi) {
+      ccb.addRange(lowerLo - ('a' - 'A'), lowerHi - ('a' - 'A'));
+    }
+  }
+
+  static void addUnicodeFoldedRange(CharClassBuilder ccb, int lo, int hi) {
+    ccb.addRange(lo, hi);
+    UnicodeCaseClosureIndex.addSourcesForTargetsInRange(ccb, lo, hi);
+  }
+
+  static boolean hasUnicodeCaseVariant(int cp) {
+    return Character.toUpperCase(cp) != cp
+        || Character.toLowerCase(cp) != cp
+        || Character.toTitleCase(cp) != cp
+        || Character.toLowerCase(Character.toUpperCase(cp)) != cp
+        || Character.toUpperCase(Character.toLowerCase(cp)) != cp;
+  }
+
+  static int cycleFoldRune(int r) {
+    int[][] cf = UnicodeTables.CASE_FOLD;
+    int idx = lookupCaseFold(r);
+    if (idx < 0) {
+      return r;
+    }
+    return applyFold(cf[idx], r);
+  }
+
+  private static int lookupCaseFold(int r) {
+    int[][] cf = UnicodeTables.CASE_FOLD;
+    int lo = 0;
+    int hi = cf.length - 1;
+    while (lo <= hi) {
+      int mid = (lo + hi) >>> 1;
+      if (cf[mid][0] <= r && r <= cf[mid][1]) {
+        return mid;
+      }
+      if (r < cf[mid][0]) {
+        hi = mid - 1;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return lo < cf.length ? -(lo + 1) : CASE_FOLD_NOT_FOUND;
+  }
+
+  private static int applyFold(int[] entry, int r) {
+    int delta = entry[2];
+    if (delta == UnicodeTables.EVEN_ODD_SKIP) {
+      if ((r - entry[0]) % 2 != 0) return r;
+      delta = UnicodeTables.EVEN_ODD;
+    }
+    if (delta == UnicodeTables.ODD_EVEN_SKIP) {
+      if ((r - entry[0]) % 2 != 0) return r;
+      delta = UnicodeTables.ODD_EVEN;
+    }
+    if (delta == UnicodeTables.EVEN_ODD) {
+      return (r % 2 == 0) ? r + 1 : r - 1;
+    }
+    if (delta == UnicodeTables.ODD_EVEN) {
+      return (r % 2 == 1) ? r + 1 : r - 1;
+    }
+    return r + delta;
+  }
+
+  private static final class UnicodeCaseClosureIndex {
+    static final long[] TARGET_TO_SOURCE = buildTargetToSourcePairs();
+
+    private static void addSourcesForTargetsInRange(CharClassBuilder ccb, int lo, int hi) {
+      int index = lowerBoundTarget(lo);
+      while (index < TARGET_TO_SOURCE.length) {
+        long pair = TARGET_TO_SOURCE[index];
+        int target = target(pair);
+        if (target > hi) {
+          return;
+        }
+        ccb.addRune(source(pair));
+        index++;
+      }
+    }
+
+    private static int lowerBoundTarget(int target) {
+      long key = pack(target, 0);
+      int lo = 0;
+      int hi = TARGET_TO_SOURCE.length;
+      while (lo < hi) {
+        int mid = (lo + hi) >>> 1;
+        if (TARGET_TO_SOURCE[mid] < key) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      return lo;
+    }
+
+    private static long[] buildTargetToSourcePairs() {
+      LongArrayBuilder pairs = new LongArrayBuilder();
+      for (int source = 0; source <= Utils.MAX_RUNE; source++) {
+        addPair(pairs, source, Character.toUpperCase(source));
+        addPair(pairs, source, Character.toLowerCase(source));
+        addPair(pairs, source, Character.toTitleCase(source));
+        addPair(pairs, source, Character.toLowerCase(Character.toUpperCase(source)));
+        addPair(pairs, source, Character.toUpperCase(Character.toLowerCase(source)));
+
+        int folded = cycleFoldRune(source);
+        while (folded != source) {
+          addPair(pairs, source, folded);
+          folded = cycleFoldRune(folded);
+        }
+      }
+
+      long[] sorted = pairs.toArray();
+      Arrays.sort(sorted);
+      return deduplicate(sorted);
+    }
+
+    private static void addPair(LongArrayBuilder pairs, int source, int target) {
+      if (source != target) {
+        pairs.add(pack(target, source));
+      }
+    }
+
+    private static long[] deduplicate(long[] sorted) {
+      if (sorted.length == 0) {
+        return sorted;
+      }
+      int size = 1;
+      for (int i = 1; i < sorted.length; i++) {
+        if (sorted[i] != sorted[size - 1]) {
+          sorted[size++] = sorted[i];
+        }
+      }
+      return Arrays.copyOf(sorted, size);
+    }
+
+    private static long pack(int target, int source) {
+      return ((long) target << Integer.SIZE) | Integer.toUnsignedLong(source);
+    }
+
+    private static int target(long pair) {
+      return (int) (pair >>> Integer.SIZE);
+    }
+
+    private static int source(long pair) {
+      return (int) pair;
+    }
+  }
+
+  private static final class LongArrayBuilder {
+    private long[] values = new long[4096];
+    private int size;
+
+    void add(long value) {
+      if (size == values.length) {
+        values = Arrays.copyOf(values, values.length * 2);
+      }
+      values[size++] = value;
+    }
+
+    long[] toArray() {
+      return Arrays.copyOf(values, size);
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/CompilerTest.java
+++ b/safere/src/test/java/org/safere/CompilerTest.java
@@ -27,6 +27,12 @@ class CompilerTest {
     return Compiler.compile(re);
   }
 
+  private static boolean fullMatch(Prog prog, String text) {
+    Nfa.SearchResult result =
+        Nfa.search(prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FULL_MATCH, prog.numCaptures());
+    return result.groups() != null;
+  }
+
   // ---------------------------------------------------------------------------
   // Literals
   // ---------------------------------------------------------------------------
@@ -349,15 +355,8 @@ class CompilerTest {
       Prog prog = compile("(?i)abc");
       assertThat(prog).isNotNull();
       assertHasInstOp(prog, InstOp.CHAR_RANGE);
-      boolean hasFoldCase = false;
-      for (int i = 0; i < prog.size(); i++) {
-        Inst inst = prog.inst(i);
-        if (inst.op == InstOp.CHAR_RANGE && inst.foldCase) {
-          hasFoldCase = true;
-          break;
-        }
-      }
-      assertThat(hasFoldCase).isTrue();
+      assertThat(fullMatch(prog, "ABC")).isTrue();
+      assertThat(fullMatch(prog, "ABD")).isFalse();
     }
 
     @Test

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -1325,23 +1325,20 @@ class ParserTest {
 
     @Test
     void caseInsensitive_inline() {
-      Regexp re = parse("(?i)a");
-      assertThat(re.foldCase()).isTrue();
+      assertThat(fullMatch("(?i)a", "A", PERL)).isTrue();
+      assertThat(fullMatch("(?i)a", "b", PERL)).isFalse();
     }
 
     @Test
     void caseInsensitive_scoped() {
-      Regexp re = parse("(?i:abc)");
-      assertThat(re.op).isEqualTo(RegexpOp.NON_CAPTURE);
-      assertThat(re.sub().foldCase()).isTrue();
+      assertThat(fullMatch("(?i:abc)", "ABC", PERL)).isTrue();
+      assertThat(fullMatch("(?i:abc)", "ABD", PERL)).isFalse();
     }
 
     @Test
     void caseInsensitive_turnedOff() {
-      Regexp re = parse("(?i)a(?-i)b");
-      assertThat(re.op).isEqualTo(RegexpOp.CONCAT);
-      assertThat(re.subs.get(0).foldCase()).isTrue();
-      assertThat(re.subs.get(1).foldCase()).isFalse();
+      assertThat(fullMatch("(?i)a(?-i)b", "Ab", PERL)).isTrue();
+      assertThat(fullMatch("(?i)a(?-i)b", "AB", PERL)).isFalse();
     }
 
     @Test
@@ -1373,9 +1370,8 @@ class ParserTest {
 
     @Test
     void combinedFlags() {
-      Regexp re = parse("(?is)a.b");
-      assertThat(re.op).isEqualTo(RegexpOp.CONCAT);
-      assertThat(re.subs.get(0).foldCase()).isTrue();
+      assertThat(fullMatch("(?is)a.b", "A\nb", PERL)).isTrue();
+      assertThat(fullMatch("(?is)a.b", "a\nc", PERL)).isFalse();
     }
 
     @Test

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -55,6 +55,33 @@ class PatternInternalTest {
   }
 
   @Test
+  void caseInsensitiveAsciiLiteralPreservesLiteralAccelerators() {
+    Pattern p = Pattern.compile("(?i)needle");
+
+    assertThat(p.literalMatch()).isEqualTo("needle");
+    assertThat(p.prefix()).isEqualTo("needle");
+    assertThat(p.prefixFoldCase()).isTrue();
+  }
+
+  @Test
+  void caseInsensitiveAsciiPrefixPreservesPrefixAccelerator() {
+    Pattern p = Pattern.compile("(?i)needle\\d+");
+
+    assertThat(p.literalMatch()).isNull();
+    assertThat(p.prefix()).isEqualTo("needle");
+    assertThat(p.prefixFoldCase()).isTrue();
+  }
+
+  @Test
+  void caseInsensitiveAsciiLiteralUsesLiteralMatchMetadata() {
+    Pattern p = Pattern.compile("(?i)i");
+
+    assertThat(p.literalMatch()).isEqualTo("i");
+    assertThat(p.prefix()).isEqualTo("i");
+    assertThat(p.prefixFoldCase()).isTrue();
+  }
+
+  @Test
   void dotStarAroundWhitespaceRecordsRequiredWhitespaceClass() {
     Pattern p = Pattern.compile(".*\\s+.*");
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -191,6 +191,45 @@ class PatternTest {
     }
 
     @Test
+    void inlineCaseInsensitiveAsciiLiteralKeepsLiteralFastPathMetadata() {
+      Pattern p = Pattern.compile("(?i)needle");
+
+      assertThat(p.literalMatch()).isEqualTo("needle");
+      assertThat(p.prefix()).isEqualTo("needle");
+      assertThat(p.prefixFoldCase()).isTrue();
+    }
+
+    @Test
+    void inlineCaseInsensitiveAsciiPrefixKeepsPrefixAccelerationMetadata() {
+      Pattern p = Pattern.compile("(?i)needle\\d+");
+
+      assertThat(p.literalMatch()).isNull();
+      assertThat(p.prefix()).isEqualTo("needle");
+      assertThat(p.prefixFoldCase()).isTrue();
+    }
+
+    @Test
+    void asciiCaseInsensitiveLiteralFastPathDoesNotUseUnicodeCaseFolding() {
+      Pattern p = Pattern.compile("(?i)i");
+
+      assertThat(p.literalMatch()).isEqualTo("i");
+      assertThat(p.matcher("I").matches()).isTrue();
+      assertThat(p.matcher("\u0130").matches()).isFalse();
+      assertThat(p.matcher("\u0131").matches()).isFalse();
+    }
+
+    @Test
+    void asciiCaseInsensitivePrefixAccelerationSkipsUnicodeCaseVariants() {
+      Pattern p = Pattern.compile("(?i)i.");
+      Matcher m = p.matcher("\u0130xix");
+
+      assertThat(p.prefix()).isEqualTo("i");
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+      assertThat(m.group()).isEqualTo("ix");
+    }
+
+    @Test
     void dotall() {
       Pattern p = Pattern.compile("a.b", Pattern.DOTALL);
       assertThat(p.flags()).isEqualTo(Pattern.DOTALL);

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -191,28 +191,9 @@ class PatternTest {
     }
 
     @Test
-    void inlineCaseInsensitiveAsciiLiteralKeepsLiteralFastPathMetadata() {
-      Pattern p = Pattern.compile("(?i)needle");
-
-      assertThat(p.literalMatch()).isEqualTo("needle");
-      assertThat(p.prefix()).isEqualTo("needle");
-      assertThat(p.prefixFoldCase()).isTrue();
-    }
-
-    @Test
-    void inlineCaseInsensitiveAsciiPrefixKeepsPrefixAccelerationMetadata() {
-      Pattern p = Pattern.compile("(?i)needle\\d+");
-
-      assertThat(p.literalMatch()).isNull();
-      assertThat(p.prefix()).isEqualTo("needle");
-      assertThat(p.prefixFoldCase()).isTrue();
-    }
-
-    @Test
     void asciiCaseInsensitiveLiteralFastPathDoesNotUseUnicodeCaseFolding() {
       Pattern p = Pattern.compile("(?i)i");
 
-      assertThat(p.literalMatch()).isEqualTo("i");
       assertThat(p.matcher("I").matches()).isTrue();
       assertThat(p.matcher("\u0130").matches()).isFalse();
       assertThat(p.matcher("\u0131").matches()).isFalse();
@@ -223,7 +204,6 @@ class PatternTest {
       Pattern p = Pattern.compile("(?i)i.");
       Matcher m = p.matcher("\u0130xix");
 
-      assertThat(p.prefix()).isEqualTo("i");
       assertThat(m.find()).isTrue();
       assertThat(m.start()).isEqualTo(2);
       assertThat(m.group()).isEqualTo("ix");

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -129,7 +129,7 @@ class SimplifierTest {
         Arguments.of("(?iu)K", "[Kk\\x{212a}]"),
         Arguments.of("(?iu)k", "[Kk\\x{212a}]"),
         Arguments.of("(?iu)\\x{212a}", "[Kk\\x{212a}]"),
-        Arguments.of("(?iu)[a-z]", "[A-Za-z\\x{17f}\\x{212a}]"),
+        Arguments.of("(?iu)[a-z]", "[A-Za-z\\x{130}-\\x{131}\\x{17f}\\x{212a}]"),
         Arguments.of("(?i)[\\x00-\\x{FFFD}]", "[\\x00-\\x{fffd}]"),
         Arguments.of("(?i)[\\x00-\\x{10ffff}]", "."),
 

--- a/safere/src/test/java/org/safere/SimplifierTest.java
+++ b/safere/src/test/java/org/safere/SimplifierTest.java
@@ -120,9 +120,9 @@ class SimplifierTest {
         Arguments.of("[[:cntrl:][:^cntrl:]]", "[:\\^clnrt]"),
 
         // Unicode case folding
-        Arguments.of("(?i)A", "[Aa]"),
+        Arguments.of("(?i)A", "A"),
         Arguments.of("(?i)a", "[Aa]"),
-        Arguments.of("(?i)K", "[Kk]"),
+        Arguments.of("(?i)K", "K"),
         Arguments.of("(?i)k", "[Kk]"),
         Arguments.of("(?i)\\x{212a}", "\\x{212a}"),
         Arguments.of("(?i)[a-z]", "[A-Za-z]"),
@@ -205,9 +205,9 @@ class SimplifierTest {
         Arguments.of("\\d*\\d*", "[0-9]*"),
         Arguments.of(".*.*", ".*"),
         // FoldCase works, but must be consistent:
-        Arguments.of("(?i)A*a*", "[Aa]*"),
-        Arguments.of("(?i)a+A+", "[Aa][Aa]+"),
-        Arguments.of("(?i)A*(?-i)a*", "[Aa]*a*"),
+        Arguments.of("(?i)A*a*", "A*[Aa]*"),
+        Arguments.of("(?i)a+A+", "[Aa]+A+"),
+        Arguments.of("(?i)A*(?-i)a*", "A*a*"),
         Arguments.of("(?i)a+(?-i)A+", "[Aa]+A+"),
         // NonGreedy works, but must be consistent:
         Arguments.of("a*?a*?", "a*?"),
@@ -219,9 +219,9 @@ class SimplifierTest {
         Arguments.of("\\d*\\d", "[0-9]+"),
         Arguments.of(".*.", ".+"),
         // FoldCase consistent:
-        Arguments.of("(?i)A*a", "[Aa]+"),
-        Arguments.of("(?i)a+A", "[Aa][Aa]+"),
-        Arguments.of("(?i)A*(?-i)a", "[Aa]*a"),
+        Arguments.of("(?i)A*a", "A*[Aa]"),
+        Arguments.of("(?i)a+A", "[Aa]+A"),
+        Arguments.of("(?i)A*(?-i)a", "A*a"),
         Arguments.of("(?i)a+(?-i)A", "[Aa]+A"),
         // The second element is a literal string beginning with the literal:
         Arguments.of("a*aa", "aa+"),

--- a/safere/src/test/java/org/safere/UnicodeCaseFoldingJdkImplementationDetailTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCaseFoldingJdkImplementationDetailTest.java
@@ -1,0 +1,52 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Inventory of observed JDK Unicode case-insensitive range behavior that appears to depend on
+ * {@code java.util.regex} implementation details rather than on specified regex semantics.
+ *
+ * <p>These cases are intentionally not active SafeRE compatibility requirements. SafeRE treats
+ * Unicode case-insensitive character classes as sets closed under Unicode case folding, so these
+ * JDK observations are documented here instead of encoded as active SafeRE expectations.
+ */
+@Disabled("Observed JDK Unicode case-folding range details; not a SafeRE compatibility target")
+@DisplayName("JDK Unicode case-folding implementation-detail inventory")
+class UnicodeCaseFoldingJdkImplementationDetailTest {
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("jdkRangeCases")
+  @DisplayName("selected Unicode case-insensitive ranges have JDK implementation-specific misses")
+  void selectedUnicodeCaseInsensitiveRangesHaveJdkImplementationSpecificMisses(
+      String description, String regex, String input) {
+    java.util.regex.Pattern pattern =
+        java.util.regex.Pattern.compile(
+            regex, java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.UNICODE_CASE);
+
+    assertThat(pattern.matcher(input).matches()).as(description).isFalse();
+  }
+
+  private static Stream<Arguments> jdkRangeCases() {
+    return Stream.of(
+        Arguments.of(
+            "JDK does not match Kelvin sign with singleton range [K-K]", "[K-K]", "\u212A"),
+        Arguments.of(
+            "JDK does not match Kelvin sign with uppercase range [A-Z]", "[A-Z]", "\u212A"),
+        Arguments.of(
+            "JDK does not match capital I with dot with singleton range [I-I]", "[I-I]", "\u0130"),
+        Arguments.of(
+            "JDK does not match capital I with dot with uppercase range [A-Z]", "[A-Z]", "\u0130"));
+  }
+}

--- a/safere/src/test/java/org/safere/UnicodeCaseFoldingModelTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCaseFoldingModelTest.java
@@ -1,0 +1,46 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for SafeRE's documented Unicode case-folding model where it intentionally diverges from
+ * selected JDK range traces.
+ */
+@DisabledForCrosscheck(
+    "SafeRE's documented Unicode case-folding model intentionally diverges from selected JDK range"
+        + " traces")
+class UnicodeCaseFoldingModelTest {
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("closedRangeCases")
+  @DisplayName("Unicode case-insensitive ranges are closed under case folding")
+  void unicodeCaseInsensitiveRangesAreClosedUnderCaseFolding(
+      String description, String regex, String input) {
+    Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+
+    assertThat(pattern.matcher(input).matches()).as(description).isTrue();
+  }
+
+  private static Stream<Arguments> closedRangeCases() {
+    return Stream.of(
+        Arguments.of(
+            "singleton range [K-K] includes Kelvin sign's case-fold equivalent", "[K-K]", "\u212A"),
+        Arguments.of(
+            "uppercase range [A-Z] includes Kelvin sign's case-fold equivalent", "[A-Z]", "\u212A"),
+        Arguments.of(
+            "singleton range [I-I] includes capital I with dot's case variant", "[I-I]", "\u0130"),
+        Arguments.of(
+            "uppercase range [A-Z] includes capital I with dot's case variant", "[A-Z]", "\u0130"));
+  }
+}

--- a/safere/src/test/java/org/safere/UnicodeCaseTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCaseTest.java
@@ -199,6 +199,8 @@ class UnicodeCaseTest {
     "\\x{69}, \u0130, true",
     "\\x{69}, \u0131, true"
   })
+  @DisabledForCrosscheck(
+      "SafeRE intentionally follows Unicode case closure when observed JDK range behavior diverges")
   void unicodeCaseInsensitiveRangesUseUnicodeCasedClosure(
       String regex, String input, boolean expected) {
     int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;

--- a/safere/src/test/java/org/safere/UnicodeCaseTest.java
+++ b/safere/src/test/java/org/safere/UnicodeCaseTest.java
@@ -8,6 +8,8 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link Pattern#UNICODE_CASE} flag behavior.
@@ -15,8 +17,11 @@ import org.junit.jupiter.api.Test;
  * <p>{@code UNICODE_CASE} controls <i>how</i> case folding works (Unicode vs ASCII-only) when
  * {@link Pattern#CASE_INSENSITIVE} is also set. By itself, it should have no effect on matching.
  *
- * <p>{@code CASE_INSENSITIVE} alone folds ASCII only, matching the JDK. Add {@code UNICODE_CASE}
- * for Unicode-aware folding.
+ * <p>{@code CASE_INSENSITIVE} alone folds ASCII literals and ranges only, matching the JDK. Add
+ * {@code UNICODE_CASE} for Unicode-aware literal and range folding. Unicode case-sensitive
+ * character properties such as {@code \p{Lu}}, {@code \p{Ll}}, and {@code \p{Lt}} are themselves
+ * Unicode predicates, and JDK case-insensitive matching applies a Unicode cased-letter closure to
+ * those predicates even when {@code UNICODE_CASE} is not set.
  */
 class UnicodeCaseTest {
 
@@ -138,5 +143,115 @@ class UnicodeCaseTest {
     // but SafeRE uses simple case folding which maps İ→i and I→ı through Unicode tables.
     Pattern p = Pattern.compile("i", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     assertThat(p.matcher("I").matches()).isTrue();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "\\p{Lu}, A, true",
+    "\\p{Lu}, a, true",
+    "\\p{Lu}, \u01C4, true",
+    "\\p{Lu}, \u01C5, true",
+    "\\p{Lu}, \u01C6, true",
+    "\\p{Ll}, A, true",
+    "\\p{Ll}, a, true",
+    "\\p{Lt}, A, true",
+    "\\p{Lt}, a, true",
+    "\\p{Lt}, \u01C4, true",
+    "\\p{Lt}, \u01C5, true",
+    "\\p{Lt}, \u01C6, true",
+    "\\P{Lt}, A, false",
+    "[\\p{Lt}], a, true",
+    "[^\\p{Lt}], a, false",
+    "\\p{Lt}{4}, abcd, true",
+    "\\p{javaUpperCase}, \u00AA, true",
+    "\\p{javaLowerCase}, \u02B0, true",
+    "\\p{javaTitleCase}, \u01C5, true",
+    "\\p{IsUppercase}, \u0345, true",
+    "\\p{IsLowercase}, \u2160, true",
+    "\\p{Lt}, 1, false",
+    "\\p{javaUpperCase}, 1, false",
+    "\\P{Lt}, 1, true"
+  })
+  void caseInsensitiveUnicodeLetterCategoriesUseCasedLetterClosure(
+      String regex, String input, boolean expected) {
+    assertThat(Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(input).matches())
+        .isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "[h-j], \u0130, true",
+    "[h-j], \u0131, true",
+    "[H-J], \u0131, true",
+    "[^h-j], \u0130, false",
+    "[A-Z], \u0130, true",
+    "[I-I], \u0130, true",
+    "[A-Z], \u212A, true",
+    "[K-K], \u212A, true",
+    "[a-z], \u212A, true",
+    "[k-k], \u212A, true",
+    "[A-Z], \u017F, true",
+    "[S-S], \u017F, true",
+    "[\\x{212A}], K, true",
+    "[\\x{17F}], S, true",
+    "\\x{49}, \u0130, true",
+    "\\x{49}, \u0131, true",
+    "\\x{69}, \u0130, true",
+    "\\x{69}, \u0131, true"
+  })
+  void unicodeCaseInsensitiveRangesUseUnicodeCasedClosure(
+      String regex, String input, boolean expected) {
+    int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+    assertThat(Pattern.compile(regex, flags).matcher(input).matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "\\p{L}, \u0345, false",
+    "\\P{L}, \u0345, true",
+    "\\p{gc=L}, \u0345, false",
+    "\\p{Lower}, \u212A, false",
+    "\\p{ASCII}, \u212A, false"
+  })
+  void caseInsensitivePropertiesDoNotUseRangeCaseClosure(
+      String regex, String input, boolean expected) {
+    int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+    assertThat(Pattern.compile(regex, flags).matcher(input).matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "\\p{L}, \u0345, false",
+    "\\P{L}, \u0345, true",
+    "\\p{Lower}, \u0345, true",
+    "\\p{Upper}, \u0345, true"
+  })
+  void unicodeCharacterClassPropertiesUseUnicodeCompatibilityPredicates(
+      String regex, String input, boolean expected) {
+    int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS;
+    assertThat(Pattern.compile(regex, flags).matcher(input).matches()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"[h-j], \u0130, false", "[h-j], \u0131, false", "[^h-j], \u0130, true"})
+  void caseInsensitiveRangesWithoutUnicodeCaseKeepAsciiOnlyFolding(
+      String regex, String input, boolean expected) {
+    assertThat(Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(input).matches())
+        .isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "k, \u212A",
+    "K, \u212A",
+    "[k], \u212A",
+    "[K], \u212A",
+    "i, \u0130",
+    "I, \u0131",
+    "[i], \u0130",
+    "[I], \u0131"
+  })
+  void caseInsensitiveLiteralsWithoutUnicodeCaseDoNotUseUnicodeFolds(String regex, String input) {
+    assertThat(Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(input).matches()).isFalse();
   }
 }


### PR DESCRIPTION
## Summary

- Fix Unicode case-insensitive character-class closure for ranges and literals, including Turkish I and Kelvin-sign cases.
- Carry explicit property case-fold policies through Unicode group lookup instead of inferring semantics from `int[][]` table identity.
- Add a lazy inverse Unicode case-closure index so folded range expansion does not rescan all case-variant code points per compile.
- Add focused SafeRE model tests, disabled JDK implementation-detail inventory tests, fuzzer regression seeds, and a case-folding exhaustive sweep.

Fixes #358
Fixes #359
Refs #452

## Verification

Ran:

```bash
mvn -pl safere -DskipTests compile -q
mvn -pl safere -Dtest=UnicodeCaseTest,UnicodeCaseFoldingModelTest,UnicodeCaseFoldingJdkImplementationDetailTest test -q
mvn -pl safere-fuzz -am -Dtest=MatchFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q
mvn spotless:apply -q
git diff --check
```

Also checked the completed case-folding sweep output at:

```text
target/exhaustive-reports/case-folding-character-class-sweep-full/case-folding-character-class-divergences.jsonl
```

It contains 8 known intentional SafeRE/JDK divergences for Unicode uppercase range closure involving U+0130 and U+212A. No new actionable SafeRE bug appeared in that sweep.

Not run: full Maven test suite, full crosscheck suite, benchmarks.
