### PR TITLE
Add issue 481 scaling benchmarks

### DIFF
--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -111,7 +111,7 @@ else
     ./run-java-benchmarks.sh RegexBenchmark ApplicationBenchmark CompileBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
-    ./run-java-benchmarks.sh SearchScalingBenchmark CaptureScalingBenchmark
+    ./run-java-benchmarks.sh SearchScalingBenchmark Issue481ScalingBenchmark CaptureScalingBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
     ./run-java-benchmarks.sh HttpBenchmark ReplaceBenchmark FanoutBenchmark
@@ -145,7 +145,7 @@ if [ "$MODE" = "smoke" ]; then
     ./run-cpp-benchmarks.sh RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-    ./run-cpp-benchmarks.sh Regex Application Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+    ./run-cpp-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
 fi
 
 log "Extracting C++ JSONL"
@@ -156,7 +156,7 @@ if [ "$MODE" = "smoke" ]; then
     ./run-go-benchmarks.sh RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-    ./run-go-benchmarks.sh Regex Application Compile SearchScaling CaptureScaling Http Replace Fanout Pathological
+    ./run-go-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
 fi
 
 log "Extracting Go JSONL"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -56,6 +56,33 @@
     "proseUnit": "The morning sun was shining brightly casting long shadows across the rolling hills Birds were singing their melodious songs while children were playing in the sprawling gardens A gentle breeze was blowing through the swaying trees carrying the scent of blooming flowers People were walking along the winding paths enjoying the refreshing air and the stunning views "
   },
 
+  "issue481Scaling": {
+    "textSizes": [128, 1024, 10240, 102400, 1048576],
+    "splitW": {
+      "pattern": "\\W+",
+      "unit": "This is a generic sentence containing words that will be used to test splitting routines. "
+    },
+    "block": {
+      "pattern": "(?s)<block>.*?</block>",
+      "prefix": "This is a <block>",
+      "unit": "content bytes here... blah blah blah ",
+      "suffix": "</block> transcript.",
+      "negativeSuffix": " transcript without a closing block tag."
+    },
+    "tag": {
+      "pattern": "<<tag.*?>>",
+      "prefixUnit": "plain text before the tagged value ",
+      "match": "Hello <<tag type=\"typeA\" value=\"valA\">>!",
+      "negativeMatch": "Hello <<notag type=\"typeA\" value=\"valA\">>!"
+    },
+    "scheme": {
+      "pattern": "\\[(.*?)]\\(customScheme://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)",
+      "prefixUnit": "ordinary prose without a custom scheme link ",
+      "match": "Check [this link](customScheme://<id_1>) or [another](customScheme://id_2).",
+      "negativeMatch": "Check [this link](https://example.test/id_1) or [another](otherScheme://id_2)."
+    }
+  },
+
   "captureScaling": {
     "capture0": {
       "pattern": "[0-9]+-[0-9]+-[0-9]+",

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -178,6 +178,33 @@ std::string make_prose(int size, const std::string& unit) {
   return text;
 }
 
+std::string repeat_to_size(const std::string& unit, int size) {
+  std::string text;
+  text.reserve(size + unit.size());
+  while (static_cast<int>(text.size()) < size) {
+    text += unit;
+  }
+  text.resize(size);
+  return text;
+}
+
+std::string surround_to_size(const std::string& prefix,
+                             const std::string& unit,
+                             const std::string& suffix,
+                             int size) {
+  int body_size = size - static_cast<int>(prefix.size() + suffix.size());
+  if (body_size < 0) body_size = 0;
+  return prefix + repeat_to_size(unit, body_size) + suffix;
+}
+
+std::string suffix_match_to_size(const std::string& prefix_unit,
+                                 const std::string& match,
+                                 int size) {
+  int prefix_size = size - static_cast<int>(match.size());
+  if (prefix_size < 0) prefix_size = 0;
+  return repeat_to_size(prefix_unit, prefix_size) + match;
+}
+
 // Encode a Unicode code point as UTF-8 and append to the string.
 void append_utf8(std::string& s, int cp) {
   if (cp < 0x80) {
@@ -515,6 +542,121 @@ void run_search_scaling_benchmarks(const json& data,
   }
 }
 
+void run_issue481_scaling_benchmarks(const json& data,
+                                     const std::vector<std::string>& filters) {
+  const auto& sec = data["issue481Scaling"];
+  std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
+
+  RE2 split_w(sec["splitW"]["pattern"].get<std::string>());
+  RE2 block(sec["block"]["pattern"].get<std::string>());
+  RE2 tag(sec["tag"]["pattern"].get<std::string>());
+  RE2 scheme(sec["scheme"]["pattern"].get<std::string>());
+
+  auto split_length_sum = [](const std::string& text, RE2& re) {
+    int sum = 0;
+    int count = 0;
+    int start = 0;
+    int last = 0;
+    std::vector<re2::StringPiece> matches(1);
+    while (start <= static_cast<int>(text.size()) &&
+           re.Match(text, start, text.size(), RE2::UNANCHORED,
+                    matches.data(), matches.size())) {
+      int match_start = matches[0].data() - text.data();
+      int match_end = match_start + matches[0].size();
+      ++count;
+      sum += match_start - last;
+      last = match_end;
+      start = matches[0].empty() ? match_end + 1 : match_end;
+    }
+    if (last == 0) {
+      return static_cast<int>(text.size()) + 1;
+    }
+    int trailing_length = text.size() - last;
+    if (trailing_length > 0) {
+      ++count;
+      sum += trailing_length;
+    }
+    return sum + count;
+  };
+
+  auto find = [](const std::string& text, RE2& re) {
+    return RE2::PartialMatch(text, re);
+  };
+
+  auto scheme_extract = [](const std::string& text, RE2& re) {
+    int sum = 0;
+    int start = 0;
+    std::vector<re2::StringPiece> matches(3);
+    while (start <= static_cast<int>(text.size()) &&
+           re.Match(text, start, text.size(), RE2::UNANCHORED,
+                    matches.data(), matches.size())) {
+      sum += matches[1].size();
+      sum += matches[2].size();
+      int end = matches[0].data() - text.data() + matches[0].size();
+      start = matches[0].empty() ? end + 1 : end;
+    }
+    return sum;
+  };
+
+  for (int size : sizes) {
+    std::string split_text =
+        repeat_to_size(sec["splitW"]["unit"].get<std::string>(), size);
+    std::string block_text =
+        surround_to_size(sec["block"]["prefix"].get<std::string>(),
+                         sec["block"]["unit"].get<std::string>(),
+                         sec["block"]["suffix"].get<std::string>(), size);
+    std::string block_negative_text =
+        surround_to_size(sec["block"]["prefix"].get<std::string>(),
+                         sec["block"]["unit"].get<std::string>(),
+                         sec["block"]["negativeSuffix"].get<std::string>(),
+                         size);
+    std::string tag_text =
+        suffix_match_to_size(sec["tag"]["prefixUnit"].get<std::string>(),
+                             sec["tag"]["match"].get<std::string>(), size);
+    std::string tag_negative_text =
+        suffix_match_to_size(sec["tag"]["prefixUnit"].get<std::string>(),
+                             sec["tag"]["negativeMatch"].get<std::string>(),
+                             size);
+    std::string scheme_text =
+        suffix_match_to_size(sec["scheme"]["prefixUnit"].get<std::string>(),
+                             sec["scheme"]["match"].get<std::string>(), size);
+    std::string scheme_negative_text =
+        suffix_match_to_size(sec["scheme"]["prefixUnit"].get<std::string>(),
+                             sec["scheme"]["negativeMatch"].get<std::string>(),
+                             size);
+
+    std::string suffix = "." + std::to_string(size);
+    auto run = [&](const std::string& name, const std::function<void()>& fn) {
+      std::string full_name = name + suffix;
+      if (matches_filter(full_name, filters)) {
+        print_json(measure(full_name, fn, 2, 2.0, 10, 2.0, "us/op", 1000.0));
+      }
+    };
+
+    run("Issue481ScalingBenchmark.splitWords", [&]() {
+      do_not_optimize(split_length_sum(split_text, split_w));
+    });
+    run("Issue481ScalingBenchmark.blockFind", [&]() {
+      do_not_optimize(find(block_text, block));
+    });
+    run("Issue481ScalingBenchmark.blockFindNegative", [&]() {
+      do_not_optimize(find(block_negative_text, block));
+    });
+    run("Issue481ScalingBenchmark.tagFind", [&]() {
+      do_not_optimize(find(tag_text, tag));
+    });
+    run("Issue481ScalingBenchmark.tagFindNegative", [&]() {
+      do_not_optimize(find(tag_negative_text, tag));
+    });
+    run("Issue481ScalingBenchmark.schemeExtract", [&]() {
+      do_not_optimize(scheme_extract(scheme_text, scheme));
+    });
+    run("Issue481ScalingBenchmark.schemeFindNegative", [&]() {
+      do_not_optimize(find(scheme_negative_text, scheme));
+    });
+  }
+}
+
 void run_capture_scaling_benchmarks(const json& data,
                                     const std::vector<std::string>& filters) {
   const auto& sec = data["captureScaling"];
@@ -788,6 +930,7 @@ int main(int argc, char* argv[]) {
   run_application_benchmarks(data, filters);
   run_compile_benchmarks(data, filters);
   run_search_scaling_benchmarks(data, filters);
+  run_issue481_scaling_benchmarks(data, filters);
   run_capture_scaling_benchmarks(data, filters);
   run_http_benchmarks(data, filters);
   run_replace_benchmarks(data, filters);

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -223,6 +223,31 @@ func makeProse(size int, unit string) string {
 	return b.String()
 }
 
+func repeatToSize(unit string, size int) string {
+	var b strings.Builder
+	b.Grow(size + len(unit))
+	for b.Len() < size {
+		b.WriteString(unit)
+	}
+	return b.String()[:size]
+}
+
+func surroundToSize(prefix string, unit string, suffix string, size int) string {
+	bodySize := size - len(prefix) - len(suffix)
+	if bodySize < 0 {
+		bodySize = 0
+	}
+	return prefix + repeatToSize(unit, bodySize) + suffix
+}
+
+func suffixMatchToSize(prefixUnit string, match string, size int) string {
+	prefixSize := size - len(match)
+	if prefixSize < 0 {
+		prefixSize = 0
+	}
+	return repeatToSize(prefixUnit, prefixSize) + match
+}
+
 func appendUTF8(b *strings.Builder, cp int) {
 	var buf [4]byte
 	n := utf8.EncodeRune(buf[:], rune(cp))
@@ -489,6 +514,95 @@ func runSearchScalingBenchmarks(data map[string]any, filters []string) {
 		})
 		run("SearchScalingBenchmark.findIngScaled", func() {
 			sink = findIng.FindAllString(proseText, -1)
+		})
+	}
+}
+
+func runIssue481ScalingBenchmarks(data map[string]any, filters []string) {
+	sec := data["issue481Scaling"].(map[string]any)
+
+	sizes := getIntSlice(sec, "textSizes")
+	splitW := regexp.MustCompile(getString(sec, "splitW.pattern"))
+	block := regexp.MustCompile(getString(sec, "block.pattern"))
+	tag := regexp.MustCompile(getString(sec, "tag.pattern"))
+	scheme := regexp.MustCompile(getString(sec, "scheme.pattern"))
+
+	splitLengthSum := func(parts []string) int {
+		for len(parts) > 0 && parts[len(parts)-1] == "" {
+			parts = parts[:len(parts)-1]
+		}
+		sum := len(parts)
+		for _, part := range parts {
+			sum += len(part)
+		}
+		return sum
+	}
+	schemeExtract := func(text string, re *regexp.Regexp) int {
+		sum := 0
+		for _, match := range re.FindAllStringSubmatchIndex(text, -1) {
+			sum += match[3] - match[2]
+			sum += match[5] - match[4]
+		}
+		return sum
+	}
+
+	for _, size := range sizes {
+		splitText := repeatToSize(getString(sec, "splitW.unit"), size)
+		blockText := surroundToSize(
+			getString(sec, "block.prefix"),
+			getString(sec, "block.unit"),
+			getString(sec, "block.suffix"),
+			size)
+		blockNegativeText := surroundToSize(
+			getString(sec, "block.prefix"),
+			getString(sec, "block.unit"),
+			getString(sec, "block.negativeSuffix"),
+			size)
+		tagText := suffixMatchToSize(
+			getString(sec, "tag.prefixUnit"),
+			getString(sec, "tag.match"),
+			size)
+		tagNegativeText := suffixMatchToSize(
+			getString(sec, "tag.prefixUnit"),
+			getString(sec, "tag.negativeMatch"),
+			size)
+		schemeText := suffixMatchToSize(
+			getString(sec, "scheme.prefixUnit"),
+			getString(sec, "scheme.match"),
+			size)
+		schemeNegativeText := suffixMatchToSize(
+			getString(sec, "scheme.prefixUnit"),
+			getString(sec, "scheme.negativeMatch"),
+			size)
+
+		suffix := fmt.Sprintf(".%d", size)
+		run := func(name string, fn func()) {
+			fullName := name + suffix
+			if matchesFilter(fullName, filters) {
+				printJSON(measureUs(fullName, fn))
+			}
+		}
+
+		run("Issue481ScalingBenchmark.splitWords", func() {
+			sink = splitLengthSum(splitW.Split(splitText, -1))
+		})
+		run("Issue481ScalingBenchmark.blockFind", func() {
+			sink = block.MatchString(blockText)
+		})
+		run("Issue481ScalingBenchmark.blockFindNegative", func() {
+			sink = block.MatchString(blockNegativeText)
+		})
+		run("Issue481ScalingBenchmark.tagFind", func() {
+			sink = tag.MatchString(tagText)
+		})
+		run("Issue481ScalingBenchmark.tagFindNegative", func() {
+			sink = tag.MatchString(tagNegativeText)
+		})
+		run("Issue481ScalingBenchmark.schemeExtract", func() {
+			sink = schemeExtract(schemeText, scheme)
+		})
+		run("Issue481ScalingBenchmark.schemeFindNegative", func() {
+			sink = scheme.MatchString(schemeNegativeText)
 		})
 	}
 }
@@ -767,6 +881,7 @@ func main() {
 	runApplicationBenchmarks(data, filters)
 	runCompileBenchmarks(data, filters)
 	runSearchScalingBenchmarks(data, filters)
+	runIssue481ScalingBenchmarks(data, filters)
 	runCaptureScalingBenchmarks(data, filters)
 	runHTTPBenchmarks(data, filters)
 	runReplaceBenchmarks(data, filters)

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/Issue481ScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/Issue481ScalingBenchmark.java
@@ -1,0 +1,308 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Scaling benchmarks for the application-style workloads discussed in issue 481. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class Issue481ScalingBenchmark {
+
+  @Param({"128", "1024", "10240", "102400", "1048576"})
+  private int textSize;
+
+  private String splitText;
+  private String blockText;
+  private String blockNegativeText;
+  private String tagText;
+  private String tagNegativeText;
+  private String schemeText;
+  private String schemeNegativeText;
+
+  private org.safere.Pattern safereSplitW;
+  private org.safere.Pattern safereBlock;
+  private org.safere.Pattern safereTag;
+  private org.safere.Pattern safereScheme;
+
+  private java.util.regex.Pattern jdkSplitW;
+  private java.util.regex.Pattern jdkBlock;
+  private java.util.regex.Pattern jdkTag;
+  private java.util.regex.Pattern jdkScheme;
+
+  private com.google.re2j.Pattern re2jSplitW;
+  private com.google.re2j.Pattern re2jBlock;
+  private com.google.re2j.Pattern re2jTag;
+  private com.google.re2j.Pattern re2jScheme;
+
+  private org.safere.re2ffm.RE2FfmPattern re2ffmSplitW;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmBlock;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmTag;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmScheme;
+
+  @Setup
+  public void setup() {
+    BenchmarkData data = BenchmarkData.get();
+
+    String splitPattern = data.getString("issue481Scaling.splitW.pattern");
+    String blockPattern = data.getString("issue481Scaling.block.pattern");
+    String tagPattern = data.getString("issue481Scaling.tag.pattern");
+    String schemePattern = data.getString("issue481Scaling.scheme.pattern");
+
+    splitText = repeatToSize(data.getString("issue481Scaling.splitW.unit"), textSize);
+    blockText =
+        surroundToSize(
+            data.getString("issue481Scaling.block.prefix"),
+            data.getString("issue481Scaling.block.unit"),
+            data.getString("issue481Scaling.block.suffix"),
+            textSize);
+    blockNegativeText =
+        surroundToSize(
+            data.getString("issue481Scaling.block.prefix"),
+            data.getString("issue481Scaling.block.unit"),
+            data.getString("issue481Scaling.block.negativeSuffix"),
+            textSize);
+    tagText =
+        suffixMatchToSize(
+            data.getString("issue481Scaling.tag.prefixUnit"),
+            data.getString("issue481Scaling.tag.match"),
+            textSize);
+    tagNegativeText =
+        suffixMatchToSize(
+            data.getString("issue481Scaling.tag.prefixUnit"),
+            data.getString("issue481Scaling.tag.negativeMatch"),
+            textSize);
+    schemeText =
+        suffixMatchToSize(
+            data.getString("issue481Scaling.scheme.prefixUnit"),
+            data.getString("issue481Scaling.scheme.match"),
+            textSize);
+    schemeNegativeText =
+        suffixMatchToSize(
+            data.getString("issue481Scaling.scheme.prefixUnit"),
+            data.getString("issue481Scaling.scheme.negativeMatch"),
+            textSize);
+
+    safereSplitW = org.safere.Pattern.compile(splitPattern);
+    safereBlock = org.safere.Pattern.compile(blockPattern);
+    safereTag = org.safere.Pattern.compile(tagPattern);
+    safereScheme = org.safere.Pattern.compile(schemePattern);
+
+    jdkSplitW = java.util.regex.Pattern.compile(splitPattern);
+    jdkBlock = java.util.regex.Pattern.compile(blockPattern);
+    jdkTag = java.util.regex.Pattern.compile(tagPattern);
+    jdkScheme = java.util.regex.Pattern.compile(schemePattern);
+
+    re2jSplitW = com.google.re2j.Pattern.compile(splitPattern);
+    re2jBlock = com.google.re2j.Pattern.compile(blockPattern);
+    re2jTag = com.google.re2j.Pattern.compile(tagPattern);
+    re2jScheme = com.google.re2j.Pattern.compile(schemePattern);
+
+    re2ffmSplitW = org.safere.re2ffm.RE2FfmPattern.compile(splitPattern);
+    re2ffmBlock = org.safere.re2ffm.RE2FfmPattern.compile(blockPattern);
+    re2ffmTag = org.safere.re2ffm.RE2FfmPattern.compile(tagPattern);
+    re2ffmScheme = org.safere.re2ffm.RE2FfmPattern.compile(schemePattern);
+  }
+
+  @Benchmark
+  public int splitWords_safere() {
+    return splitLengthSum(safereSplitW.split(splitText));
+  }
+
+  @Benchmark
+  public int splitWords_jdk() {
+    return splitLengthSum(jdkSplitW.split(splitText));
+  }
+
+  @Benchmark
+  public int splitWords_re2j() {
+    return splitLengthSum(re2jSplitW.split(splitText));
+  }
+
+  @Benchmark
+  public int splitWords_re2ffm() {
+    return splitLengthSum(re2ffmSplitW.split(splitText));
+  }
+
+  @Benchmark
+  public boolean blockFind_safere() {
+    return safereBlock.matcher(blockText).find();
+  }
+
+  @Benchmark
+  public boolean blockFind_jdk() {
+    return jdkBlock.matcher(blockText).find();
+  }
+
+  @Benchmark
+  public boolean blockFind_re2j() {
+    return re2jBlock.matcher(blockText).find();
+  }
+
+  @Benchmark
+  public boolean blockFind_re2ffm() {
+    return re2ffmBlock.matcher(blockText).find();
+  }
+
+  @Benchmark
+  public boolean blockFindNegative_safere() {
+    return safereBlock.matcher(blockNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean blockFindNegative_jdk() {
+    return jdkBlock.matcher(blockNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean blockFindNegative_re2j() {
+    return re2jBlock.matcher(blockNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean blockFindNegative_re2ffm() {
+    return re2ffmBlock.matcher(blockNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean tagFind_safere() {
+    return safereTag.matcher(tagText).find();
+  }
+
+  @Benchmark
+  public boolean tagFind_jdk() {
+    return jdkTag.matcher(tagText).find();
+  }
+
+  @Benchmark
+  public boolean tagFind_re2j() {
+    return re2jTag.matcher(tagText).find();
+  }
+
+  @Benchmark
+  public boolean tagFind_re2ffm() {
+    return re2ffmTag.matcher(tagText).find();
+  }
+
+  @Benchmark
+  public boolean tagFindNegative_safere() {
+    return safereTag.matcher(tagNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean tagFindNegative_jdk() {
+    return jdkTag.matcher(tagNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean tagFindNegative_re2j() {
+    return re2jTag.matcher(tagNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean tagFindNegative_re2ffm() {
+    return re2ffmTag.matcher(tagNegativeText).find();
+  }
+
+  @Benchmark
+  public int schemeExtract_safere() {
+    org.safere.Matcher matcher = safereScheme.matcher(schemeText);
+    int sum = 0;
+    while (matcher.find()) {
+      sum += matcher.group(1).length();
+      sum += matcher.group(2).length();
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int schemeExtract_jdk() {
+    java.util.regex.Matcher matcher = jdkScheme.matcher(schemeText);
+    int sum = 0;
+    while (matcher.find()) {
+      sum += matcher.group(1).length();
+      sum += matcher.group(2).length();
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int schemeExtract_re2j() {
+    com.google.re2j.Matcher matcher = re2jScheme.matcher(schemeText);
+    int sum = 0;
+    while (matcher.find()) {
+      sum += matcher.group(1).length();
+      sum += matcher.group(2).length();
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public int schemeExtract_re2ffm() {
+    org.safere.re2ffm.RE2FfmMatcher matcher = re2ffmScheme.matcher(schemeText);
+    int sum = 0;
+    while (matcher.find()) {
+      sum += matcher.group(1).length();
+      sum += matcher.group(2).length();
+    }
+    return sum;
+  }
+
+  @Benchmark
+  public boolean schemeFindNegative_safere() {
+    return safereScheme.matcher(schemeNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean schemeFindNegative_jdk() {
+    return jdkScheme.matcher(schemeNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean schemeFindNegative_re2j() {
+    return re2jScheme.matcher(schemeNegativeText).find();
+  }
+
+  @Benchmark
+  public boolean schemeFindNegative_re2ffm() {
+    return re2ffmScheme.matcher(schemeNegativeText).find();
+  }
+
+  private static String repeatToSize(String unit, int size) {
+    StringBuilder sb = new StringBuilder(size + unit.length());
+    while (sb.length() < size) {
+      sb.append(unit);
+    }
+    return sb.substring(0, size);
+  }
+
+  private static String surroundToSize(String prefix, String unit, String suffix, int size) {
+    int targetBodySize = Math.max(0, size - prefix.length() - suffix.length());
+    return prefix + repeatToSize(unit, targetBodySize) + suffix;
+  }
+
+  private static String suffixMatchToSize(String prefixUnit, String match, int size) {
+    int targetPrefixSize = Math.max(0, size - match.length());
+    return repeatToSize(prefixUnit, targetPrefixSize) + match;
+  }
+
+  private static int splitLengthSum(String[] parts) {
+    int sum = parts.length;
+    for (String part : parts) {
+      sum += part.length();
+    }
+    return sum;
+  }
+}

--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmPattern.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmPattern.java
@@ -10,6 +10,8 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.ref.Cleaner;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A compiled regular expression backed by C++ RE2 via the FFM API. This is a benchmark-oriented
@@ -85,6 +87,54 @@ public final class RE2FfmPattern {
    */
   public RE2FfmMatcher matcher(String input) {
     return new RE2FfmMatcher(this, input);
+  }
+
+  /**
+   * Splits the given input around matches of this pattern. Trailing empty strings are discarded.
+   *
+   * @param input the character sequence to be split
+   * @return the array of strings computed by splitting the input around matches of this pattern
+   */
+  public String[] split(CharSequence input) {
+    return split(input, 0);
+  }
+
+  /**
+   * Splits the given input around matches of this pattern.
+   *
+   * @param input the character sequence to be split
+   * @param limit the result threshold
+   * @return the array of strings computed by splitting the input around matches of this pattern
+   */
+  public String[] split(CharSequence input, int limit) {
+    String text = input.toString();
+    RE2FfmMatcher matcher = matcher(text);
+    List<String> parts = new ArrayList<>();
+    int last = 0;
+
+    while (matcher.find()) {
+      if (limit > 0 && parts.size() >= limit - 1) {
+        break;
+      }
+      if (last == 0 && matcher.start() == 0 && matcher.end() == 0) {
+        continue;
+      }
+      parts.add(text.substring(last, matcher.start()));
+      last = matcher.end();
+    }
+    if (last == 0) {
+      return new String[] {text};
+    }
+
+    parts.add(text.substring(last));
+    if (limit == 0) {
+      int end = parts.size();
+      while (end > 0 && parts.get(end - 1).isEmpty()) {
+        end--;
+      }
+      parts = parts.subList(0, end);
+    }
+    return parts.toArray(new String[0]);
   }
 
   /** Returns the pattern string. */


### PR DESCRIPTION
## Summary

Adds issue 481 benchmark coverage for representative application-style regex workloads:

- `\W+` split over prose-like text
- `(?s)<block>.*?</block>` block extraction
- `<<tag.*?>>` tag extraction
- custom-scheme Markdown-style link extraction with capture retrieval

The Java benchmark scales each workload across `128 B`, `1 KB`, `10 KB`, `100 KB`, and `1 MB`. The shared `benchmark-data.json` inputs are also wired into the C++ RE2 and Go regexp harnesses. The Java RE2-FFM wrapper now has `split(...)` support so the Java benchmark calls pattern APIs consistently.

Fixes #481

## Quick Benchmark Signal

Ran:

```bash
./run-java-benchmarks.sh --quick Issue481ScalingBenchmark
```

Runtime: 20m03s. These are quick development results, not publication-quality `BENCHMARKS.md` results.

### Split Words: `\W+`

| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | vs JDK | vs RE2/J | vs RE2-FFM |
|--:|--:|--:|--:|--:|---|---|---|
| 128 B | 2.91 | 0.63 | 5.23 | 4.80 | 4.6x slower | **1.8x faster** | **1.7x faster** |
| 1 KB | 20.6 | 4.89 | 40.5 | 32.8 | 4.2x slower | **2.0x faster** | **1.6x faster** |
| 10 KB | 215 | 49.0 | 427 | 464 | 4.4x slower | **2.0x faster** | **2.2x faster** |
| 100 KB | 2,153 | 489 | 4,250 | 30,163 | 4.4x slower | **2.0x faster** | **14.0x faster** |
| 1 MB | 26,075 | 5,532 | 43,933 | 5,472,706 | 4.7x slower | **1.7x faster** | **209.9x faster** |

### Block Find: `(?s)<block>.*?</block>`

| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | vs JDK | vs RE2/J | vs RE2-FFM |
|--:|--:|--:|--:|--:|---|---|---|
| 128 B | 1.21 | 0.43 | 4.42 | 0.45 | 2.8x slower | **3.7x faster** | 2.7x slower |
| 1 KB | 5.21 | 4.24 | 43.3 | 2.59 | 1.2x slower | **8.3x faster** | 2.0x slower |
| 10 KB | 51.9 | 47.9 | 442 | 24.9 | 1.1x slower | **8.5x faster** | 2.1x slower |
| 100 KB | 565 | 369 | 4,429 | 250 | 1.5x slower | **7.8x faster** | 2.3x slower |
| 1 MB | 5,506 | 3,775 | 45,717 | 2,721 | 1.5x slower | **8.3x faster** | 2.0x slower |

### Tag Find: `<<tag.*?>>`

| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | vs JDK | vs RE2/J | vs RE2-FFM |
|--:|--:|--:|--:|--:|---|---|---|
| 128 B | 0.47 | 0.24 | 1.44 | 0.36 | 2.0x slower | **3.1x faster** | 1.3x slower |
| 1 KB | 0.31 | 1.35 | 1.51 | 1.37 | **4.4x faster** | **4.9x faster** | **4.4x faster** |
| 10 KB | 1.07 | 9.99 | 2.24 | 12.0 | **9.3x faster** | **2.1x faster** | **11.2x faster** |
| 100 KB | 8.44 | 131 | 9.56 | 120 | **15.5x faster** | **1.1x faster** | **14.2x faster** |
| 1 MB | 83.7 | 1,394 | 85.0 | 1,380 | **16.7x faster** | ~same | **16.5x faster** |

### Scheme Extract

| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | vs JDK | vs RE2/J | vs RE2-FFM |
|--:|--:|--:|--:|--:|---|---|---|
| 128 B | 1.22 | 0.38 | 10.0 | 1.40 | 3.2x slower | **8.2x faster** | **1.1x faster** |
| 1 KB | 1.27 | 0.58 | 9.98 | 2.41 | 2.2x slower | **7.9x faster** | **1.9x faster** |
| 10 KB | 25.0 | 28.3 | 10.8 | 13.5 | **1.1x faster** | 2.3x slower | 1.9x slower |
| 100 KB | 33.5 | 144 | 18.0 | 125 | **4.3x faster** | 1.9x slower | **3.7x faster** |
| 1 MB | 109 | 1,571 | 93.2 | 1,439 | **14.5x faster** | 1.2x slower | **13.2x faster** |

Overall, the new quick results show:

- SafeRE is consistently slower than JDK on `splitWords`, but faster than RE2/J and much faster than the current RE2-FFM split wrapper at large sizes.
- SafeRE is consistently slower than JDK/RE2-FFM on DOTALL lazy block extraction, while remaining much faster than RE2/J.
- SafeRE is strong on tag extraction once the input is at least 1 KB.
- Scheme extraction is mixed: SafeRE loses on tiny inputs, beats JDK/RE2-FFM at scale, and trails RE2/J from 10 KB upward.

## Verification

Ran:

```bash
mvn -pl safere-benchmarks -am package -DskipTests -q
go build -o /tmp/safere-regexp-benchmark .   # from safere-benchmarks/go
cmake --build safere-benchmarks/cpp/build -j8
./run-java-benchmarks.sh --quick Issue481ScalingBenchmark
```

Also ran focused Java/C++/Go smoke checks while developing the new benchmark paths.

Not run:

- Full publication-quality benchmark collection
