### PR TITLE
Fix DFA Unicode boundary start cache

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -47,6 +47,7 @@ final class MatchFuzzer {
     for (RegressionCase regression : CASE_FOLDING_MODEL_REGRESSIONS) {
       assertFullMatchesSafeRe(regression.regex(), regression.flags(), regression.inputs());
     }
+    assertUnicodeBoundaryStartCacheMatchesJdk();
 
     String regex;
     int flags;
@@ -83,6 +84,21 @@ final class MatchFuzzer {
       pattern.appendCodePoint(0x1000 + i * 2);
     }
     return pattern.toString();
+  }
+
+  private static void assertUnicodeBoundaryStartCacheMatchesJdk() {
+    String regex = "\\b.";
+    int flags = org.safere.Pattern.UNICODE_CHARACTER_CLASS;
+    FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, flags);
+    if (pattern == null) {
+      return;
+    }
+
+    String boundary = "!\u00E9" + "x".repeat(300);
+    String nonBoundary = "!!" + "x".repeat(300);
+    FuzzSupport.MatcherPair matcher = pattern.matcher(boundary);
+    matcher.region(1, boundary.length()).lookingAt();
+    matcher.reset(nonBoundary).region(1, nonBoundary.length()).lookingAt();
   }
 
   private static void assertFullMatchesSafeRe(String regex, int flags, List<String> inputs) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -180,8 +180,8 @@ final class Dfa {
    * Cache of DFA start states indexed by position context. The start state depends on four factors:
    * whether the search is anchored, whether it's a reverse context, the empty-width flags at the
    * position, and whether the previous character was a word character. This gives at most 2 × 2 ×
-   * 1024 × 2 × 2 combinations. Caching avoids the expensive {@link #expand} call and its {@code
-   * Arrays.copyOf} allocation on every DFA search.
+   * masked-empty-flag-count × 2 × 2 combinations. Caching avoids the expensive {@link #expand} call
+   * and its {@code Arrays.copyOf} allocation on every DFA search.
    */
   private final State[] startStateByContext;
 
@@ -223,7 +223,11 @@ final class Dfa {
         hasGraphemeSemantics
             ? EmptyOp.ALL_FLAGS
             : EmptyOp.ALL_FLAGS & ~EmptyOp.GRAPHEME_CLUSTER_BOUNDARY;
-    this.startCacheEmptyFlagsMask = hasGraphemeSemantics ? EmptyOp.ALL_FLAGS : 0x7F;
+    this.startCacheEmptyFlagsMask =
+        hasGraphemeSemantics
+            ? EmptyOp.ALL_FLAGS
+            : EmptyOp.ALL_FLAGS
+                & ~(EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY);
     this.reverseCacheBit = (startCacheEmptyFlagsMask + 1) << 2;
     this.anchoredCacheBit = reverseCacheBit << 1;
     this.startStateByContext = new State[anchoredCacheBit << 1];

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -271,6 +271,20 @@ class DfaTest {
       assertThat(r.matched()).isTrue();
       assertThat(r.pos()).isEqualTo(7);
     }
+
+    @Test
+    void unicodeWordBoundaryStartStateCacheDistinguishesNextCharacterContext() {
+      Regexp re = Parser.parse("\\b.", FLAGS | ParseFlags.UNICODE_CHAR_CLASS);
+      Prog prog = Compiler.compile(re);
+      Dfa dfa = new Dfa(prog, 10_000, Dfa.buildSetup(prog));
+
+      Dfa.SearchResult boundary = dfa.doSearch("!\u00E9", 1, true, false);
+      Dfa.SearchResult nonBoundary = dfa.doSearch("!!", 1, true, false);
+
+      assertThat(boundary.matched()).isTrue();
+      assertThat(boundary.pos()).isEqualTo(2);
+      assertThat(nonBoundary.matched()).isFalse();
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

- Include Unicode word-boundary empty flags in the DFA start-state cache key.
- Add a focused DFA regression for reused start states across Unicode boundary contexts.
- Add MatchFuzzer coverage for the corresponding public API matcher reuse shape.

Fixes #294

## Verification

- `mvn -pl safere -Dtest=DfaTest test`
- `mvn -pl safere-fuzz -am -Dtest=MatchFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere test -q`

## Not Run

- Full public API crosscheck validation.
