### PR TITLE
Add SafeRE bytecode diagnostics exporter

### DIFF
--- a/.agents/skills/review-fix-loop/SKILL.md
+++ b/.agents/skills/review-fix-loop/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: review-fix-loop
+description: Run Codex's noninteractive code review on a Git working tree, fix review findings at or above a requested priority such as P2, run local verification, and repeat until no in-scope findings remain. Use when the user asks to run /review, codex exec review, or a review/fix loop over uncommitted changes, branch changes, or a specific commit.
+---
+
+# Review Fix Loop
+
+## Overview
+
+Use this workflow to run the Codex reviewer from the CLI, address only the requested severity threshold, and iterate until the reviewer reports no remaining in-scope findings.
+
+## Workflow
+
+1. Confirm the review scope and threshold from the user's request.
+   - Default scope: uncommitted changes.
+   - Default threshold: P2 or higher when the user says "priority >= P2" or similar.
+   - Treat P0, P1, and P2 as in scope for a P2 threshold.
+   - Leave P3, nits, style-only suggestions, and optional improvements alone unless the user asks for them.
+
+2. Fix any already-provided review findings before running another review.
+   - Preserve unrelated user changes.
+   - Do not commit, push, reset, or revert unless the user explicitly asks.
+   - Keep staged/unstaged intent stable unless staging is part of the requested workflow.
+
+3. Run the repository's normal verification commands after each fix.
+   - Prefer commands documented in `AGENTS.md`, README files, CI configs, or project tooling.
+   - If the repo has no documented command, run the narrowest relevant build/test command you can infer.
+   - If verification cannot be run, record exactly why before continuing.
+
+4. Run the noninteractive reviewer.
+   - Expect review runs to take about 5-15 minutes. If the command returns a
+     running session, wait in longer intervals rather than polling or tailing
+     logs frequently; inspect the JSONL log only when the run appears stuck or
+     has exceeded the expected window.
+   - For uncommitted changes, use:
+
+```bash
+tmpdir="$(mktemp -d)"
+codex exec review --uncommitted --json --output-last-message "$tmpdir/review.md" --ephemeral > "$tmpdir/review.jsonl"
+sed -n '1,240p' "$tmpdir/review.md"
+```
+
+   - For branch review, add `--base <branch>` instead of `--uncommitted` when the user asks for a base branch review.
+   - For commit review, use `--commit <sha>` when the user asks for a specific commit.
+   - Prefer `codex exec review` over `codex review` when you need `--json` or `--output-last-message`.
+
+5. Parse the final review message.
+   - If there are no findings, stop.
+   - If findings remain but all are below the requested threshold, stop and report that no in-scope findings remain.
+   - If there are in-scope findings, fix them, verify, and run the reviewer again.
+
+6. Avoid unbounded loops.
+   - If the same in-scope finding survives two fix attempts, inspect the diff and tests carefully.
+   - If it is genuinely blocked by missing information or an external issue, stop and explain the blocker.
+   - If it is a false positive, document why and continue only if the user requested false-positive suppression or documentation.
+
+## Review Output Handling
+
+Use temporary files for reviewer JSONL and final messages unless the user asks to keep artifacts. The useful artifact for humans is usually the `--output-last-message` file; the JSONL stream is mainly for debugging failed reviewer runs.
+
+When reporting back, include:
+
+- The in-scope findings fixed.
+- Verification commands run and their results.
+- Whether a final reviewer pass found no in-scope findings.
+- Any remaining out-of-scope findings, only if they are material to the user.

--- a/.agents/skills/review-fix-loop/SKILL.md
+++ b/.agents/skills/review-fix-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-fix-loop
-description: Run Codex's noninteractive code review on a Git working tree, fix review findings at or above a requested priority such as P2, run local verification, and repeat until no in-scope findings remain. Use when the user asks to run /review, codex exec review, or a review/fix loop over uncommitted changes, branch changes, or a specific commit.
+description: Run Codex's noninteractive code review on a Git working tree, fix review findings at or above a requested priority such as P2, run local verification, and repeat until no in-scope findings remain. Use when the user asks to run /review, codex exec review, or a review/fix loop over branch changes against main, uncommitted changes, or a specific commit.
 ---
 
 # Review Fix Loop
@@ -12,7 +12,11 @@ Use this workflow to run the Codex reviewer from the CLI, address only the reque
 ## Workflow
 
 1. Confirm the review scope and threshold from the user's request.
-   - Default scope: uncommitted changes.
+   - Default scope: everything currently on this branch/worktree compared
+     against `main`, including committed branch changes plus staged, unstaged,
+     and untracked work when the reviewer supports that branch-diff scope.
+   - Use uncommitted-only scope only when the user explicitly asks to review
+     uncommitted changes.
    - Default threshold: P2 or higher when the user says "priority >= P2" or similar.
    - Treat P0, P1, and P2 as in scope for a P2 threshold.
    - Leave P3, nits, style-only suggestions, and optional improvements alone unless the user asks for them.
@@ -32,7 +36,15 @@ Use this workflow to run the Codex reviewer from the CLI, address only the reque
      running session, wait in longer intervals rather than polling or tailing
      logs frequently; inspect the JSONL log only when the run appears stuck or
      has exceeded the expected window.
-   - For uncommitted changes, use:
+   - For the default branch/worktree review against `main`, use:
+
+```bash
+tmpdir="$(mktemp -d)"
+codex exec review --base main --json --output-last-message "$tmpdir/review.md" --ephemeral > "$tmpdir/review.jsonl"
+sed -n '1,240p' "$tmpdir/review.md"
+```
+
+   - For an explicitly requested uncommitted-only review, use:
 
 ```bash
 tmpdir="$(mktemp -d)"
@@ -40,7 +52,7 @@ codex exec review --uncommitted --json --output-last-message "$tmpdir/review.md"
 sed -n '1,240p' "$tmpdir/review.md"
 ```
 
-   - For branch review, add `--base <branch>` instead of `--uncommitted` when the user asks for a base branch review.
+   - For branch review against a different base, replace `main` with the requested base branch.
    - For commit review, use `--commit <sha>` when the user asks for a specific commit.
    - Prefer `codex exec review` over `codex review` when you need `--json` or `--output-last-message`.
 

--- a/.agents/skills/review-fix-loop/agents/openai.yaml
+++ b/.agents/skills/review-fix-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Fix Loop"
+  short_description: "Iterate Codex review findings safely"
+  default_prompt: "Use $review-fix-loop to run Codex review against main, including committed and local changes, and fix P2+ findings until clean."

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -133,6 +133,7 @@
                         <exclude name="ProgTest.java"/>
                         <exclude name="RegexpOpTest.java"/>
                         <exclude name="RegexpTest.java"/>
+                        <exclude name="SafeReDiagnosticsTest.java"/>
                         <exclude name="SimplifierTest.java"/>
                         <exclude name="UnicodeJdkConsistencyTest.java"/>
                         <exclude name="UnicodeTablesTest.java"/>

--- a/safere/src/main/java/org/safere/SafeReDiagnostics.java
+++ b/safere/src/main/java/org/safere/SafeReDiagnostics.java
@@ -12,6 +12,9 @@ import java.util.Objects;
  *
  * <p>This API is intended for tests and verification tooling. The JSON schema is versioned, but
  * this class is not part of SafeRE's regex-matching API.
+ *
+ * <p>In bytecode fixture results, each group record includes {@code matched}. Nonparticipating
+ * captures are exported with {@code matched: false} and Java/SafeRE {@code -1} start/end offsets.
  */
 public final class SafeReDiagnostics {
 
@@ -34,6 +37,7 @@ public final class SafeReDiagnostics {
   }
 
   private static final String SCHEMA = "safere-bytecode-v1";
+  private static final Nfa.MatchKind BYTECODE_MATCH_KIND = Nfa.MatchKind.FIRST_MATCH;
 
   /**
    * Exports one verifier fixture JSONL record using SafeRE's NFA-facing compiled program.
@@ -82,13 +86,29 @@ public final class SafeReDiagnostics {
     json.append(',');
     appendProducer(json);
     json.append(',');
-    appendCase(json, caseId, regex, flags, input, mode, engine);
+    appendCase(json, caseId, regex, flags, input, mode, engine, BYTECODE_MATCH_KIND);
     json.append(',');
-    appendResult(json, prog, input);
+    appendResult(json, prog, input, BYTECODE_MATCH_KIND);
     json.append(',');
     appendProgram(json, prog);
     json.append('}');
     return json.toString();
+  }
+
+  /**
+   * Compiles a pattern and exports one verifier fixture JSONL record using SafeRE's NFA engine
+   * result metadata.
+   *
+   * @param caseId stable fixture case identifier
+   * @param regex source regular expression to compile and record in the fixture
+   * @param flags source flags value to compile and record in the fixture
+   * @param input input text to record and match
+   * @param mode match mode for result metadata; currently only {@link BytecodeMatchMode#ANCHORED}
+   * @return one complete JSON object followed by no trailing newline
+   */
+  public static String bytecodeCaseToJsonLine(
+      String caseId, String regex, int flags, String input, BytecodeMatchMode mode) {
+    return bytecodeCaseToJsonLine(caseId, regex, flags, input, mode, Pattern.compile(regex, flags));
   }
 
   /**
@@ -126,7 +146,8 @@ public final class SafeReDiagnostics {
       int flags,
       String input,
       BytecodeMatchMode mode,
-      BytecodeResultEngine engine) {
+      BytecodeResultEngine engine,
+      Nfa.MatchKind matchKind) {
     json.append("\"case\":{");
     appendStringField(json, "id", caseId);
     json.append(',');
@@ -141,6 +162,8 @@ public final class SafeReDiagnostics {
     appendStringField(json, "mode", mode.jsonName);
     json.append(',');
     appendStringField(json, "engine", engine.name());
+    json.append(',');
+    appendStringField(json, "matchKind", matchKind.name());
     json.append('}');
   }
 
@@ -170,7 +193,8 @@ public final class SafeReDiagnostics {
     return true;
   }
 
-  private static void appendResult(StringBuilder json, Prog prog, String input) {
+  private static void appendResult(
+      StringBuilder json, Prog prog, String input, Nfa.MatchKind matchKind) {
     Nfa.SearchResult searchResult =
         Nfa.search(
             prog,
@@ -180,7 +204,7 @@ public final class SafeReDiagnostics {
             input.length(),
             0,
             Nfa.Anchor.ANCHORED,
-            Nfa.MatchKind.FIRST_MATCH,
+            matchKind,
             prog.numCaptures(),
             null);
     int[] groups = searchResult.groups();
@@ -195,6 +219,8 @@ public final class SafeReDiagnostics {
         }
         json.append('{');
         appendNumberField(json, "group", group);
+        json.append(',');
+        appendBooleanField(json, "matched", groups[2 * group] >= 0);
         json.append(',');
         appendNumberField(json, "start", groups[2 * group]);
         json.append(',');

--- a/safere/src/main/java/org/safere/SafeReDiagnostics.java
+++ b/safere/src/main/java/org/safere/SafeReDiagnostics.java
@@ -1,0 +1,383 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Objects;
+
+/**
+ * Diagnostic export helpers for verifier fixtures and bytecode inspection.
+ *
+ * <p>This API is intended for tests and verification tooling. The JSON schema is versioned, but
+ * this class is not part of SafeRE's regex-matching API.
+ */
+public final class SafeReDiagnostics {
+
+  /** Match mode for exported result metadata. */
+  public enum BytecodeMatchMode {
+    /** Run an NFA search anchored at the beginning of the input. */
+    ANCHORED("anchored");
+
+    private final String jsonName;
+
+    BytecodeMatchMode(String jsonName) {
+      this.jsonName = jsonName;
+    }
+  }
+
+  /** Engine used to produce bytecode fixture result metadata. */
+  public enum BytecodeResultEngine {
+    /** SafeRE's Pike VM NFA engine. */
+    NFA
+  }
+
+  private static final String SCHEMA = "safere-bytecode-v1";
+
+  /**
+   * Exports one verifier fixture JSONL record using SafeRE's NFA-facing compiled program.
+   *
+   * <p>The exported program is {@code Pattern.prog()}, not the DFA-oriented flattened program. The
+   * result object is produced by directly invoking SafeRE's NFA on that same program.
+   *
+   * @param caseId stable fixture case identifier
+   * @param regex source regular expression to record in the fixture
+   * @param flags source flags value to record in the fixture
+   * @param input input text to record and match
+   * @param mode match mode for result metadata; currently only {@link BytecodeMatchMode#ANCHORED}
+   * @param engine engine for result metadata; currently only {@link BytecodeResultEngine#NFA}
+   * @param pattern compiled SafeRE pattern whose NFA program is exported
+   * @return one complete JSON object followed by no trailing newline
+   */
+  public static String bytecodeCaseToJsonLine(
+      String caseId,
+      String regex,
+      int flags,
+      String input,
+      BytecodeMatchMode mode,
+      BytecodeResultEngine engine,
+      Pattern pattern) {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(regex, "regex");
+    Objects.requireNonNull(input, "input");
+    Objects.requireNonNull(mode, "mode");
+    Objects.requireNonNull(engine, "engine");
+    Objects.requireNonNull(pattern, "pattern");
+    if (mode != BytecodeMatchMode.ANCHORED) {
+      throw new IllegalArgumentException("Unsupported match mode: " + mode);
+    }
+    if (engine != BytecodeResultEngine.NFA) {
+      throw new IllegalArgumentException("Unsupported diagnostic engine: " + engine);
+    }
+
+    Prog prog = pattern.prog();
+    if (prog.didFlatten()) {
+      throw new IllegalArgumentException("NFA bytecode export requires an unflattened program");
+    }
+
+    StringBuilder json = new StringBuilder();
+    json.append('{');
+    appendStringField(json, "schema", SCHEMA);
+    json.append(',');
+    appendProducer(json);
+    json.append(',');
+    appendCase(json, caseId, regex, flags, input, mode, engine);
+    json.append(',');
+    appendResult(json, prog, input);
+    json.append(',');
+    appendProgram(json, prog);
+    json.append('}');
+    return json.toString();
+  }
+
+  /**
+   * Exports one verifier fixture JSONL record using SafeRE's NFA engine result metadata.
+   *
+   * @param caseId stable fixture case identifier
+   * @param regex source regular expression to record in the fixture
+   * @param flags source flags value to record in the fixture
+   * @param input input text to record and match
+   * @param mode match mode for result metadata; currently only {@link BytecodeMatchMode#ANCHORED}
+   * @param pattern compiled SafeRE pattern whose NFA program is exported
+   * @return one complete JSON object followed by no trailing newline
+   */
+  public static String bytecodeCaseToJsonLine(
+      String caseId,
+      String regex,
+      int flags,
+      String input,
+      BytecodeMatchMode mode,
+      Pattern pattern) {
+    return bytecodeCaseToJsonLine(
+        caseId, regex, flags, input, mode, BytecodeResultEngine.NFA, pattern);
+  }
+
+  private static void appendProducer(StringBuilder json) {
+    json.append("\"producer\":{");
+    appendStringField(json, "name", "safere");
+    json.append('}');
+  }
+
+  private static void appendCase(
+      StringBuilder json,
+      String caseId,
+      String regex,
+      int flags,
+      String input,
+      BytecodeMatchMode mode,
+      BytecodeResultEngine engine) {
+    json.append("\"case\":{");
+    appendStringField(json, "id", caseId);
+    json.append(',');
+    appendStringField(json, "pattern", regex);
+    json.append(',');
+    appendFlags(json, flags);
+    json.append(',');
+    appendNumberField(json, "flagsValue", flags);
+    json.append(',');
+    appendStringField(json, "input", input);
+    json.append(',');
+    appendStringField(json, "mode", mode.jsonName);
+    json.append(',');
+    appendStringField(json, "engine", engine.name());
+    json.append('}');
+  }
+
+  private static void appendFlags(StringBuilder json, int flags) {
+    json.append("\"flags\":[");
+    boolean needsComma = false;
+    needsComma = appendFlag(json, needsComma, flags, Pattern.UNIX_LINES, "UNIX_LINES");
+    needsComma = appendFlag(json, needsComma, flags, Pattern.CASE_INSENSITIVE, "CASE_INSENSITIVE");
+    needsComma = appendFlag(json, needsComma, flags, Pattern.COMMENTS, "COMMENTS");
+    needsComma = appendFlag(json, needsComma, flags, Pattern.MULTILINE, "MULTILINE");
+    needsComma = appendFlag(json, needsComma, flags, Pattern.LITERAL, "LITERAL");
+    needsComma = appendFlag(json, needsComma, flags, Pattern.DOTALL, "DOTALL");
+    needsComma = appendFlag(json, needsComma, flags, Pattern.UNICODE_CASE, "UNICODE_CASE");
+    appendFlag(json, needsComma, flags, Pattern.UNICODE_CHARACTER_CLASS, "UNICODE_CHARACTER_CLASS");
+    json.append(']');
+  }
+
+  private static boolean appendFlag(
+      StringBuilder json, boolean needsComma, int flags, int flag, String name) {
+    if ((flags & flag) == 0) {
+      return needsComma;
+    }
+    if (needsComma) {
+      json.append(',');
+    }
+    appendString(json, name);
+    return true;
+  }
+
+  private static void appendResult(StringBuilder json, Prog prog, String input) {
+    Nfa.SearchResult searchResult =
+        Nfa.search(
+            prog,
+            input,
+            0,
+            input.length(),
+            input.length(),
+            0,
+            Nfa.Anchor.ANCHORED,
+            Nfa.MatchKind.FIRST_MATCH,
+            prog.numCaptures(),
+            null);
+    int[] groups = searchResult.groups();
+    json.append("\"result\":{");
+    appendBooleanField(json, "matched", groups != null);
+    json.append(',');
+    json.append("\"groups\":[");
+    if (groups != null) {
+      for (int group = 0; group < prog.numCaptures(); group++) {
+        if (group > 0) {
+          json.append(',');
+        }
+        json.append('{');
+        appendNumberField(json, "group", group);
+        json.append(',');
+        appendNumberField(json, "start", groups[2 * group]);
+        json.append(',');
+        appendNumberField(json, "end", groups[2 * group + 1]);
+        json.append('}');
+      }
+    }
+    json.append("]}");
+  }
+
+  private static void appendProgram(StringBuilder json, Prog prog) {
+    json.append("\"program\":{");
+    appendStringField(json, "shape", "nfa-prog");
+    json.append(',');
+    appendBooleanField(json, "didFlatten", prog.didFlatten());
+    json.append(',');
+    appendNumberField(json, "size", prog.size());
+    json.append(',');
+    appendNumberField(json, "start", prog.start());
+    json.append(',');
+    appendNumberField(json, "startUnanchored", prog.startUnanchored());
+    json.append(',');
+    appendNumberField(json, "numCaptures", prog.numCaptures());
+    json.append(',');
+    appendNumberField(json, "numCaptureSlots", 2 * Math.max(prog.numCaptures(), 1));
+    json.append(',');
+    appendNumberField(json, "numLoopRegs", prog.numLoopRegs());
+    json.append(',');
+    appendBooleanField(json, "anchorStart", prog.anchorStart());
+    json.append(',');
+    appendBooleanField(json, "anchorEnd", prog.anchorEnd());
+    json.append(',');
+    appendBooleanField(json, "dollarAnchorEnd", prog.dollarAnchorEnd());
+    json.append(',');
+    appendBooleanField(json, "reversed", prog.reversed());
+    json.append(',');
+    appendBooleanField(json, "unixLines", prog.unixLines());
+    json.append(',');
+    appendBooleanField(
+        json, "requiresPikeNfaCaptureSemantics", prog.requiresPikeNfaCaptureSemantics());
+    json.append(',');
+    appendBooleanField(json, "hasGraphemeSemantics", prog.hasGraphemeSemantics());
+    json.append(',');
+    appendBooleanField(json, "hasGraphemeClusterInstruction", prog.hasGraphemeClusterInstruction());
+    json.append(',');
+    appendInstructions(json, prog);
+    json.append('}');
+  }
+
+  private static void appendInstructions(StringBuilder json, Prog prog) {
+    json.append("\"instructions\":[");
+    for (int id = 0; id < prog.size(); id++) {
+      if (id > 0) {
+        json.append(',');
+      }
+      Inst inst = prog.inst(id);
+      json.append('{');
+      appendNumberField(json, "id", id);
+      json.append(',');
+      appendStringField(json, "op", inst.op.name());
+      appendInstructionFields(json, inst);
+      json.append('}');
+    }
+    json.append(']');
+  }
+
+  private static void appendInstructionFields(StringBuilder json, Inst inst) {
+    switch (inst.op) {
+      case FAIL -> {}
+      case MATCH -> {
+        json.append(',');
+        appendNumberField(json, "arg", inst.arg);
+      }
+      case NOP, CAPTURE, EMPTY_WIDTH, GRAPHEME_CLUSTER -> appendArgOutFields(json, inst);
+      case ALT, ALT_MATCH -> appendOutOut1Fields(json, inst);
+      case CHAR_RANGE -> appendCharRangeFields(json, inst);
+      case CHAR_CLASS -> appendCharClassFields(json, inst);
+      case PROGRESS_CHECK -> appendProgressCheckFields(json, inst);
+    }
+  }
+
+  private static void appendArgOutFields(StringBuilder json, Inst inst) {
+    if (inst.op == InstOp.CAPTURE || inst.op == InstOp.EMPTY_WIDTH) {
+      json.append(',');
+      appendNumberField(json, "arg", inst.arg);
+    }
+    json.append(',');
+    appendNumberField(json, "out", inst.out);
+  }
+
+  private static void appendOutOut1Fields(StringBuilder json, Inst inst) {
+    json.append(',');
+    appendNumberField(json, "out", inst.out);
+    json.append(',');
+    appendNumberField(json, "out1", inst.out1);
+  }
+
+  private static void appendCharRangeFields(StringBuilder json, Inst inst) {
+    json.append(',');
+    appendNumberField(json, "out", inst.out);
+    json.append(',');
+    appendNumberField(json, "lo", inst.lo);
+    json.append(',');
+    appendNumberField(json, "hi", inst.hi);
+    json.append(',');
+    appendBooleanField(json, "foldCase", inst.foldCase);
+  }
+
+  private static void appendCharClassFields(StringBuilder json, Inst inst) {
+    json.append(',');
+    appendNumberField(json, "out", inst.out);
+    json.append(',');
+    json.append("\"ranges\":[");
+    for (int i = 0; i < inst.ranges.length; i += 2) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append('[').append(inst.ranges[i]).append(',').append(inst.ranges[i + 1]).append(']');
+    }
+    json.append(']');
+  }
+
+  private static void appendProgressCheckFields(StringBuilder json, Inst inst) {
+    json.append(',');
+    appendNumberField(json, "arg", inst.arg);
+    json.append(',');
+    appendNumberField(json, "out", inst.out);
+    json.append(',');
+    appendNumberField(json, "out1", inst.out1);
+    json.append(',');
+    appendBooleanField(json, "nonGreedy", inst.foldCase);
+  }
+
+  private static void appendStringField(StringBuilder json, String name, String value) {
+    appendString(json, name);
+    json.append(':');
+    appendString(json, value);
+  }
+
+  private static void appendNumberField(StringBuilder json, String name, int value) {
+    appendString(json, name);
+    json.append(':').append(value);
+  }
+
+  private static void appendBooleanField(StringBuilder json, String name, boolean value) {
+    appendString(json, name);
+    json.append(':').append(value);
+  }
+
+  private static void appendString(StringBuilder json, String value) {
+    json.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '"' -> json.append("\\\"");
+        case '\\' -> json.append("\\\\");
+        case '\b' -> json.append("\\b");
+        case '\f' -> json.append("\\f");
+        case '\n' -> json.append("\\n");
+        case '\r' -> json.append("\\r");
+        case '\t' -> json.append("\\t");
+        default -> appendJsonChar(json, ch);
+      }
+    }
+    json.append('"');
+  }
+
+  private static void appendJsonChar(StringBuilder json, char ch) {
+    if (ch < 0x20 || Character.isSurrogate(ch)) {
+      appendUnicodeEscape(json, ch);
+    } else {
+      json.append(ch);
+    }
+  }
+
+  private static void appendUnicodeEscape(StringBuilder json, char ch) {
+    json.append("\\u");
+    String hex = Integer.toHexString(ch);
+    for (int i = hex.length(); i < 4; i++) {
+      json.append('0');
+    }
+    json.append(hex);
+  }
+
+  private SafeReDiagnostics() {}
+}

--- a/safere/src/test/java/org/safere/SafeReDiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/SafeReDiagnosticsTest.java
@@ -1,0 +1,161 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SafeReDiagnostics}. */
+@DisabledForCrosscheck("diagnostic exporter test uses SafeRE-specific bytecode shape")
+class SafeReDiagnosticsTest {
+
+  @Test
+  void exportsNfaProgramShapeFromPatternProg() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "literal-a",
+            "a",
+            0,
+            "a",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("a"));
+
+    assertThat(json).contains("\"schema\":\"safere-bytecode-v1\"");
+    assertThat(json).contains("\"producer\":{\"name\":\"safere\"}");
+    assertThat(json).contains("\"shape\":\"nfa-prog\"");
+    assertThat(json).contains("\"didFlatten\":false");
+    assertThat(json).contains("\"op\":\"CHAR_RANGE\"");
+    assertThat(json).contains("\"lo\":97");
+    assertThat(json).contains("\"hi\":97");
+    assertThat(json).contains("\"foldCase\":false");
+    assertThat(json).contains("\"op\":\"MATCH\"");
+  }
+
+  @Test
+  void exportsAnchoredNfaCaptureGroups() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "capture",
+            "(a)",
+            0,
+            "a",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("(a)"));
+
+    assertThat(json).contains("\"matched\":true");
+    assertThat(json).contains("\"numCaptures\":2");
+    assertThat(json).contains("\"numCaptureSlots\":4");
+    assertThat(json).contains("{\"group\":0,\"start\":0,\"end\":1}");
+    assertThat(json).contains("{\"group\":1,\"start\":0,\"end\":1}");
+  }
+
+  @Test
+  void exportsUnmatchedAnchoredNfaResult() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "miss",
+            "a",
+            0,
+            "b",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("a"));
+
+    assertThat(json).contains("\"matched\":false");
+    assertThat(json).contains("\"groups\":[]");
+  }
+
+  @Test
+  void exportsCharClassRangesAsPairs() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "digits",
+            "[0-9A-Z]",
+            0,
+            "5",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("[0-9A-Z]"));
+
+    assertThat(json).contains("\"op\":\"CHAR_CLASS\"");
+    assertThat(json).contains("\"ranges\":[[48,57],[65,90]]");
+  }
+
+  @Test
+  void exportsFlagsAndEscapedStringsDeterministically() {
+    int flags = Pattern.CASE_INSENSITIVE | Pattern.MULTILINE;
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "escape",
+            "a\\nb",
+            flags,
+            "a\nb",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("a\\nb", flags));
+
+    assertThat(json).contains("\"pattern\":\"a\\\\nb\"");
+    assertThat(json).contains("\"input\":\"a\\nb\"");
+    assertThat(json).contains("\"flags\":[\"CASE_INSENSITIVE\",\"MULTILINE\"]");
+    assertThat(json).contains("\"flagsValue\":" + flags);
+  }
+
+  @Test
+  void escapesLoneSurrogateCodeUnitsInJsonStrings() {
+    String loneHighSurrogate = String.valueOf((char) 0xD800);
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "surrogate",
+            "a",
+            0,
+            loneHighSurrogate,
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("a"));
+
+    assertThat(json).contains("\"input\":\"\\ud800\"");
+    assertThat(json).doesNotContain(loneHighSurrogate);
+  }
+
+  @Test
+  void exportsProgressCheckGreedinessBySemanticName() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "nullable-loop",
+            "(?:a?)*?",
+            0,
+            "",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("(?:a?)*?"));
+
+    String progressCheck = instructionWithOp(json, "PROGRESS_CHECK");
+    assertThat(progressCheck).contains("\"nonGreedy\":true");
+    assertThat(progressCheck).doesNotContain("\"foldCase\"");
+  }
+
+  @Test
+  void omitsUnsupportedMatcherEndpointMetadata() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "literal-a",
+            "a",
+            0,
+            "a",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("a"));
+
+    assertThat(json).doesNotContain("hitEnd");
+    assertThat(json).doesNotContain("requireEnd");
+  }
+
+  private static String instructionWithOp(String json, String op) {
+    String marker = "\"op\":\"" + op + "\"";
+    int opIndex = json.indexOf(marker);
+    assertThat(opIndex).isGreaterThanOrEqualTo(0);
+    int start = json.lastIndexOf('{', opIndex);
+    int end = json.indexOf('}', opIndex);
+    assertThat(start).isGreaterThanOrEqualTo(0);
+    assertThat(end).isGreaterThan(opIndex);
+    return json.substring(start, end + 1);
+  }
+}

--- a/safere/src/test/java/org/safere/SafeReDiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/SafeReDiagnosticsTest.java
@@ -26,6 +26,7 @@ class SafeReDiagnosticsTest {
 
     assertThat(json).contains("\"schema\":\"safere-bytecode-v1\"");
     assertThat(json).contains("\"producer\":{\"name\":\"safere\"}");
+    assertThat(json).contains("\"matchKind\":\"FIRST_MATCH\"");
     assertThat(json).contains("\"shape\":\"nfa-prog\"");
     assertThat(json).contains("\"didFlatten\":false");
     assertThat(json).contains("\"op\":\"CHAR_RANGE\"");
@@ -49,8 +50,23 @@ class SafeReDiagnosticsTest {
     assertThat(json).contains("\"matched\":true");
     assertThat(json).contains("\"numCaptures\":2");
     assertThat(json).contains("\"numCaptureSlots\":4");
-    assertThat(json).contains("{\"group\":0,\"start\":0,\"end\":1}");
-    assertThat(json).contains("{\"group\":1,\"start\":0,\"end\":1}");
+    assertThat(json).contains("{\"group\":0,\"matched\":true,\"start\":0,\"end\":1}");
+    assertThat(json).contains("{\"group\":1,\"matched\":true,\"start\":0,\"end\":1}");
+  }
+
+  @Test
+  void exportsNonparticipatingCapturesWithExplicitMatchedFlagAndMinusOneOffsets() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "optional-capture",
+            "(a)?",
+            0,
+            "",
+            SafeReDiagnostics.BytecodeMatchMode.ANCHORED,
+            Pattern.compile("(a)?"));
+
+    assertThat(json).contains("{\"group\":0,\"matched\":true,\"start\":0,\"end\":0}");
+    assertThat(json).contains("{\"group\":1,\"matched\":false,\"start\":-1,\"end\":-1}");
   }
 
   @Test
@@ -66,6 +82,17 @@ class SafeReDiagnosticsTest {
 
     assertThat(json).contains("\"matched\":false");
     assertThat(json).contains("\"groups\":[]");
+  }
+
+  @Test
+  void compilesPatternInConvenienceOverload() {
+    String json =
+        SafeReDiagnostics.bytecodeCaseToJsonLine(
+            "compiled", "a", 0, "a", SafeReDiagnostics.BytecodeMatchMode.ANCHORED);
+
+    assertThat(json).contains("\"pattern\":\"a\"");
+    assertThat(json).contains("\"matched\":true");
+    assertThat(json).contains("\"op\":\"CHAR_RANGE\"");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `SafeReDiagnostics` for verifier-oriented JSONL bytecode fixtures over the NFA-facing `Pattern.prog()` shape.
- Include anchored NFA result metadata with explicit `matchKind`, group participation, stable `-1` offsets for nonparticipating captures, and semantic `PROGRESS_CHECK.nonGreedy` export.
- Add focused diagnostics tests and repo-local `review-fix-loop` skill metadata/default scope updates.

## Verification

Ran:

- `mvn -pl safere -Dtest=SafeReDiagnosticsTest test -q`
- `mvn -pl safere spotless:check -q`
- `codex exec review --base main --json --output-last-message "$tmpdir/review.md" --ephemeral`

Also ran earlier during development before the final metadata/result-schema follow-ups:

- `mvn -pl safere test -q`

Not run after the final follow-ups:

- Full `mvn -pl safere test -q`
