### PR TITLE
Optimize `replaceFirst` and `replaceAll` when there is no match.

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2129,10 +2129,11 @@ public final class Matcher implements MatchResult {
    */
   public String replaceFirst(String replacement) {
     reset();
-    StringBuilder sb = new StringBuilder();
-    if (find()) {
-      appendReplacement(sb, replacement);
+    if (!find()) {
+      return text;
     }
+    StringBuilder sb = new StringBuilder();
+    appendReplacement(sb, replacement);
     appendTail(sb);
     return sb.toString();
   }
@@ -2149,13 +2150,14 @@ public final class Matcher implements MatchResult {
   public String replaceFirst(Function<MatchResult, String> replacer) {
     requireNonNull(replacer, "replacer");
     reset();
-    StringBuilder sb = new StringBuilder();
-    if (find()) {
-      int expectedModCount = modCount;
-      String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
-      checkConcurrentModification(expectedModCount);
-      appendReplacement(sb, replacement);
+    if (!find()) {
+      return text;
     }
+    StringBuilder sb = new StringBuilder();
+    int expectedModCount = modCount;
+    String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
+    checkConcurrentModification(expectedModCount);
+    appendReplacement(sb, replacement);
     appendTail(sb);
     return sb.toString();
   }
@@ -2168,20 +2170,22 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
+    reset();
+    if (!find()) {
+      return text;
+    }
     // Pre-compile the replacement template once, avoiding per-match parseInt/substring overhead.
     ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
-
-    reset();
     StringBuilder sb = new StringBuilder();
     boolean needsCaptures = templateNeedsCaptures(template);
-    while (find()) {
+    do {
       if (needsCaptures || !groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
       applyReplacementTemplate(sb, template);
       appendPos = groups[1];
-    }
+    } while (find());
     appendTail(sb);
     return sb.toString();
   }
@@ -2198,13 +2202,16 @@ public final class Matcher implements MatchResult {
   public String replaceAll(Function<MatchResult, String> replacer) {
     requireNonNull(replacer, "replacer");
     reset();
+    if (!find()) {
+      return text;
+    }
     StringBuilder sb = new StringBuilder();
-    while (find()) {
+    do {
       int expectedModCount = modCount;
       String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
       checkConcurrentModification(expectedModCount);
       appendReplacement(sb, replacement);
-    }
+    } while (find());
     appendTail(sb);
     return sb.toString();
   }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1149,6 +1149,14 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("numeric replacement reference with invalid digit does not throw if no match")
+    void numericReplacementReferenceInvalidFirstDigitDoesNotThrowIfNoMatch() {
+      Pattern p = Pattern.compile("\\d+");
+
+      assertThat(p.matcher("foobar").replaceAll("$99")).isEqualTo("foobar");
+    }
+
+    @Test
     @DisplayName("replaceAll() with named backreference")
     void replaceAllWithNamedBackref() {
       Pattern p = Pattern.compile("(?<word>\\w+)");


### PR DESCRIPTION
If there is no match then we can simply return the input string unaltered. There is no need to reconstruct a copy using a `StringBuilder`.
    
This showed up when comparing against RE2-over-JNI in a production-like environment. SafeRE was on average faster for all operations other than `replaceFirst`. With the changes here, it is faster there too.

Also fix a minor incompatibility in `replaceAll(String)`. It does not matter if the replacement string is invalid, when the match doesn't happen anyway. This is consistent with `java.util.regex`, but previously the precomputed `ReplacementSegment[]` would cause an exception even in the absence of a match.
