### PR TITLE
Use Objects.requireNonNull

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Follow the [Google Java Style Guide](https://google.github.io/styleguide/javagui
 - Use `@Override` on all overriding methods
 - Write Javadoc for all public and protected members
 - Use `{@code ...}` in Javadoc for code fragments
+- Prefer `Objects.requireNonNull` over explicit comparisons to `null` for
+  validating required arguments and state, when appropriate.
 - Fields: `camelCase`; constants: `UPPER_SNAKE_CASE`; classes: `PascalCase`
 
 ## Project Structure

--- a/safere/src/main/java/org/safere/EngineContext.java
+++ b/safere/src/main/java/org/safere/EngineContext.java
@@ -5,6 +5,8 @@
 
 package org.safere;
 
+import static java.util.Objects.requireNonNull;
+
 /** Immutable execution bounds shared by regex engines. */
 record EngineContext(
     String text,
@@ -21,12 +23,8 @@ record EngineContext(
     GraphemeSupport.Context graphemeContext) {
 
   EngineContext {
-    if (text == null) {
-      throw new NullPointerException("text");
-    }
-    if (graphemeContext == null) {
-      throw new NullPointerException("graphemeContext");
-    }
+    requireNonNull(text, "text");
+    requireNonNull(graphemeContext, "graphemeContext");
   }
 
   static EngineContext create(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -5,6 +5,8 @@
 
 package org.safere;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2145,9 +2147,7 @@ public final class Matcher implements MatchResult {
    * @throws NullPointerException if the replacer function is null
    */
   public String replaceFirst(Function<MatchResult, String> replacer) {
-    if (replacer == null) {
-      throw new NullPointerException("replacer");
-    }
+    requireNonNull(replacer, "replacer");
     reset();
     StringBuilder sb = new StringBuilder();
     if (find()) {
@@ -2196,9 +2196,7 @@ public final class Matcher implements MatchResult {
    * @throws NullPointerException if the replacer function is null
    */
   public String replaceAll(Function<MatchResult, String> replacer) {
-    if (replacer == null) {
-      throw new NullPointerException("replacer");
-    }
+    requireNonNull(replacer, "replacer");
     reset();
     StringBuilder sb = new StringBuilder();
     while (find()) {


### PR DESCRIPTION
This is mostly a tiny readability improvement.

There's no performance downside, `requireNonNull` gets special treatment from the JIT (it has a `@ForceInline` annotation), and it might actually be faster because because it results in slightly smaller bytecode which could affect other inlining decisions.