### PR TITLE
Add compact divergence audit

### DIFF
--- a/.agents/skills/divergence-result-review/SKILL.md
+++ b/.agents/skills/divergence-result-review/SKILL.md
@@ -77,6 +77,10 @@ For Unicode grapheme behavior, use Unicode UAX #29 and the project design:
    - one example showing captures or statefulness if relevant.
 4. Separate already-known intentional classes from unknown classes. Use existing project tests and
    design docs to avoid reopening decisions already made.
+5. When reviewing completed sweep outputs, include representative `KNOWN_INTENTIONAL` samples.
+   Verify that the actual trace mismatch matches the documented reason for that class; do not
+   assume the stored classification is correct. A too-broad known classifier can hide an unrelated
+   bug even when the class label looks familiar.
 
 ## Classification
 

--- a/INTENTIONAL_DIVERGENCES.md
+++ b/INTENTIONAL_DIVERGENCES.md
@@ -158,6 +158,7 @@ Sweep names:
 - `BOUNDARY_CLUSTER_ALTERNATIVE_FIND_CURSOR`
 - `GRAPHEME_BOUNDARY_ALTERNATIVE_FIND_CURSOR`
 - `GRAPHEME_BOUNDARY_ALTERNATIVE_GRAPHEME_MODEL`
+- `GRAPHEME_BOUNDARY_CAPTURE_GRAPHEME_MODEL`
 
 Issue reference: #451.
 
@@ -174,6 +175,12 @@ correct because the documented `find()` cursor rule is position-based, and
 ordinary zero-width constructs remain observable under the same pattern shape.
 The JDK trace looks like a special interaction between its grapheme
 implementation and repeated-find state, not a general regex rule.
+
+The same underlying model difference can be visible through captures around a
+zero-width `\b{g}` assertion. SafeRE keeps captures consistent with its
+grapheme-boundary predicate; observed JDK traces can expose captures from
+positions that SafeRE does not treat as grapheme boundaries, such as positions
+inside a full surrogate-pair grapheme view.
 
 ## Region-Local Grapheme Continuation Clusters
 
@@ -228,5 +235,6 @@ applied normally.
 | `BOUNDARY_CLUSTER_ALTERNATIVE_FIND_CURSOR` | Intentional | Grapheme Boundary Alternatives and find Cursor State |
 | `GRAPHEME_BOUNDARY_ALTERNATIVE_FIND_CURSOR` | Intentional | Grapheme Boundary Alternatives and find Cursor State |
 | `GRAPHEME_BOUNDARY_ALTERNATIVE_GRAPHEME_MODEL` | Intentional | Grapheme Boundary Alternatives and find Cursor State |
+| `GRAPHEME_BOUNDARY_CAPTURE_GRAPHEME_MODEL` | Intentional | Grapheme Boundary Alternatives and find Cursor State |
 | `REGION_LOCAL_CONTINUATION_CLUSTER` | Intentional | Region-Local Grapheme Continuation Clusters |
 | `TRANSPARENT_BOUNDARY_JDK_DETAIL` | Intentional | Transparent Grapheme Boundary Details |

--- a/run-exhaustive-audit.sh
+++ b/run-exhaustive-audit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+quote_exec_arg() {
+  local value="$1"
+  value="${value//\'/\'\\\'\'}"
+  printf "'%s'" "$value"
+}
+
+exec_args=""
+for arg in "$@"; do
+  if [[ -n "$exec_args" ]]; then
+    exec_args+=" "
+  fi
+  exec_args+="$(quote_exec_arg "$arg")"
+done
+
+mvn -pl safere-exhaustive -am -DskipTests install -q
+mvn -pl safere-exhaustive exec:java \
+  -Dexec.mainClass=org.safere.exhaustive.CompactDivergenceAudit \
+  -Dexec.args="$exec_args" \
+  -q

--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -45,6 +45,61 @@ explicitly stream every recorded divergence in every classification into
 expanded JSONL. Sweep replay mode writes bounded diagnostic reports directly
 because its input is already explicit JSONL.
 
+## Compact Known-Divergence Audit
+
+Use compact audit after changing parser behavior, matcher behavior, or sweep
+classifiers, and when reviewing whether a known-intentional bucket is hiding
+bugs. It currently supports zero-width quantifier archives. It samples every
+`KNOWN_INTENTIONAL` class in an existing compact archive, replays those case
+indices through the current sweep classifier, and writes a transition table from
+archived classification to current classification:
+
+```bash
+./run-exhaustive-audit.sh \
+  --input-dir=target/exhaustive-reports/zero-width-quantifier-sweep-full
+```
+
+By default the audit samples 1000 records from each known-intentional class and
+writes reports under `audit/` inside the archive:
+
+- `source-counts.tsv`: exact archived counts and sampled counts per source
+  classification.
+- `transition-counts.tsv`: sampled
+  `sourceClass -> replayClass` counts, including `NO_DIVERGENCE` for cases that
+  no longer diverge under the current code.
+
+Use `--sample-limit=N` for a larger audit sample, and `--output-dir=...` to keep
+multiple audit runs. Suspicious transitions are source known-intentional classes
+that replay as `UNKNOWN` or as an `EXPECTED_ZERO` class. A transition to
+`NO_DIVERGENCE` usually means the old bucket contained cases fixed by newer
+code. A transition to another `KNOWN_INTENTIONAL` class usually means the old
+classifier was broader than the current one; review the target class to confirm
+the remaining mismatch shape is still intentional.
+
+The audit is intentionally classification-focused. It does not replace expanding
+or replaying specific JSONL examples when a suspicious transition needs a small
+human-readable reproducer.
+
+## Full Sweep Review Procedure
+
+Use this workflow when running a full exhaustive sweep for review:
+
+1. Run the full sweep with a fresh `--output-dir`.
+2. Run the expander on that compact archive.
+3. Inspect `progress.json` and `expanded/class-counts.tsv`.
+4. Fix any nonzero `EXPECTED_ZERO` classes. These are known bug classes that
+   should disappear in a clean run.
+5. Review and classify any `UNKNOWN` examples. Fix real bugs, or add a narrow
+   classifier and documentation when the divergence is intentional.
+6. Review representative `KNOWN_INTENTIONAL` samples from the expanded output.
+   Confirm that the actual trace mismatch matches the documented reason for
+   that class; do not assume the stored classification is correct.
+7. Replay only the affected expanded JSONL files after fixes or classifier
+   changes. Avoid rerunning the full sweep until targeted replay shows the
+   actionable and unknown classes are clean.
+8. Optionally run compact audit mode against older archives to compare archived
+   known-intentional buckets with the current classifier.
+
 ## Character Class Sweep
 
 Run through the dispatcher script so dependency classpaths are handled by Maven:

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceAudit.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceAudit.java
@@ -1,0 +1,249 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.exhaustive;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/** Replays sampled compact known-divergence buckets through the current sweep classifier. */
+public final class CompactDivergenceAudit {
+  private static final int DEFAULT_SAMPLE_LIMIT = 1000;
+  private static final String NO_DIVERGENCE = "NO_DIVERGENCE";
+  private static final String NO_DIVERGENCE_STATUS = "NO_DIVERGENCE";
+
+  private CompactDivergenceAudit() {}
+
+  public static void main(String[] args) throws IOException {
+    Options options = Options.parse(args);
+    CompactDivergenceLogs.Manifest manifest =
+        CompactDivergenceLogs.readManifest(options.inputDir());
+    AuditSweep sweep = auditSweep(manifest.sweep());
+    validateCompatibleSweep(manifest, sweep);
+
+    Map<String, SourceSamples> sourceSamples = sampleSourceBuckets(options, manifest);
+    Map<String, Map<String, Long>> transitions = new LinkedHashMap<>();
+    for (var entry : sourceSamples.entrySet()) {
+      String sourceClass = entry.getKey();
+      Map<String, Long> replayCounts = new LinkedHashMap<>();
+      transitions.put(sourceClass, replayCounts);
+      for (long caseIndex : entry.getValue().samples()) {
+        AuditClassification replayClass = sweep.classify(caseIndex);
+        replayCounts.merge(replayClass.name(), 1L, Long::sum);
+      }
+    }
+
+    Path outputDir = options.outputDir();
+    Files.createDirectories(outputDir);
+    writeSourceCounts(outputDir.resolve("source-counts.tsv"), sourceSamples);
+    writeTransitions(outputDir.resolve("transition-counts.tsv"), manifest, sweep, transitions);
+
+    System.out.println("inputDir=" + options.inputDir());
+    System.out.println("outputDir=" + outputDir);
+    System.out.println("sampleLimit=" + options.sampleLimit());
+    for (var entry : sourceSamples.entrySet()) {
+      System.out.println(entry.getKey() + "=" + entry.getValue().count());
+    }
+  }
+
+  private static Map<String, SourceSamples> sampleSourceBuckets(
+      Options options, CompactDivergenceLogs.Manifest manifest) throws IOException {
+    Map<String, SourceSamples> samples = new LinkedHashMap<>();
+    for (int i = 0; i < manifest.classifications().size(); i++) {
+      if (manifest.classificationStatuses().get(i) != DivergenceStatus.KNOWN_INTENTIONAL) {
+        continue;
+      }
+      String classification = manifest.classifications().get(i);
+      samples.put(
+          classification, new SourceSamples(options.sampleLimit(), classification.hashCode()));
+    }
+    CompactDivergenceLogs.readRecords(
+        options.inputDir(),
+        manifest,
+        record -> {
+          String classification = manifest.classifications().get(record.classificationId());
+          SourceSamples sourceSamples = samples.get(classification);
+          if (sourceSamples != null) {
+            sourceSamples.record(record.caseIndex());
+          }
+        });
+    return samples;
+  }
+
+  private static void writeSourceCounts(Path path, Map<String, SourceSamples> sourceSamples)
+      throws IOException {
+    try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+      writer.write("sourceClass\tsourceCount\tsampled");
+      writer.newLine();
+      for (var entry : sourceSamples.entrySet()) {
+        writer.write(entry.getKey());
+        writer.write('\t');
+        writer.write(Long.toString(entry.getValue().count()));
+        writer.write('\t');
+        writer.write(Integer.toString(entry.getValue().samples().size()));
+        writer.newLine();
+      }
+    }
+  }
+
+  private static void writeTransitions(
+      Path path,
+      CompactDivergenceLogs.Manifest manifest,
+      AuditSweep sweep,
+      Map<String, Map<String, Long>> transitions)
+      throws IOException {
+    try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+      writer.write("sourceClass\tsourceStatus\treplayClass\treplayStatus\tcount");
+      writer.newLine();
+      for (var sourceEntry : transitions.entrySet()) {
+        String sourceClass = sourceEntry.getKey();
+        String sourceStatus = sourceStatus(manifest, sourceClass);
+        for (var replayEntry : sourceEntry.getValue().entrySet()) {
+          writer.write(sourceClass);
+          writer.write('\t');
+          writer.write(sourceStatus);
+          writer.write('\t');
+          writer.write(replayEntry.getKey());
+          writer.write('\t');
+          writer.write(replayStatus(sweep, replayEntry.getKey()));
+          writer.write('\t');
+          writer.write(Long.toString(replayEntry.getValue()));
+          writer.newLine();
+        }
+      }
+    }
+  }
+
+  private static String sourceStatus(CompactDivergenceLogs.Manifest manifest, String sourceClass) {
+    int index = manifest.classifications().indexOf(sourceClass);
+    if (index < 0) {
+      throw new IllegalArgumentException("source class is not in manifest: " + sourceClass);
+    }
+    return manifest.classificationStatuses().get(index).name();
+  }
+
+  private static String replayStatus(AuditSweep sweep, String replayClass) {
+    if (replayClass.equals(NO_DIVERGENCE)) {
+      return NO_DIVERGENCE_STATUS;
+    }
+    DivergenceStatus status = sweep.statuses().get(replayClass);
+    if (status == null) {
+      throw new IllegalArgumentException("replay class is not in current sweep: " + replayClass);
+    }
+    return status.name();
+  }
+
+  private static void validateCompatibleSweep(
+      CompactDivergenceLogs.Manifest manifest, AuditSweep sweep) {
+    // This is a best-effort guard against stale indices, not a proof that ordering is unchanged.
+    if (manifest.totalCases() != sweep.totalCases()) {
+      throw new IllegalArgumentException(
+          "compact log case count does not match current sweep: archive="
+              + manifest.totalCases()
+              + " current="
+              + sweep.totalCases());
+    }
+  }
+
+  private static AuditSweep auditSweep(String sweep) {
+    return switch (sweep) {
+      case "zero-width-quantifier" ->
+          new AuditSweep(
+              ZeroWidthQuantifierDivergenceSweep.totalCases(),
+              ZeroWidthQuantifierDivergenceSweep.divergenceClassificationStatusMap(),
+              caseIndex -> {
+                String classification =
+                    ZeroWidthQuantifierDivergenceSweep.auditClassificationName(caseIndex);
+                if (classification == null) {
+                  return new AuditClassification(NO_DIVERGENCE);
+                }
+                return new AuditClassification(classification);
+              });
+      default -> throw new IllegalArgumentException("unsupported compact audit sweep: " + sweep);
+    };
+  }
+
+  private record Options(Path inputDir, Path outputDir, int sampleLimit) {
+    static Options parse(String[] args) {
+      Path inputDir = null;
+      Path outputDir = null;
+      int sampleLimit = DEFAULT_SAMPLE_LIMIT;
+      for (String arg : args) {
+        if (arg.startsWith("--input-dir=")) {
+          inputDir = Path.of(arg.substring("--input-dir=".length()));
+        } else if (arg.startsWith("--output-dir=")) {
+          outputDir = Path.of(arg.substring("--output-dir=".length()));
+        } else if (arg.startsWith("--sample-limit=")) {
+          sampleLimit = Integer.parseInt(arg.substring("--sample-limit=".length()));
+        } else {
+          throw new IllegalArgumentException("unknown argument: " + arg);
+        }
+      }
+      if (inputDir == null) {
+        throw new IllegalArgumentException("--input-dir is required");
+      }
+      if (outputDir == null) {
+        outputDir = inputDir.resolve("audit");
+      }
+      if (sampleLimit < 0) {
+        throw new IllegalArgumentException("--sample-limit must be non-negative");
+      }
+      return new Options(inputDir, outputDir, sampleLimit);
+    }
+  }
+
+  private static final class SourceSamples {
+    private final int limit;
+    private final Random random;
+    private final List<Long> samples = new ArrayList<>();
+    private long count;
+
+    SourceSamples(int limit, int seed) {
+      this.limit = limit;
+      this.random = new Random(seed);
+    }
+
+    void record(long caseIndex) {
+      count++;
+      if (samples.size() < limit) {
+        samples.add(caseIndex);
+        return;
+      }
+      long replacement = random.nextLong(count);
+      if (replacement < limit) {
+        samples.set((int) replacement, caseIndex);
+      }
+    }
+
+    long count() {
+      return count;
+    }
+
+    List<Long> samples() {
+      return samples;
+    }
+  }
+
+  private record AuditClassification(String name) {}
+
+  private interface AuditCaseClassifier {
+    AuditClassification classify(long caseIndex);
+  }
+
+  private record AuditSweep(
+      long totalCases, Map<String, DivergenceStatus> statuses, AuditCaseClassifier classifier) {
+    AuditClassification classify(long caseIndex) {
+      return classifier.classify(caseIndex);
+    }
+  }
+}

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ZeroWidthQuantifierDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ZeroWidthQuantifierDivergenceSweep.java
@@ -561,6 +561,19 @@ public final class ZeroWidthQuantifierDivergenceSweep {
     return Arrays.stream(DivergenceClass.values()).map(DivergenceClass::status).toList();
   }
 
+  static Map<String, DivergenceStatus> divergenceClassificationStatusMap() {
+    Map<String, DivergenceStatus> statuses = new LinkedHashMap<>();
+    for (DivergenceClass classification : DivergenceClass.values()) {
+      statuses.put(classification.name(), classification.status());
+    }
+    return statuses;
+  }
+
+  static String auditClassificationName(long caseIndex) {
+    DivergenceClass classification = auditClassification(caseAt(caseIndex));
+    return classification == null ? null : classification.name();
+  }
+
   private enum DivergenceClass implements DivergenceClassification {
     STACK_OVERFLOW(
         DivergenceStatus.EXPECTED_ZERO,
@@ -600,6 +613,10 @@ public final class ZeroWidthQuantifierDivergenceSweep {
         DivergenceStatus.KNOWN_INTENTIONAL,
         "Observed JDK traces for alternatives involving explicit \\b{g} expose grapheme"
             + " segmentation details that conflict with SafeRE's documented grapheme model."),
+    GRAPHEME_BOUNDARY_CAPTURE_GRAPHEME_MODEL(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "Observed JDK capture traces for explicit \\b{g} expose grapheme segmentation details"
+            + " that conflict with SafeRE's documented grapheme model."),
     ASCII_WORD_BOUNDARY_COMBINING_MARK(
         DivergenceStatus.KNOWN_INTENTIONAL,
         "SafeRE follows the documented default ASCII word-character model for \\b and \\B"
@@ -808,29 +825,37 @@ public final class ZeroWidthQuantifierDivergenceSweep {
     RegexSweep.Outcome safere =
         RegexSweep.safeReTraceOutcome(
             spec.regex(), spec.flagMode().flags(), spec.inputs(), FIND_LIMIT);
-    if (isStackSafetySentinel(spec)) {
-      if (safere.error().contains("StackOverflowError")) {
-        String bucketName = bucketFor(spec, jdk, safere);
-        recordDivergence(
-            runState,
-            summary,
-            caseIndex,
-            spec,
-            jdk,
-            safere,
-            bucketName,
-            DivergenceClass.STACK_OVERFLOW,
-            workerIndex);
-      }
-      return;
-    }
-    if (RegexSweep.semanticallyEqual(jdk, safere)) {
+    DivergenceClass classification = classifyEvaluatedDivergence(spec, jdk, safere);
+    if (classification == null) {
       return;
     }
     String bucketName = bucketFor(spec, jdk, safere);
-    DivergenceClass classification = classifyDivergence(spec, jdk, safere);
     recordDivergence(
         runState, summary, caseIndex, spec, jdk, safere, bucketName, classification, workerIndex);
+  }
+
+  private static DivergenceClass auditClassification(CaseSpec spec) {
+    RegexSweep.Outcome jdk =
+        RegexSweep.jdkTraceOutcome(
+            spec.regex(), spec.flagMode().flags(), spec.inputs(), FIND_LIMIT);
+    RegexSweep.Outcome safere =
+        RegexSweep.safeReTraceOutcome(
+            spec.regex(), spec.flagMode().flags(), spec.inputs(), FIND_LIMIT);
+    return classifyEvaluatedDivergence(spec, jdk, safere);
+  }
+
+  private static DivergenceClass classifyEvaluatedDivergence(
+      CaseSpec spec, RegexSweep.Outcome jdk, RegexSweep.Outcome safere) {
+    if (isStackSafetySentinel(spec)) {
+      if (safere.error().contains("StackOverflowError")) {
+        return DivergenceClass.STACK_OVERFLOW;
+      }
+      return null;
+    }
+    if (RegexSweep.semanticallyEqual(jdk, safere)) {
+      return null;
+    }
+    return classifyDivergence(spec, jdk, safere);
   }
 
   private static void recordDivergence(
@@ -875,9 +900,6 @@ public final class ZeroWidthQuantifierDivergenceSweep {
     if (isPossessiveQuantifierUnsupported(spec, jdk, safere)) {
       return DivergenceClass.POSSESSIVE_QUANTIFIER_UNSUPPORTED;
     }
-    if (isZeroWidthPossessiveCaptureRetentionDivergence(spec, jdk, safere)) {
-      return DivergenceClass.ZERO_WIDTH_POSSESSIVE_CAPTURE_RETENTION;
-    }
     if (isKnownGraphemeBoundaryAlternativeFindCursor(spec, jdk, safere)) {
       return DivergenceClass.GRAPHEME_BOUNDARY_ALTERNATIVE_FIND_CURSOR;
     }
@@ -887,8 +909,14 @@ public final class ZeroWidthQuantifierDivergenceSweep {
     if (isKnownGraphemeBoundaryAlternativeGraphemeModel(spec, jdk, safere)) {
       return DivergenceClass.GRAPHEME_BOUNDARY_ALTERNATIVE_GRAPHEME_MODEL;
     }
+    if (isKnownGraphemeBoundaryCaptureGraphemeModel(spec, jdk, safere)) {
+      return DivergenceClass.GRAPHEME_BOUNDARY_CAPTURE_GRAPHEME_MODEL;
+    }
     if (isKnownAsciiWordBoundaryCombiningMarkDivergence(spec, jdk, safere)) {
       return DivergenceClass.ASCII_WORD_BOUNDARY_COMBINING_MARK;
+    }
+    if (isZeroWidthPossessiveCaptureRetentionDivergence(spec, jdk, safere)) {
+      return DivergenceClass.ZERO_WIDTH_POSSESSIVE_CAPTURE_RETENTION;
     }
     if (isKnownFailedPathCaptureLeakageDivergence(spec, jdk, safere)) {
       return DivergenceClass.FAILED_PATH_CAPTURE_LEAKAGE;
@@ -1029,8 +1057,26 @@ public final class ZeroWidthQuantifierDivergenceSweep {
         && isGraphemeSensitiveAlternativeTraceDifference(jdk.trace(), safere.trace());
   }
 
+  private static boolean isKnownGraphemeBoundaryCaptureGraphemeModel(
+      CaseSpec spec, RegexSweep.Outcome jdk, RegexSweep.Outcome safere) {
+    return jdk.accepted()
+        && safere.accepted()
+        && containsExplicitGraphemeBoundary(spec.operand())
+        && hasGraphemeSensitiveTrace(jdk.trace(), safere.trace())
+        && normalizeCaptureFields(jdk.trace()).equals(normalizeCaptureFields(safere.trace()));
+  }
+
   private static boolean containsExplicitGraphemeBoundary(Operand operand) {
-    return operand.label().contains("graphemeBoundary");
+    return operand.label().contains("graphemeBoundary")
+        || operand.regex().contains("\\b{g}")
+        || operand.regex().contains("\\\\b{g}");
+  }
+
+  private static boolean hasGraphemeSensitiveTrace(String jdkTrace, String safereTrace) {
+    return jdkTrace.contains("\\uD83D")
+        || safereTrace.contains("\\uD83D")
+        || jdkTrace.indexOf('\u200D') >= 0
+        || safereTrace.indexOf('\u200D') >= 0;
   }
 
   static boolean isRepeatedGraphemeBoundaryCompositionTraceDifferenceForTesting(

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/CompactDivergenceLogsTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/CompactDivergenceLogsTest.java
@@ -279,4 +279,32 @@ class CompactDivergenceLogsTest {
 
     assertThat(Files.readAllLines(tempDir.resolve("expanded/known-sample.jsonl"))).hasSize(1);
   }
+
+  @Test
+  void auditSamplesKnownIntentionalBucketsAndReportsCurrentClassification() throws Exception {
+    int sourceClass =
+        ZeroWidthQuantifierDivergenceSweep.divergenceClassificationNames()
+            .indexOf("POSSESSIVE_QUANTIFIER_UNSUPPORTED");
+    try (CompactDivergenceLogs logs =
+        new CompactDivergenceLogs(
+            tempDir,
+            "zero-width-quantifier",
+            0,
+            100,
+            ZeroWidthQuantifierDivergenceSweep.totalCasesForTesting(),
+            1,
+            ZeroWidthQuantifierDivergenceSweep.divergenceClassificationNames(),
+            ZeroWidthQuantifierDivergenceSweep.divergenceClassificationStatuses())) {
+      logs.record(0, 0, sourceClass);
+    }
+
+    CompactDivergenceAudit.main(new String[] {"--input-dir=" + tempDir});
+
+    assertThat(Files.readString(tempDir.resolve("audit/source-counts.tsv")))
+        .contains("POSSESSIVE_QUANTIFIER_UNSUPPORTED\t1\t1");
+    assertThat(Files.readString(tempDir.resolve("audit/transition-counts.tsv")))
+        .contains(
+            "POSSESSIVE_QUANTIFIER_UNSUPPORTED\tKNOWN_INTENTIONAL\tNO_DIVERGENCE\t"
+                + "NO_DIVERGENCE\t1");
+  }
 }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -519,6 +519,52 @@ class SweepCliSmokeTest {
   }
 
   @Test
+  void zeroWidthQuantifierReplayClassifiesCapturedPossessiveAsciiBoundaryAsKnownIntentional()
+      throws Exception {
+    Path replayFile = tempDir.resolve("zero-width-captured-word-boundary-possessive.jsonl");
+    Path outputDir = tempDir.resolve("zero-width-captured-word-boundary-possessive");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"operandLabel":"atom:wordBoundary","operandRegex":"\\\\b","wrapperLabel":"capturing","wrapperTemplate":"(%s)","quantifierChainLabel":"star,plus","quantifierChain":"*+","contextLabel":"bare","contextTemplate":"%s","flagLabel":"none","flagPrefix":"","flags":0,"trivia":""}}
+        """);
+
+    String output =
+        captureOutput(
+            () -> ZeroWidthQuantifierDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("divergences=1", "actionableDivergences=0");
+    assertThat(Files.exists(outputDir.resolve("zero-width-quantifier-divergences.jsonl")))
+        .isFalse();
+    assertThat(Files.readString(outputDir.resolve("zero-width-quantifier-class-counts.tsv")))
+        .contains("ASCII_WORD_BOUNDARY_COMBINING_MARK\tKNOWN_INTENTIONAL\t1")
+        .contains("ZERO_WIDTH_POSSESSIVE_CAPTURE_RETENTION\tEXPECTED_ZERO\t0");
+  }
+
+  @Test
+  void zeroWidthQuantifierReplayClassifiesTargetedCapturedPossessiveGraphemeBoundaryAsKnown()
+      throws Exception {
+    Path replayFile = tempDir.resolve("zero-width-targeted-grapheme-possessive.jsonl");
+    Path outputDir = tempDir.resolve("zero-width-targeted-grapheme-possessive");
+    Files.writeString(
+        replayFile,
+        """
+        {"case":{"operandLabel":"targeted:capturedGraphemeBoundary","operandRegex":"\\\\b{g}","wrapperLabel":"capturing","wrapperTemplate":"(%s)","quantifierChainLabel":"star,plus","quantifierChain":"*+","contextLabel":"capturedThenOptionalLiteral","contextTemplate":"(%s)a?","flagLabel":"none","flagPrefix":"","flags":0,"trivia":""}}
+        """);
+
+    String output =
+        captureOutput(
+            () -> ZeroWidthQuantifierDivergenceSweep.main(replayArgs(outputDir, replayFile)));
+
+    assertThat(output).contains("divergences=1", "actionableDivergences=0");
+    assertThat(Files.exists(outputDir.resolve("zero-width-quantifier-divergences.jsonl")))
+        .isFalse();
+    assertThat(Files.readString(outputDir.resolve("zero-width-quantifier-class-counts.tsv")))
+        .contains("GRAPHEME_BOUNDARY_CAPTURE_GRAPHEME_MODEL\tKNOWN_INTENTIONAL\t1")
+        .contains("UNKNOWN\tUNKNOWN\t0");
+  }
+
+  @Test
   void zeroWidthQuantifierAsciiWordBoundaryClassifierRequiresCombiningMarkOnlyDifference() {
     String common = ",a:matches=false,a:find0=false";
 
@@ -540,7 +586,7 @@ class SweepCliSmokeTest {
     Files.writeString(
         replayFile,
         """
-        {"case":{"operandLabel":"atom:syntheticBoundary","operandRegex":"\\\\b{g}","wrapperLabel":"capturing","wrapperTemplate":"(%s)","quantifierChainLabel":"plus","quantifierChain":"+","contextLabel":"mixedLeadingLiteralAlternativeReversed","contextTemplate":"(?:a|%s).","flagLabel":"commentsEmbeddedComment","flagPrefix":"(?x)","flags":0,"trivia":"#q\\n"}}
+        {"case":{"operandLabel":"atom:syntheticBoundary","operandRegex":"\\\\b","wrapperLabel":"bare","wrapperTemplate":"%s","quantifierChainLabel":"plus","quantifierChain":"+","contextLabel":"bare","contextTemplate":"%s","flagLabel":"none","flagPrefix":"","flags":0,"trivia":""}}
         """);
 
     assertThat(


### PR DESCRIPTION
## Summary

- add compact audit mode for zero-width quantifier compact divergence archives
- sample known-intentional buckets and replay them through the current classifier
- document the audit workflow and add classifier coverage for grapheme-boundary capture model divergences

Refs #427

## Verification

- `mvn -pl safere-exhaustive test -q`

## Not run

- Full exhaustive sweeps were not rerun.
