### PR TITLE
Add replaceFirst no-match benchmark

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -92,6 +92,12 @@
       "replacement": "bb",
       "op": "replaceFirst"
     },
+    "literalReplaceFirstNoMatch": {
+      "pattern": "authorization=",
+      "text": "INFO service=checkout method=GET path=/api/orders/123 status=200 latency_ms=17 trace_id=8f14e45fceea167a user=anonymous region=us-east-1 cache=hit; INFO service=checkout method=POST path=/api/orders status=201 latency_ms=42 trace_id=c9f0f895fb98ab91 user=anonymous region=us-east-1 cache=miss; INFO service=inventory method=GET path=/api/items/sku-481516 status=200 latency_ms=11 trace_id=45c48cce2e2d7fbdea1afc51c7c6ad26 user=anonymous region=us-west-2 cache=hit; INFO service=payments method=GET path=/api/charges/ch_123 status=404 latency_ms=23 trace_id=d3d9446802a44259755d38e6d163e820 user=anonymous region=us-east-2 cache=miss; INFO service=shipping method=PATCH path=/api/shipments/shp_987 status=202 latency_ms=36 trace_id=6512bd43d9caa6e02c990b0a82652dca user=anonymous region=us-west-1 cache=hit",
+      "replacement": "authorization=REDACTED",
+      "op": "replaceFirst"
+    },
     "literalReplaceAll": {
       "pattern": "b",
       "text": "ababababab",

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ReplaceBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ReplaceBenchmark.java
@@ -30,8 +30,14 @@ public class ReplaceBenchmark {
   private java.util.regex.Pattern jdkLiteral;
   private com.google.re2j.Pattern re2jLiteral;
   private org.safere.re2ffm.RE2FfmPattern re2ffmLiteral;
+  private org.safere.Pattern safeLiteralNoMatch;
+  private java.util.regex.Pattern jdkLiteralNoMatch;
+  private com.google.re2j.Pattern re2jLiteralNoMatch;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmLiteralNoMatch;
   private String literalReplaceFirstText;
   private String literalReplaceFirstReplacement;
+  private String literalReplaceFirstNoMatchText;
+  private String literalReplaceFirstNoMatchReplacement;
   private String literalReplaceAllText;
   private String literalReplaceAllReplacement;
 
@@ -67,6 +73,12 @@ public class ReplaceBenchmark {
     literalReplaceFirstText = data.getString("replace.literalReplaceFirst.text");
     literalReplaceFirstReplacement = data.getString("replace.literalReplaceFirst.replacement");
 
+    String literalReplaceFirstNoMatchPattern =
+        data.getString("replace.literalReplaceFirstNoMatch.pattern");
+    literalReplaceFirstNoMatchText = data.getString("replace.literalReplaceFirstNoMatch.text");
+    literalReplaceFirstNoMatchReplacement =
+        data.getString("replace.literalReplaceFirstNoMatch.replacement");
+
     String literalReplaceAllPattern = data.getString("replace.literalReplaceAll.pattern");
     literalReplaceAllText = data.getString("replace.literalReplaceAll.text");
     literalReplaceAllReplacement = data.getString("replace.literalReplaceAll.replacement");
@@ -75,6 +87,12 @@ public class ReplaceBenchmark {
     jdkLiteral = java.util.regex.Pattern.compile(literalReplaceFirstPattern);
     re2jLiteral = com.google.re2j.Pattern.compile(literalReplaceFirstPattern);
     re2ffmLiteral = org.safere.re2ffm.RE2FfmPattern.compile(literalReplaceFirstPattern);
+
+    safeLiteralNoMatch = org.safere.Pattern.compile(literalReplaceFirstNoMatchPattern);
+    jdkLiteralNoMatch = java.util.regex.Pattern.compile(literalReplaceFirstNoMatchPattern);
+    re2jLiteralNoMatch = com.google.re2j.Pattern.compile(literalReplaceFirstNoMatchPattern);
+    re2ffmLiteralNoMatch =
+        org.safere.re2ffm.RE2FfmPattern.compile(literalReplaceFirstNoMatchPattern);
 
     String pigPattern = data.getString("replace.pigLatinReplaceAll.pattern");
     pigLatinText = data.getString("replace.pigLatinReplaceAll.text");
@@ -130,6 +148,36 @@ public class ReplaceBenchmark {
     return re2ffmLiteral
         .matcher(literalReplaceFirstText)
         .replaceFirst(literalReplaceFirstReplacement);
+  }
+
+  // ===== Literal replaceFirst with no match =====
+
+  @Benchmark
+  public String literalReplaceFirstNoMatch_safere() {
+    return safeLiteralNoMatch
+        .matcher(literalReplaceFirstNoMatchText)
+        .replaceFirst(literalReplaceFirstNoMatchReplacement);
+  }
+
+  @Benchmark
+  public String literalReplaceFirstNoMatch_jdk() {
+    return jdkLiteralNoMatch
+        .matcher(literalReplaceFirstNoMatchText)
+        .replaceFirst(literalReplaceFirstNoMatchReplacement);
+  }
+
+  @Benchmark
+  public String literalReplaceFirstNoMatch_re2j() {
+    return re2jLiteralNoMatch
+        .matcher(literalReplaceFirstNoMatchText)
+        .replaceFirst(literalReplaceFirstNoMatchReplacement);
+  }
+
+  @Benchmark
+  public String literalReplaceFirstNoMatch_re2ffm() {
+    return re2ffmLiteralNoMatch
+        .matcher(literalReplaceFirstNoMatchText)
+        .replaceFirst(literalReplaceFirstNoMatchReplacement);
   }
 
   // ===== Simple literal replaceAll =====


### PR DESCRIPTION
## Summary

Adds a targeted `ReplaceBenchmark.literalReplaceFirstNoMatch` case for the production-like workload shape where `replaceFirst` scans realistic request/log text and finds no occurrence to replace.

The benchmark is added to the shared `benchmark-data.json` replace section and wired into the Java JMH harness for SafeRE, JDK, RE2/J, and RE2-FFM. The C++ and Go harnesses already iterate the shared replace data dynamically.

Refs #478 

## Quick development signal

These are quick-mode results, not publication-quality BENCHMARKS.md numbers.

Before PR 478, with this benchmark cherry-picked onto `origin/main`:

```text
ReplaceBenchmark.literalReplaceFirstNoMatch_jdk     avgt    5  263.985 +/-  4.581  ns/op
ReplaceBenchmark.literalReplaceFirstNoMatch_re2ffm  avgt    5  367.364 +/- 37.596  ns/op
ReplaceBenchmark.literalReplaceFirstNoMatch_re2j    avgt    5  169.858 +/-  2.887  ns/op
ReplaceBenchmark.literalReplaceFirstNoMatch_safere  avgt    5  160.515 +/-  1.951  ns/op
```

After PR 478, with this benchmark cherry-picked onto `pr-478-review`:

```text
ReplaceBenchmark.literalReplaceFirstNoMatch_jdk     avgt    5  268.275 +/- 18.976  ns/op
ReplaceBenchmark.literalReplaceFirstNoMatch_re2ffm  avgt    5  349.625 +/-  9.332  ns/op
ReplaceBenchmark.literalReplaceFirstNoMatch_re2j    avgt    5  170.625 +/-  6.921  ns/op
ReplaceBenchmark.literalReplaceFirstNoMatch_safere  avgt    5   77.642 +/-  7.962  ns/op
```

## Verification

Ran:

```bash
./run-java-benchmarks.sh --quick ReplaceBenchmark.literalReplaceFirstNoMatch
```

Not run:

```text
Full SafeRE test suite.
Publication-quality benchmark run.
```
