### PR TITLE
Fix DFA sandwich leftmost-start handling

### DIFF
--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -211,6 +211,39 @@ remain observable when no scalar can be consumed. The sweep classifies
 implementation-detail divergences; other generated divergences are reported as
 `UNKNOWN`.
 
+## DFA Sandwich Leftmost-Start Sweep
+
+Run through the dispatcher script:
+
+```bash
+./run-exhaustive-sweep.sh DfaSandwichLeftmostStartDivergenceSweep \
+  --output-dir=target/exhaustive-reports/dfa-sandwich-leftmost-start-sweep-full
+```
+
+For a smaller ad hoc local check, run a generated-case index range:
+
+```bash
+./run-exhaustive-sweep.sh DfaSandwichLeftmostStartDivergenceSweep --range=:1000 \
+  --output-dir=target/exhaustive-reports/dfa-sandwich-leftmost-start-sweep-smoke
+```
+
+The DFA sandwich leftmost-start sweep compares SafeRE with `java.util.regex`
+for unanchored patterns whose forward DFA earliest end and reverse DFA start
+can disagree with JDK leftmost-first `find()` semantics. It crosses leading
+empty and boundary prefixes, consuming repeated middles, required consuming
+suffixes, alternation contexts, flags, and overlapping inputs. Each generated
+case compares compile acceptance plus public matcher traces for `matches()`,
+`lookingAt()`, repeated `find()`, captures, and replacement APIs when captures
+exist.
+
+Use this sweep before review when changing DFA sandwich routing, reverse-DFA
+start authority, prefix/start acceleration, leftmost-start reliability guards,
+or BitState/NFA fallback decisions. The sweep treats all divergences as
+actionable or unknown because the generated patterns are ordinary supported
+syntax. Generated sweep mode writes the shared compact archive described above;
+use the expander to materialize exact counts and replayable JSONL after the
+sweep.
+
 ## Grapheme Cluster Sweep
 
 Run through the dispatcher script:

--- a/safere-exhaustive/README.md
+++ b/safere-exhaustive/README.md
@@ -208,8 +208,10 @@ boundary, while zero-width coverage verifies which candidate boundary positions
 remain observable when no scalar can be consumed. The sweep classifies
 `ASCII_WORD_BOUNDARY_COMBINING_MARK`, `OPAQUE_REGION_CRLF_PAIR_CONTEXT`, and
 `BOUNDARY_ANY_CLASS_SPLIT_SURROGATE_SCALAR_COMPOSITION` as known intentional
-implementation-detail divergences; other generated divergences are reported as
-`UNKNOWN`.
+implementation-detail divergences. It also classifies
+`NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION` for observed JDK `\B`
+matches at the interior UTF-16 position of a transparent split surrogate pair.
+Other generated divergences are reported as `UNKNOWN`.
 
 ## DFA Sandwich Leftmost-Start Sweep
 

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceExpander.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceExpander.java
@@ -231,6 +231,10 @@ public final class CompactDivergenceExpander {
           sweepDefinition(
               RegionZeroWidthDivergenceSweep.totalCases(),
               RegionZeroWidthDivergenceSweep::compactReplayJson);
+      case "dfa-sandwich-leftmost-start" ->
+          sweepDefinition(
+              DfaSandwichLeftmostStartDivergenceSweep.totalCases(),
+              DfaSandwichLeftmostStartDivergenceSweep::compactReplayJson);
       case "case-folding-character-class" ->
           sweepDefinition(
               CaseFoldingCharacterClassDivergenceSweep.totalCases(),

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/DfaSandwichLeftmostStartDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/DfaSandwichLeftmostStartDivergenceSweep.java
@@ -1,0 +1,413 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.exhaustive;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Offline differential sweep for reverse-DFA sandwich leftmost-start semantics. */
+public final class DfaSandwichLeftmostStartDivergenceSweep {
+  private static final int FIND_LIMIT = 8;
+  private static final int FIRST_UNKNOWN_LIMIT = 100;
+  private static final int ACTIONABLE_SAMPLE_LIMIT = 100;
+  private static final long DEFAULT_PROGRESS_INTERVAL = 100_000;
+
+  private static final List<PrefixCase> PREFIXES =
+      List.of(
+          prefix("empty", ""),
+          prefix("emptyNonCapturing", "(?:)"),
+          prefix("nonWordBoundary", "\\B"),
+          prefix("wordBoundary", "\\b"),
+          prefix("emptyThenNonWordBoundary", "(?:)\\B"),
+          prefix("emptyThenWordBoundary", "(?:)\\b"));
+
+  private static final List<MiddleCase> MIDDLES =
+      List.of(
+          middle("empty", ""),
+          middle("negatedAStar", "[^a]*"),
+          middle("negatedAStarCaptured", "([^a])*"),
+          middle("negatedAStarNonCapturing", "(?:[^a])*"),
+          middle("dotStar", ".*"),
+          middle("dotStarCaptured", "(.)*"),
+          middle("shortFirstAlternativeStar", "(?:b|bb)*"),
+          middle("longFirstAlternativeStar", "(?:bb|b)*"),
+          middle("shortFirstAlternativeStarCaptured", "(b|bb)*"),
+          middle("boundedNegatedA", "[^a]{0,3}"),
+          middle("boundedNegatedARepeated", "(?:[^a]{1,2})*"),
+          middle("nullableBRepeated", "(?:b?)*"));
+
+  private static final List<SuffixCase> SUFFIXES =
+      List.of(
+          suffix("negatedAPair", "[^a][^a]"),
+          suffix("negatedATriple", "[^a][^a][^a]"),
+          suffix("literalBPair", "bb"),
+          suffix("literalBTriple", "bbb"),
+          suffix("literalBThenNegatedA", "b[^a]"),
+          suffix("anyClassPair", "[\\s\\S][\\s\\S]"),
+          suffix("dotPair", ".."));
+
+  private static final List<ContextCase> CONTEXTS =
+      List.of(
+          context("bare", "%s"),
+          context("capturedWhole", "(%s)"),
+          context("nonCapturedWhole", "(?:%s)"),
+          context("alternativeAfterLiteralA", "a|%s"),
+          context("alternativeBeforeLiteralA", "%s|a"),
+          context("alternativeAfterLiteralBB", "bb|%s"),
+          context("alternativeBeforeLiteralBB", "%s|bb"));
+
+  private static final List<FlagMode> FLAG_MODES =
+      List.of(
+          flags("none", 0),
+          flags("dotall", java.util.regex.Pattern.DOTALL),
+          flags("multiline", java.util.regex.Pattern.MULTILINE),
+          flags("unicodeCharacterClass", java.util.regex.Pattern.UNICODE_CHARACTER_CLASS));
+
+  private static final List<String> INPUTS =
+      List.of(
+          "", "a", "b", "bb", "bbb", "bbbb", "bbbbb", "abbbb", "bbbbx", "xbbbb", "baabbbb", "!!!!",
+          "!!", "a_bbbb", "bb\nbb", "\nbbbb", "bbbb\n");
+
+  private DfaSandwichLeftmostStartDivergenceSweep() {}
+
+  public static void main(String[] args) throws IOException {
+    SweepOptions options =
+        SweepOptions.parse(
+            args,
+            Path.of("target", "exhaustive-reports", "dfa-sandwich-leftmost-start-sweep"),
+            "dfa-sandwich-leftmost-start-divergences.jsonl",
+            DEFAULT_PROGRESS_INTERVAL);
+    Files.createDirectories(options.outputDir());
+    if (options.replayFile() != null) {
+      Files.deleteIfExists(options.jsonlPath());
+    }
+    options.printStartup("dfa-sandwich-leftmost-start");
+
+    if (options.replayFile() != null) {
+      runReplay(options);
+      return;
+    }
+
+    ClassifiedDivergenceSummary<DivergenceClass> summary = newSummary();
+    SweepRunState state = runSweep(options, summary);
+    summary.writeReports(options.outputDir());
+    System.out.println("checked=" + state.checked.sum());
+    System.out.println("generated=" + state.generated);
+    System.out.println("totalCases=" + totalCases());
+    System.out.println("divergences=" + state.divergences.sum());
+    System.out.println("actionableDivergences=" + summary.actionableCount());
+    System.out.println("unknownDivergences=" + summary.count(DivergenceClass.UNKNOWN));
+    System.out.println("threads=" + options.threads());
+  }
+
+  static long totalCases() {
+    return (long) PREFIXES.size()
+        * MIDDLES.size()
+        * SUFFIXES.size()
+        * CONTEXTS.size()
+        * FLAG_MODES.size();
+  }
+
+  static String compactReplayJson(long caseIndex, String classification) {
+    CaseSpec spec = caseFromIndex(caseIndex);
+    return divergenceJson(
+        spec,
+        spec.regex(),
+        new RegexSweep.Outcome(false, "", ""),
+        new RegexSweep.Outcome(false, "", ""),
+        DivergenceClass.valueOf(classification),
+        caseIndex);
+  }
+
+  private static SweepRunState runSweep(
+      SweepOptions options, ClassifiedDivergenceSummary<DivergenceClass> summary)
+      throws IOException {
+    try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
+      runState.enableCompactLogs(
+          "dfa-sandwich-leftmost-start",
+          totalCases(),
+          divergenceClassificationNames(),
+          divergenceClassificationStatuses());
+      SweepWorkers.run(
+          options.threads(),
+          "dfa-sandwich-leftmost-start-sweep-",
+          workerIndex -> {
+            SweepWorkers.ProgressReporter progressReporter =
+                new SweepWorkers.ProgressReporter(runState, workerIndex);
+            long generated = 0;
+            long end = Math.min(options.rangeEndExclusive(), totalCases());
+            for (long caseIndex = options.rangeStartInclusive(); caseIndex < end; caseIndex++) {
+              generated = caseIndex + 1;
+              if (caseIndex % options.threads() != workerIndex) {
+                continue;
+              }
+              progressReporter.checked();
+              evaluateCase(runState, summary, caseFromIndex(caseIndex), workerIndex, caseIndex);
+              progressReporter.reportIfNeeded(generated);
+            }
+            runState.recordGenerated(generated);
+            runState.updateWorkerNextCaseIndex(workerIndex, generated);
+          });
+      return runState;
+    }
+  }
+
+  private static void runReplay(SweepOptions options) throws IOException {
+    ClassifiedDivergenceSummary<DivergenceClass> summary = newSummary();
+    try (BufferedReader reader =
+            Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
+        SweepRunState runState = new SweepRunState(options, 0)) {
+      long generated =
+          SweepWorkers.runStreamingLines(
+              options.threads(),
+              "dfa-sandwich-leftmost-start-replay-",
+              reader,
+              line -> {
+                CaseSpec spec = replayCaseOrNull(line);
+                if (spec == null) {
+                  return;
+                }
+                runState.checked.increment();
+                evaluateCase(runState, summary, spec, -1, -1);
+              });
+      runState.recordGenerated(generated);
+      summary.writeReports(options.outputDir());
+      System.out.println("checked=" + runState.checked.sum());
+      System.out.println("generated=" + runState.generated);
+      System.out.println("divergences=" + runState.divergences.sum());
+      System.out.println("actionableDivergences=" + summary.actionableCount());
+      System.out.println("unknownDivergences=" + summary.count(DivergenceClass.UNKNOWN));
+      System.out.println("threads=" + options.threads());
+      System.out.println("jsonl=" + options.jsonlPath());
+      if (summary.actionableCount() > 0 || summary.count(DivergenceClass.UNKNOWN) > 0) {
+        throw new IllegalStateException(
+            "replay found "
+                + summary.actionableCount()
+                + " actionable and "
+                + summary.count(DivergenceClass.UNKNOWN)
+                + " unknown behavioral divergences");
+      }
+    }
+  }
+
+  private static CaseSpec replayCaseOrNull(String line) {
+    JsonObject object = SweepJson.parseObjectOrNull(line);
+    if (object == null) {
+      return null;
+    }
+    JsonObject caseObject = SweepJson.object(object, "case");
+    return new CaseSpec(
+        new PrefixCase(
+            SweepJson.string(caseObject, "prefixLabel"),
+            SweepJson.string(caseObject, "prefixRegex")),
+        new MiddleCase(
+            SweepJson.string(caseObject, "middleLabel"),
+            SweepJson.string(caseObject, "middleRegex")),
+        new SuffixCase(
+            SweepJson.string(caseObject, "suffixLabel"),
+            SweepJson.string(caseObject, "suffixRegex")),
+        new ContextCase(
+            SweepJson.string(caseObject, "contextLabel"),
+            SweepJson.string(caseObject, "contextTemplate")),
+        new FlagMode(
+            SweepJson.string(caseObject, "flagLabel"), SweepJson.integer(caseObject, "flags")));
+  }
+
+  private static void evaluateCase(
+      SweepRunState runState,
+      ClassifiedDivergenceSummary<DivergenceClass> summary,
+      CaseSpec spec,
+      int workerIndex,
+      long caseIndex) {
+    String regex = spec.regex();
+    RegexSweep.Outcome jdk =
+        RegexSweep.jdkTraceOutcome(regex, spec.flagMode().flags(), INPUTS, FIND_LIMIT);
+    RegexSweep.Outcome safere =
+        RegexSweep.safeReTraceOutcome(regex, spec.flagMode().flags(), INPUTS, FIND_LIMIT);
+    if (RegexSweep.semanticallyEqual(jdk, safere)) {
+      return;
+    }
+
+    DivergenceClass classification = classify(jdk, safere);
+    String json = divergenceJson(spec, regex, jdk, safere, classification, caseIndex);
+    if (workerIndex >= 0 && caseIndex >= 0) {
+      runState.recordCompactDivergence(workerIndex, caseIndex, classification.ordinal());
+    } else {
+      runState.recordDivergence();
+    }
+    runState.appendJsonl(json);
+    summary.record(classification, caseIndex, json);
+  }
+
+  private static DivergenceClass classify(RegexSweep.Outcome jdk, RegexSweep.Outcome safere) {
+    if (jdk.accepted() != safere.accepted()) {
+      return DivergenceClass.ACCEPTANCE_MISMATCH;
+    }
+    if (jdk.accepted()) {
+      return DivergenceClass.TRACE_MISMATCH;
+    }
+    return DivergenceClass.UNKNOWN;
+  }
+
+  private static String divergenceJson(
+      CaseSpec spec,
+      String regex,
+      RegexSweep.Outcome jdk,
+      RegexSweep.Outcome safere,
+      DivergenceClass classification,
+      long caseIndex) {
+    JsonObject root = SweepJson.object();
+    root.addProperty("classification", classification.name());
+    root.addProperty("caseIndex", caseIndex);
+    root.add("case", caseJson(spec, regex));
+    root.add("jdk", outcomeJson(jdk));
+    root.add("safere", outcomeJson(safere));
+    return SweepJson.toJson(root);
+  }
+
+  private static JsonObject caseJson(CaseSpec spec, String regex) {
+    JsonObject object = SweepJson.object();
+    object.addProperty("prefixLabel", spec.prefix().label());
+    object.addProperty("prefixRegex", spec.prefix().regex());
+    object.addProperty("middleLabel", spec.middle().label());
+    object.addProperty("middleRegex", spec.middle().regex());
+    object.addProperty("suffixLabel", spec.suffix().label());
+    object.addProperty("suffixRegex", spec.suffix().regex());
+    object.addProperty("contextLabel", spec.context().label());
+    object.addProperty("contextTemplate", spec.context().template());
+    object.addProperty("flagLabel", spec.flagMode().label());
+    object.addProperty("flags", spec.flagMode().flags());
+    object.addProperty("regex", regex);
+    JsonArray inputs = new JsonArray();
+    for (String input : INPUTS) {
+      inputs.add(input);
+    }
+    object.add("inputs", inputs);
+    return object;
+  }
+
+  private static JsonObject outcomeJson(RegexSweep.Outcome outcome) {
+    JsonObject object = SweepJson.object();
+    object.addProperty("accepted", outcome.accepted());
+    object.addProperty("trace", outcome.trace());
+    object.addProperty("error", outcome.error());
+    return object;
+  }
+
+  private static ClassifiedDivergenceSummary<DivergenceClass> newSummary() {
+    return new ClassifiedDivergenceSummary<>(
+        DivergenceClass.class,
+        DivergenceClass.UNKNOWN,
+        "dfa-sandwich-leftmost-start",
+        FIRST_UNKNOWN_LIMIT,
+        ACTIONABLE_SAMPLE_LIMIT);
+  }
+
+  private static List<String> divergenceClassificationNames() {
+    return java.util.Arrays.stream(DivergenceClass.values()).map(Enum::name).toList();
+  }
+
+  private static List<DivergenceStatus> divergenceClassificationStatuses() {
+    return java.util.Arrays.stream(DivergenceClass.values())
+        .map(DivergenceClassification::status)
+        .toList();
+  }
+
+  private static CaseSpec caseFromIndex(long index) {
+    int flagIndex = (int) (index % FLAG_MODES.size());
+    index /= FLAG_MODES.size();
+    int contextIndex = (int) (index % CONTEXTS.size());
+    index /= CONTEXTS.size();
+    int suffixIndex = (int) (index % SUFFIXES.size());
+    index /= SUFFIXES.size();
+    int middleIndex = (int) (index % MIDDLES.size());
+    index /= MIDDLES.size();
+    int prefixIndex = (int) (index % PREFIXES.size());
+    return new CaseSpec(
+        PREFIXES.get(prefixIndex),
+        MIDDLES.get(middleIndex),
+        SUFFIXES.get(suffixIndex),
+        CONTEXTS.get(contextIndex),
+        FLAG_MODES.get(flagIndex));
+  }
+
+  private static PrefixCase prefix(String label, String regex) {
+    return new PrefixCase(label, regex);
+  }
+
+  private static MiddleCase middle(String label, String regex) {
+    return new MiddleCase(label, regex);
+  }
+
+  private static SuffixCase suffix(String label, String regex) {
+    return new SuffixCase(label, regex);
+  }
+
+  private static ContextCase context(String label, String template) {
+    return new ContextCase(label, template);
+  }
+
+  private static FlagMode flags(String label, int flags) {
+    return new FlagMode(label, flags);
+  }
+
+  private enum DivergenceClass implements DivergenceClassification {
+    ACCEPTANCE_MISMATCH(
+        DivergenceStatus.EXPECTED_ZERO,
+        "DFA sandwich leftmost-start cases use supported regex syntax and must compile the same as"
+            + " java.util.regex."),
+    TRACE_MISMATCH(
+        DivergenceStatus.EXPECTED_ZERO,
+        "DFA sandwich optimizations must preserve java.util.regex traces for matches(),"
+            + " lookingAt(), find(), captures, and replacements."),
+    UNKNOWN(DivergenceStatus.UNKNOWN, "Unclassified DFA sandwich leftmost-start sweep divergence.");
+
+    private final DivergenceStatus status;
+    private final String rationale;
+
+    DivergenceClass(DivergenceStatus status, String rationale) {
+      this.status = status;
+      this.rationale = rationale;
+    }
+
+    @Override
+    public DivergenceStatus status() {
+      return status;
+    }
+
+    @Override
+    public String rationale() {
+      return rationale;
+    }
+  }
+
+  private record PrefixCase(String label, String regex) {}
+
+  private record MiddleCase(String label, String regex) {}
+
+  private record SuffixCase(String label, String regex) {}
+
+  private record ContextCase(String label, String template) {}
+
+  private record FlagMode(String label, int flags) {}
+
+  private record CaseSpec(
+      PrefixCase prefix,
+      MiddleCase middle,
+      SuffixCase suffix,
+      ContextCase context,
+      FlagMode flagMode) {
+    String regex() {
+      return context.template().formatted(prefix.regex() + middle.regex() + suffix.regex());
+    }
+  }
+}

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/RegionZeroWidthDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/RegionZeroWidthDivergenceSweep.java
@@ -22,6 +22,7 @@ public final class RegionZeroWidthDivergenceSweep {
           DivergenceClass.ASCII_WORD_BOUNDARY_COMBINING_MARK,
           DivergenceClass.OPAQUE_REGION_CRLF_PAIR_CONTEXT,
           DivergenceClass.BOUNDARY_ANY_CLASS_SPLIT_SURROGATE_SCALAR_COMPOSITION,
+          DivergenceClass.NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION,
           DivergenceClass.UNKNOWN);
 
   private static final List<RegexCase> REGEXES =
@@ -284,6 +285,9 @@ public final class RegionZeroWidthDivergenceSweep {
     if (isBoundaryAnyClassSplitSurrogateScalarCompositionDivergence(spec)) {
       return DivergenceClass.BOUNDARY_ANY_CLASS_SPLIT_SURROGATE_SCALAR_COMPOSITION;
     }
+    if (isNonWordBoundarySplitSurrogateInteriorPositionDivergence(spec)) {
+      return DivergenceClass.NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION;
+    }
     return DivergenceClass.UNKNOWN;
   }
 
@@ -336,6 +340,23 @@ public final class RegionZeroWidthDivergenceSweep {
           case "nonWordBoundaryThenAnyClass",
               "nonWordBoundaryAnyClassOrAsciiY",
               "asciiYOrNonWordBoundaryAnyClass" ->
+              true;
+          default -> false;
+        };
+  }
+
+  private static boolean isNonWordBoundarySplitSurrogateInteriorPositionDivergence(CaseSpec spec) {
+    return "splitHighThroughAscii".equals(spec.textRegion().label())
+        && spec.boundsMode().transparentBounds()
+        && switch (spec.regexCase().label()) {
+          case "nonWordBoundary",
+              "nonWordBoundaryOrAsciiA",
+              "nonWordBoundaryOrAsciiY",
+              "asciiAOrNonWordBoundary",
+              "asciiYOrNonWordBoundary",
+              "nonWordBoundaryThenDot",
+              "nonWordBoundaryDotOrAsciiY",
+              "asciiYOrNonWordBoundaryDot" ->
               true;
           default -> false;
         };
@@ -664,6 +685,11 @@ public final class RegionZeroWidthDivergenceSweep {
         "Observed JDK traces distinguish . from [\\s\\S] after \\B at a transparent split-surrogate"
             + " boundary. SafeRE keeps [\\s\\S] compositional with ordinary scalar-consuming"
             + " atoms."),
+    NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION(
+        DivergenceStatus.KNOWN_INTENTIONAL,
+        "Observed JDK traces expose a \\B match at the interior UTF-16 position of a"
+            + " transparent split surrogate pair. SafeRE keeps word-boundary matching"
+            + " compositional with its scalar boundary model."),
     UNKNOWN(DivergenceStatus.UNKNOWN, "Unclassified SafeRE/JDK region zero-width divergence.");
 
     private final DivergenceStatus status;

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -217,6 +217,14 @@ class SweepCliSmokeTest {
             RegionZeroWidthDivergenceSweep.classifyDivergenceShapeForTesting(
                 "$", 0, "\r\n", 1, 2, false, true))
         .isEqualTo("OPAQUE_REGION_CRLF_PAIR_CONTEXT");
+    assertThat(
+            RegionZeroWidthDivergenceSweep.classifyDivergenceShapeForTesting(
+                "\\B", 0, "x\uD83D\uDE00y", 1, 4, true, true))
+        .isEqualTo("NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION");
+    assertThat(
+            RegionZeroWidthDivergenceSweep.classifyDivergenceShapeForTesting(
+                "y|\\B.", java.util.regex.Pattern.DOTALL, "x\uD83D\uDE00y", 1, 4, true, false))
+        .isEqualTo("NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION");
   }
 
   @Test

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -49,6 +49,9 @@ final class MatchFuzzer {
     }
     assertUnicodeBoundaryStartCacheMatchesJdk();
     assertTrailingLineTerminatorEndAnchorFindsMatchJdk();
+    assertZeroWidthAlternationFindsLeftmostStartJdk();
+    assertZeroWidthPossessiveCaptureRetentionJdk();
+    assertDfaSandwichLeftmostStartCasesMatchJdk();
 
     String regex;
     int flags;
@@ -112,6 +115,38 @@ final class MatchFuzzer {
       }
       for (String input : inputs) {
         pattern.matcher(input).find();
+      }
+    }
+  }
+
+  private static void assertZeroWidthAlternationFindsLeftmostStartJdk() {
+    List<String> regexes =
+        List.of("(?:\\B{1}|a).", "(?:a|\\B?).", "(?:a|(\\B)?).", "(?:(?:)\\B|a).");
+    for (String regex : regexes) {
+      FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
+      if (pattern != null) {
+        pattern.matcher("ab").find();
+      }
+    }
+  }
+
+  private static void assertZeroWidthPossessiveCaptureRetentionJdk() {
+    FuzzSupport.CompiledPattern pattern =
+        FuzzSupport.compileCompatibleOrSkip("(?m:^(\\B)*+$)", org.safere.Pattern.MULTILINE);
+    if (pattern == null) {
+      return;
+    }
+    pattern.matcher("\n").find();
+    pattern.matcher("\na").find();
+  }
+
+  private static void assertDfaSandwichLeftmostStartCasesMatchJdk() {
+    List<String> regexes =
+        List.of("\\B([^a])*[^a][^a]", "\\B(?:[^a])*[^a][^a]", "\\B[^a]*[^a][^a]", "\\B(?:b|bb)*bb");
+    for (String regex : regexes) {
+      FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
+      if (pattern != null) {
+        pattern.matcher("bbbb").find();
       }
     }
   }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1270,8 +1270,9 @@ public final class Matcher implements MatchResult {
     // Prefix acceleration: if the pattern starts with a literal prefix, skip ahead to where
     // that prefix first appears instead of searching from the current position.
     int effectiveStart = searchFrom;
+    boolean literalPrefixCandidateStart = false;
     String prefix = parentPattern.prefix();
-    if (options.startAcceleration() && !prog.hasWordBoundary() && prefix != null) {
+    if (options.startAcceleration() && prefix != null) {
       int idx;
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, prefix, searchFrom);
@@ -1288,6 +1289,7 @@ public final class Matcher implements MatchResult {
         return applyEngineResult(new NoMatchResult());
       }
       effectiveStart = idx;
+      literalPrefixCandidateStart = true;
     }
 
     // Character-class prefix acceleration: when the pattern starts with a character class (and
@@ -1461,29 +1463,41 @@ public final class Matcher implements MatchResult {
     // Skip the reverse DFA phase when the pattern is anchored at the start — the match start is
     // already known to be effectiveStart, so the reverse scan is unnecessary.
     //
-    // Skip entirely when the DFA's match start is unreliable (patterns with lazy quantifiers,
-    // anchors inside quantifiers, or alternation). Lazy quantifiers can make a non-leftmost match
+    // When the DFA's match start is unreliable (patterns with lazy quantifiers, bounded repeats,
+    // anchors inside quantifiers, or alternation), the reverse DFA result is only authoritative if
+    // it proves the match starts at effectiveStart. Lazy quantifiers can make a non-leftmost match
     // end earlier, causing the DFA to find the wrong start. Alternation can have the same effect:
     // when alternatives match at different start positions with different endpoints, the forward
     // DFA's earliest-end result may come from a non-leftmost match, and the reverse DFA from that
-    // endpoint cannot find the leftmost start. In those cases, fall through to the BitState/NFA
-    // fallback which correctly handles all semantics.
+    // wrong endpoint cannot find the leftmost start. In those cases, fall through to the
+    // BitState/NFA fallback which correctly handles all semantics.
     //
-    // For patterns where the DFA start IS reliable but the end may be wrong (bounded repeats),
-    // the sandwich still narrows the range — capturesResolved is set to false so
-    // resolveCaptures() corrects the end position using the submatch engine.
+    // When the accepted start is authoritative, the sandwich still treats group(0) as deferred for
+    // programs whose end may be wrong; resolveCaptures() corrects the end position using the
+    // submatch engine.
     // Skip when a region is active — deferred capture resolution runs on the full text but the
     // DFA ran on the region substring, causing empty-width assertion mismatches at boundaries.
-    if (options.dfa()
-        && !regionActive
-        && fwdResult != null
-        && fwdResult.pos() > effectiveStart
-        && (!options.semanticGuards() || parentPattern.dfaStartReliable())) {
+    if (options.dfa() && !regionActive && fwdResult != null && fwdResult.pos() > effectiveStart) {
       int earlyEnd = fwdResult.pos();
 
       if (prog.anchorStart()) {
         // Anchored: match start is effectiveStart. Run forward DFA (anchored, first-match) to find
         // actual end, then defer inner captures until requested.
+        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+        if (fwdFirst != null && fwdFirst.matched()) {
+          int matchEnd = fwdFirst.pos();
+          return applyEngineResult(
+              new DeferredMatchResult(
+                  effectiveStart,
+                  matchEnd,
+                  prog.numCaptures(),
+                  !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
+                  false));
+        }
+      } else if (literalPrefixCandidateStart) {
+        // A literal prefix occurrence is a candidate match start, even when the prefix is preceded
+        // by zero-width assertions. Verify that candidate directly; if it fails, the exact fallback
+        // below can still search for later prefix occurrences.
         Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
         if (fwdFirst != null && fwdFirst.matched()) {
           int matchEnd = fwdFirst.pos();
@@ -1798,6 +1812,32 @@ public final class Matcher implements MatchResult {
       boolean longest,
       boolean endMatch,
       int nsubmatch) {
+    return searchWithBitStateOrNfa(
+        prog,
+        text,
+        startPos,
+        searchLimit,
+        endPos,
+        graphemeConsumeEndPos,
+        anchored,
+        longest,
+        endMatch,
+        nsubmatch,
+        false);
+  }
+
+  private int[] searchWithBitStateOrNfa(
+      Prog prog,
+      String text,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int graphemeConsumeEndPos,
+      boolean anchored,
+      boolean longest,
+      boolean endMatch,
+      int nsubmatch,
+      boolean preserveOuterEmptyContext) {
     // Try BitState if the full text is small enough for the visited bitmap. BitState is an
     // optimization; if capture-priority backtracking exceeds its work budget, fall back to the
     // Pike NFA below.
@@ -1850,12 +1890,20 @@ public final class Matcher implements MatchResult {
     }
     boolean graphemeRegionContext = fullTextRegionContext && prog.hasGraphemeSemantics();
     int consumeRegionStart = graphemeRegionContext && !transparentBounds ? regionStart : 0;
-    int boundaryRegionStart = fullTextRegionContext && !transparentBounds ? regionStart : 0;
-    int boundaryEndPos = fullTextRegionContext && !transparentBounds ? endPos : text.length();
+    // Deferred capture replay bounds consumption to group(0), but empty-width assertions still
+    // need the matcher region context that produced the match.
+    boolean useOuterEmptyContext = fullTextRegionContext || preserveOuterEmptyContext;
+    int emptyContextEnd = preserveOuterEmptyContext ? regionEnd : endPos;
+    int boundaryRegionStart = useOuterEmptyContext && !transparentBounds ? regionStart : 0;
+    int boundaryEndPos =
+        useOuterEmptyContext && !transparentBounds ? emptyContextEnd : text.length();
     int anchorEndPos =
-        fullTextRegionContext && !anchoringBounds && prog.anchorEnd() ? text.length() : endPos;
-    int emptyAnchorStartPos = fullTextRegionContext && anchoringBounds ? regionStart : 0;
-    int emptyAnchorEndPos = fullTextRegionContext && !anchoringBounds ? text.length() : endPos;
+        useOuterEmptyContext && !anchoringBounds && prog.anchorEnd()
+            ? text.length()
+            : emptyContextEnd;
+    int emptyAnchorStartPos = useOuterEmptyContext && anchoringBounds ? regionStart : 0;
+    int emptyAnchorEndPos =
+        useOuterEmptyContext && !anchoringBounds ? text.length() : emptyContextEnd;
     Nfa.SearchResult nfaResult =
         Nfa.search(
             prog,
@@ -2488,10 +2536,12 @@ public final class Matcher implements MatchResult {
               deferredMatchStart,
               deferredMatchEnd,
               deferredMatchEnd,
+              deferredMatchEnd,
               true,
               false,
               deferredEndMatch,
-              prog.numCaptures());
+              prog.numCaptures(),
+              true);
     }
     if (result != null) {
       groups = result;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -108,6 +108,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasNullableAlternation;
   private final transient boolean hasBoundedRepeat;
   private final transient boolean hasAnchorInQuant;
+  private final transient boolean startsWithZeroWidthAssertion;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
   private final transient boolean[] charClassPrefixAscii;
@@ -226,6 +227,7 @@ public final class Pattern implements Serializable {
       boolean hasNullableAlternation,
       boolean hasBoundedRepeat,
       boolean hasAnchorInQuant,
+      boolean startsWithZeroWidthAssertion,
       boolean startsWithGraphemeClusterBoundary,
       boolean hasInternalGraphemeClusterBoundary,
       boolean[] charClassPrefixAscii,
@@ -262,6 +264,7 @@ public final class Pattern implements Serializable {
     this.hasNullableAlternation = hasNullableAlternation;
     this.hasBoundedRepeat = hasBoundedRepeat;
     this.hasAnchorInQuant = hasAnchorInQuant;
+    this.startsWithZeroWidthAssertion = startsWithZeroWidthAssertion;
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
     this.charClassPrefixAscii = charClassPrefixAscii;
@@ -334,6 +337,7 @@ public final class Pattern implements Serializable {
     boolean hasNullableAlt = hasAlt && hasNullableAlternation(re);
     boolean hasBounded = hasBoundedRepeat(re);
     boolean hasAnchorQuant = hasAnchorInQuantifier(re);
+    boolean startsWithZeroWidth = startsWithZeroWidthAssertion(metadataAst);
     boolean startsWithGcb = startsWithGraphemeClusterBoundary(metadataAst);
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
     // Extract character-class prefix for acceleration when no literal prefix exists.
@@ -360,6 +364,7 @@ public final class Pattern implements Serializable {
         hasNullableAlt,
         hasBounded,
         hasAnchorQuant,
+        startsWithZeroWidth,
         startsWithGcb,
         hasInternalGcb,
         ccPrefixAscii,
@@ -844,10 +849,11 @@ public final class Pattern implements Serializable {
    * </ul>
    */
   boolean dfaStartReliable() {
-    if (hasBoundedRepeat || hasAnchorInQuant) {
-      return true;
-    }
-    return true;
+    return !hasLazy
+        && !hasBoundedRepeat
+        && !hasAnchorInQuant
+        && !hasAlternation
+        && !startsWithZeroWidthAssertion;
   }
 
   /**
@@ -1206,6 +1212,38 @@ public final class Pattern implements Serializable {
     return false;
   }
 
+  private static boolean startsWithZeroWidthAssertion(Regexp re) {
+    Regexp node = unwrapCaptures(re);
+    if (node == null) {
+      return false;
+    }
+    if (node.op == RegexpOp.CONCAT) {
+      for (Regexp child : node.subs) {
+        Regexp candidate = unwrapCaptures(child);
+        if (candidate == null || candidate.op == RegexpOp.EMPTY_MATCH) {
+          continue;
+        }
+        return isZeroWidthAssertion(candidate);
+      }
+      return false;
+    }
+    return isZeroWidthAssertion(node);
+  }
+
+  private static boolean isZeroWidthAssertion(Regexp re) {
+    return switch (re.op) {
+      case BEGIN_LINE,
+          END_LINE,
+          BEGIN_TEXT,
+          END_TEXT,
+          WORD_BOUNDARY,
+          NO_WORD_BOUNDARY,
+          GRAPHEME_CLUSTER_BOUNDARY ->
+          true;
+      default -> false;
+    };
+  }
+
   /**
    * Returns {@code true} if the given regexp can match the empty string. Used to detect nullable
    * alternation branches where OnePass's longest-match semantics may differ from first-match.
@@ -1549,20 +1587,7 @@ public final class Pattern implements Serializable {
    * String#indexOf} before running the full engine.
    */
   private static PrefixResult extractPrefix(Regexp re) {
-    Regexp node = re;
-
-    // See through leading captures and concat wrappers.
-    while (node != null) {
-      if (node.op == RegexpOp.CAPTURE) {
-        node = node.sub();
-        continue;
-      }
-      if (node.op == RegexpOp.CONCAT && node.nsub() > 0) {
-        node = node.subs.getFirst();
-        continue;
-      }
-      break;
-    }
+    Regexp node = firstPrefixCandidate(re);
     if (node == null) {
       return new PrefixResult(null, false);
     }
@@ -1586,6 +1611,31 @@ public final class Pattern implements Serializable {
 
     String prefix = foldCase ? sb.toString().toLowerCase(Locale.ROOT) : sb.toString();
     return new PrefixResult(prefix, foldCase);
+  }
+
+  private static Regexp firstPrefixCandidate(Regexp re) {
+    Regexp node = unwrapCaptures(re);
+    if (node == null) {
+      return null;
+    }
+    if (node.op == RegexpOp.CONCAT) {
+      for (Regexp child : node.subs) {
+        Regexp candidate = unwrapCaptures(child);
+        if (candidate == null || isLeadingZeroWidth(candidate)) {
+          continue;
+        }
+        return candidate;
+      }
+      return null;
+    }
+    return isLeadingZeroWidth(node) ? null : node;
+  }
+
+  private static boolean isLeadingZeroWidth(Regexp re) {
+    return switch (re.op) {
+      case EMPTY_MATCH, WORD_BOUNDARY, NO_WORD_BOUNDARY -> true;
+      default -> false;
+    };
   }
 
   /**
@@ -1853,7 +1903,7 @@ public final class Pattern implements Serializable {
 
   private static Regexp unwrapCaptures(Regexp re) {
     Regexp node = re;
-    while (node != null && node.op == RegexpOp.CAPTURE) {
+    while (node != null && (node.op == RegexpOp.CAPTURE || node.op == RegexpOp.NON_CAPTURE)) {
       node = node.sub();
     }
     return node;

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -92,8 +92,8 @@ class EnginePathEquivalenceTest {
   @Test
   @DisplayName("DFA start-reliability guard has semantic content")
   void dfaStartReliabilityGuardHasSemanticContent() {
-    String regex = "(bcd|abcde)";
-    String input = "abcde";
+    String regex = "(?:\\B{1}|a).";
+    String input = "ab";
     Pattern canonical = Pattern.compile(regex);
     Pattern unguarded =
         Pattern.compile(
@@ -105,10 +105,10 @@ class EnginePathEquivalenceTest {
                 .bitState(false)
                 .build());
 
-    assertThat(canonical.dfaStartReliable()).isTrue();
+    assertThat(canonical.dfaStartReliable()).isFalse();
     assertThat(findTrace(unguarded.matcher(input)))
-        .as("unguarded DFA sandwich matches the canonical trace with priority pruning")
-        .isEqualTo(findTrace(canonical.matcher(input)));
+        .as("unguarded DFA sandwich should expose why the start-reliability guard exists")
+        .isNotEqualTo(findTrace(canonical.matcher(input)));
   }
 
   @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -676,6 +676,31 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() preserves leftmost start for zero-width alternation branches")
+    void findPreservesLeftmostStartForZeroWidthAlternationBranches() {
+      assertFirstFindMatchesJdk("(?:\\B{1}|a).", "ab");
+      assertFirstFindMatchesJdk("(?:a|\\B?).", "ab");
+      assertFirstFindMatchesJdk("(?:a|(\\B)?).", "ab");
+      assertFirstFindMatchesJdk("(?:(?:)\\B|a).", "ab");
+    }
+
+    @Test
+    @DisplayName("find() preserves leftmost start before repeated consuming tails")
+    void findPreservesLeftmostStartBeforeRepeatedConsumingTails() {
+      assertFirstFindMatchesJdk("\\B([^a])*[^a][^a]", "bbbb");
+      assertFirstFindMatchesJdk("\\B(?:[^a])*[^a][^a]", "bbbb");
+      assertFirstFindMatchesJdk("\\B[^a]*[^a][^a]", "bbbb");
+      assertFirstFindMatchesJdk("\\B(?:b|bb)*bb", "bbbb");
+    }
+
+    @Test
+    @DisplayName("find() keeps searching after a failed boundary-prefixed literal candidate")
+    void findKeepsSearchingAfterFailedBoundaryPrefixedLiteralCandidate() {
+      assertFirstFindMatchesJdk("\\bfoo", "_foo foo");
+      assertFirstFindMatchesJdk("\\Bfoo", " foo afoo");
+    }
+
+    @Test
     @DisplayName("find() respects non-word boundaries inside repetitions")
     void findNonWordBoundaryInsideRepetitions() {
       Pattern p = Pattern.compile("(?:(?:(?:\\B)\\w)*)");

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -73,6 +73,32 @@ class PatternInternalTest {
   }
 
   @Test
+  void leadingWordBoundaryPreservesLiteralPrefixAccelerator() {
+    Pattern p = Pattern.compile("\\bSCRUB:begin_strip\\b(?s:.*?)\\bSCRUB:end_strip\\b");
+
+    assertThat(p.literalMatch()).isNull();
+    assertThat(p.prefix()).isEqualTo("SCRUB:begin_strip");
+  }
+
+  @Test
+  void leadingTextAnchorsDoNotExposeMovableLiteralPrefixAccelerator() {
+    assertThat(Pattern.compile("^SCRUB").prefix()).isNull();
+    assertThat(Pattern.compile("\\ASCRUB").prefix()).isNull();
+  }
+
+  @Test
+  void leadingZeroWidthAssertionMakesDfaStartUnreliable() {
+    assertThat(Pattern.compile("\\B([^a])*[^a][^a]").dfaStartReliable()).isFalse();
+    assertThat(Pattern.compile("(?:)\\B[^a]*[^a][^a]").dfaStartReliable()).isFalse();
+  }
+
+  @Test
+  void nullableConsumingPrefixBeforeBoundaryCanKeepDfaStartReliable() {
+    assertThat(Pattern.compile("[^\\n]*\\bSCRUB:strip_line\\b[^\\n]*\\n?").dfaStartReliable())
+        .isTrue();
+  }
+
+  @Test
   void caseInsensitiveAsciiLiteralUsesLiteralMatchMetadata() {
     Pattern p = Pattern.compile("(?i)i");
 

--- a/safere/src/test/java/org/safere/QuantifiedCaptureSemanticsTest.java
+++ b/safere/src/test/java/org/safere/QuantifiedCaptureSemanticsTest.java
@@ -89,6 +89,15 @@ class QuantifiedCaptureSemanticsTest {
         Arguments.of(new GeneratedCase("word boundary star possessive", "(\\b)*+", "a", null)),
         Arguments.of(new GeneratedCase("non-word boundary star possessive", "(\\B)*+", "", null)),
         Arguments.of(
+            new GeneratedCase(
+                "multiline non-word boundary star possessive", "(?m:^(\\B)*+$)", "\n", null)),
+        Arguments.of(
+            new GeneratedCase(
+                "multiline non-word boundary star possessive before text",
+                "(?m:^(\\B)*+$)",
+                "\na",
+                null)),
+        Arguments.of(
             new GeneratedCase("grapheme boundary star possessive", "(\\b{g})*+", "", null)),
         Arguments.of(new GeneratedCase("begin anchor star possessive", "(^)*+", "a", null)),
         Arguments.of(new GeneratedCase("end anchor star possessive", "($)*+", "a", null)),


### PR DESCRIPTION
## Summary

- fix DFA sandwich start authority so reverse-DFA starts that can skip earlier leftmost candidates fall back to the exact engine
- keep the scrubber performance win by allowing reliable later starts and literal-prefix candidate verification where safe
- add `DfaSandwichLeftmostStartDivergenceSweep` plus docs, expander support, JUnit regressions, and MatchFuzzer seeds

## Verification

- `mvn -pl safere -Dtest='MatcherTest$FindTests#findPreservesLeftmostStartBeforeRepeatedConsumingTails+findPreservesLeftmostStartForZeroWidthAlternationBranches+findKeepsSearchingAfterFailedBoundaryPrefixedLiteralCandidate,PatternInternalTest#leadingZeroWidthAssertionMakesDfaStartUnreliable+nullableConsumingPrefixBeforeBoundaryCanKeepDfaStartReliable+leadingWordBoundaryPreservesLiteralPrefixAccelerator+leadingTextAnchorsDoNotExposeMovableLiteralPrefixAccelerator,QuantifiedCaptureSemanticsTest#zeroWidthPossessiveQuantifiersPreserveCaptures,EnginePathEquivalenceTest#dfaStartReliabilityGuardHasSemanticContent' test`
- `./run-exhaustive-sweep.sh DfaSandwichLeftmostStartDivergenceSweep --output-dir=/tmp/dfa-sandwich-leftmost-start-pr`
- `./run-exhaustive-expander.sh --input-dir=/tmp/dfa-sandwich-leftmost-start-pr` (`ACCEPTANCE_MISMATCH=0`, `TRACE_MISMATCH=0`, `UNKNOWN=0`)
- `mvn -pl safere-fuzz -am -Dtest=MatchFuzzer -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl safere-exhaustive test -q`
- `mvn -pl safere test -q`
- `git diff --check`

Quick development benchmark signal, not publication-quality:

- `./run-java-benchmarks.sh --quick ScrubberBenchmark.scrubWithDirectives_safere`: `648,531.087 ns/op`

## Not run

- Full safere-exhaustive sweep set beyond the new DFA sandwich leftmost-start sweep.
- Publication-quality benchmarks.
