### PR TITLE
Statically link libstdc++ and libgcc into FFM RE2 shim

### DIFF
--- a/safere-ffm-re2/src/main/native/CMakeLists.txt
+++ b/safere-ffm-re2/src/main/native/CMakeLists.txt
@@ -33,3 +33,4 @@ FetchContent_MakeAvailable(abseil-cpp re2)
 # Build our C shim as a shared library, statically linking RE2 into it
 add_library(re2_shim SHARED re2_shim.cpp)
 target_link_libraries(re2_shim PRIVATE re2::re2)
+target_link_options(re2_shim PRIVATE "-static-libstdc++" "-static-libgcc")

--- a/safere-ffm-re2/src/main/native/CMakeLists.txt
+++ b/safere-ffm-re2/src/main/native/CMakeLists.txt
@@ -33,4 +33,7 @@ FetchContent_MakeAvailable(abseil-cpp re2)
 # Build our C shim as a shared library, statically linking RE2 into it
 add_library(re2_shim SHARED re2_shim.cpp)
 target_link_libraries(re2_shim PRIVATE re2::re2)
-target_link_options(re2_shim PRIVATE "-static-libstdc++" "-static-libgcc")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
+    AND CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang)$")
+  target_link_options(re2_shim PRIVATE "-static-libstdc++" "-static-libgcc")
+endif()


### PR DESCRIPTION
Statically link the C++ standard library and GCC runtime library into the compiled libre2_shim.so binary.

This prevents UnsatisfiedLinkErrors in environments where the running Java VM's dynamic library loader and the compiled native library target mismatched glibc/libstdc++ versions.  Static linking increases the portability of the FFM benchmark wrapper across different Linux installations.