### PR TITLE
Make benchmark collection Java-only by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,9 +325,13 @@ per invocation and collect results incrementally:
 - **Pathological benchmarks always use `-f 0`.** The script handles this
   automatically — PathologicalBenchmark and PathologicalComparisonBenchmark
   run without forking because the JDK engine can hang on large inputs.
-- **NEVER run benchmarks in parallel.** All benchmark runs (Java, C++, Go)
-  must run sequentially, one at a time. Parallel runs compete for CPU,
-  cache, and memory bandwidth, producing inaccurate results.
+- **Default benchmark collection is Java-only.** `./collect-benchmark-results.sh`
+  collects SafeRE, JDK, RE2/J, and RE2-FFM results by default. Use
+  `./collect-benchmark-results.sh --cross-language` only when broader C++ RE2
+  and Go `regexp` context is explicitly needed.
+- **NEVER run benchmarks in parallel.** All benchmark runs must run
+  sequentially, one at a time. Parallel runs compete for CPU, cache, and memory
+  bandwidth, producing inaccurate results.
 - **Do not commit optimizations that do not improve benchmark results.**
   Every optimization must be validated with before/after benchmarks.
 - **All harnesses share `benchmark-data.json`.** This ensures identical

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -32,6 +32,8 @@ vs RE2/J vs RE2-FFM comparison is apples-to-apples.
 
 For instructions on collecting benchmark data, see
 [Benchmarks](README.md#benchmarks) in the README.
+The standard collection path is Java-only; C++ RE2 and Go `regexp` are optional
+cross-language context collected with `./collect-benchmark-results.sh --cross-language`.
 
 For the empirical evaluation of Java benchmark configuration tradeoffs, see
 [Java Benchmark Configuration Evaluation](safere-benchmarks/CONFIGURATION_EVALUATION.md).

--- a/README.md
+++ b/README.md
@@ -393,11 +393,22 @@ root:
 ./collect-benchmark-results.sh
 ```
 
+The default collection is Java-only: SafeRE, `java.util.regex`, RE2/J, and
+RE2-FFM. These are the normal engineering comparisons because they run in the
+same JVM environment.
+
 Use the longer Java mode when confirming close, surprising, or especially
 important comparisons:
 
 ```bash
 ./collect-benchmark-results.sh --long
+```
+
+Use the cross-language mode only when you need broader ecosystem context from
+C++ RE2 and Go `regexp`:
+
+```bash
+./collect-benchmark-results.sh --cross-language
 ```
 
 To verify the collection pipeline without doing a full run:
@@ -406,9 +417,8 @@ To verify the collection pipeline without doing a full run:
 ./collect-benchmark-results.sh --smoke
 ```
 
-The script runs the Java, C++ RE2, and Go benchmark batches sequentially,
-captures raw output, extracts native JSON-lines results, and generates merged
-markdown tables.
+The script runs benchmark batches sequentially, captures raw output, and
+generates markdown tables.
 
 By default, results are written to a timestamped directory under
 `benchmark-results/`, and `benchmark-results/latest` is updated to point to
@@ -425,11 +435,16 @@ The important files in that directory are:
 
 ```text
 jmh-output.txt
-cpp-results.jsonl
-go-results.jsonl
 merged-tables.md
 java-memory.txt
 java-pattern-memory.txt
+```
+
+Cross-language runs also include:
+
+```text
+cpp-results.jsonl
+go-results.jsonl
 ```
 
 ### Targeted Benchmark Runs
@@ -477,19 +492,28 @@ cross-language comparison. Prerequisites: CMake ≥ 3.14 + C++17 compiler
 
 ### Comparing Results Manually
 
-A comparison script merges JMH, C++, and Go results into side-by-side markdown:
+A comparison script turns JMH output into side-by-side markdown:
 
 ```bash
 python3 safere-benchmarks/scripts/compare-benchmarks.py \
-  --jmh jmh-output.txt --json cpp-results.jsonl go-results.jsonl
+  --jmh jmh-output.txt
 ```
 
-To verify that all harnesses emitted the application benchmark names defined in
-`benchmark-data.json`, add:
+Add C++ and Go JSON-lines files when comparing cross-language results:
 
 ```bash
 python3 safere-benchmarks/scripts/compare-benchmarks.py \
-  --jmh jmh-output.txt --json cpp-results.jsonl go-results.jsonl \
+  --jmh jmh-output.txt \
+  --json cpp-results.jsonl go-results.jsonl \
+  --engines safere,jdk,re2j,re2_ffm,re2_cpp,go
+```
+
+To verify that emitted application benchmark names match `benchmark-data.json`,
+add:
+
+```bash
+python3 safere-benchmarks/scripts/compare-benchmarks.py \
+  --jmh jmh-output.txt \
   --benchmark-data safere-benchmarks/benchmark-data.json \
   --check-application-names
 ```

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -7,12 +7,14 @@
 # Usage:
 #   ./collect-benchmark-results.sh
 #   ./collect-benchmark-results.sh --long
+#   ./collect-benchmark-results.sh --cross-language
 #   ./collect-benchmark-results.sh --smoke
 #   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 #
 # The script intentionally does not run the test suite. It runs benchmark
-# batches sequentially, captures raw output, extracts native JSONL results, and
-# generates merged markdown tables.
+# batches sequentially, captures raw output, and generates markdown tables.
+# By default it collects Java/JMH results only. Use --cross-language to also
+# collect C++ RE2 and Go regexp results.
 
 set -euo pipefail
 
@@ -20,20 +22,23 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEFAULT_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 OUTPUT_DIR="$SCRIPT_DIR/benchmark-results/$DEFAULT_RUN_ID"
 MODE="standard"
+CROSS_LANGUAGE=false
 
 usage() {
   cat <<EOF
 Usage:
   ./collect-benchmark-results.sh
   ./collect-benchmark-results.sh --long
+  ./collect-benchmark-results.sh --cross-language
   ./collect-benchmark-results.sh --smoke
   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 
 Collects benchmark outputs for updating BENCHMARKS.md.
 
 Options:
-  --long        Use the longer Java confirmation mode.
-  --smoke       Run one small benchmark through the collection pipeline.
+  --long            Use the longer Java confirmation mode.
+  --cross-language  Also run C++ RE2 and Go regexp benchmark harnesses.
+  --smoke           Run one small benchmark through the collection pipeline.
 EOF
 }
 
@@ -41,6 +46,10 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --long)
       MODE="long"
+      shift
+      ;;
+    --cross-language)
+      CROSS_LANGUAGE=true
       shift
       ;;
     --smoke)
@@ -102,6 +111,7 @@ cd "$SCRIPT_DIR"
 
 log "Writing benchmark outputs to $OUTPUT_DIR"
 log "Mode: $MODE"
+log "Cross-language: $CROSS_LANGUAGE"
 
 JAVA_MODE_ARGS=()
 if [ "$MODE" = "long" ]; then
@@ -152,34 +162,42 @@ run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \
   java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
     org.safere.benchmark.MemoryBenchmark
 
-if [ "$MODE" = "smoke" ]; then
-  run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-    ./run-cpp-benchmarks.sh RegexBenchmark.literalMatch
-else
-  run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-    ./run-cpp-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
-fi
-
-log "Extracting C++ JSONL"
-extract_jsonl "$OUTPUT_DIR/cpp-raw.txt" "$OUTPUT_DIR/cpp-results.jsonl"
-
-if [ "$MODE" = "smoke" ]; then
-  run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-    ./run-go-benchmarks.sh RegexBenchmark.literalMatch
-else
-  run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-    ./run-go-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
-fi
-
-log "Extracting Go JSONL"
-extract_jsonl "$OUTPUT_DIR/go-raw.txt" "$OUTPUT_DIR/go-results.jsonl"
-
-log "Generating merged markdown tables"
+COMPARE_ENGINES="safere,jdk,re2j,re2_ffm"
 COMPARE_ARGS=(
   --jmh "$OUTPUT_DIR/jmh-output.txt"
-  --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl"
-  --engines safere,jdk,re2j,re2_ffm,re2_cpp,go
 )
+
+if [ "$CROSS_LANGUAGE" = true ]; then
+  if [ "$MODE" = "smoke" ]; then
+    run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
+      ./run-cpp-benchmarks.sh RegexBenchmark.literalMatch
+  else
+    run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
+      ./run-cpp-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
+  fi
+
+  log "Extracting C++ JSONL"
+  extract_jsonl "$OUTPUT_DIR/cpp-raw.txt" "$OUTPUT_DIR/cpp-results.jsonl"
+
+  if [ "$MODE" = "smoke" ]; then
+    run_and_capture "$OUTPUT_DIR/go-raw.txt" \
+      ./run-go-benchmarks.sh RegexBenchmark.literalMatch
+  else
+    run_and_capture "$OUTPUT_DIR/go-raw.txt" \
+      ./run-go-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
+  fi
+
+  log "Extracting Go JSONL"
+  extract_jsonl "$OUTPUT_DIR/go-raw.txt" "$OUTPUT_DIR/go-results.jsonl"
+
+  COMPARE_ARGS+=(
+    --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl"
+  )
+  COMPARE_ENGINES="safere,jdk,re2j,re2_ffm,re2_cpp,go"
+fi
+
+log "Generating markdown tables"
+COMPARE_ARGS+=(--engines "$COMPARE_ENGINES")
 if [ "$MODE" != "smoke" ]; then
   COMPARE_ARGS+=(
     --benchmark-data safere-benchmarks/benchmark-data.json
@@ -212,9 +230,14 @@ Point the agent at:
 
 Key files:
   jmh-output.txt
-  cpp-results.jsonl
-  go-results.jsonl
   merged-tables.md
   java-memory.txt
   java-pattern-memory.txt
 EOF
+
+if [ "$CROSS_LANGUAGE" = true ]; then
+  cat <<EOF
+  cpp-results.jsonl
+  go-results.jsonl
+EOF
+fi


### PR DESCRIPTION
## Summary

- make `./collect-benchmark-results.sh` collect Java/JMH results only by default
- add `--cross-language` to opt into C++ RE2 and Go `regexp` benchmark collection
- keep `--long` scoped to Java JMH while preserving smoke-mode behavior
- update README, BENCHMARKS.md, and AGENTS.md to document Java-only as the standard collection path

## Verification

- `bash -n collect-benchmark-results.sh run-java-benchmarks.sh`
- `./collect-benchmark-results.sh --help`
- `./collect-benchmark-results.sh --smoke --output-dir /tmp/safere-benchmark-collection-smoke-java`
  - produced Java-only files: `jmh-output.txt`, `merged-tables.md`, `java-memory.txt`, `java-pattern-memory.txt`
  - did not produce C++/Go JSONL files
- `codex exec review --base main --json --output-last-message ... --ephemeral`
  - reviewer found no discrete regressions

Refs #483
