### PR TITLE
Fix grapheme find required literal fast reject

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -431,10 +431,14 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean containsRequiredMatchClass(int[] ranges) {
+    return containsRequiredMatchClass(ranges, 0);
+  }
+
+  private boolean containsRequiredMatchClass(int[] ranges, int fromIndex) {
     long b0 = parentPattern.requiredMatchClassBitmap0();
     long b1 = parentPattern.requiredMatchClassBitmap1();
 
-    int i = 0;
+    int i = Math.max(0, fromIndex);
     int len = text.length();
     while (i < len) {
       int cp = text.codePointAt(i);
@@ -1237,6 +1241,13 @@ public final class Matcher implements MatchResult {
     // when a region is active). Return false immediately to avoid the DFA matching at every
     // position because the compiler strips the anchor into prog.anchorStart().
     if (prog.anchorStart() && searchFrom > 0) {
+      return applyEngineResult(new NoMatchResult());
+    }
+
+    int[] requiredRanges = parentPattern.requiredMatchClassRanges();
+    if (options.charClassMatchFastPaths()
+        && requiredRanges != null
+        && !containsRequiredMatchClass(requiredRanges, searchFrom)) {
       return applyEngineResult(new NoMatchResult());
     }
 

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2100,6 +2100,12 @@ public final class Pattern implements Serializable {
     if (node.op == RegexpOp.NON_CAPTURE) {
       node = node.sub();
     }
+    if (node.op == RegexpOp.LITERAL) {
+      return literalCharClass(node.rune, node.flags);
+    }
+    if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
+      return literalCharClass(node.runes[0], node.flags);
+    }
     if (node.op == RegexpOp.CHAR_CLASS && node.charClass != null) {
       return node.charClass.isEmpty() ? null : node.charClass;
     }
@@ -2110,6 +2116,18 @@ public final class Pattern implements Serializable {
       return node.sub().charClass;
     }
     return null;
+  }
+
+  private static CharClass literalCharClass(int cp, int flags) {
+    CharClassBuilder ccb = new CharClassBuilder();
+    if ((flags & ParseFlags.FOLD_CASE) == 0) {
+      ccb.addRange(cp, cp);
+    } else if ((flags & ParseFlags.UNICODE_CASE) == 0) {
+      UnicodeCaseFolding.addAsciiFoldedRange(ccb, cp, cp);
+    } else {
+      UnicodeCaseFolding.addUnicodeFoldedRange(ccb, cp, cp);
+    }
+    return ccb.build();
   }
 
   private static CharClassScanInfo buildCharClassScanInfo(CharClass cc) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -380,6 +380,23 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("find() required-class precheck starts at current search position")
+    void findRequiredClassPrecheckStartsAtCurrentSearchPosition() {
+      Matcher m = Pattern.compile("\\b{g}z").matcher("z\uD83C\uDDE6\uD83C\uDDE6");
+
+      assertThat(m.find(1)).isFalse();
+    }
+
+    @Test
+    @DisplayName("find() required-literal precheck respects case-insensitive flags")
+    void findRequiredLiteralPrecheckRespectsCaseInsensitiveFlags() {
+      Matcher m = Pattern.compile("(?i:abc)def").matcher("ABCdef");
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("ABCdef");
+    }
+
+    @Test
     @DisplayName("find(int) starts search from given position")
     void findWithStart() {
       Pattern p = Pattern.compile("\\d+");

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -115,6 +115,13 @@ class PatternInternalTest {
   }
 
   @Test
+  void boundaryPrefixedLiteralRecordsRequiredClass() {
+    Pattern p = Pattern.compile("\\b{g}z");
+
+    assertThat(p.requiredMatchClassRanges()).isNotNull();
+  }
+
+  @Test
   void pureNullablePatternsDoNotRecordRequiredCharacterClasses() {
     Pattern p = Pattern.compile(".*");
 


### PR DESCRIPTION
## Summary

- Fast-reject `find()` when a required consuming literal/class is absent from the remaining input.
- Extend required-match metadata to represent mandatory literals, including case-folded literals.
- Add regression coverage for grapheme boundary misses and case-insensitive required literals.

## Verification

- `mvn -pl safere clean verify -Dtest.parallelism=4 --batch-mode --no-transfer-progress`
