### PR TITLE
Harden flaky linear-time timing tests

### DIFF
--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -14,7 +14,7 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.IntConsumer;
+import java.util.function.Consumer;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
@@ -541,13 +541,15 @@ class LinebreakGraphemeTest {
 
       assertFourXInputStaysNearLinear(
           "repeated find() over grapheme clusters",
-          length -> {
-            Matcher matcher = pattern.matcher("a".repeat(length));
+          "a".repeat(20_000),
+          "a".repeat(80_000),
+          text -> {
+            Matcher matcher = pattern.matcher(text);
             int count = 0;
             while (matcher.find()) {
               count++;
             }
-            assertThat(count).isEqualTo(length);
+            assertThat(count).isEqualTo(text.length());
           });
     }
 
@@ -559,7 +561,9 @@ class LinebreakGraphemeTest {
 
       assertFourXInputStaysNearLinear(
           "low-surrogate search-position miss",
-          length -> assertThat(pattern.matcher("\uDC00".repeat(length)).find()).isFalse());
+          "\uDC00".repeat(20_000),
+          "\uDC00".repeat(80_000),
+          text -> assertThat(pattern.matcher(text).find()).isFalse());
     }
 
     @Test
@@ -570,7 +574,9 @@ class LinebreakGraphemeTest {
 
       assertFourXInputStaysNearLinear(
           "regional-indicator boundary miss",
-          length -> assertThat(pattern.matcher("\uD83C\uDDE6".repeat(length)).find()).isFalse());
+          "\uD83C\uDDE6".repeat(20_000),
+          "\uD83C\uDDE6".repeat(80_000),
+          text -> assertThat(pattern.matcher(text).find()).isFalse());
     }
 
     @Test
@@ -581,10 +587,14 @@ class LinebreakGraphemeTest {
 
       assertFourXInputStaysNearLinear(
           "failed unanchored \\X suffix miss",
-          length -> assertThat(pattern.matcher("a" + "\u0301".repeat(length)).find()).isFalse());
+          "a" + "\u0301".repeat(20_000),
+          "a" + "\u0301".repeat(80_000),
+          text -> assertThat(pattern.matcher(text).find()).isFalse());
       assertFourXInputStaysNearLinear(
           "failed unanchored regional-indicator \\X suffix miss",
-          length -> assertThat(pattern.matcher("\uD83C\uDDE6".repeat(length)).find()).isFalse());
+          "\uD83C\uDDE6".repeat(20_000),
+          "\uD83C\uDDE6".repeat(80_000),
+          text -> assertThat(pattern.matcher(text).find()).isFalse());
     }
 
     @Test
@@ -886,10 +896,12 @@ class LinebreakGraphemeTest {
       assertThat(matcher.end()).isEqualTo(2);
     }
 
-    private static void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
-      task.accept(1_000);
-      long smallerNanos = bestRuntimeNanos(() -> task.accept(5_000));
-      long largerNanos = bestRuntimeNanos(() -> task.accept(20_000));
+    private static void assertFourXInputStaysNearLinear(
+        String scenario, String smallerInput, String largerInput, Consumer<String> task) {
+      task.accept(smallerInput);
+      task.accept(largerInput);
+      long smallerNanos = bestRuntimeNanos(() -> task.accept(smallerInput));
+      long largerNanos = bestRuntimeNanos(() -> task.accept(largerInput));
 
       assertThat(largerNanos)
           .as(

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.time.Duration;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.regex.MatchResult;
 import org.junit.jupiter.api.DisplayName;
@@ -175,8 +176,10 @@ class MatcherTest {
 
       assertNoPerformanceCliff(
           "matches()+group(1)",
-          length -> {
-            Matcher m = p.matcher("a".repeat(length * 20));
+          "a".repeat(100),
+          "a".repeat(5_000),
+          input -> {
+            Matcher m = p.matcher(input);
             assertThat(m.matches()).isTrue();
             assertThat(m.group(1)).isEqualTo("a");
             assertThat(m.group(2)).isEqualTo("a");
@@ -2506,6 +2509,29 @@ class MatcherTest {
                 + "positive input; near=%d ns, larger=%d ns",
             api, nearMinimumNanos, largerPositiveNanos)
         .isLessThan(largerPositiveNanos * 50);
+  }
+
+  private static void assertNoPerformanceCliff(
+      String api, String nearMinimumInput, String largerPositiveInput, Consumer<String> scenario) {
+    scenario.accept(nearMinimumInput);
+    scenario.accept(largerPositiveInput);
+    long largerPositiveNanos = bestRuntimeNanos(() -> scenario.accept(largerPositiveInput));
+    long nearMinimumNanos = bestRuntimeNanos(() -> scenario.accept(nearMinimumInput));
+
+    assertThat(nearMinimumNanos)
+        .as(
+            "%s near-minimum input should not be dramatically slower than a larger "
+                + "positive input; near=%d ns, larger=%d ns",
+            api, nearMinimumNanos, largerPositiveNanos)
+        .isLessThan(largerPositiveNanos * 50);
+  }
+
+  private static long bestRuntimeNanos(Runnable task) {
+    long best = Long.MAX_VALUE;
+    for (int i = 0; i < 3; i++) {
+      best = Math.min(best, runtimeNanos(task));
+    }
+    return best;
   }
 
   private static long runtimeNanos(Runnable task) {


### PR DESCRIPTION
## Summary

- harden the grapheme linear-time timing helper to warm and measure prebuilt 20k/80k inputs
- harden the ambiguous repeated-capture timing check to warm and measure prebuilt inputs
- keep the repeated-capture comparison below the BitState/NFA size threshold so it tests the original near-minimum cliff instead of a deliberate engine transition

Fixes #456
Fixes #475

## Verification

Ran:

```bash
mvn -pl safere spotless:check -q
mvn -pl safere -Dtest='LinebreakGraphemeTest$GraphemeClusterTests#failedUnanchoredGraphemeSuffixMissesStayNearLinear' test -q
mvn -pl safere -Dtest='LinebreakGraphemeTest$GraphemeClusterTests#repeatedFindOverGraphemeClustersReusesPerInputContext+lowSurrogateSearchPositionsStayNearLinear+regionalIndicatorBoundaryMissesStayNearLinear+failedUnanchoredGraphemeSuffixMissesStayNearLinear' test -q
mvn -pl safere -Dtest='MatcherTest$MatchesTests#groupAccessWithAmbiguousRepeatedCapturesStaysLinear' test -q
mvn -pl safere -Dtest='MatcherTest$MatchesTests#groupAccessWithAmbiguousRepeatedCapturesStaysLinear,LinebreakGraphemeTest$GraphemeClusterTests#repeatedFindOverGraphemeClustersReusesPerInputContext+lowSurrogateSearchPositionsStayNearLinear+regionalIndicatorBoundaryMissesStayNearLinear+failedUnanchoredGraphemeSuffixMissesStayNearLinear' test -q
```

Not run:

```bash
mvn -pl safere test -q
```
