### PR TITLE
Adopt empirical Java benchmark configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,8 +179,9 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   keywords may only close the issue after merge as a commit reference.
 - For performance optimization PRs, include before/after benchmark results in
   the PR description and state the measured improvement or regression for the
-  specific change. If using quick benchmarks, clearly label them as quick
-  development signal rather than publication-quality results.
+  specific change. Use the standard Java benchmark configuration by default;
+  use `--long` when confirming close, surprising, or especially important
+  comparisons.
 - Do not push directly to `main`. Always create a branch and open a PR.
 ## GitHub Issues
 
@@ -288,11 +289,11 @@ Benchmark classes have no `@Fork`, `@Warmup`, or `@Measurement` annotations
 — all statistical rigor settings are controlled by the script.
 
 ```bash
-# BENCHMARKS.md updates — publication-quality (default, no flags needed)
+# BENCHMARKS.md updates and routine benchmark evidence
 ./run-java-benchmarks.sh RegexBenchmark
 
-# Quick development iteration ONLY — fast but NOT for BENCHMARKS.md
-./run-java-benchmarks.sh --quick RegexBenchmark
+# Longer confirmation run for close, surprising, or important comparisons
+./run-java-benchmarks.sh --long RegexBenchmark
 ```
 
 **Run benchmarks in batches, not all at once.** Run 2–3 benchmark classes
@@ -314,12 +315,13 @@ per invocation and collect results incrementally:
 
 ### Key Rules
 
-- **The default run is always publication-quality.** Running the script
-  without `--quick` produces 3 forks, 3 warmup × 5s, 5 measurement × 5s.
-  No environment variables or extra flags needed.
-- **Use `--quick` for development iteration only.** Quick mode uses 1 fork,
-  3 warmup × 1s, 5 measurement × 1s. Never use `--quick` results in
-  BENCHMARKS.md.
+- **The default run is the standard Java benchmark configuration.** Running the
+  script without mode flags uses 2 forks, 2 warmup × 500ms, and 5 measurement
+  × 500ms. This empirically selected configuration is the default for routine
+  benchmark evidence and BENCHMARKS.md updates.
+- **Use `--long` for confirmation.** Long mode uses 2 forks, 3 warmup × 1s,
+  and 5 measurement × 1s. Use it for close, surprising, or especially important
+  comparisons where the extra runtime is justified.
 - **Pathological benchmarks always use `-f 0`.** The script handles this
   automatically — PathologicalBenchmark and PathologicalComparisonBenchmark
   run without forking because the JDK engine can hang on large inputs.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -30,8 +30,11 @@ the same algorithmic ballpark as other RE2-family engines, not to declare a
 winner across language boundaries. Within the Java ecosystem, the SafeRE vs JDK
 vs RE2/J vs RE2-FFM comparison is apples-to-apples.
 
-For instructions on collecting publication-quality benchmark data, see
+For instructions on collecting benchmark data, see
 [Benchmarks](README.md#benchmarks) in the README.
+
+For the empirical evaluation of Java benchmark configuration tradeoffs, see
+[Java Benchmark Configuration Evaluation](safere-benchmarks/CONFIGURATION_EVALUATION.md).
 
 ## Methodology
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Application workloads live in `safere-benchmarks/benchmark-data.json`, where
 each case defines its operation semantics and expected result for the Java,
 C++, and Go harnesses.
 
-### Publication-Quality Benchmark Collection
+### Benchmark Collection
 
 To collect a full set of benchmark data for updating
 [BENCHMARKS.md](BENCHMARKS.md), run the collection script from the repository
@@ -391,6 +391,13 @@ root:
 
 ```bash
 ./collect-benchmark-results.sh
+```
+
+Use the longer Java mode when confirming close, surprising, or especially
+important comparisons:
+
+```bash
+./collect-benchmark-results.sh --long
 ```
 
 To verify the collection pipeline without doing a full run:
@@ -430,20 +437,18 @@ java-pattern-memory.txt
 Always use the wrapper scripts — they run `mvn install` first to ensure
 the benchmark module picks up the latest SafeRE code. These are useful for
 development iteration or focused investigation; use
-`./collect-benchmark-results.sh` for full publication-quality collection.
+`./collect-benchmark-results.sh` for a full collection.
 
 ```bash
 # Java benchmarks (throughput)
 ./run-java-benchmarks.sh                        # standard benchmarks
 ./run-java-benchmarks.sh RegexBenchmark         # specific class
 ./run-java-benchmarks.sh ApplicationBenchmark   # application workloads
+./run-java-benchmarks.sh --long RegexBenchmark  # longer confirmation run
 
 # Java memory profiling (allocation rates via JMH GC profiler)
 ./run-java-memory-benchmarks.sh                 # all benchmarks
 ./run-java-memory-benchmarks.sh RegexBenchmark  # specific class
-
-# Fast development iteration only — NOT for BENCHMARKS.md
-./run-java-benchmarks.sh --quick RegexBenchmark
 ```
 
 `CrosscheckOverheadBenchmark` is excluded from the no-argument Java benchmark
@@ -451,7 +456,7 @@ run. It measures overhead in the `safere-crosscheck` facade and should be run
 explicitly only when optimizing crosscheck:
 
 ```bash
-./run-java-benchmarks.sh --quick CrosscheckOverheadBenchmark
+./run-java-benchmarks.sh CrosscheckOverheadBenchmark
 ```
 
 ### C++ RE2 and Go Benchmarks

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -2,10 +2,11 @@
 # Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
 # See LICENSE file in the project root for details.
 #
-# Collect publication-quality benchmark outputs for updating BENCHMARKS.md.
+# Collect benchmark outputs for updating BENCHMARKS.md.
 #
 # Usage:
 #   ./collect-benchmark-results.sh
+#   ./collect-benchmark-results.sh --long
 #   ./collect-benchmark-results.sh --smoke
 #   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 #
@@ -18,24 +19,30 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEFAULT_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 OUTPUT_DIR="$SCRIPT_DIR/benchmark-results/$DEFAULT_RUN_ID"
-MODE="publish"
+MODE="standard"
 
 usage() {
   cat <<EOF
 Usage:
   ./collect-benchmark-results.sh
+  ./collect-benchmark-results.sh --long
   ./collect-benchmark-results.sh --smoke
   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 
-Collects publication-quality benchmark outputs for updating BENCHMARKS.md.
+Collects benchmark outputs for updating BENCHMARKS.md.
 
 Options:
+  --long        Use the longer Java confirmation mode.
   --smoke       Run one small benchmark through the collection pipeline.
 EOF
 }
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    --long)
+      MODE="long"
+      shift
+      ;;
     --smoke)
       MODE="smoke"
       shift
@@ -96,6 +103,11 @@ cd "$SCRIPT_DIR"
 log "Writing benchmark outputs to $OUTPUT_DIR"
 log "Mode: $MODE"
 
+JAVA_MODE_ARGS=()
+if [ "$MODE" = "long" ]; then
+  JAVA_MODE_ARGS=(--long)
+fi
+
 if [ "$MODE" = "smoke" ]; then
   run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
     ./run-java-benchmarks.sh --smoke RegexBenchmark.literalMatch
@@ -108,19 +120,19 @@ if [ "$MODE" = "smoke" ]; then
     ./run-java-memory-benchmarks.sh --smoke RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
-    ./run-java-benchmarks.sh RegexBenchmark ApplicationBenchmark CompileBenchmark
+    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" RegexBenchmark ApplicationBenchmark CompileBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
-    ./run-java-benchmarks.sh SearchScalingBenchmark Issue481ScalingBenchmark CaptureScalingBenchmark
+    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" SearchScalingBenchmark Issue481ScalingBenchmark CaptureScalingBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
-    ./run-java-benchmarks.sh HttpBenchmark ReplaceBenchmark FanoutBenchmark
+    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" HttpBenchmark ReplaceBenchmark FanoutBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-04-pathological.txt" \
-    ./run-java-benchmarks.sh PathologicalBenchmark PathologicalComparisonBenchmark
+    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" PathologicalBenchmark PathologicalComparisonBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-05-patternset.txt" \
-    ./run-java-benchmarks.sh PatternSetBenchmark
+    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" PatternSetBenchmark
 
   log "Combining Java JMH output"
   cat \

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -5,8 +5,8 @@
 # Run SafeRE JMH benchmarks.
 #
 # Usage:
-#   ./run-java-benchmarks.sh RegexBenchmark         # publication-quality (default)
-#   ./run-java-benchmarks.sh --quick RegexBenchmark  # fast dev iteration
+#   ./run-java-benchmarks.sh RegexBenchmark         # standard benchmark run
+#   ./run-java-benchmarks.sh --long RegexBenchmark  # longer confirmation run
 #   ./run-java-benchmarks.sh --smoke RegexBenchmark  # CI smoke test (minimal)
 #   ./run-java-benchmarks.sh --first-compile UnicodeFirstCompileBenchmark
 #   ./run-java-benchmarks.sh                         # run all benchmarks
@@ -21,10 +21,12 @@
 # between annotation values and command-line overrides.
 #
 # Modes:
-#   Default (no flags):  Publication-quality — 3 forks, 3 warmup × 5s,
-#                        5 measurement × 5s. Use for BENCHMARKS.md.
-#   --quick:             Dev iteration — 1 fork, 3 warmup × 1s,
-#                        5 measurement × 1s. NOT for BENCHMARKS.md.
+#   Default (no flags):  Standard — 2 forks, 2 warmup × 500ms,
+#                        5 measurement × 500ms. Use for routine benchmark
+#                        evidence and BENCHMARKS.md updates.
+#   --long:              Longer confirmation run — 2 forks, 3 warmup × 1s,
+#                        5 measurement × 1s. Use for close, surprising, or
+#                        especially important comparisons.
 #   --smoke:             CI smoke test — 0 forks, 1 warmup × 1s,
 #                        1 measurement × 1s. Just verifies benchmarks compile
 #                        and run without errors.
@@ -46,22 +48,35 @@ BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 DEFAULT_BENCHMARK_REGEX="^(?!org\\.safere\\.benchmark\\.CrosscheckOverheadBenchmark\\.).*$"
 
-# Publication-quality settings: 3 forks × (3 warmup × 5s + 5 measurement × 5s).
-# 15 samples per method — sufficient for meaningful confidence intervals.
-PUBLISH_OPTS="-f 3 -wi 3 -w 5 -i 5 -r 5"
-QUICK_OPTS="-f 1 -wi 3 -w 1 -i 5 -r 1"
+# Empirically selected Java benchmark settings. See
+# safere-benchmarks/CONFIGURATION_EVALUATION.md.
+STANDARD_OPTS="-f 2 -wi 2 -w 500ms -i 5 -r 500ms"
+LONG_OPTS="-f 2 -wi 3 -w 1 -i 5 -r 1"
 SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 FIRST_COMPILE_OPTS="-f 10 -wi 0 -i 1 -r 1 -bm ss"
 
 # Pathological benchmarks must run without forking (JDK can hang).
-PATHOLOGICAL_PUBLISH_OPTS="-f 0 -wi 3 -w 5 -i 5 -r 5"
-PATHOLOGICAL_QUICK_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
+PATHOLOGICAL_STANDARD_OPTS="-f 0 -wi 2 -w 500ms -i 5 -r 500ms"
+PATHOLOGICAL_LONG_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
 PATHOLOGICAL_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 
+usage() {
+  cat <<EOF
+Usage:
+  ./run-java-benchmarks.sh [--long|--smoke|--first-compile] [BenchmarkClass ...]
+
+Modes:
+  default          Standard benchmark run.
+  --long           Longer confirmation run for close or important comparisons.
+  --smoke          Minimal compile-and-run smoke test.
+  --first-compile  Fresh-fork single-shot cold compile signal.
+EOF
+}
+
 # Parse mode flag.
-MODE="publish"
-if [ "${1:-}" = "--quick" ]; then
-  MODE="quick"
+MODE="standard"
+if [ "${1:-}" = "--long" ]; then
+  MODE="long"
   shift
 elif [ "${1:-}" = "--smoke" ]; then
   MODE="smoke"
@@ -69,6 +84,13 @@ elif [ "${1:-}" = "--smoke" ]; then
 elif [ "${1:-}" = "--first-compile" ]; then
   MODE="first-compile"
   shift
+elif [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+elif [[ "${1:-}" == --* ]]; then
+  echo "ERROR: unknown mode: $1" >&2
+  usage >&2
+  exit 2
 fi
 
 if [ "$MODE" = "first-compile" ]; then
@@ -79,14 +101,14 @@ elif [ "$MODE" = "smoke" ]; then
   JMH_OPTS="$SMOKE_OPTS"
   PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_SMOKE_OPTS"
   echo "=== Smoke-test mode (CI only) ==="
-elif [ "$MODE" = "quick" ]; then
-  JMH_OPTS="$QUICK_OPTS"
-  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_QUICK_OPTS"
-  echo "=== Quick mode (NOT for BENCHMARKS.md) ==="
+elif [ "$MODE" = "long" ]; then
+  JMH_OPTS="$LONG_OPTS"
+  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_LONG_OPTS"
+  echo "=== Long mode (confirmation run) ==="
 else
-  JMH_OPTS="$PUBLISH_OPTS"
-  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_PUBLISH_OPTS"
-  echo "=== Publication mode (for BENCHMARKS.md) ==="
+  JMH_OPTS="$STANDARD_OPTS"
+  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_STANDARD_OPTS"
+  echo "=== Standard mode ==="
 fi
 
 # JVM args for FFM native access and native library path.

--- a/safere-benchmarks/CONFIGURATION_EVALUATION.md
+++ b/safere-benchmarks/CONFIGURATION_EVALUATION.md
@@ -1,0 +1,232 @@
+# Java Benchmark Configuration Evaluation
+
+## Goal
+
+The goal of this experiment was to find the fastest Java benchmark
+configuration that gives stable enough results for engineering decisions.
+
+The benchmark question we care about is not just whether an individual raw JMH
+score is stable. Most SafeRE benchmark decisions are comparative: did SafeRE get
+faster or slower relative to JDK, RE2/J, or RE2-FFM? For that reason, this
+experiment evaluates stability of SafeRE/competitor ratios across independent
+benchmark invocations.
+
+## Experiment
+
+- Benchmarked commit: `6b89c5360ae07956d07a5366d999b20b33072b44`
+- Commit date/time: 2026-06-19T23:02:22Z
+- Repeats: 3 independent process-level invocations per config/task
+- Winner deadband: +/- 5%
+- Script: `safere-benchmarks/scripts/evaluate-java-benchmark-configs.py`
+
+The repeated invocations are intentionally process-level repeats. JMH's internal
+samples are useful, but the development workflow question is: if we rerun the
+benchmark command, does the conclusion hold?
+
+## Metrics
+
+The primary decision metric is **p90 ratio CV**.
+
+Ratio CV is the coefficient of variation of the SafeRE/competitor ratio across
+independent invocations. It directly measures whether the comparative benchmark
+result is stable. The p90 value is used because median ratio CV is too forgiving:
+it can hide a small number of noisy benchmark/competitor pairs that still affect
+the interpretation.
+
+The supporting metrics are:
+
+| Metric | Use |
+|---|---|
+| p90 ratio CV | Primary quality metric. Lower means SafeRE/competitor conclusions are more stable. |
+| Winner flips | Sanity check. Nonzero flips mean a config is suspect even if CV looks acceptable. |
+| Wall-clock runtime | Cost metric for comparing configs. |
+| Median ratio CV | Secondary quality metric, but too forgiving on its own. |
+| Score CV | Diagnostic metric for raw score noise, not the main decision metric. |
+
+## Candidate Configurations
+
+| Config | Label | Forks | Warmup iterations | Warmup time | Measurement iterations | Measurement time |
+|---|---|---:|---:|---:|---:|---:|
+| A0 | absolute floor | 0 | 0 | - | 1 | 100ms |
+| A1 | floor + tiny warmup | 0 | 1 | 100ms | 1 | 100ms |
+| B | very cheap forked | 1 | 1 | 200ms | 3 | 200ms |
+| C | cheap candidate | 1 | 2 | 500ms | 5 | 500ms |
+| D | former quick | 1 | 3 | 1s | 5 | 1s |
+| E | adopted standard | 2 | 2 | 500ms | 5 | 500ms |
+| F | adopted long | 2 | 3 | 1s | 5 | 1s |
+| P | former default/production | 3 | 3 | 5s | 5 | 5s |
+
+## Broader Validation
+
+The broader validation run used 10 representative tasks:
+
+| Task | Benchmark coverage |
+|---|---|
+| `literalMatch` | Tiny literal fast path |
+| `emailFind` | Ordinary find workload |
+| `urlExtraction` | Application extraction workload |
+| `pigLatinReplaceAll` | Replacement/allocation-heavy workload |
+| `tagFind128` | Short Issue 481 find workload |
+| `tagFind1MiB` | Large Issue 481 find workload |
+| `schemeExtract128` | Short Issue 481 extraction workload |
+| `schemeExtract1MiB` | Large Issue 481 extraction workload |
+| `splitWords10KiB` | Mid-size split workload |
+| `searchEasyFail100KiB` | Larger search-scaling workload |
+
+The clean broader run compared only the practical contenders: C, D, E, and F.
+It did not include P because the earlier calibration showed P dominates runtime
+and is not a practical candidate for routine feedback.
+
+Report: `benchmark-results/config-eval-broader-cdef/report.md`
+
+| Config | Label | Runtime | Relative to E | p90 ratio CV | Winner flips |
+|---|---|---:|---:|---:|---:|
+| C | cheap candidate | 471.2s | 0.51x | 5.5% | 0/28 |
+| D | former quick | 1009.0s | 1.08x | 5.9% | 1/27 |
+| E | adopted standard | 931.5s | 1.00x | 4.5% | 0/28 |
+| F | adopted long | 2011.7s | 2.16x | 2.2% | 0/27 |
+
+Full stability results:
+
+| Config | Median score CV | p90 score CV | Median ratio CV | p90 ratio CV | Winner flips |
+|---|---:|---:|---:|---:|---:|
+| C | 0.7% | 2.3% | 1.8% | 5.5% | 0/28 |
+| D | 0.6% | 2.0% | 1.1% | 5.9% | 1/27 |
+| E | 0.7% | 1.4% | 1.4% | 4.5% | 0/28 |
+| F | 0.7% | 1.8% | 0.9% | 2.2% | 0/27 |
+
+## Initial Calibration
+
+| Config | Label | Runtime | Relative to E | p90 ratio CV | Winner flips |
+|---|---|---:|---:|---:|---:|
+| A0 | absolute floor | 7.7s | 0.03x | 17.6% | 0/9 |
+| A1 | floor + tiny warmup | 11.3s | 0.04x | 31.4% | 1/9 |
+| B | very cheap forked | 44.6s | 0.16x | 14.9% | 0/9 |
+| C | cheap candidate | 142.5s | 0.51x | 6.6% | 0/8 |
+| D | former quick | 303.9s | 1.08x | 4.9% | 0/9 |
+| E | adopted standard | 281.3s | 1.00x | 4.4% | 0/8 |
+| F | adopted long | 603.4s | 2.15x | 4.1% | 0/8 |
+| P | former default/production | 4359.8s | 15.50x | 5.6% | 0/8 |
+
+## Full Stability Results
+
+| Config | Median score CV | p90 score CV | Median ratio CV | p90 ratio CV | Winner flips |
+|---|---:|---:|---:|---:|---:|
+| A0 | 3.9% | 13.1% | 7.1% | 17.6% | 0/9 |
+| A1 | 5.8% | 26.3% | 17.6% | 31.4% | 1/9 |
+| B | 4.0% | 11.0% | 4.0% | 14.9% | 0/9 |
+| C | 3.0% | 4.3% | 3.4% | 6.6% | 0/8 |
+| D | 2.0% | 5.9% | 3.1% | 4.9% | 0/9 |
+| E | 0.6% | 2.8% | 1.4% | 4.4% | 0/8 |
+| F | 1.0% | 2.6% | 1.5% | 4.1% | 0/8 |
+| P | 0.5% | 1.4% | 0.6% | 5.6% | 0/8 |
+
+## Interpretation
+
+The broader validation supports E as the best routine-feedback candidate. It is
+slightly faster than the former quick configuration D, has better p90 ratio CV
+(4.5% vs 5.9%), and had no winner flips. D had one winner flip in the broader
+run, which is a direct strike against using it as the default decision-making
+configuration.
+
+F is the most stable practical configuration tested: p90 ratio CV improved to
+2.2%. The cost is substantial, though: F took about 2.16x as long as E. That
+makes F useful as a longer confirmation mode, but not as the first-line
+development feedback configuration.
+
+C is cheaper than E and performed better than expected in the broader run, but
+its p90 ratio CV was still worse than E (5.5% vs 4.5%). Since C is only about
+2x faster than E and gives weaker stability, it is better treated as a lower
+bound than as the primary configuration.
+
+In the initial three-task calibration, the absolute floor configurations were
+too noisy for comparative decisions.
+A0 is extremely fast, but p90 ratio CV is 17.6%. A1 is worse despite adding a
+tiny warmup, with p90 ratio CV of 31.4% and one winner flip.
+
+The former default/production configuration P is much more expensive and did
+not improve the primary decision metric in the initial calibration run. It took
+about 15.5x as long as E, and its p90 ratio CV was worse than E because
+`urlExtraction_safere` had a slow fork in one repeat. This does not prove that
+longer runs are never useful, but it does show that the former default settings
+are not automatically more decision-stable for the kind of comparative ratios we
+care about.
+
+## Adopted Procedure
+
+Use E as the standard Java benchmark configuration:
+
+```text
+-f 2 -wi 2 -w 500ms -i 5 -r 500ms
+```
+
+This means:
+
+| Setting | Value |
+|---|---:|
+| Forks | 2 |
+| Warmup iterations | 2 |
+| Warmup time | 500ms each |
+| Measurement iterations | 5 |
+| Measurement time | 500ms each |
+
+Use F as the longer confirmation mode when a result is close, surprising, or
+important enough to justify roughly doubling the runtime:
+
+```text
+-f 2 -wi 3 -w 1 -i 5 -r 1
+```
+
+The benchmark runner exposes these as:
+
+```bash
+./run-java-benchmarks.sh RegexBenchmark
+./run-java-benchmarks.sh --long RegexBenchmark
+```
+
+## Reproducing
+
+The initial calibration run used:
+
+```bash
+python3 safere-benchmarks/scripts/evaluate-java-benchmark-configs.py \
+  --no-build \
+  --configs A0,A1,B,C,D \
+  --tasks literalMatch,emailFind,urlExtraction \
+  --repeats 3 \
+  --output-dir benchmark-results/config-eval-initial
+```
+
+The longer configurations were added with:
+
+```bash
+python3 safere-benchmarks/scripts/evaluate-java-benchmark-configs.py \
+  --no-build \
+  --configs E,F,P \
+  --tasks literalMatch,emailFind,urlExtraction \
+  --repeats 3 \
+  --output-dir benchmark-results/config-eval-initial \
+  --resume
+```
+
+The broader validation run used:
+
+```bash
+python3 safere-benchmarks/scripts/evaluate-java-benchmark-configs.py \
+  --configs C,D,E,F \
+  --tasks calibration \
+  --repeats 3 \
+  --output-dir benchmark-results/config-eval-broader-cdef
+```
+
+The combined report was regenerated from saved JSON outputs with:
+
+```bash
+python3 safere-benchmarks/scripts/evaluate-java-benchmark-configs.py \
+  --no-build \
+  --configs A0,A1,B,C,D,E,F,P \
+  --tasks literalMatch,emailFind,urlExtraction \
+  --repeats 3 \
+  --output-dir benchmark-results/config-eval-initial \
+  --resume
+```

--- a/safere-benchmarks/scripts/evaluate-java-benchmark-configs.py
+++ b/safere-benchmarks/scripts/evaluate-java-benchmark-configs.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
+# See LICENSE file in the project root for details.
+
+"""Evaluate JMH configuration stability for SafeRE Java benchmarks.
+
+This script answers: what is the cheapest JMH configuration that gives stable
+enough results for engineering decisions?
+
+It runs selected Java/JMH benchmarks repeatedly under named candidate
+configurations, stores JMH JSON outputs, and writes a Markdown report with:
+
+  * wall-clock time
+  * per-result coefficient of variation across independent invocations
+  * SafeRE/competitor ratio coefficient of variation
+  * winner flips outside a configurable deadband
+
+The repeated invocations are intentionally process-level repeats. JMH's
+internal samples are useful, but this script measures the question we care
+about during development: "if I rerun this command, does the conclusion hold?"
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import math
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+BENCHMARK_JAR = REPO_ROOT / "safere-benchmarks" / "target" / "benchmarks.jar"
+RE2_SHIM_DIR = REPO_ROOT / "safere-ffm-re2" / "build"
+
+JVM_ARGS = [
+    "--enable-native-access=ALL-UNNAMED",
+    f"-Dre2shim.library.path={RE2_SHIM_DIR}",
+]
+
+ENGINE_SUFFIXES = collections.OrderedDict(
+    [
+        ("_safere", "safere"),
+        ("_jdk", "jdk"),
+        ("_re2ffm", "re2ffm"),
+        ("_re2j", "re2j"),
+    ]
+)
+COMPETITORS = ("jdk", "re2j", "re2ffm")
+
+
+@dataclass(frozen=True)
+class Config:
+    name: str
+    jmh_args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Task:
+    name: str
+    pattern: str
+    params: tuple[tuple[str, str], ...] = ()
+
+
+CONFIGS = {
+    "A0": Config("A0", ("-f", "0", "-wi", "0", "-i", "1", "-r", "100ms")),
+    "A1": Config("A1", ("-f", "0", "-wi", "1", "-w", "100ms", "-i", "1", "-r", "100ms")),
+    "A2": Config("A2", ("-f", "1", "-wi", "0", "-i", "1", "-r", "100ms")),
+    "B": Config("B", ("-f", "1", "-wi", "1", "-w", "200ms", "-i", "3", "-r", "200ms")),
+    "C": Config("C", ("-f", "1", "-wi", "2", "-w", "500ms", "-i", "5", "-r", "500ms")),
+    "D": Config("D", ("-f", "1", "-wi", "3", "-w", "1", "-i", "5", "-r", "1")),
+    "E": Config("E", ("-f", "2", "-wi", "2", "-w", "500ms", "-i", "5", "-r", "500ms")),
+    "F": Config("F", ("-f", "2", "-wi", "3", "-w", "1", "-i", "5", "-r", "1")),
+    "P": Config("P", ("-f", "3", "-wi", "3", "-w", "5", "-i", "5", "-r", "5")),
+}
+
+CALIBRATION_TASKS = [
+    Task("literalMatch", "RegexBenchmark.literalMatch_"),
+    Task("emailFind", "RegexBenchmark.emailFind_"),
+    Task("urlExtraction", "ApplicationBenchmark.urlExtraction_"),
+    Task("pigLatinReplaceAll", "ReplaceBenchmark.pigLatinReplaceAll_"),
+    Task("tagFind128", "Issue481ScalingBenchmark.tagFind_", (("textSize", "128"),)),
+    Task("tagFind1MiB", "Issue481ScalingBenchmark.tagFind_", (("textSize", "1048576"),)),
+    Task("schemeExtract128", "Issue481ScalingBenchmark.schemeExtract_", (("textSize", "128"),)),
+    Task("schemeExtract1MiB", "Issue481ScalingBenchmark.schemeExtract_", (("textSize", "1048576"),)),
+    Task("splitWords10KiB", "Issue481ScalingBenchmark.splitWords_", (("textSize", "10240"),)),
+    Task("searchEasyFail100KiB", "SearchScalingBenchmark.searchEasyFail_", (("textSize", "102400"),)),
+]
+
+
+def run_command(cmd: list[str], cwd: Path, log_path: Path | None = None) -> None:
+    with subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    ) as proc:
+        fh = log_path.open("w") if log_path else None
+        try:
+          for line in proc.stdout or []:
+              print(line, end="")
+              if fh:
+                  fh.write(line)
+        finally:
+            if fh:
+                fh.close()
+        if proc.wait() != 0:
+            raise subprocess.CalledProcessError(proc.returncode, cmd)
+
+
+def build_benchmarks() -> None:
+    run_command(["mvn", "install", "-DskipTests", "-q", "-f", str(REPO_ROOT / "pom.xml")], REPO_ROOT)
+
+
+def selected_configs(names: str) -> list[Config]:
+    result = []
+    for name in [part.strip() for part in names.split(",") if part.strip()]:
+        if name not in CONFIGS:
+            raise SystemExit(f"Unknown config {name}. Known configs: {', '.join(CONFIGS)}")
+        result.append(CONFIGS[name])
+    return result
+
+
+def selected_tasks(names: str) -> list[Task]:
+    if names == "calibration":
+        return CALIBRATION_TASKS
+    wanted = {part.strip() for part in names.split(",") if part.strip()}
+    tasks = [task for task in CALIBRATION_TASKS if task.name in wanted]
+    missing = wanted - {task.name for task in tasks}
+    if missing:
+        raise SystemExit(
+            f"Unknown task(s): {', '.join(sorted(missing))}. "
+            f"Known tasks: {', '.join(task.name for task in CALIBRATION_TASKS)}"
+        )
+    return tasks
+
+
+def run_jmh(config: Config, task: Task, repeat: int, output_dir: Path) -> float:
+    json_path = output_dir / f"{config.name}-{task.name}-r{repeat}.json"
+    log_path = output_dir / f"{config.name}-{task.name}-r{repeat}.log"
+    cmd = [
+        "java",
+        *JVM_ARGS,
+        "-jar",
+        str(BENCHMARK_JAR),
+        "-jvmArgs",
+        " ".join(JVM_ARGS),
+        *config.jmh_args,
+        "-foe",
+        "true",
+        "-rf",
+        "json",
+        "-rff",
+        str(json_path),
+        task.pattern,
+    ]
+    for key, value in task.params:
+        cmd.extend(["-p", f"{key}={value}"])
+    start = time.monotonic()
+    print(f"\n=== {config.name} {task.name} repeat {repeat} ===")
+    print(" ".join(cmd))
+    run_command(cmd, REPO_ROOT, log_path)
+    return time.monotonic() - start
+
+
+def parse_engine(benchmark: str) -> tuple[str, str]:
+    method = benchmark.rsplit(".", 1)[-1]
+    for suffix, engine in ENGINE_SUFFIXES.items():
+        if method.endswith(suffix):
+            return engine, benchmark[: -len(suffix)]
+    return "safere", benchmark
+
+
+def params_key(params: dict[str, str]) -> str:
+    if not params:
+        return ""
+    return ",".join(f"{key}={params[key]}" for key in sorted(params))
+
+
+def load_result_file(path: Path):
+    with path.open() as fh:
+        data = json.load(fh)
+    for item in data:
+        engine, base = parse_engine(item["benchmark"])
+        metric = item["primaryMetric"]
+        yield {
+            "benchmark": base,
+            "engine": engine,
+            "params": params_key(item.get("params", {})),
+            "score": float(metric["score"]),
+            "error": float(metric.get("scoreError") or 0.0),
+            "unit": metric["scoreUnit"],
+        }
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def cv(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    m = mean(values)
+    if m == 0:
+        return 0.0
+    return statistics.stdev(values) / m
+
+
+def verdict(ratio: float, deadband: float) -> str:
+    if ratio < 1.0 - deadband:
+        return "safere"
+    if ratio > 1.0 + deadband:
+        return "competitor"
+    return "same"
+
+
+def summarize(output_dir: Path, configs: list[Config], tasks: list[Task], repeats: int, deadband: float) -> str:
+    timings = collections.defaultdict(list)
+    measurements = collections.defaultdict(list)
+
+    for config in configs:
+        for task in tasks:
+            timing_path = output_dir / f"{config.name}-{task.name}-timings.json"
+            if timing_path.exists():
+                timings[(config.name, task.name)] = json.loads(timing_path.read_text())
+            for repeat in range(1, repeats + 1):
+                path = output_dir / f"{config.name}-{task.name}-r{repeat}.json"
+                if not path.exists():
+                    continue
+                for result in load_result_file(path):
+                    key = (
+                        config.name,
+                        task.name,
+                        result["benchmark"],
+                        result["params"],
+                        result["engine"],
+                    )
+                    measurements[key].append(result["score"])
+
+    lines = []
+    lines.append("# Java Benchmark Configuration Stability\n")
+    lines.append(f"Repeats per config/task: {repeats}")
+    lines.append(f"Winner deadband: +/- {deadband * 100:.1f}%")
+    lines.append("")
+    lines.append("## Configurations")
+    lines.append("")
+    lines.append("| Config | JMH arguments |")
+    lines.append("|---|---|")
+    for config in configs:
+        lines.append(f"| {config.name} | `{' '.join(config.jmh_args)}` |")
+
+    lines.append("")
+    lines.append("## Runtime")
+    lines.append("")
+    lines.append("| Config | Total wall time | Mean task-repeat time |")
+    lines.append("|---|---:|---:|")
+    for config in configs:
+        values = []
+        for task in tasks:
+            values.extend(timings.get((config.name, task.name), []))
+        total = sum(values)
+        avg = mean(values) if values else 0.0
+        lines.append(f"| {config.name} | {total:.1f}s | {avg:.2f}s |")
+
+    score_rows = []
+    ratio_rows = []
+    flip_rows = []
+    for config in configs:
+        per_score_cvs = []
+        ratios_by_pair = collections.defaultdict(list)
+        repeated_pairs = collections.defaultdict(list)
+        for key, values in measurements.items():
+            cfg, task_name, benchmark, params, engine = key
+            if cfg != config.name:
+                continue
+            per_score_cvs.append(cv(values))
+            if engine == "safere":
+                continue
+            safe_values = measurements.get((cfg, task_name, benchmark, params, "safere"), [])
+            if len(safe_values) != len(values):
+                continue
+            pair = (task_name, benchmark, params, engine)
+            ratios = [safe / other for safe, other in zip(safe_values, values)]
+            ratios_by_pair[pair] = ratios
+            repeated_pairs[(benchmark, params, engine)].extend(ratios)
+        ratio_cvs = [cv(values) for values in ratios_by_pair.values()]
+        flips = 0
+        decisions = 0
+        for ratios in ratios_by_pair.values():
+            labels = {verdict(ratio, deadband) for ratio in ratios}
+            labels.discard("same")
+            if labels:
+                decisions += 1
+                if len(labels) > 1:
+                    flips += 1
+        score_rows.append((config.name, per_score_cvs))
+        ratio_rows.append((config.name, ratio_cvs))
+        flip_rows.append((config.name, flips, decisions))
+
+    def percentile(values: list[float], p: float) -> float:
+        if not values:
+            return 0.0
+        sorted_values = sorted(values)
+        index = min(len(sorted_values) - 1, math.ceil(p * len(sorted_values)) - 1)
+        return sorted_values[index]
+
+    lines.append("")
+    lines.append("## Stability")
+    lines.append("")
+    lines.append("| Config | Median score CV | p90 score CV | Median ratio CV | p90 ratio CV | Winner flips |")
+    lines.append("|---|---:|---:|---:|---:|---:|")
+    ratios_by_config = dict(ratio_rows)
+    flips_by_config = {name: (flips, decisions) for name, flips, decisions in flip_rows}
+    for name, score_cvs in score_rows:
+        ratio_cvs = ratios_by_config.get(name, [])
+        flips, decisions = flips_by_config[name]
+        lines.append(
+            "| "
+            + f"{name} | {percentile(score_cvs, 0.5) * 100:.1f}% "
+            + f"| {percentile(score_cvs, 0.9) * 100:.1f}% "
+            + f"| {percentile(ratio_cvs, 0.5) * 100:.1f}% "
+            + f"| {percentile(ratio_cvs, 0.9) * 100:.1f}% "
+            + f"| {flips}/{decisions} |"
+        )
+
+    lines.append("")
+    lines.append("## Detailed Ratio CVs")
+    lines.append("")
+    lines.append("| Config | Task | Benchmark | Params | Competitor | Mean SafeRE/competitor | Ratio CV |")
+    lines.append("|---|---|---|---|---|---:|---:|")
+    for config in configs:
+        for key, values in measurements.items():
+            cfg, task_name, benchmark, params, engine = key
+            if cfg != config.name or engine == "safere":
+                continue
+            safe_values = measurements.get((cfg, task_name, benchmark, params, "safere"), [])
+            if len(safe_values) != len(values):
+                continue
+            ratios = [safe / other for safe, other in zip(safe_values, values)]
+            lines.append(
+                f"| {cfg} | {task_name} | {benchmark} | {params or '-'} | {engine} "
+                f"| {mean(ratios):.3f} | {cv(ratios) * 100:.1f}% |"
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--configs", default="A0,A1,A2,B,C,D,E")
+    parser.add_argument("--tasks", default="calibration")
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--deadband", type=float, default=0.05)
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--no-build", action="store_true")
+    parser.add_argument("--resume", action="store_true")
+    args = parser.parse_args()
+
+    configs = selected_configs(args.configs)
+    tasks = selected_tasks(args.tasks)
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+    else:
+        output_dir = REPO_ROOT / "benchmark-results" / f"config-eval-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}"
+    if not output_dir.is_absolute():
+        output_dir = REPO_ROOT / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.no_build:
+        build_benchmarks()
+    if not BENCHMARK_JAR.exists():
+        raise SystemExit(f"Benchmark JAR not found: {BENCHMARK_JAR}")
+
+    for config in configs:
+        for task in tasks:
+            timing_path = output_dir / f"{config.name}-{task.name}-timings.json"
+            timings = json.loads(timing_path.read_text()) if args.resume and timing_path.exists() else []
+            for repeat in range(1, args.repeats + 1):
+                json_path = output_dir / f"{config.name}-{task.name}-r{repeat}.json"
+                if args.resume and json_path.exists():
+                    continue
+                elapsed = run_jmh(config, task, repeat, output_dir)
+                timings.append(elapsed)
+                timing_path.write_text(json.dumps(timings, indent=2) + "\n")
+
+    report = summarize(output_dir, configs, tasks, args.repeats, args.deadband)
+    report_path = output_dir / "report.md"
+    report_path.write_text(report)
+    latest = REPO_ROOT / "benchmark-results" / "config-eval-latest"
+    latest.parent.mkdir(exist_ok=True)
+    if latest.exists() or latest.is_symlink():
+        if latest.is_dir() and not latest.is_symlink():
+            shutil.rmtree(latest)
+        else:
+            latest.unlink()
+    latest.symlink_to(output_dir)
+    print(f"\nReport written to {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/safere-crosscheck/README.md
+++ b/safere-crosscheck/README.md
@@ -188,5 +188,5 @@ benchmark run because it is a diagnostic benchmark for optimizing
 Run it explicitly when working on crosscheck performance:
 
 ```bash
-./run-java-benchmarks.sh --quick CrosscheckOverheadBenchmark
+./run-java-benchmarks.sh CrosscheckOverheadBenchmark
 ```


### PR DESCRIPTION
## Summary

- adopt the empirically selected standard Java benchmark configuration as the default runner mode
- add `--long` as the longer confirmation mode and remove the old throughput `--quick`/publication split
- update benchmark collection, README, AGENTS.md, BENCHMARKS.md, and crosscheck docs to match the new procedure
- add the durable Java benchmark configuration evaluation writeup and the helper script used to evaluate candidate configs

## Benchmark procedure

Default Java throughput benchmarks now use config E:

```text
-f 2 -wi 2 -w 500ms -i 5 -r 500ms
```

`--long` uses config F for close, surprising, or especially important comparisons:

```text
-f 2 -wi 3 -w 1 -i 5 -r 1
```

Pathological benchmark classes still run with `-f 0`, using mode-matched warmup and measurement settings.

## Verification

- `bash -n run-java-benchmarks.sh collect-benchmark-results.sh`
- `python3 -m py_compile safere-benchmarks/scripts/evaluate-java-benchmark-configs.py`
- `./run-java-benchmarks.sh --help`
- `./collect-benchmark-results.sh --help`
- `./run-java-benchmarks.sh --smoke RegexBenchmark.literalMatch`
- `rg -n -e "run-java-benchmarks\\.sh --quick" .`
- `codex exec review --base main --json --output-last-message ... --ephemeral` after fixing the stale crosscheck README command: no discrete correctness issues found

Fixes #483
