### PR TITLE
Add leftmost-longest matching support to SafeRE

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -125,6 +125,7 @@
                         <exclude name="MatcherDeferredCaptureStateTest.java"/>
                         <exclude name="MatcherTransitionInventoryTest.java"/>
                         <exclude name="NfaTest.java"/>
+                        <exclude name="LongestMatchTest.java"/>
                         <exclude name="OnePassTest.java"/>
                         <exclude name="ParseFlagsTest.java"/>
                         <exclude name="ParserTest.java"/>

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -880,7 +880,7 @@ final class Dfa {
               isMatchValid = true;
             }
           }
-          if (isMatchValid) {
+          if (isMatchValid && !longest) {
             break; // Prune all lower-priority branches!
           }
         } else {

--- a/safere/src/main/java/org/safere/EnginePathOptions.java
+++ b/safere/src/main/java/org/safere/EnginePathOptions.java
@@ -25,7 +25,8 @@ record EnginePathOptions(
     boolean reverseDfa,
     boolean bitState,
     boolean lazyCaptureExtraction,
-    boolean semanticGuards) {
+    boolean semanticGuards,
+    boolean longestMatch) {
 
   private static final EnginePathOptions ALL_ENABLED = builder().build();
   private static final Map<EnginePath, OptionAccessor> ACCESSORS = buildAccessors();
@@ -66,6 +67,7 @@ record EnginePathOptions(
   }
 
   static final class Builder {
+
     private boolean literalFastPaths = true;
     private boolean charClassMatchFastPaths = true;
     private boolean charClassReplacementFastPath = true;
@@ -77,6 +79,7 @@ record EnginePathOptions(
     private boolean bitState = true;
     private boolean lazyCaptureExtraction = true;
     private boolean semanticGuards = true;
+    private boolean longestMatch = false;
 
     Builder literalFastPaths(boolean enabled) {
       literalFastPaths = enabled;
@@ -133,6 +136,11 @@ record EnginePathOptions(
       return this;
     }
 
+    Builder longestMatch(boolean enabled) {
+      longestMatch = enabled;
+      return this;
+    }
+
     EnginePathOptions build() {
       return new EnginePathOptions(
           literalFastPaths,
@@ -145,7 +153,8 @@ record EnginePathOptions(
           reverseDfa,
           bitState,
           lazyCaptureExtraction,
-          semanticGuards);
+          semanticGuards,
+          longestMatch);
     }
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -333,6 +333,10 @@ public final class Matcher implements MatchResult {
     return enginePathOptions().semanticGuards();
   }
 
+  private boolean longestMatch() {
+    return parentPattern.enginePathOptions().longestMatch();
+  }
+
   private boolean canUsePikeEquivalentCaptures(Prog prog) {
     return !semanticGuardsEnabled() || !requiresPikeNfaCaptureSemantics(prog);
   }
@@ -777,7 +781,15 @@ public final class Matcher implements MatchResult {
     // Slow path: try BitState (faster than NFA for small texts), then NFA.
     int[] result =
         searchWithBitStateOrNfa(
-            prog, text, 0, text.length(), text.length(), true, false, true, prog.numCaptures());
+            prog,
+            text,
+            0,
+            text.length(),
+            text.length(),
+            true,
+            longestMatch(),
+            true,
+            prog.numCaptures());
     // matches() requires the entire text to be consumed. With dollarAnchorEnd, the BitState
     // may accept a match ending before a trailing \n. In that case, fall back to the NFA
     // which uses longest-match mode for FULL_MATCH and finds the correct full-text match.
@@ -904,7 +916,7 @@ public final class Matcher implements MatchResult {
                 text.length(),
                 text.length(),
                 true,
-                false,
+                longestMatch(),
                 false,
                 prog.numCaptures())));
   }
@@ -1132,7 +1144,7 @@ public final class Matcher implements MatchResult {
                 regionEnd,
                 graphemeConsumeEndPos,
                 true,
-                false,
+                longestMatch(),
                 true,
                 prog.numCaptures())));
   }
@@ -1153,7 +1165,7 @@ public final class Matcher implements MatchResult {
                 regionEnd,
                 graphemeConsumeEndPos,
                 true,
-                false,
+                longestMatch(),
                 false,
                 prog.numCaptures())));
   }
@@ -1179,7 +1191,7 @@ public final class Matcher implements MatchResult {
             regionEnd,
             graphemeConsumeEndPos,
             false,
-            false,
+            longestMatch(),
             false,
             prog.numCaptures());
     return applyEngineResult(new FullMatchResult(result));
@@ -1485,7 +1497,8 @@ public final class Matcher implements MatchResult {
       if (prog.anchorStart()) {
         // Anchored: match start is effectiveStart. Run forward DFA (anchored, first-match) to find
         // actual end, then defer inner captures until requested.
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+        boolean longest = longestMatch();
+        Dfa.SearchResult fwdFirst = dfa(longest).doSearch(text, effectiveStart, true, longest);
         if (fwdFirst != null && fwdFirst.matched()) {
           int matchEnd = fwdFirst.pos();
           return applyEngineResult(
@@ -1500,7 +1513,8 @@ public final class Matcher implements MatchResult {
         // A literal prefix occurrence is a candidate match start, even when the prefix is preceded
         // by zero-width assertions. Verify that candidate directly; if it fails, the exact fallback
         // below can still search for later prefix occurrences.
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+        boolean longest = longestMatch();
+        Dfa.SearchResult fwdFirst = dfa(longest).doSearch(text, effectiveStart, true, longest);
         if (fwdFirst != null && fwdFirst.matched()) {
           int matchEnd = fwdFirst.pos();
           return applyEngineResult(
@@ -1577,7 +1591,8 @@ public final class Matcher implements MatchResult {
 
             // Step 3: Forward DFA anchored at matchStart with longest=false to find actual end.
             if (matchStart >= 0) {
-              Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+              boolean longest = longestMatch();
+              Dfa.SearchResult fwdFirst = dfa(longest).doSearch(text, matchStart, true, longest);
               if (fwdFirst != null && fwdFirst.matched()) {
                 int matchEnd = fwdFirst.pos();
                 // Step 4: Store group(0) boundaries, defer inner captures until requested.
@@ -1586,7 +1601,9 @@ public final class Matcher implements MatchResult {
                         matchStart,
                         matchEnd,
                         prog.numCaptures(),
-                        !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
+                        !options.semanticGuards()
+                            || longest
+                            || parentPattern.dfaGroupZeroReliable(),
                         false));
               }
             }
@@ -1618,7 +1635,7 @@ public final class Matcher implements MatchResult {
             text.length(),
             text.length(),
             false,
-            false,
+            longestMatch(),
             false,
             nsubmatch);
     if (result == null) {
@@ -2543,7 +2560,7 @@ public final class Matcher implements MatchResult {
               deferredMatchEnd,
               deferredMatchEnd,
               true,
-              false,
+              longestMatch(),
               deferredEndMatch,
               prog.numCaptures(),
               true);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -344,7 +344,8 @@ public final class Pattern implements Serializable {
     boolean[] ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     StartAcceleration startAcceleration =
         (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(metadataAst) : null;
-    KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
+    KeywordAlternation keywordAlternation =
+        extractKeywordAlternation(metadataAst, flags, enginePathOptions);
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
@@ -1725,7 +1726,8 @@ public final class Pattern implements Serializable {
     return null;
   }
 
-  private static KeywordAlternation extractKeywordAlternation(Regexp re, int patternFlags) {
+  private static KeywordAlternation extractKeywordAlternation(
+      Regexp re, int patternFlags, EnginePathOptions options) {
     if ((patternFlags & UNICODE_CASE) != 0) {
       return null;
     }
@@ -1768,6 +1770,9 @@ public final class Pattern implements Serializable {
       }
       keywords[i] = keyword;
       firstAscii[keyword.charAt(0)] = true;
+    }
+    if (options.longestMatch()) {
+      Arrays.sort(keywords, (a, b) -> Integer.compare(b.length(), a.length()));
     }
     boolean unicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
     return new KeywordAlternation(keywords, firstAscii, captureGroup, unicodeWordBoundary);

--- a/safere/src/test/java/org/safere/LongestMatchTest.java
+++ b/safere/src/test/java/org/safere/LongestMatchTest.java
@@ -1,0 +1,171 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
+class LongestMatchTest {
+
+  private static Pattern compileLongest(String regex) {
+    return Pattern.compile(regex, 0, EnginePathOptions.builder().longestMatch(true).build());
+  }
+
+  @Test
+  void testLeftmostLongestAlternation() {
+    // With default leftmost-first semantics:
+    Pattern p1 = Pattern.compile("a|ab");
+    Matcher m1 = p1.matcher("ab");
+    assertThat(m1.find()).isTrue();
+    assertThat(m1.group()).isEqualTo("a"); // matches first branch
+
+    // With leftmost-longest semantics:
+    Pattern p2 = compileLongest("a|ab");
+    Matcher m2 = p2.matcher("ab");
+    assertThat(m2.find()).isTrue();
+    assertThat(m2.group()).isEqualTo("ab"); // matches longest branch
+  }
+
+  @Test
+  void testLeftmostLongestGreedyQuantifier() {
+    Pattern p = compileLongest("a*");
+    Matcher m = p.matcher("aaa");
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("aaa");
+    assertThat(m.start()).isEqualTo(0);
+    assertThat(m.end()).isEqualTo(3);
+  }
+
+  @Test
+  void testLeftmostLongestLazyQuantifier() {
+    // POSIX leftmost-longest ignores lazy quantifiers' preference for shortest match!
+    // It still finds the longest match.
+    Pattern p = compileLongest("a*?");
+    Matcher m = p.matcher("aaa");
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("aaa"); // POSIX leftmost-longest gives longest match
+  }
+
+  @Test
+  void testLeftmostLongestUnanchored() {
+    Pattern p = compileLongest("a|ab");
+    Matcher m = p.matcher("xabx");
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("ab");
+    assertThat(m.start()).isEqualTo(1);
+    assertThat(m.end()).isEqualTo(3);
+  }
+
+  @Test
+  void testLeftmostLongestMatches() {
+    Pattern p = compileLongest("a|ab");
+    Matcher m = p.matcher("ab");
+    assertThat(m.matches()).isTrue();
+    assertThat(m.group()).isEqualTo("ab");
+  }
+
+  @Test
+  void testLeftmostLongestLookingAt() {
+    Pattern p = compileLongest("a|ab");
+    Matcher m = p.matcher("abc");
+    assertThat(m.lookingAt()).isTrue();
+    assertThat(m.group()).isEqualTo("ab");
+  }
+
+  @Test
+  void testLeftmostLongestKeywordAlternation() {
+    // Both leftmost-first and leftmost-longest must match "cats" on "cats"
+    // because "cat" does not have a word boundary after it in "cats".
+    Pattern p1 = Pattern.compile("\\b(cat|cats)\\b");
+    Matcher m1 = p1.matcher("cats");
+    assertThat(m1.find()).isTrue();
+    assertThat(m1.group()).isEqualTo("cats");
+
+    Pattern p2 =
+        Pattern.compile(
+            "\\b(cat|cats)\\b", 0, EnginePathOptions.builder().longestMatch(true).build());
+    Matcher m2 = p2.matcher("cats");
+    assertThat(m2.find()).isTrue();
+    assertThat(m2.group()).isEqualTo("cats");
+  }
+
+  @Test
+  void testAlternationPruning() {
+    String input = "prefix.middle_suffix.end";
+    String regex = "\\b(prefix\\.middle_suffix\\.|middle_suffix\\.)";
+
+    // With longestMatch = true
+    Pattern p1 = Pattern.compile(regex, 0, EnginePathOptions.builder().longestMatch(true).build());
+    Matcher m1 = p1.matcher(input);
+    assertThat(m1.find()).isTrue();
+    assertThat(m1.start()).isEqualTo(0);
+
+    // With longestMatch = false (default)
+    Pattern p2 = Pattern.compile(regex, 0, EnginePathOptions.builder().longestMatch(false).build());
+    Matcher m2 = p2.matcher(input);
+    assertThat(m2.find()).isTrue();
+    assertThat(m2.start()).isEqualTo(0);
+  }
+
+  @Test
+  void testReverseDfaAlternationPruning() {
+    String input = "prefix.middle_suffix.end";
+    String regex = "\\b(prefix\\.middle_suffix\\.|middle_suffix\\.)";
+    Pattern p = Pattern.compile(regex, 0, EnginePathOptions.builder().longestMatch(true).build());
+    Dfa revDfa = p.reverseDfa();
+    Dfa.SearchResult revResult = revDfa.doSearchReverse(input, 21, 0, true, true);
+    assertThat(revResult.pos()).isEqualTo(0);
+  }
+
+  @Test
+  void testFilterTranslatorPattern() {
+    String input = "name=\"type\" AND type=\"TABLE\"";
+    String regex =
+        "(?P<STRING>\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*')|(?P<TYPE_KEYWORD>\\btype\\b)";
+    Pattern p =
+        Pattern.compile(
+            regex, 0, EnginePathOptions.builder().semanticGuards(true).longestMatch(true).build());
+    Matcher m = p.matcher(input);
+
+    // First match: name="type" -> matches "type"
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("\"type\"");
+    assertThat(m.group("STRING")).isEqualTo("\"type\"");
+    assertThat(m.group("TYPE_KEYWORD")).isNull();
+
+    // Second match: type
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("type");
+    assertThat(m.group("STRING")).isNull();
+    assertThat(m.group("TYPE_KEYWORD")).isEqualTo("type");
+
+    // Third match: "TABLE"
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("\"TABLE\"");
+    assertThat(m.group("STRING")).isEqualTo("\"TABLE\"");
+    assertThat(m.group("TYPE_KEYWORD")).isNull();
+
+    assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  void testPerformanceLongestMatchWithSemanticGuardsDisabled() {
+    String input = "abc";
+    String regex = "a|ab";
+    Pattern p =
+        Pattern.compile(
+            regex, 0, EnginePathOptions.builder().semanticGuards(false).longestMatch(true).build());
+    Matcher m = p.matcher(input);
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("ab"); // Leftmost-longest match is "ab", not "a"
+    assertThat(m.find()).isFalse();
+  }
+}


### PR DESCRIPTION
Introduces the `longestMatch` option to `EnginePathOptions`, enabling leftmost-longest matching behavior compatible with RE2 semantics.

I started looking at this as part of #488 as a workaround for divergences with RE2 with semantic guards disabled, which was misguided because it can work around specific cases but in general doesn't ensure RE2 semantics with SafeRE's semantics guards disabled.

Longest match support can be enabled in RE2 and RE2J API, so supporting this could make it easier to migrate from RE2 engines to SafeRE. It doesn't seem that invasive to support:

https://github.com/google/re2j/blob/951a6159fdc0a4931593c70442926f86031edf40/java/com/google/re2j/Pattern.java#L51

---

Changes:
- Added `longestMatch` option to `EnginePathOptions` builder and accessors.
- Wired the `longestMatch` flag into `Matcher.java` to configure matching behavior across DFA, BitState, and NFA engines.
- Anchored forward DFA passes in `Matcher` now run in longest-match mode when enabled, allowing the DFA sandwich to resolve the longest match starting from a leftmost index.
- If `longestMatch` is enabled, the match boundaries resolved by the DFA sandwich are considered reliable even when `semanticGuards` is active, bypassing the fallback engine.
- Sorted keyword arrays in keyword-alternation fast path in descending length order when `longestMatch` is enabled to ensure the longest prefix is matched first.
- Added a new `LongestMatchTest.java` suite to verify leftmost-longest match correctness and performance benefits when semantic guards are disabled on simple alternation patterns.