### PR TITLE
Enable additional Error Prone checks and clean up findings

### DIFF
--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -64,7 +64,7 @@
             <!-- Continue compilation past type-checking errors so Error Prone can analyze
                  code that has downstream errors in later phases. -->
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xplugin:ErrorProne -Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
@@ -84,13 +84,14 @@
             <configuration>
               <compilerArgs>
                 <arg>-Xlint</arg>
+                <arg>-Werror</arg>
                 <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
                      compile all files in a single batch (required by Error Prone). -->
                 <arg>-XDcompilePolicy=simple</arg>
                 <!-- Continue compilation past type-checking errors so Error Prone can analyze
                      code that has downstream errors in later phases. -->
                 <arg>--should-stop=ifError=FLOW</arg>
-                <arg>-Xplugin:ErrorProne</arg>
+                <arg>-Xplugin:ErrorProne -Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -263,12 +263,12 @@ final class BitState {
    * position) pair has been explored. Sized for the full text so the instance can be reused across
    * searches with different start/end bounds.
    */
-  private long[] visited;
+  private final long[] visited;
 
   private int textSlots;
 
   /** Tracks which words in the visited bitmap were dirtied, for incremental clearing. */
-  private int[] dirtyWords;
+  private final int[] dirtyWords;
 
   private int dirtyCount;
 
@@ -276,10 +276,10 @@ final class BitState {
   private final boolean[] cycleAlts;
 
   /** Current capture registers. */
-  private int[] cap;
+  private final int[] cap;
 
   /** Current loop progress-check registers. */
-  private int[] loopRegs;
+  private final int[] loopRegs;
 
   /** Best match found so far. */
   private int[] bestMatch;

--- a/safere/src/main/java/org/safere/CharClass.java
+++ b/safere/src/main/java/org/safere/CharClass.java
@@ -7,6 +7,8 @@
 
 package org.safere;
 
+import java.util.Locale;
+
 /**
  * An immutable character class, represented as a sorted, non-overlapping list of Unicode code point
  * ranges. Each range is an inclusive {@code [lo, hi]} pair.
@@ -100,9 +102,9 @@ final class CharClass {
       int lo = lo(i);
       int hi = hi(i);
       if (lo == hi) {
-        sb.append(String.format("0x%X", lo));
+        sb.append(String.format(Locale.ROOT, "0x%X", lo));
       } else {
-        sb.append(String.format("0x%X-0x%X", lo, hi));
+        sb.append(String.format(Locale.ROOT, "0x%X-0x%X", lo, hi));
       }
     }
     sb.append(']');

--- a/safere/src/main/java/org/safere/CharClassExpander.java
+++ b/safere/src/main/java/org/safere/CharClassExpander.java
@@ -125,7 +125,7 @@ final class CharClassExpander {
   static void addRange(CharClassBuilder ccb, int lo, int hi, int parseFlags) {
     boolean cutnl =
         (parseFlags & ParseFlags.CLASS_NL) == 0 || (parseFlags & ParseFlags.NEVER_NL) != 0;
-    if (cutnl && lo <= '\n' && '\n' <= hi) {
+    if (cutnl && lo <= '\n' && hi >= '\n') {
       if (lo < '\n') {
         addRange(ccb, lo, '\n' - 1, parseFlags);
       }

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -285,7 +285,7 @@ final class Compiler extends Walker<Compiler.Frag> {
       };
     }
 
-    private Regexp lowerQuantifier(Regexp re, Regexp sub) {
+    private static Regexp lowerQuantifier(Regexp re, Regexp sub) {
       if (!needsCaptureRetentionLowering(re, sub)) {
         return copyWithChildren(re, List.of(sub));
       }

--- a/safere/src/main/java/org/safere/Inst.java
+++ b/safere/src/main/java/org/safere/Inst.java
@@ -5,6 +5,8 @@
 
 package org.safere;
 
+import java.util.Locale;
+
 /**
  * A single instruction in a compiled regular expression program. Each instruction has an {@link
  * InstOp opcode} and opcode-specific data.
@@ -307,29 +309,33 @@ final class Inst {
   @Override
   public String toString() {
     return switch (op) {
-      case ALT -> String.format("alt -> %d | %d", out, out1);
-      case ALT_MATCH -> String.format("altmatch -> %d | %d", out, out1);
+      case ALT -> String.format(Locale.ROOT, "alt -> %d | %d", out, out1);
+      case ALT_MATCH -> String.format(Locale.ROOT, "altmatch -> %d | %d", out, out1);
       case CHAR_RANGE ->
-          String.format("char [0x%X-0x%X]%s -> %d", lo, hi, foldCase ? "/i" : "", out);
-      case CAPTURE -> String.format("capture %d -> %d", arg, out);
-      case EMPTY_WIDTH -> String.format("empty 0x%X -> %d", arg, out);
-      case MATCH -> String.format("match %d", arg);
-      case NOP -> String.format("nop -> %d", out);
+          String.format(Locale.ROOT, "char [0x%X-0x%X]%s -> %d", lo, hi, foldCase ? "/i" : "", out);
+      case CAPTURE -> String.format(Locale.ROOT, "capture %d -> %d", arg, out);
+      case EMPTY_WIDTH -> String.format(Locale.ROOT, "empty 0x%X -> %d", arg, out);
+      case MATCH -> String.format(Locale.ROOT, "match %d", arg);
+      case NOP -> String.format(Locale.ROOT, "nop -> %d", out);
       case FAIL -> "fail";
-      case GRAPHEME_CLUSTER -> String.format("grapheme_cluster -> %d", out);
+      case GRAPHEME_CLUSTER -> String.format(Locale.ROOT, "grapheme_cluster -> %d", out);
       case PROGRESS_CHECK ->
           String.format(
+              Locale.ROOT,
               "progress_check reg=%d body=%d exit=%d %s",
-              arg, out, out1, foldCase ? "non-greedy" : "greedy");
+              arg,
+              out,
+              out1,
+              foldCase ? "non-greedy" : "greedy");
       case CHAR_CLASS -> {
         StringBuilder sb = new StringBuilder("charclass [");
         for (int i = 0; i < ranges.length; i += 2) {
           if (i > 0) {
             sb.append(',');
           }
-          sb.append(String.format("0x%X-0x%X", ranges[i], ranges[i + 1]));
+          sb.append(String.format(Locale.ROOT, "0x%X-0x%X", ranges[i], ranges[i + 1]));
         }
-        sb.append(String.format("] -> %d", out));
+        sb.append(String.format(Locale.ROOT, "] -> %d", out));
         yield sb.toString();
       }
     };

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -82,7 +82,7 @@ final class Nfa {
   private final EngineContext context;
 
   private boolean matched;
-  private int[] bestMatch;
+  private final int[] bestMatch;
 
   private Nfa(Prog prog, EngineContext context, int ncapture, boolean longest, boolean endmatch) {
     this.prog = prog;
@@ -425,7 +425,7 @@ final class Nfa {
     }
   }
 
-  private void mergeDelayedQueue(
+  private static void mergeDelayedQueue(
       Map<Integer, QueueState> delayed, int pos, QueueState destination) {
     QueueState source = delayed.remove(pos);
     if (source == null) {
@@ -671,8 +671,6 @@ final class Nfa {
             // until a later CAPTURE or PROGRESS_CHECK transition clones them.
             q.add(
                 new NfaThread(id, t0, consumedInput, ip.op == InstOp.GRAPHEME_CLUSTER ? pos : -1));
-
-        default -> {}
       }
     }
   }

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -499,15 +499,15 @@ final class Parser {
 
   // ---- Stack operations ----
 
-  private boolean isMarker(StackEntry e) {
+  private static boolean isMarker(StackEntry e) {
     return e != null && e.re != null && e.re.matchId < 0 && e.re.op == RegexpOp.NO_MATCH;
   }
 
-  private boolean isLeftParen(StackEntry e) {
+  private static boolean isLeftParen(StackEntry e) {
     return isMarker(e) && e.re.matchId == LEFT_PAREN;
   }
 
-  private boolean isVerticalBar(StackEntry e) {
+  private static boolean isVerticalBar(StackEntry e) {
     return isMarker(e) && e.re.matchId == VERTICAL_BAR;
   }
 
@@ -712,7 +712,7 @@ final class Parser {
         && isZeroWidth(stacktop.re);
   }
 
-  private boolean hasCapture(Regexp re) {
+  private static boolean hasCapture(Regexp re) {
     ArrayDeque<Regexp> pending = new ArrayDeque<>();
     pending.add(re);
     while (!pending.isEmpty()) {
@@ -727,14 +727,14 @@ final class Parser {
     return false;
   }
 
-  private boolean isQuantifiedZeroWidth(Regexp re) {
+  private static boolean isQuantifiedZeroWidth(Regexp re) {
     return switch (re.op) {
       case STAR, PLUS, QUEST, REPEAT -> isZeroWidth(re.subs.getFirst());
       default -> false;
     };
   }
 
-  private boolean isZeroWidth(Regexp re) {
+  private static boolean isZeroWidth(Regexp re) {
     ArrayDeque<Regexp> pending = new ArrayDeque<>();
     pending.add(re);
     while (!pending.isEmpty()) {
@@ -992,7 +992,7 @@ final class Parser {
 
   // ---- Literal string coalescing ----
 
-  private List<Regexp> coalesceLiteralStrings(List<Regexp> subs) {
+  private static List<Regexp> coalesceLiteralStrings(List<Regexp> subs) {
     List<Regexp> coalesced = new ArrayList<>(subs.size());
     int literalStart = -1;
     int literalLength = 0;
@@ -1018,7 +1018,7 @@ final class Parser {
     return coalesced;
   }
 
-  private void flushLiteralString(
+  private static void flushLiteralString(
       List<Regexp> source,
       List<Regexp> target,
       int start,
@@ -1047,15 +1047,15 @@ final class Parser {
     target.add(Regexp.literalString(runes, literalFlags));
   }
 
-  private boolean isLiteralStringPart(Regexp re) {
+  private static boolean isLiteralStringPart(Regexp re) {
     return re.op == RegexpOp.LITERAL || re.op == RegexpOp.LITERAL_STRING;
   }
 
-  private boolean literalFold(int flags) {
+  private static boolean literalFold(int flags) {
     return (flags & ParseFlags.FOLD_CASE) != 0;
   }
 
-  private int literalLength(Regexp re) {
+  private static int literalLength(Regexp re) {
     return re.op == RegexpOp.LITERAL ? 1 : re.runes.length;
   }
 
@@ -1719,7 +1719,7 @@ final class Parser {
     return index;
   }
 
-  private NormalizedClassPattern finishNormalizedClassPattern(
+  private static NormalizedClassPattern finishNormalizedClassPattern(
       StringBuilder normalized, List<Integer> originalIndexes, int originalEnd, boolean changed) {
     if (!changed) {
       return null;
@@ -1894,7 +1894,7 @@ final class Parser {
     }
   }
 
-  private CharClassBuilder snapshotPendingExpression(ClassExpressionFrame frame) {
+  private static CharClassBuilder snapshotPendingExpression(ClassExpressionFrame frame) {
     if (frame.accumulatedClass == null && !frame.hasPendingScalarItems) {
       return null;
     }
@@ -1930,7 +1930,7 @@ final class Parser {
     pos++;
   }
 
-  private void finishRawAmpersandSeparatorBeforeClassClose(ClassExpressionFrame frame) {
+  private static void finishRawAmpersandSeparatorBeforeClassClose(ClassExpressionFrame frame) {
     frame.accumulatedClass = new CharClassBuilder().addCharClass(frame.rawAmpersandLeftExpression);
     frame.currentIntersectionOperand = frame.accumulatedClass;
     frame.currentIntersectionOperandRole = ClassAtomRole.ORDINARY_SCALAR;
@@ -1994,7 +1994,7 @@ final class Parser {
         && pattern.charAt(tail.pos()) == ']';
   }
 
-  private CharClassBuilder nestedRightBeforeTrailingAmpersandExpression(
+  private static CharClassBuilder nestedRightBeforeTrailingAmpersandExpression(
       ClassExpressionFrame frame,
       boolean rawAmpersandRangeTail,
       boolean preserveDeferredOrdinaryScalars) {
@@ -2171,7 +2171,7 @@ final class Parser {
     return hasRangeTail;
   }
 
-  private void finishNestedRightAsCurrentOperand(
+  private static void finishNestedRightAsCurrentOperand(
       ClassExpressionFrame frame, CharClassBuilder expression) {
     frame.accumulatedClass = expression;
     frame.currentIntersectionOperand = expression;
@@ -2191,7 +2191,7 @@ final class Parser {
     frame.intersectionRightOnlyNestedClasses = false;
   }
 
-  private void finishNestedRightAsEmptyUntilClassTerminator(ClassExpressionFrame frame) {
+  private static void finishNestedRightAsEmptyUntilClassTerminator(ClassExpressionFrame frame) {
     frame.accumulatedClass = new CharClassBuilder();
     frame.currentIntersectionOperand = frame.accumulatedClass;
     frame.currentIntersectionOperandRole = ClassAtomRole.INTERSECTION_OPERAND;
@@ -2426,7 +2426,8 @@ final class Parser {
     frame.intersectionRightOnlyNestedClasses = false;
   }
 
-  private void finishRawAmpersandSeparatorAsEmptyUntilClassTerminator(ClassExpressionFrame frame) {
+  private static void finishRawAmpersandSeparatorAsEmptyUntilClassTerminator(
+      ClassExpressionFrame frame) {
     frame.accumulatedClass = new CharClassBuilder();
     frame.currentIntersectionOperand = frame.accumulatedClass;
     frame.currentIntersectionOperandRole = ClassAtomRole.RAW_AMPERSAND_SEPARATOR;
@@ -2780,7 +2781,7 @@ final class Parser {
     frame.rawAmpersandLeftExpression = null;
   }
 
-  private CharClassBuilder emptyCompletedIntersectionBeforeCommentsClose(
+  private static CharClassBuilder emptyCompletedIntersectionBeforeCommentsClose(
       ClassExpressionFrame frame) {
     if (frame.accumulatedClass == null || frame.currentIntersectionOperand == null) {
       return null;
@@ -2790,7 +2791,7 @@ final class Parser {
     return completed.isEmpty() ? completed : null;
   }
 
-  private void finishOddAmpersandRunAsCurrentUntilClassTerminator(
+  private static void finishOddAmpersandRunAsCurrentUntilClassTerminator(
       ClassExpressionFrame frame, CharClassBuilder expression) {
     frame.accumulatedClass = expression;
     frame.currentIntersectionOperand = expression;
@@ -2812,13 +2813,13 @@ final class Parser {
     frame.ignoreUntilClassTerminator = true;
   }
 
-  private void finishOddAmpersandRunAsEmptyUntilClassTerminator(ClassExpressionFrame frame) {
+  private static void finishOddAmpersandRunAsEmptyUntilClassTerminator(ClassExpressionFrame frame) {
     finishOddAmpersandRunAsCurrentUntilClassTerminator(frame, new CharClassBuilder());
     frame.suppressNegation = true;
     frame.propagateSuppressNegation = true;
   }
 
-  private void startIntersectionRightAfterNormalizedOddRun(
+  private static void startIntersectionRightAfterNormalizedOddRun(
       ClassExpressionFrame frame, CharClassBuilder expression, NormalizedAmpersandRun run) {
     frame.accumulatedClass = expression;
     frame.currentIntersectionOperand = expression;
@@ -3223,7 +3224,7 @@ final class Parser {
     return snapshot;
   }
 
-  private boolean accumulatedClassAlreadyContainsLiteralAmpersand(
+  private static boolean accumulatedClassAlreadyContainsLiteralAmpersand(
       ClassExpressionFrame frame, CharClassBuilder expression) {
     return frame.accumulatedClass != null
         && frame.accumulatedClass.contains('&')
@@ -3483,7 +3484,7 @@ final class Parser {
     }
   }
 
-  private void foldRawAmpersandSeparatorBeforeNestedClass(
+  private static void foldRawAmpersandSeparatorBeforeNestedClass(
       ClassExpressionFrame frame, CharClassBuilder completed) {
     CharClassBuilder expression = new CharClassBuilder();
     if (frame.rawAmpersandSeparatorRepeated) {
@@ -3587,7 +3588,7 @@ final class Parser {
     throw new PatternSyntaxException("missing closing ]", pattern, pos);
   }
 
-  private CharClassBuilder unionClass(CharClassBuilder left, CharClassBuilder right) {
+  private static CharClassBuilder unionClass(CharClassBuilder left, CharClassBuilder right) {
     if (left == null) {
       return new CharClassBuilder().addCharClass(right);
     }

--- a/safere/src/main/java/org/safere/Prog.java
+++ b/safere/src/main/java/org/safere/Prog.java
@@ -10,6 +10,7 @@ package org.safere;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A compiled regular expression program, consisting of an array of {@link Inst} instructions. This
@@ -292,7 +293,8 @@ final class Prog {
         sb.append(' ');
       }
       sb.append(
-          String.format("%d. %s\n", i, instArray != null ? instArray[i] : instructions.get(i)));
+          String.format(
+              Locale.ROOT, "%d. %s\n", i, instArray != null ? instArray[i] : instructions.get(i)));
     }
     return sb.toString();
   }
@@ -300,8 +302,12 @@ final class Prog {
   @Override
   public String toString() {
     return String.format(
+        Locale.ROOT,
         "Prog{size=%d, start=%d, startUnanchored=%d, captures=%d}",
-        size(), start, startUnanchored, numCaptures);
+        size(),
+        start,
+        startUnanchored,
+        numCaptures);
   }
 
   // ---------------------------------------------------------------------------
@@ -408,7 +414,7 @@ final class Prog {
     }
   }
 
-  private void addEpsilonSuccessor(
+  private static void addEpsilonSuccessor(
       int id, boolean[] reachable, boolean[] visited, ArrayDeque<Integer> stack) {
     if (id > 0 && id < reachable.length && reachable[id] && !visited[id]) {
       visited[id] = true;
@@ -416,7 +422,7 @@ final class Prog {
     }
   }
 
-  private void addSuccessor(int id, boolean[] reachable, ArrayDeque<Integer> stack) {
+  private static void addSuccessor(int id, boolean[] reachable, ArrayDeque<Integer> stack) {
     if (id > 0 && id < reachable.length && !reachable[id]) {
       reachable[id] = true;
       stack.push(id);

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -9,6 +9,7 @@ package org.safere;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A node in the regular expression abstract syntax tree (AST). Each node has a {@link RegexpOp}
@@ -375,7 +376,6 @@ final class Regexp {
               }
               yield PREC_ATOM;
             }
-            default -> PREC_ATOM;
           };
       return nprec;
     }
@@ -476,7 +476,6 @@ final class Regexp {
         case NON_CAPTURE -> sb.append(')');
         case CAPTURE -> sb.append(')');
         case HAVE_MATCH -> sb.append("(?HaveMatch:").append(re.matchId).append(')');
-        default -> sb.append("[").append(re.op).append("]");
       }
 
       // If the parent is an alternation, append | separator.
@@ -563,9 +562,9 @@ final class Regexp {
       default -> {}
     }
     if (r < 0x100) {
-      sb.append(String.format("\\x%02x", r));
+      sb.append(String.format(Locale.ROOT, "\\x%02x", r));
     } else {
-      sb.append(String.format("\\x{%x}", r));
+      sb.append(String.format(Locale.ROOT, "\\x{%x}", r));
     }
   }
 }

--- a/safere/src/test/java/org/safere/BoundaryMatcherTest.java
+++ b/safere/src/test/java/org/safere/BoundaryMatcherTest.java
@@ -197,7 +197,7 @@ class BoundaryMatcherTest {
   @DisplayName("\\b{g} (grapheme cluster boundary)")
   class GraphemeClusterBoundary {
 
-    private void assertFindSameAsJdk(String regex, String input) {
+    private static void assertFindSameAsJdk(String regex, String input) {
       java.util.regex.Matcher jdkMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
       Matcher safeMatcher = Pattern.compile(regex).matcher(input);
 
@@ -216,7 +216,7 @@ class BoundaryMatcherTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
-    private void assertTraceSameAsJdk(String regex, String input, int start, int end) {
+    private static void assertTraceSameAsJdk(String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
       Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
@@ -255,7 +255,7 @@ class BoundaryMatcherTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
-    private void assertSafeReFindBounds(
+    private static void assertSafeReFindBounds(
         String regex, String input, int start, int end, List<String> expected) {
       Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
       List<String> safeMatches = new ArrayList<>();
@@ -267,7 +267,8 @@ class BoundaryMatcherTest {
           .containsExactlyElementsOf(expected);
     }
 
-    private void assertTransparentTraceSameAsJdk(String regex, String input, int start, int end) {
+    private static void assertTransparentTraceSameAsJdk(
+        String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex)
               .matcher(input)
@@ -314,7 +315,8 @@ class BoundaryMatcherTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
-    private void assertCapturedFindTraceSameAsJdk(String regex, String input, int start, int end) {
+    private static void assertCapturedFindTraceSameAsJdk(
+        String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
       Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
@@ -327,7 +329,7 @@ class BoundaryMatcherTest {
           .containsExactlyElementsOf(jdkMatches);
     }
 
-    private List<String> capturedFindTrace(java.util.regex.Matcher matcher) {
+    private static List<String> capturedFindTrace(java.util.regex.Matcher matcher) {
       List<String> trace = new ArrayList<>();
       while (matcher.find()) {
         trace.add(capturedMatchTrace(matcher));
@@ -335,7 +337,7 @@ class BoundaryMatcherTest {
       return trace;
     }
 
-    private List<String> capturedFindTrace(Matcher matcher) {
+    private static List<String> capturedFindTrace(Matcher matcher) {
       List<String> trace = new ArrayList<>();
       while (matcher.find()) {
         trace.add(capturedMatchTrace(matcher));
@@ -343,7 +345,7 @@ class BoundaryMatcherTest {
       return trace;
     }
 
-    private String capturedMatchTrace(java.util.regex.Matcher matcher) {
+    private static String capturedMatchTrace(java.util.regex.Matcher matcher) {
       StringBuilder builder = new StringBuilder();
       builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
       builder.append(matcher.group());
@@ -353,7 +355,7 @@ class BoundaryMatcherTest {
       return builder.toString();
     }
 
-    private String capturedMatchTrace(Matcher matcher) {
+    private static String capturedMatchTrace(Matcher matcher) {
       StringBuilder builder = new StringBuilder();
       builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
       builder.append(matcher.group());

--- a/safere/src/test/java/org/safere/CrossEngineTest.java
+++ b/safere/src/test/java/org/safere/CrossEngineTest.java
@@ -380,7 +380,7 @@ class CrossEngineTest {
   // Comparison helpers
   // ---------------------------------------------------------------------------
 
-  private void compareMatches(
+  private static void compareMatches(
       Pattern safeRePattern, java.util.regex.Pattern jdkPattern, TestCase tc, boolean expectEqual) {
     boolean safeReResult = safeRePattern.matcher(tc.input()).matches();
     boolean jdkResult = jdkPattern.matcher(tc.input()).matches();
@@ -395,7 +395,7 @@ class CrossEngineTest {
     // For SAFERE_REJECTS, we just verify SafeRE didn't crash (it already ran).
   }
 
-  private void compareFind(
+  private static void compareFind(
       Pattern safeRePattern, java.util.regex.Pattern jdkPattern, TestCase tc, boolean expectEqual) {
     List<MatchResult> safeReMatches = collectFinds(safeRePattern.matcher(tc.input()));
     List<MatchResult> jdkMatches = collectFindsJdk(jdkPattern.matcher(tc.input()));
@@ -432,7 +432,7 @@ class CrossEngineTest {
     }
   }
 
-  private void compareReplaceAll(
+  private static void compareReplaceAll(
       Pattern safeRePattern, java.util.regex.Pattern jdkPattern, TestCase tc, boolean expectEqual) {
     String replacement = "X";
     String safeReResult = safeRePattern.matcher(tc.input()).replaceAll(replacement);
@@ -445,7 +445,7 @@ class CrossEngineTest {
     }
   }
 
-  private void compareSplit(
+  private static void compareSplit(
       Pattern safeRePattern, java.util.regex.Pattern jdkPattern, TestCase tc, boolean expectEqual) {
     String[] safeReParts = safeRePattern.split(tc.input());
     String[] jdkParts = jdkPattern.split(tc.input());
@@ -462,7 +462,7 @@ class CrossEngineTest {
   // ---------------------------------------------------------------------------
 
   /** Collects all {@code find()} results from a SafeRE {@link Matcher}. */
-  private List<MatchResult> collectFinds(Matcher matcher) {
+  private static List<MatchResult> collectFinds(Matcher matcher) {
     List<MatchResult> results = new ArrayList<>();
     while (matcher.find()) {
       int gc = matcher.groupCount();
@@ -476,7 +476,7 @@ class CrossEngineTest {
   }
 
   /** Collects all {@code find()} results from a JDK {@link java.util.regex.Matcher}. */
-  private List<MatchResult> collectFindsJdk(java.util.regex.Matcher matcher) {
+  private static List<MatchResult> collectFindsJdk(java.util.regex.Matcher matcher) {
     List<MatchResult> results = new ArrayList<>();
     while (matcher.find()) {
       int gc = matcher.groupCount();

--- a/safere/src/test/java/org/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/org/safere/ExhaustiveUtils.java
@@ -7,10 +7,11 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.fail;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
-import java.util.Stack;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.regex.PatternSyntaxException;
@@ -353,7 +354,7 @@ final class ExhaustiveUtils {
 
   /** Evaluate postfix sequence into a regexp string and emit it (plus anchored variants). */
   private static void runPostfix(List<String> post, String wrapper, Consumer<String> handler) {
-    Stack<String> regexps = new Stack<>();
+    Deque<String> regexps = new ArrayDeque<>();
     for (String cmd : post) {
       int nargs = countArgs(cmd);
       if (nargs == 0) {

--- a/safere/src/test/java/org/safere/GraphemeJdkImplementationDetailTest.java
+++ b/safere/src/test/java/org/safere/GraphemeJdkImplementationDetailTest.java
@@ -195,7 +195,7 @@ class GraphemeJdkImplementationDetailTest {
     assertTraceSameAsJdk("\\X{2}", regionStartsInsidePair, 1, 4);
   }
 
-  private void assertTraceSameAsJdk(String regex, String input, int start, int end) {
+  private static void assertTraceSameAsJdk(String regex, String input, int start, int end) {
     java.util.regex.Matcher jdkMatcher =
         java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
     Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
@@ -217,7 +217,8 @@ class GraphemeJdkImplementationDetailTest {
         .containsExactly(findBounds(jdkMatcher).toArray(int[][]::new));
   }
 
-  private void assertTransparentTraceSameAsJdk(String regex, String input, int start, int end) {
+  private static void assertTransparentTraceSameAsJdk(
+      String regex, String input, int start, int end) {
     java.util.regex.Matcher jdkMatcher =
         java.util.regex.Pattern.compile(regex)
             .matcher(input)
@@ -243,7 +244,8 @@ class GraphemeJdkImplementationDetailTest {
         .containsExactly(findBounds(jdkMatcher).toArray(int[][]::new));
   }
 
-  private void assertCapturedFindTraceSameAsJdk(String regex, String input, int start, int end) {
+  private static void assertCapturedFindTraceSameAsJdk(
+      String regex, String input, int start, int end) {
     java.util.regex.Matcher jdkMatcher =
         java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
     Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
@@ -253,7 +255,7 @@ class GraphemeJdkImplementationDetailTest {
         .containsExactlyElementsOf(capturedFindTrace(jdkMatcher));
   }
 
-  private void assertTransparentCapturedFindTraceSameAsJdk(
+  private static void assertTransparentCapturedFindTraceSameAsJdk(
       String regex, String input, int start, int end) {
     java.util.regex.Matcher jdkMatcher =
         java.util.regex.Pattern.compile(regex)
@@ -270,7 +272,7 @@ class GraphemeJdkImplementationDetailTest {
         .containsExactlyElementsOf(capturedFindTrace(jdkMatcher));
   }
 
-  private List<int[]> findBounds(java.util.regex.Matcher matcher) {
+  private static List<int[]> findBounds(java.util.regex.Matcher matcher) {
     List<int[]> matches = new ArrayList<>();
     while (matcher.find()) {
       matches.add(new int[] {matcher.start(), matcher.end()});
@@ -278,7 +280,7 @@ class GraphemeJdkImplementationDetailTest {
     return matches;
   }
 
-  private List<int[]> findBounds(Matcher matcher) {
+  private static List<int[]> findBounds(Matcher matcher) {
     List<int[]> matches = new ArrayList<>();
     while (matcher.find()) {
       matches.add(new int[] {matcher.start(), matcher.end()});
@@ -286,7 +288,7 @@ class GraphemeJdkImplementationDetailTest {
     return matches;
   }
 
-  private List<String> capturedFindTrace(java.util.regex.Matcher matcher) {
+  private static List<String> capturedFindTrace(java.util.regex.Matcher matcher) {
     List<String> trace = new ArrayList<>();
     while (matcher.find()) {
       trace.add(capturedMatchTrace(matcher));
@@ -294,7 +296,7 @@ class GraphemeJdkImplementationDetailTest {
     return trace;
   }
 
-  private List<String> capturedFindTrace(Matcher matcher) {
+  private static List<String> capturedFindTrace(Matcher matcher) {
     List<String> trace = new ArrayList<>();
     while (matcher.find()) {
       trace.add(capturedMatchTrace(matcher));
@@ -302,7 +304,7 @@ class GraphemeJdkImplementationDetailTest {
     return trace;
   }
 
-  private String capturedMatchTrace(java.util.regex.Matcher matcher) {
+  private static String capturedMatchTrace(java.util.regex.Matcher matcher) {
     StringBuilder builder = new StringBuilder();
     builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
     builder.append(matcher.group());
@@ -312,7 +314,7 @@ class GraphemeJdkImplementationDetailTest {
     return builder.toString();
   }
 
-  private String capturedMatchTrace(Matcher matcher) {
+  private static String capturedMatchTrace(Matcher matcher) {
     StringBuilder builder = new StringBuilder();
     builder.append(matcher.start()).append('-').append(matcher.end()).append(':');
     builder.append(matcher.group());

--- a/safere/src/test/java/org/safere/GraphemeRegionCompatibilityMatrixTest.java
+++ b/safere/src/test/java/org/safere/GraphemeRegionCompatibilityMatrixTest.java
@@ -320,7 +320,7 @@ class GraphemeRegionCompatibilityMatrixTest {
             "long end-anchored base-plus-mark input uses grapheme engine semantics",
             "Long inputs exercise optimized engine selection while preserving grapheme-aware end"
                 + " anchors.",
-            ("a\u0301").repeat(1000) + "z",
+            "a\u0301".repeat(1000) + "z",
             0,
             2001,
             false,

--- a/safere/src/test/java/org/safere/InstOpTest.java
+++ b/safere/src/test/java/org/safere/InstOpTest.java
@@ -19,6 +19,7 @@ class InstOpTest {
   }
 
   @Test
+  @SuppressWarnings("EnumOrdinal") // Testing precise enum definition layout / ordering
   void orderMatchesRe2() {
     assertThat(InstOp.ALT.ordinal()).isEqualTo(0);
     assertThat(InstOp.ALT_MATCH.ordinal()).isEqualTo(1);

--- a/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
+++ b/safere/src/test/java/org/safere/JdkSyntaxCompatibilityTest.java
@@ -2836,6 +2836,8 @@ class JdkSyntaxCompatibilityTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("lineTerminators")
     @DisplayName("dot does not match line terminator")
+    @SuppressWarnings(
+        "BareDotMetacharacter") // Specifically testing behavior of bare dot metacharacter
     void dotDoesNotMatch(String desc, String terminator) {
       // dot should NOT match line terminators (without DOTALL)
       java.util.regex.Matcher jdkM = java.util.regex.Pattern.compile(".").matcher(terminator);

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -765,26 +765,7 @@ class LinebreakGraphemeTest {
       assertThat(clusters).containsExactly("H", "e\u0301", "l", "l", "o");
     }
 
-    private void assertFindBoundsSameAsJdk(String regex, String input) {
-      java.util.regex.Matcher jdkMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
-      Matcher safeMatcher = Pattern.compile(regex).matcher(input);
-
-      List<int[]> jdkMatches = new ArrayList<>();
-      while (jdkMatcher.find()) {
-        jdkMatches.add(new int[] {jdkMatcher.start(), jdkMatcher.end()});
-      }
-
-      List<int[]> safeMatches = new ArrayList<>();
-      while (safeMatcher.find()) {
-        safeMatches.add(new int[] {safeMatcher.start(), safeMatcher.end()});
-      }
-
-      assertThat(safeMatches)
-          .as("find() positions for /%s/ on %s", regex, input)
-          .containsExactly(jdkMatches.toArray(int[][]::new));
-    }
-
-    private void assertFirstFindBounds(String regex, String input, int start, int end) {
+    private static void assertFirstFindBounds(String regex, String input, int start, int end) {
       Matcher matcher = Pattern.compile(regex).matcher(input);
       assertThat(matcher.find()).as("first find() for /%s/ on %s", regex, input).isTrue();
       assertThat(matcher.start())
@@ -794,7 +775,7 @@ class LinebreakGraphemeTest {
       assertThat(matcher.find()).as("second find() for /%s/ on %s", regex, input).isFalse();
     }
 
-    private void assertFindGroupsSameAsJdk(String regex, String input, int start, int end) {
+    private static void assertFindGroupsSameAsJdk(String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
       Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
@@ -808,28 +789,7 @@ class LinebreakGraphemeTest {
       }
     }
 
-    private void assertTransparentFindGroupsSameAsJdk(
-        String regex, String input, int start, int end) {
-      java.util.regex.Matcher jdkMatcher =
-          java.util.regex.Pattern.compile(regex)
-              .matcher(input)
-              .region(start, end)
-              .useTransparentBounds(true);
-      Matcher safeMatcher =
-          Pattern.compile(regex).matcher(input).region(start, end).useTransparentBounds(true);
-
-      assertThat(safeMatcher.find()).as("SafeRE find() should match").isEqualTo(jdkMatcher.find());
-      assertThat(safeMatcher.groupCount()).isEqualTo(jdkMatcher.groupCount());
-      for (int group = 0; group <= jdkMatcher.groupCount(); group++) {
-        assertThat(safeMatcher.group(group))
-            .as(
-                "group %s for transparent /%s/ on %s region [%s,%s]",
-                group, regex, input, start, end)
-            .isEqualTo(jdkMatcher.group(group));
-      }
-    }
-
-    private void assertTraceSameAsJdk(String regex, String input, int start, int end) {
+    private static void assertTraceSameAsJdk(String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex).matcher(input).region(start, end);
       Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
@@ -861,7 +821,7 @@ class LinebreakGraphemeTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
-    private void assertSafeReFindBounds(
+    private static void assertSafeReFindBounds(
         String regex, String input, int start, int end, List<String> expected) {
       Matcher safeMatcher = Pattern.compile(regex).matcher(input).region(start, end);
       List<String> safeMatches = new ArrayList<>();
@@ -873,7 +833,8 @@ class LinebreakGraphemeTest {
           .containsExactlyElementsOf(expected);
     }
 
-    private void assertTransparentTraceSameAsJdk(String regex, String input, int start, int end) {
+    private static void assertTransparentTraceSameAsJdk(
+        String regex, String input, int start, int end) {
       java.util.regex.Matcher jdkMatcher =
           java.util.regex.Pattern.compile(regex)
               .matcher(input)
@@ -911,21 +872,21 @@ class LinebreakGraphemeTest {
           .containsExactly(jdkMatches.toArray(int[][]::new));
     }
 
-    private long allocatedForImmediateTwoClusterFind(
+    private static long allocatedForImmediateTwoClusterFind(
         AllocationTracker allocationTracker, long threadId, Pattern pattern, String text) {
       long before = allocationTracker.allocatedBytes(threadId);
       assertImmediateTwoClusterMatch(pattern, text);
       return allocationTracker.allocatedBytes(threadId) - before;
     }
 
-    private void assertImmediateTwoClusterMatch(Pattern pattern, String text) {
+    private static void assertImmediateTwoClusterMatch(Pattern pattern, String text) {
       Matcher matcher = pattern.matcher(text);
       assertThat(matcher.find()).isTrue();
       assertThat(matcher.start()).isZero();
       assertThat(matcher.end()).isEqualTo(2);
     }
 
-    private void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
+    private static void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
       task.accept(1_000);
       long smallerNanos = bestRuntimeNanos(() -> task.accept(5_000));
       long largerNanos = bestRuntimeNanos(() -> task.accept(20_000));
@@ -937,7 +898,7 @@ class LinebreakGraphemeTest {
           .isLessThan(smallerNanos * 10);
     }
 
-    private long bestRuntimeNanos(Runnable task) {
+    private static long bestRuntimeNanos(Runnable task) {
       long best = Long.MAX_VALUE;
       for (int i = 0; i < 3; i++) {
         best = Math.min(best, runtimeNanos(task));
@@ -945,7 +906,7 @@ class LinebreakGraphemeTest {
       return best;
     }
 
-    private long runtimeNanos(Runnable task) {
+    private static long runtimeNanos(Runnable task) {
       return assertTimeoutPreemptively(
           PERFORMANCE_SCENARIO_TIMEOUT,
           () -> {
@@ -955,7 +916,7 @@ class LinebreakGraphemeTest {
           });
     }
 
-    private AllocationTracker allocationTracker() {
+    private static AllocationTracker allocationTracker() {
       try {
         Class<?> managementFactoryClass = Class.forName("java.lang.management.ManagementFactory");
         Object threadBean = managementFactoryClass.getMethod("getThreadMXBean").invoke(null);

--- a/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
+++ b/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
@@ -193,6 +193,7 @@ class MatcherStateMachineTraceTest {
     return events;
   }
 
+  @SuppressWarnings("UnusedMethod")
   private interface TraceSubject {
     boolean matches();
 
@@ -242,7 +243,7 @@ class MatcherStateMachineTraceTest {
   }
 
   private static final class SafeReSubject implements TraceSubject {
-    private Matcher matcher;
+    private final Matcher matcher;
 
     SafeReSubject(Matcher matcher) {
       this.matcher = matcher;
@@ -379,7 +380,7 @@ class MatcherStateMachineTraceTest {
   }
 
   private static final class JdkSubject implements TraceSubject {
-    private java.util.regex.Matcher matcher;
+    private final java.util.regex.Matcher matcher;
 
     JdkSubject(java.util.regex.Matcher matcher) {
       this.matcher = matcher;
@@ -562,6 +563,7 @@ class MatcherStateMachineTraceTest {
       return value("end(" + group + ")", subject -> subject.end(group));
     }
 
+    @SuppressWarnings("UnusedMethod")
     static Step reset() {
       return effect("reset", TraceSubject::reset);
     }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -561,10 +561,12 @@ class MatcherTest {
     void findStartAccelerationForLineStartWhitespace() {
       assertAllFindsMatchJdk(
           "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
-          "java.lang.IllegalStateException: failed\n"
-              + "\tat org.example.api.Handler.handle(Handler.java:87)\n"
-              + "Caused by: java.io.IOException: timeout\r\n"
-              + "\tat org.example.net.Client.read(Client.java:203)");
+          """
+          java.lang.IllegalStateException: failed
+          \tat org.example.api.Handler.handle(Handler.java:87)
+          Caused by: java.io.IOException: timeout\r
+          \tat org.example.net.Client.read(Client.java:203)\
+          """);
     }
 
     @Test
@@ -593,11 +595,11 @@ class MatcherTest {
       assertFirstFindMatchesJdk(regex, input);
     }
 
-    private void assertAllFindsMatchJdk(String regex, String input) {
+    private static void assertAllFindsMatchJdk(String regex, String input) {
       assertAllFindsMatchJdk(regex, 0, input);
     }
 
-    private void assertAllFindsMatchJdk(String regex, int flags, String input) {
+    private static void assertAllFindsMatchJdk(String regex, int flags, String input) {
       Matcher m = Pattern.compile(regex, flags).matcher(input);
       java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex, flags).matcher(input);
 
@@ -631,9 +633,11 @@ class MatcherTest {
     @DisplayName("find() fallback paths match JDK for unreliable DFA-start patterns")
     void findFallbackMatchesJdkForUnreliableDfaStartPatterns(String regex) {
       String text =
-          "java.lang.IllegalStateException: failed\n"
-              + "\tat org.example.Main.main(Main.java:25)\n"
-              + "xxabcde yy aaa failed bcX";
+          """
+          java.lang.IllegalStateException: failed
+          \tat org.example.Main.main(Main.java:25)
+          xxabcde yy aaa failed bcX\
+          """;
       Matcher m = Pattern.compile(regex).matcher(text);
       java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(text);
 
@@ -1484,6 +1488,7 @@ class MatcherTest {
 
   @Nested
   @DisplayName("StringBuffer append methods")
+  @SuppressWarnings("JdkObsolete") // Testing legacy StringBuffer API compatibility
   class StringBufferAppendTests {
 
     @Test
@@ -1907,7 +1912,7 @@ class MatcherTest {
   class ReverseFirstDfaTests {
 
     /** Helper to create a string of repeated characters. */
-    private String repeat(char ch, int count) {
+    private static String repeat(char ch, int count) {
       return String.valueOf(ch).repeat(count);
     }
 
@@ -2439,24 +2444,6 @@ class MatcherTest {
     return Pattern.compile(
         ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-  }
-
-  private static String scimFilterPattern() {
-    return "\\A"
-        + "([Uu][Rr][Nn]:[Ii][Ee][Tt][Ff]:[Pp][Aa][Rr][Aa][Mm][Ss]:"
-        + "[Ss][Cc][Ii][Mm]:[Ss][Cc][Hh][Ee][Mm][Aa][Ss]:[Cc][Oo][Rr][Ee]:"
-        + "2\\.0:[Uu][Ss][Ee][Rr]:)?"
-        + "[Ii][Dd] [Ee][Qq] "
-        + "(?:\"(?:(?:[^\"\\\\]|(\\\\)+\")*){3,500}\"|null)"
-        + "\\z";
-  }
-
-  private static String scimFilterInput(int valueLength) {
-    return "id eq \"" + "a".repeat(valueLength) + "\"";
-  }
-
-  private static String nestedCapturingGroups(int depth) {
-    return "(".repeat(depth) + "a" + ")".repeat(depth);
   }
 
   private static void assertNoPerformanceCliff(String api, IntConsumer scenario) {

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -25,6 +25,8 @@ class ParserTest {
   /** Perl-compatible flags, used as the default for most tests. */
   private static final int PERL = ParseFlags.LIKE_PERL;
 
+  // Used as a sink to prevent JVM dead-code elimination in microbenchmarks.
+  @SuppressWarnings("unused")
   private static Regexp parseTimingSink;
 
   /**

--- a/safere/src/test/java/org/safere/RE2ExhaustiveTest.java
+++ b/safere/src/test/java/org/safere/RE2ExhaustiveTest.java
@@ -253,51 +253,6 @@ class RE2ExhaustiveTest {
   }
 
   /**
-   * Check submatch group positions against expected UTF-8 byte-offset pairs.
-   *
-   * <p>Compares each group's start/end against the expected values after converting from UTF-8 byte
-   * offsets to Java char offsets.
-   */
-  private static void checkGroups(
-      Matcher m,
-      int[][] expected,
-      String text,
-      String pattern,
-      String method,
-      List<String> failures) {
-    int numGroups = Math.min(expected.length, m.groupCount() + 1);
-    for (int g = 0; g < numGroups; g++) {
-      int expectStart;
-      int expectEnd;
-      if (expected[g][0] == -1 && expected[g][1] == -1) {
-        expectStart = -1;
-        expectEnd = -1;
-      } else {
-        expectStart = utf8ByteToCharOffset(text, expected[g][0]);
-        expectEnd = utf8ByteToCharOffset(text, expected[g][1]);
-      }
-
-      int actualStart = m.start(g);
-      int actualEnd = m.end(g);
-
-      if (actualStart != expectStart || actualEnd != expectEnd) {
-        failures.add(
-            String.format(
-                "%s() group %d pat=\"%s\" text=\"%s\": got [%d,%d), want [%d,%d)",
-                method,
-                g,
-                escape(pattern),
-                escape(text),
-                actualStart,
-                actualEnd,
-                expectStart,
-                expectEnd));
-        break; // one failure per test case is enough
-      }
-    }
-  }
-
-  /**
    * Check submatch groups, falling back to JDK cross-validation when RE2 expected values disagree
    * with SafeRE. If JDK agrees with SafeRE's group positions, the mismatch is a known RE2
    * behavioral difference (not a bug).

--- a/safere/src/test/java/org/safere/RE2FindTest.java
+++ b/safere/src/test/java/org/safere/RE2FindTest.java
@@ -31,6 +31,8 @@ class RE2FindTest {
    * array of (start, end) UTF-8 byte-offset pairs for group 0, group 1, etc. A value of -1 means
    * the group did not participate.
    */
+  @SuppressWarnings(
+      "ArrayRecordComponent") // Simple package-private test case helper holds 2D arrays
   record FindTestCase(String pattern, String text, int[][] matches) {
     @Override
     public String toString() {
@@ -64,7 +66,6 @@ class RE2FindTest {
     if (byteOffset < 0) {
       return -1;
     }
-    byte[] utf8 = text.getBytes(StandardCharsets.UTF_8);
     int charOffset = 0;
     int b = 0;
     while (b < byteOffset && charOffset < text.length()) {

--- a/safere/src/test/java/org/safere/RE2FindTest.java
+++ b/safere/src/test/java/org/safere/RE2FindTest.java
@@ -31,8 +31,8 @@ class RE2FindTest {
    * array of (start, end) UTF-8 byte-offset pairs for group 0, group 1, etc. A value of -1 means
    * the group did not participate.
    */
-  @SuppressWarnings(
-      "ArrayRecordComponent") // Simple package-private test case helper holds 2D arrays
+  // Simple package-private test case helper holds 2D arrays
+  @SuppressWarnings("ArrayRecordComponent")
   record FindTestCase(String pattern, String text, int[][] matches) {
     @Override
     public String toString() {

--- a/safere/src/test/java/org/safere/RE2PosixTest.java
+++ b/safere/src/test/java/org/safere/RE2PosixTest.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class RE2PosixTest {
 
   /** A single POSIX test case. */
+  @SuppressWarnings(
+      "ArrayRecordComponent") // Simple package-private test case helper holds 2D arrays
   record PosixTestCase(
       String file,
       int lineNum,
@@ -312,7 +314,7 @@ class RE2PosixTest {
     return false;
   }
 
-  private void runTest(PosixTestCase tc) {
+  private static void runTest(PosixTestCase tc) {
     int flags = 0;
     if (tc.caseInsensitive()) {
       flags |= Pattern.CASE_INSENSITIVE;

--- a/safere/src/test/java/org/safere/RE2PosixTest.java
+++ b/safere/src/test/java/org/safere/RE2PosixTest.java
@@ -43,9 +43,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 @DisplayName("RE2 POSIX Tests (from basic.dat, nullsubexpr.dat, repetition.dat)")
 class RE2PosixTest {
 
-  /** A single POSIX test case. */
-  @SuppressWarnings(
-      "ArrayRecordComponent") // Simple package-private test case helper holds 2D arrays
+  // Simple package-private test case helper holds 2D arrays
+  @SuppressWarnings("ArrayRecordComponent")
   record PosixTestCase(
       String file,
       int lineNum,

--- a/safere/src/test/java/org/safere/RandomTest.java
+++ b/safere/src/test/java/org/safere/RandomTest.java
@@ -35,19 +35,19 @@ class RandomTest {
   /** Small egrep-style patterns with literal alphabet. */
   @Test
   void smallEgrepLiterals() {
-    randomTest(5, 5, new String[] {"a", "b", "c", "."}, EGREP_OPS, 15, "abc");
+    randomTest(5, new String[] {"a", "b", "c", "."}, EGREP_OPS, 15, "abc");
   }
 
   /** Bigger egrep-style patterns. */
   @Test
   void bigEgrepLiterals() {
-    randomTest(8, 8, new String[] {"a", "b", "c", "."}, EGREP_OPS, 15, "abc");
+    randomTest(8, new String[] {"a", "b", "c", "."}, EGREP_OPS, 15, "abc");
   }
 
   /** Patterns with capturing groups. */
   @Test
   void smallEgrepCaptures() {
-    randomTest(5, 5, new String[] {"a", "(b)", "."}, EGREP_OPS, 15, "abc");
+    randomTest(5, new String[] {"a", "(b)", "."}, EGREP_OPS, 15, "abc");
   }
 
   /** Complex patterns with character classes, anchors, and quantifiers. */
@@ -60,7 +60,7 @@ class RandomTest {
       "%s%s", "%s|%s", "%s*", "%s*?", "%s+", "%s+?", "%s?", "%s??", "%s{0}", "%s{0,}", "%s{1}",
       "%s{1,}", "%s{0,1}", "%s{0,2}", "%s{1,2}", "%s{2}", "%s{2,}", "%s{3,4}"
     };
-    randomTest(8, 8, atoms, ops, 20, "abc123\t\n");
+    randomTest(8, atoms, ops, 20, "abc123\t\n");
   }
 
   // -----------------------------------------------------------------------
@@ -75,8 +75,8 @@ class RandomTest {
   // Core test logic
   // -----------------------------------------------------------------------
 
-  private void randomTest(
-      int maxAtoms, int maxOps, String[] atoms, String[] ops, int maxStrLen, String strAlphabet) {
+  private static void randomTest(
+      int maxOps, String[] atoms, String[] ops, int maxStrLen, String strAlphabet) {
     Random regexpRng = new Random(REGEXP_SEED);
     Random stringRng = new Random(STRING_SEED);
 
@@ -98,7 +98,7 @@ class RandomTest {
     List<String> failures = new ArrayList<>();
 
     for (int i = 0; i < REGEXP_COUNT; i++) {
-      String pattern = generateRandomRegexp(regexpRng, atoms, ops, maxAtoms, maxOps);
+      String pattern = generateRandomRegexp(regexpRng, atoms, ops, maxOps);
 
       // Try to compile with both engines.
       Pattern saferePattern;
@@ -193,8 +193,7 @@ class RandomTest {
   // Random regexp generation
   // -----------------------------------------------------------------------
 
-  private static String generateRandomRegexp(
-      Random rng, String[] atoms, String[] ops, int maxAtoms, int maxOps) {
+  private static String generateRandomRegexp(Random rng, String[] atoms, String[] ops, int maxOps) {
     int numOps = rng.nextInt(maxOps) + 1;
     // Start with a random atom.
     String expr = atoms[rng.nextInt(atoms.length)];

--- a/safere/src/test/java/org/safere/RegexpOpTest.java
+++ b/safere/src/test/java/org/safere/RegexpOpTest.java
@@ -19,11 +19,13 @@ class RegexpOpTest {
   }
 
   @Test
+  @SuppressWarnings("EnumOrdinal") // Testing precise enum definition layout / ordering
   void firstOpIsNoMatch() {
     assertThat(RegexpOp.values()[0]).isEqualTo(RegexpOp.NO_MATCH);
   }
 
   @Test
+  @SuppressWarnings("EnumOrdinal") // Testing precise enum definition layout / ordering
   void lastOpIsHaveMatch() {
     assertThat(RegexpOp.values()[RegexpOp.values().length - 1]).isEqualTo(RegexpOp.HAVE_MATCH);
   }

--- a/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
+++ b/safere/src/test/java/org/safere/UnicodePropertySyntaxTest.java
@@ -32,11 +32,6 @@ class UnicodePropertySyntaxTest {
     return Pattern.compile(regex).matcher(input).find();
   }
 
-  /** Returns true if the regex matches the entire input. */
-  private static boolean matches(String regex, String input) {
-    return Pattern.compile(regex).matcher(input).matches();
-  }
-
   /** Cross-validates against JDK: asserts SafeRE and JDK agree on find(). */
   private static void assertMatchesJdk(String regex, String input) {
     boolean safere = find(regex, input);

--- a/safere/src/test/java/org/safere/UnicodeTablesTest.java
+++ b/safere/src/test/java/org/safere/UnicodeTablesTest.java
@@ -46,7 +46,7 @@ class UnicodeTablesTest {
     assertThat(cn).isNotNull();
     for (Map.Entry<String, int[][]> entry : UnicodeGeneratedTables.CATEGORIES.entrySet()) {
       String name = entry.getKey();
-      if (name.length() != 2 || "Cn".equals(name)) {
+      if (name.length() != 2 || name.equals("Cn")) {
         continue;
       }
       assertThat(overlaps(cn, entry.getValue()))


### PR DESCRIPTION
- FieldCanBeFinal: Promoted fields to final when they are only assigned in constructors.
- MethodCanBeStatic: Made helper methods static when they do not reference instance state.
- YodaCondition: Flipped comparisons to place the variable/expression first.
- UnusedVariable, UnusedMethod, UnusedNestedClass, UnusedTypeParameter: Removed dead code and parameters across main and test sources.
- UnnecessaryDefaultInEnumSwitch: Removed redundant default cases in enum switches where all constants are fully covered.
- StringSplitter: Disabled this check since SafeRE doesn't use Guava

Added appropriate @SuppressWarnings annotations where warnings were intentional (e.g., benchmark-related variables in ParserTest, legacy StringBuffer API tests, and unused trace subject lifecycle methods).

Removed unused SCIM-related test helpers in MatcherTest that were left over from previous test deletions.