### PR TITLE
Add real-world comparative regex scaling microbenchmarks

### DIFF
--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -130,7 +130,8 @@ if [ "$MODE" = "smoke" ]; then
     ./run-java-memory-benchmarks.sh --smoke RegexBenchmark.literalMatch
 else
   run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
-    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" RegexBenchmark ApplicationBenchmark CompileBenchmark
+    ./run-java-benchmarks.sh \
+      "${JAVA_MODE_ARGS[@]}" RegexBenchmark ApplicationBenchmark RealWorldRegexBenchmark CompileBenchmark
 
   run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
     ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" SearchScalingBenchmark Issue481ScalingBenchmark CaptureScalingBenchmark
@@ -173,7 +174,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
       ./run-cpp-benchmarks.sh RegexBenchmark.literalMatch
   else
     run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-      ./run-cpp-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
+      ./run-cpp-benchmarks.sh Regex Application RealWorldRegex Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
   fi
 
   log "Extracting C++ JSONL"
@@ -184,7 +185,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
       ./run-go-benchmarks.sh RegexBenchmark.literalMatch
   else
     run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-      ./run-go-benchmarks.sh Regex Application Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
+      ./run-go-benchmarks.sh Regex Application RealWorldRegex Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
   fi
 
   log "Extracting Go JSONL"

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -125,14 +125,31 @@ is_pathological() {
   esac
 }
 
+normalize_benchmark_filter() {
+  local bench="$1"
+  local package_regex="org\\.safere\\.benchmark"
+
+  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ [\^\$\[\]\(\)\|\*\+\?] ]]; then
+    printf '%s\n' "$bench"
+  elif [[ "$bench" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    printf '^%s\\.%s\\.\n' "$package_regex" "$bench"
+  elif [[ "$bench" =~ ^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$ ]]; then
+    printf '^%s\\.%s\\.%s($|_)\n' "$package_regex" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    printf '%s\n' "$bench"
+  fi
+}
+
 run_benchmark() {
   local bench="$1"
+  local filter
   local opts="$JMH_OPTS"
   if is_pathological "$bench"; then
     opts="$PATHOLOGICAL_JMH_OPTS"
   fi
+  filter="$(normalize_benchmark_filter "$bench")"
   echo "=== Running $bench ($opts) ==="
-  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "$bench"
+  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "$filter"
 }
 
 if [ $# -eq 0 ]; then

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -56,12 +56,28 @@ JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DI
 echo "=== Building safere + benchmark JAR ==="
 mvn install -DskipTests -q -f "$SCRIPT_DIR/pom.xml"
 
+normalize_benchmark_filter() {
+  local bench="$1"
+  local package_regex="org\\.safere\\.benchmark"
+
+  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ [\^\$\[\]\(\)\|\*\+\?] ]]; then
+    printf '%s\n' "$bench"
+  elif [[ "$bench" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    printf '^%s\\.%s\\.\n' "$package_regex" "$bench"
+  elif [[ "$bench" =~ ^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$ ]]; then
+    printf '^%s\\.%s\\.%s($|_)\n' "$package_regex" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    printf '%s\n' "$bench"
+  fi
+}
+
 if [ $# -eq 0 ]; then
   echo "=== Running all benchmarks with GC profiling ==="
   java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" -prof gc $JMH_OPTS
 else
   for bench in "$@"; do
+    filter="$(normalize_benchmark_filter "$bench")"
     echo "=== Running $bench with GC profiling ==="
-    java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" -prof gc $JMH_OPTS "$bench"
+    java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" -prof gc $JMH_OPTS "$filter"
   done
 fi

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -177,6 +177,112 @@
     "baseWithDirectives": "public class Foo {\n  // SCRUB:strip_line\n  public void bar() {\n    // SCRUB:begin_strip\n    System.out.println(\"Secret code\");\n    // SCRUB:end_strip\n  }\n}\n"
   },
 
+  "realWorldRegex": {
+    "textSizes": [1000, 10000],
+    "safeDelimiterAlphabet": " ",
+    "seed": 42,
+    "cases": [
+      {
+        "name": "mapFieldPath",
+        "pattern": "([\\S]+)\\b\\[(.+)\\]",
+        "op": "find",
+        "match": "config.overrides[some_value]",
+        "nonMatch": "config.overrides"
+      },
+      {
+        "name": "markupImageLink",
+        "pattern": "<<!(image|media|link)(\\([^\\)]*\\))?/?>?>",
+        "op": "replaceAllEmpty",
+        "match": "<<!image(src=\"http://image.png\")>>",
+        "nonMatch": "<<!image"
+      },
+      {
+        "name": "versionList",
+        "pattern": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
+        "op": "replaceAllEmpty",
+        "match": "[1.2.3, 4.5.6]",
+        "nonMatch": "[1.2.3,"
+      },
+      {
+        "name": "malformedEntity",
+        "pattern": "<[^>]*entity[^>]*>{1,2}",
+        "op": "replaceAllEmpty",
+        "match": "<entity id=\"123\">",
+        "nonMatch": "<ent id=\"123\">"
+      },
+      {
+        "name": "markupEntity",
+        "pattern": "<<!entity.*?>>",
+        "op": "find",
+        "match": "<<!entity(id=\"123\")>>",
+        "nonMatch": "<<entity(id=\"123\")"
+      },
+      {
+        "name": "customProtocolLink",
+        "pattern": "\\[(.*?)]\\(customProtocol://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)",
+        "op": "find",
+        "match": "[Click here](customProtocol://<doc_1>)",
+        "nonMatch": "[Click here](http://google.com)"
+      },
+      {
+        "name": "wildcardSearch",
+        "pattern": "(?is).*\\b(you|your)\\b.*",
+        "op": "find",
+        "match": "What can I do for you today?",
+        "nonMatch": "What is the capital of France?"
+      },
+      {
+        "name": "metadataBlock",
+        "pattern": "(?s)<meta_start>.*?<meta_end>",
+        "op": "replaceAllEmpty",
+        "match": "<meta_start>Thinking process: analyzing query...<meta_end>",
+        "nonMatch": "<meta_start>Thinking process: analyzing query..."
+      },
+      {
+        "name": "blockedTags1",
+        "pattern": "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```",
+        "op": "replaceAllEmpty",
+        "match": "```code_block\n# tags_identified: shopping\n```",
+        "nonMatch": "```code_block\n# tags: shopping\n```"
+      },
+      {
+        "name": "blockedTags2",
+        "pattern": "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>",
+        "op": "replaceAllEmpty",
+        "match": "<container>\n# topic_identified: sports\n</container>",
+        "nonMatch": "<container>\n# topic: sports\n</container>"
+      },
+      {
+        "name": "overlappingUrl",
+        "pattern": "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
+        "op": "replaceAllEmpty",
+        "match": "https://www.example.com/search?q=testing&hl=en",
+        "nonMatch": "some-random-domain-name"
+      },
+      {
+        "name": "caseInsensitiveKeyword",
+        "pattern": "(?i)keyword_to_find",
+        "op": "replaceAllEmpty",
+        "match": "KEYWORD_TO_FIND",
+        "nonMatch": "other_random_words"
+      },
+      {
+        "name": "boundedNameMatch",
+        "pattern": "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)",
+        "op": "replaceAllEmpty",
+        "match": "first name value",
+        "nonMatch": "first name other_value"
+      },
+      {
+        "name": "templateTagMatch",
+        "pattern": "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)",
+        "op": "replaceAllEmpty",
+        "match": "<template name>content to match</template",
+        "nonMatch": "plain text without template tag"
+      }
+    ]
+  },
+
   "application": [
     {
       "name": "uuidValidation",

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -205,6 +205,26 @@ std::string suffix_match_to_size(const std::string& prefix_unit,
   return repeat_to_size(prefix_unit, prefix_size) + match;
 }
 
+std::string generated_real_world_input(const std::string& unit, int size,
+                                       const std::string& alphabet,
+                                       int seed) {
+  if (static_cast<int>(unit.size()) >= size) {
+    return unit.substr(0, size);
+  }
+  std::string text;
+  text.reserve(size + unit.size());
+  int delimiter_index = seed;
+  while (static_cast<int>(text.size()) < size) {
+    text += unit;
+    if (static_cast<int>(text.size()) < size) {
+      text += alphabet[delimiter_index % alphabet.size()];
+      ++delimiter_index;
+    }
+  }
+  text.resize(size);
+  return text;
+}
+
 // Encode a Unicode code point as UTF-8 and append to the string.
 void append_utf8(std::string& s, int cp) {
   if (cp < 0x80) {
@@ -465,6 +485,77 @@ void run_application_benchmarks(const json& data,
         do_not_optimize(run_int(app_case));
       }
     });
+  }
+}
+
+void run_real_world_regex_benchmarks(
+    const json& data, const std::vector<std::string>& filters) {
+  const auto& sec = data["realWorldRegex"];
+  std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
+  std::string alphabet = sec["safeDelimiterAlphabet"].get<std::string>();
+  int seed = sec["seed"].get<int>();
+
+  struct RealWorldCase {
+    std::string name;
+    std::string op;
+    std::string pattern;
+    std::string match;
+    std::string non_match;
+    RE2 re;
+
+    explicit RealWorldCase(const json& item)
+        : name(item.at("name").get<std::string>()),
+          op(item.at("op").get<std::string>()),
+          pattern(item.at("pattern").get<std::string>()),
+          match(item.at("match").get<std::string>()),
+          non_match(item.at("nonMatch").get<std::string>()),
+          re(pattern) {}
+  };
+
+  std::vector<std::unique_ptr<RealWorldCase>> cases;
+  for (const auto& item : sec["cases"]) {
+    cases.push_back(std::make_unique<RealWorldCase>(item));
+  }
+
+  for (const auto& case_ptr : cases) {
+    const RealWorldCase& c = *case_ptr;
+    if (!c.re.ok()) {
+      fprintf(stderr, "ERROR: invalid real-world regex pattern: %s\n",
+              c.name.c_str());
+      exit(1);
+    }
+    if (c.op != "find" && c.op != "replaceAllEmpty") {
+      fprintf(stderr, "ERROR: invalid real-world regex op: %s\n",
+              c.op.c_str());
+      exit(1);
+    }
+  }
+
+  for (const auto& case_ptr : cases) {
+    const RealWorldCase& c = *case_ptr;
+    for (bool match : {true, false}) {
+      const std::string& unit = match ? c.match : c.non_match;
+      std::string match_label = match ? "match" : "noMatch";
+      for (int size : sizes) {
+        std::string text = generated_real_world_input(unit, size, alphabet, seed);
+        std::string name = "RealWorldRegexBenchmark.runBenchmark." + c.name +
+                           "." + match_label + "." + std::to_string(size);
+        if (!matches_filter(name, filters)) {
+          continue;
+        }
+        if (c.op == "find") {
+          print_json(measure(name, [&]() {
+            do_not_optimize(RE2::PartialMatch(text, c.re));
+          }));
+        } else {
+          print_json(measure(name, [&]() {
+            std::string replaced = text;
+            RE2::GlobalReplace(&replaced, c.re, "");
+            do_not_optimize(replaced);
+          }));
+        }
+      }
+    }
   }
 }
 
@@ -928,6 +1019,7 @@ int main(int argc, char* argv[]) {
 
   run_regex_benchmarks(data, filters);
   run_application_benchmarks(data, filters);
+  run_real_world_regex_benchmarks(data, filters);
   run_compile_benchmarks(data, filters);
   run_search_scaling_benchmarks(data, filters);
   run_issue481_scaling_benchmarks(data, filters);

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -248,6 +248,23 @@ func suffixMatchToSize(prefixUnit string, match string, size int) string {
 	return repeatToSize(prefixUnit, prefixSize) + match
 }
 
+func generatedRealWorldInput(unit string, size int, alphabet string, seed int) string {
+	if len(unit) >= size {
+		return unit[:size]
+	}
+	var b strings.Builder
+	b.Grow(size + len(unit))
+	delimiterIndex := seed
+	for b.Len() < size {
+		b.WriteString(unit)
+		if b.Len() < size {
+			b.WriteByte(alphabet[delimiterIndex%len(alphabet)])
+			delimiterIndex++
+		}
+	}
+	return b.String()[:size]
+}
+
 func appendUTF8(b *strings.Builder, cp int) {
 	var buf [4]byte
 	n := utf8.EncodeRune(buf[:], rune(cp))
@@ -445,6 +462,84 @@ func runApplicationBenchmarks(data map[string]any, filters []string) {
 				sink = runInt(c)
 			}
 		})
+	}
+}
+
+func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
+	sec, ok := data["realWorldRegex"].(map[string]any)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "ERROR: realWorldRegex benchmark data must be an object")
+		os.Exit(1)
+	}
+	sizes := getIntSlice(sec, "textSizes")
+	alphabet := getString(sec, "safeDelimiterAlphabet")
+	seed := getInt(sec, "seed")
+
+	type realWorldCase struct {
+		name     string
+		op       string
+		pattern  string
+		match    string
+		nonMatch string
+		re       *regexp.Regexp
+	}
+
+	rawCases, ok := sec["cases"].([]any)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "ERROR: realWorldRegex cases must be a list")
+		os.Exit(1)
+	}
+	cases := make([]realWorldCase, 0, len(rawCases))
+	for _, raw := range rawCases {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			fmt.Fprintln(os.Stderr, "ERROR: invalid realWorldRegex benchmark case")
+			os.Exit(1)
+		}
+		op := getString(item, "op")
+		if op != "find" && op != "replaceAllEmpty" {
+			fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex op: %s\n", op)
+			os.Exit(1)
+		}
+		pattern := getString(item, "pattern")
+		cases = append(cases, realWorldCase{
+			name:     getString(item, "name"),
+			op:       op,
+			pattern:  pattern,
+			match:    getString(item, "match"),
+			nonMatch: getString(item, "nonMatch"),
+			re:       regexp.MustCompile(pattern),
+		})
+	}
+
+	for _, c := range cases {
+		c := c
+		for _, match := range []bool{true, false} {
+			unit := c.nonMatch
+			matchLabel := "noMatch"
+			if match {
+				unit = c.match
+				matchLabel = "match"
+			}
+			for _, size := range sizes {
+				text := generatedRealWorldInput(unit, size, alphabet, seed)
+				name := fmt.Sprintf(
+					"RealWorldRegexBenchmark.runBenchmark.%s.%s.%d",
+					c.name, matchLabel, size)
+				if !matchesFilter(name, filters) {
+					continue
+				}
+				if c.op == "find" {
+					printJSON(measureNs(name, func() {
+						sink = c.re.FindStringIndex(text) != nil
+					}))
+				} else {
+					printJSON(measureNs(name, func() {
+						sink = c.re.ReplaceAllString(text, "")
+					}))
+				}
+			}
+		}
 	}
 }
 
@@ -879,6 +974,7 @@ func main() {
 
 	runRegexBenchmarks(data, filters)
 	runApplicationBenchmarks(data, filters)
+	runRealWorldRegexBenchmarks(data, filters)
 	runCompileBenchmarks(data, filters)
 	runSearchScalingBenchmarks(data, filters)
 	runIssue481ScalingBenchmarks(data, filters)

--- a/safere-benchmarks/scripts/compare-benchmarks.py
+++ b/safere-benchmarks/scripts/compare-benchmarks.py
@@ -32,6 +32,8 @@ JSON-lines format (one object per line):
 JMH text format (whitespace-separated):
   Benchmark                          Mode  Cnt   Score   Error  Units
   RegexBenchmark.literalMatch_jdk    avgt    5  23.456 ± 1.234  ns/op
+  Benchmark                          (engine)  (inputSize)  Mode  Cnt  Score  Error  Units
+  RealWorldRegexBenchmark.runBenchmark SafeRE  1000         avgt    5  23.456 ± 1.234 us/op
 """
 
 import argparse
@@ -58,6 +60,13 @@ _DEFAULT_ENGINE = "safere"
 _ENGINE_ALIASES = {
     "go_regexp": "go",
 }
+_JMH_ENGINE_PARAMS = {
+    "SafeRE": "safere",
+    "JDK": "jdk",
+    "RE2J": "re2j",
+    "RE2_FFM": "re2_ffm",
+}
+_JMH_MODES = {"avgt", "thrpt", "sample", "ss", "all"}
 
 
 def _engine_from_method(method):
@@ -94,11 +103,111 @@ _JMH_LINE_RE = re.compile(
 )
 
 
+def _parse_jmh_header(line):
+    parts = line.split()
+    if not parts or parts[0] != "Benchmark" or "Mode" not in parts:
+        return None
+    mode_index = parts.index("Mode")
+    return [part[1:-1] for part in parts[1:mode_index]
+            if part.startswith("(") and part.endswith(")")]
+
+
+def _parse_jmh_parameterized_line(line, param_names):
+    if not param_names:
+        return None
+    parts = line.split()
+    if not parts or parts[0] == "Benchmark":
+        return None
+    try:
+        mode_index = next(i for i, part in enumerate(parts[1:], 1) if part in _JMH_MODES)
+    except StopIteration:
+        return None
+    if mode_index != 1 + len(param_names):
+        return None
+
+    full_name = parts[0]
+    params = dict(zip(param_names, parts[1:mode_index]))
+    mode = parts[mode_index]
+    del mode
+
+    value_index = mode_index + 1
+    if value_index < len(parts) and parts[value_index].isdigit():
+        value_index += 1
+    if value_index >= len(parts):
+        return None
+    try:
+        score = float(parts[value_index])
+    except ValueError:
+        return None
+    value_index += 1
+
+    error = 0.0
+    if value_index < len(parts) and parts[value_index] == "±":
+        value_index += 1
+        if value_index >= len(parts):
+            return None
+        try:
+            error = float(parts[value_index])
+        except ValueError:
+            return None
+        value_index += 1
+
+    if value_index >= len(parts):
+        return None
+    unit = parts[value_index]
+
+    dot = full_name.rfind(".")
+    if dot == -1:
+        return None
+    class_name = full_name[: dot]
+    method = full_name[dot + 1 :]
+
+    engine, base_method = _engine_from_method(method)
+    if "engine" in params and params["engine"] != "N/A":
+        engine = _JMH_ENGINE_PARAMS.get(params["engine"], params["engine"].lower())
+
+    benchmark = _parameterized_benchmark_name(class_name, base_method, params, param_names)
+    return Result(engine=engine, benchmark=benchmark, score=score, error=error, unit=unit)
+
+
+def _parameterized_benchmark_name(class_name, method, params, param_names):
+    active_params = {
+        name: params[name] for name in param_names
+        if name != "engine" and params.get(name) != "N/A"
+    }
+    if (
+        class_name.endswith("RealWorldRegexBenchmark")
+        and method == "runBenchmark"
+        and active_params
+    ):
+        match_label = "match" if params.get("match") == "true" else "noMatch"
+        return (
+            f"{class_name}.{method}.{params['patternName']}."
+            f"{match_label}.{params['inputSize']}"
+        )
+
+    suffixes = [active_params[name] for name in param_names if name in active_params]
+    if suffixes:
+        return f"{class_name}.{method}." + ".".join(suffixes)
+    return f"{class_name}.{method}" if class_name else method
+
+
 def parse_jmh(path):
     """Parse a JMH text-output file and return a list of ``Result`` objects."""
     results = []
+    param_names = []
     with open(path) as fh:
         for line in fh:
+            parsed_header = _parse_jmh_header(line)
+            if parsed_header is not None:
+                param_names = parsed_header
+                continue
+
+            parameterized_result = _parse_jmh_parameterized_line(line, param_names)
+            if parameterized_result is not None:
+                results.append(parameterized_result)
+                continue
+
             m = _JMH_LINE_RE.match(line)
             if not m:
                 continue

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -117,4 +117,18 @@ public final class BenchmarkData {
     }
     return Collections.unmodifiableMap(cases);
   }
+
+  /** Returns real-world regex benchmark cases in JSON order, keyed by case name. */
+  public Map<String, RealWorldRegexCase> getRealWorldRegexCases() {
+    JsonArray arr = root.getAsJsonObject("realWorldRegex").getAsJsonArray("cases");
+    Map<String, RealWorldRegexCase> cases = new LinkedHashMap<>();
+    for (JsonElement item : arr) {
+      RealWorldRegexCase regexCase = RealWorldRegexCase.fromJson(item.getAsJsonObject());
+      if (cases.put(regexCase.name, regexCase) != null) {
+        throw new IllegalArgumentException(
+            "Duplicate real-world regex benchmark case: " + regexCase.name);
+      }
+    }
+    return Collections.unmodifiableMap(cases);
+  }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -1,0 +1,237 @@
+package org.safere.benchmark;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Comparative performance benchmark for regular expression engines using real-world regex patterns.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class RealWorldRegexBenchmark {
+
+  /** Regex operation types to benchmark. */
+  public enum Operation {
+    FIND,
+    REPLACE_ALL_EMPTY
+  }
+
+  /** Functional interface for regex search operation. */
+  @FunctionalInterface
+  public interface RegexFind {
+    boolean find(String input);
+  }
+
+  /** Functional interface for regex replace operation. */
+  @FunctionalInterface
+  public interface RegexReplaceAll {
+    String replaceAll(String input, String replacement);
+  }
+
+  /** Container wrapping pattern instances and operations for a specific regex engine. */
+  public record RegexEngine(Object pattern, RegexFind finder, RegexReplaceAll replacer)
+      implements AutoCloseable {
+
+    @Override
+    public void close() throws Exception {
+      if (pattern instanceof AutoCloseable closeable) {
+        closeable.close();
+      }
+    }
+  }
+
+  /** Unified benchmark operation resolved during setup. */
+  @FunctionalInterface
+  public interface BenchmarkOperation {
+    /** Executes the pre-configured operation. */
+    Object execute(String input);
+  }
+
+  /** Engine types available for benchmarking. */
+  public enum EngineType {
+    SafeRE {
+      @Override
+      public RegexEngine compile(String patternStr) {
+        org.safere.Pattern p = org.safere.Pattern.compile(patternStr);
+        return new RegexEngine(
+            p,
+            input -> p.matcher(input).find(),
+            (input, replacement) -> p.matcher(input).replaceAll(replacement));
+      }
+    },
+    JDK {
+      @Override
+      public RegexEngine compile(String patternStr) {
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile(patternStr);
+        return new RegexEngine(
+            p,
+            input -> p.matcher(input).find(),
+            (input, replacement) -> p.matcher(input).replaceAll(replacement));
+      }
+    },
+    RE2J {
+      @Override
+      public RegexEngine compile(String patternStr) {
+        com.google.re2j.Pattern p = com.google.re2j.Pattern.compile(patternStr);
+        return new RegexEngine(
+            p,
+            input -> p.matcher(input).find(),
+            (input, replacement) -> p.matcher(input).replaceAll(replacement));
+      }
+    },
+    RE2_FFM {
+      @Override
+      public RegexEngine compile(String patternStr) {
+        org.safere.re2ffm.RE2FfmPattern p = org.safere.re2ffm.RE2FfmPattern.compile(patternStr);
+        return new RegexEngine(
+            p,
+            input -> p.matcher(input).find(),
+            (input, replacement) -> p.matcher(input).replaceAll(replacement));
+      }
+    };
+
+    public abstract RegexEngine compile(String patternStr);
+  }
+
+  /** Pattern types to benchmark. */
+  public enum PatternType {
+    MAP_FIELD_PATH(
+        "([\\S]+)\\b\\[(.+)\\]",
+        Operation.FIND,
+        "config.overrides[some_value]",
+        "config.overrides"),
+    MARKUP_IMAGE_LINK(
+        "<<!(image|media|link)(\\([^\\)]*\\))?/?>?>",
+        Operation.REPLACE_ALL_EMPTY,
+        "<<!image(src=\"http://image.png\")>>",
+        "<<!image"),
+    VERSION_LIST(
+        " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
+        Operation.REPLACE_ALL_EMPTY,
+        "[1.2.3, 4.5.6]",
+        "[1.2.3,"),
+    MALFORMED_ENTITY(
+        "<[^>]*entity[^>]*>{1,2}",
+        Operation.REPLACE_ALL_EMPTY,
+        "<entity id=\"123\">",
+        "<ent id=\"123\">"),
+    MARKUP_ENTITY(
+        "<<!entity.*?>>", Operation.FIND, "<<!entity(id=\"123\")>>", "<<entity(id=\"123\")"),
+    CUSTOM_PROTOCOL_LINK(
+        "\\[(.*?)]\\(customProtocol://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)",
+        Operation.FIND,
+        "[Click here](customProtocol://<doc_1>)",
+        "[Click here](http://google.com)"),
+    WILDCARD_SEARCH(
+        "(?is).*\\b(you|your)\\b.*",
+        Operation.FIND,
+        "What can I do for you today?",
+        "What is the capital of France?"),
+    METADATA_BLOCK(
+        "(?s)<meta_start>.*?<meta_end>",
+        Operation.REPLACE_ALL_EMPTY,
+        "<meta_start>Thinking process: analyzing query...<meta_end>",
+        "<meta_start>Thinking process: analyzing query..."),
+    BLOCKED_TAGS_1(
+        "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```",
+        Operation.REPLACE_ALL_EMPTY,
+        "```code_block\n# tags_identified: shopping\n```",
+        "```code_block\n# tags: shopping\n```"),
+    BLOCKED_TAGS_2(
+        "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>",
+        Operation.REPLACE_ALL_EMPTY,
+        "<container>\n# topic_identified: sports\n</container>",
+        "<container>\n# topic: sports\n</container>");
+
+    // The regular expression pattern string
+    private final String patternStr;
+    // The operation type (FIND or REPLACE_ALL_EMPTY)
+    private final Operation operation;
+    // The sample text segment that matches the pattern
+    private final String matchPart;
+    // The sample text segment that does not match the pattern
+    private final String nonMatchPart;
+
+    PatternType(String patternStr, Operation operation, String matchPart, String nonMatchPart) {
+      this.patternStr = patternStr;
+      this.operation = operation;
+      this.matchPart = matchPart;
+      this.nonMatchPart = nonMatchPart;
+    }
+  }
+
+  @Param public EngineType engine;
+  @Param public PatternType patternType;
+
+  @Param({"1000", "10000"})
+  public int inputSize;
+
+  @Param({"true", "false"})
+  public boolean match;
+
+  private RegexEngine regexEngine;
+  private BenchmarkOperation benchmarkOp;
+  private String testInput;
+
+  @Setup
+  public void setup() {
+    regexEngine = engine.compile(patternType.patternStr);
+
+    benchmarkOp =
+        switch (patternType.operation) {
+          case FIND -> input -> regexEngine.finder().find(input);
+          case REPLACE_ALL_EMPTY -> input -> regexEngine.replacer().replaceAll(input, "");
+        };
+
+    String template = match ? patternType.matchPart : patternType.nonMatchPart;
+    testInput = generateInput(template, inputSize);
+  }
+
+  @TearDown
+  public void tearDown() throws Exception {
+    regexEngine.close();
+  }
+
+  // Safe characters used to pad test inputs. Excludes vowels to avoid forming accidental
+  // matches (e.g. "you" or "your" in WILDCARD_SEARCH) and special regex syntax characters
+  // (e.g. "<", ">", "[", "]", etc.) to avoid corrupting the structure of templates.
+  private static final String SAFE_DELIMITER_ALPHABET =
+      "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789";
+
+  private String generateInput(String template, int size) {
+    if (template.length() >= size) {
+      return template.substring(0, size);
+    }
+    StringBuilder sb = new StringBuilder(size);
+    Random rand = new Random(42); // Fixed seed for reproducibility
+    while (sb.length() < size) {
+      sb.append(template);
+      if (sb.length() < size) {
+        sb.append(SAFE_DELIMITER_ALPHABET.charAt(rand.nextInt(SAFE_DELIMITER_ALPHABET.length())));
+      }
+    }
+    return sb.substring(0, size);
+  }
+
+  @Benchmark
+  public void runBenchmark(Blackhole bh) {
+    bh.consume(benchmarkOp.execute(testInput));
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -179,7 +179,15 @@ public class RealWorldRegexBenchmark {
         "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)",
         Operation.REPLACE_ALL_EMPTY,
         "first name value",
-        "first name other_value");
+        "first name other_value"),
+    /**
+     * Template tag matching with a trailing boundary (exercises BitState EmptyOp specialization)
+     */
+    TEMPLATE_TAG_MATCH(
+        "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)",
+        Operation.REPLACE_ALL_EMPTY,
+        "<template name>content to match</template>",
+        "plain text without template tag");
 
     // The regular expression pattern string
     private final String patternStr;

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -1,11 +1,14 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
 package org.safere.benchmark;
 
-import java.util.Random;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -13,25 +16,13 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-/**
- * Comparative performance benchmark for regular expression engines using real-world regex patterns.
- */
+/** Comparative performance benchmark for regex engines using real-world regex patterns. */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class RealWorldRegexBenchmark {
-
-  /** Regex operation types to benchmark. */
-  public enum Operation {
-    FIND,
-    REPLACE_ALL_EMPTY
-  }
 
   /** Functional interface for regex search operation. */
   @FunctionalInterface
@@ -110,104 +101,25 @@ public class RealWorldRegexBenchmark {
     public abstract RegexEngine compile(String patternStr);
   }
 
-  /** Pattern types to benchmark. */
-  public enum PatternType {
-    MAP_FIELD_PATH(
-        "([\\S]+)\\b\\[(.+)\\]",
-        Operation.FIND,
-        "config.overrides[some_value]",
-        "config.overrides"),
-    MARKUP_IMAGE_LINK(
-        "<<!(image|media|link)(\\([^\\)]*\\))?/?>?>",
-        Operation.REPLACE_ALL_EMPTY,
-        "<<!image(src=\"http://image.png\")>>",
-        "<<!image"),
-    VERSION_LIST(
-        " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
-        Operation.REPLACE_ALL_EMPTY,
-        "[1.2.3, 4.5.6]",
-        "[1.2.3,"),
-    MALFORMED_ENTITY(
-        "<[^>]*entity[^>]*>{1,2}",
-        Operation.REPLACE_ALL_EMPTY,
-        "<entity id=\"123\">",
-        "<ent id=\"123\">"),
-    MARKUP_ENTITY(
-        "<<!entity.*?>>", Operation.FIND, "<<!entity(id=\"123\")>>", "<<entity(id=\"123\")"),
-    CUSTOM_PROTOCOL_LINK(
-        "\\[(.*?)]\\(customProtocol://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)",
-        Operation.FIND,
-        "[Click here](customProtocol://<doc_1>)",
-        "[Click here](http://google.com)"),
-    WILDCARD_SEARCH(
-        "(?is).*\\b(you|your)\\b.*",
-        Operation.FIND,
-        "What can I do for you today?",
-        "What is the capital of France?"),
-    METADATA_BLOCK(
-        "(?s)<meta_start>.*?<meta_end>",
-        Operation.REPLACE_ALL_EMPTY,
-        "<meta_start>Thinking process: analyzing query...<meta_end>",
-        "<meta_start>Thinking process: analyzing query..."),
-    BLOCKED_TAGS_1(
-        "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```",
-        Operation.REPLACE_ALL_EMPTY,
-        "```code_block\n# tags_identified: shopping\n```",
-        "```code_block\n# tags: shopping\n```"),
-    BLOCKED_TAGS_2(
-        "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>",
-        Operation.REPLACE_ALL_EMPTY,
-        "<container>\n# topic_identified: sports\n</container>",
-        "<container>\n# topic: sports\n</container>"),
-    /** URL detection with overlapping alternation prefixes (triggers DFA sandwich) */
-    OVERLAPPING_URL(
-        "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
-        Operation.REPLACE_ALL_EMPTY,
-        "https://www.example.com/search?q=testing&hl=en",
-        "some-random-domain-name"),
-    /** Case-insensitive keyword matching (exercises compile-time case folding) */
-    CASE_INSENSITIVE_KEYWORD(
-        "(?i)keyword_to_find",
-        Operation.REPLACE_ALL_EMPTY,
-        "KEYWORD_TO_FIND",
-        "other_random_words"),
-    /**
-     * Pattern starting with a word boundary and having a suffix alternation (exercises
-     * leftmost-first reverse DFA correctness)
-     */
-    BOUNDED_NAME_MATCH(
-        "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)",
-        Operation.REPLACE_ALL_EMPTY,
-        "first name value",
-        "first name other_value"),
-    /**
-     * Template tag matching with a trailing boundary (exercises BitState EmptyOp specialization)
-     */
-    TEMPLATE_TAG_MATCH(
-        "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)",
-        Operation.REPLACE_ALL_EMPTY,
-        "<template name>content to match</template>",
-        "plain text without template tag");
-
-    // The regular expression pattern string
-    private final String patternStr;
-    // The operation type (FIND or REPLACE_ALL_EMPTY)
-    private final Operation operation;
-    // The sample text segment that matches the pattern
-    private final String matchPart;
-    // The sample text segment that does not match the pattern
-    private final String nonMatchPart;
-
-    PatternType(String patternStr, Operation operation, String matchPart, String nonMatchPart) {
-      this.patternStr = patternStr;
-      this.operation = operation;
-      this.matchPart = matchPart;
-      this.nonMatchPart = nonMatchPart;
-    }
-  }
-
   @Param public EngineType engine;
-  @Param public PatternType patternType;
+
+  @Param({
+    "mapFieldPath",
+    "markupImageLink",
+    "versionList",
+    "malformedEntity",
+    "markupEntity",
+    "customProtocolLink",
+    "wildcardSearch",
+    "metadataBlock",
+    "blockedTags1",
+    "blockedTags2",
+    "overlappingUrl",
+    "caseInsensitiveKeyword",
+    "boundedNameMatch",
+    "templateTagMatch"
+  })
+  public String patternName;
 
   @Param({"1000", "10000"})
   public int inputSize;
@@ -221,16 +133,28 @@ public class RealWorldRegexBenchmark {
 
   @Setup
   public void setup() {
-    regexEngine = engine.compile(patternType.patternStr);
+    BenchmarkData data = BenchmarkData.get();
+    Map<String, RealWorldRegexCase> cases = data.getRealWorldRegexCases();
+    RealWorldRegexCase regexCase = cases.get(patternName);
+    if (regexCase == null) {
+      throw new IllegalArgumentException("Unknown real-world regex benchmark case: " + patternName);
+    }
+
+    regexEngine = engine.compile(regexCase.pattern);
 
     benchmarkOp =
-        switch (patternType.operation) {
-          case FIND -> input -> regexEngine.finder().find(input);
-          case REPLACE_ALL_EMPTY -> input -> regexEngine.replacer().replaceAll(input, "");
+        switch (regexCase.op) {
+          case "find" -> input -> regexEngine.finder().find(input);
+          case "replaceAllEmpty" -> input -> regexEngine.replacer().replaceAll(input, "");
+          default ->
+              throw new IllegalArgumentException(
+                  "Unknown real-world regex benchmark op: " + regexCase.op);
         };
 
-    String template = match ? patternType.matchPart : patternType.nonMatchPart;
-    testInput = generateInput(template, inputSize);
+    String template = match ? regexCase.match : regexCase.nonMatch;
+    String alphabet = data.getString("realWorldRegex.safeDelimiterAlphabet");
+    int seed = data.getInt("realWorldRegex.seed");
+    testInput = generateInput(template, inputSize, alphabet, seed);
   }
 
   @TearDown
@@ -238,22 +162,17 @@ public class RealWorldRegexBenchmark {
     regexEngine.close();
   }
 
-  // Safe characters used to pad test inputs. Excludes vowels to avoid forming accidental
-  // matches (e.g. "you" or "your" in WILDCARD_SEARCH) and special regex syntax characters
-  // (e.g. "<", ">", "[", "]", etc.) to avoid corrupting the structure of templates.
-  private static final String SAFE_DELIMITER_ALPHABET =
-      "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789";
-
-  private String generateInput(String template, int size) {
+  private String generateInput(String template, int size, String alphabet, int seed) {
     if (template.length() >= size) {
       return template.substring(0, size);
     }
     StringBuilder sb = new StringBuilder(size);
-    Random rand = new Random(42); // Fixed seed for reproducibility
+    int delimiterIndex = seed;
     while (sb.length() < size) {
       sb.append(template);
       if (sb.length() < size) {
-        sb.append(SAFE_DELIMITER_ALPHABET.charAt(rand.nextInt(SAFE_DELIMITER_ALPHABET.length())));
+        sb.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
+        delimiterIndex++;
       }
     }
     return sb.substring(0, size);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -158,7 +158,28 @@ public class RealWorldRegexBenchmark {
         "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>",
         Operation.REPLACE_ALL_EMPTY,
         "<container>\n# topic_identified: sports\n</container>",
-        "<container>\n# topic: sports\n</container>");
+        "<container>\n# topic: sports\n</container>"),
+    /** URL detection with overlapping alternation prefixes (triggers DFA sandwich) */
+    OVERLAPPING_URL(
+        "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
+        Operation.REPLACE_ALL_EMPTY,
+        "https://www.example.com/search?q=testing&hl=en",
+        "some-random-domain-name"),
+    /** Case-insensitive keyword matching (exercises compile-time case folding) */
+    CASE_INSENSITIVE_KEYWORD(
+        "(?i)keyword_to_find",
+        Operation.REPLACE_ALL_EMPTY,
+        "KEYWORD_TO_FIND",
+        "other_random_words"),
+    /**
+     * Pattern starting with a word boundary and having a suffix alternation (exercises
+     * leftmost-first reverse DFA correctness)
+     */
+    BOUNDED_NAME_MATCH(
+        "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)",
+        Operation.REPLACE_ALL_EMPTY,
+        "first name value",
+        "first name other_value");
 
     // The regular expression pattern string
     private final String patternStr;

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
@@ -1,0 +1,46 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.JsonObject;
+
+/** One data-driven real-world regex benchmark case from {@code benchmark-data.json}. */
+final class RealWorldRegexCase {
+
+  final String name;
+  final String op;
+  final String pattern;
+  final String match;
+  final String nonMatch;
+
+  private RealWorldRegexCase(
+      String name, String op, String pattern, String match, String nonMatch) {
+    this.name = name;
+    this.op = op;
+    this.pattern = pattern;
+    this.match = match;
+    this.nonMatch = nonMatch;
+  }
+
+  static RealWorldRegexCase fromJson(JsonObject obj) {
+    String name = requireString(obj, "name");
+    String op = requireString(obj, "op");
+    String pattern = requireString(obj, "pattern");
+    String match = requireString(obj, "match");
+    String nonMatch = requireString(obj, "nonMatch");
+    if (!"find".equals(op) && !"replaceAllEmpty".equals(op)) {
+      throw new IllegalArgumentException("Unknown real-world regex benchmark op: " + op);
+    }
+    return new RealWorldRegexCase(name, op, pattern, match, nonMatch);
+  }
+
+  private static String requireString(JsonObject obj, String field) {
+    if (!obj.has(field) || obj.get(field).isJsonNull()) {
+      throw new IllegalArgumentException("Real-world regex case requires " + field);
+    }
+    return obj.get(field).getAsString();
+  }
+}


### PR DESCRIPTION
Introduce `RealWorldRegexBenchmark` to compare matching and replacement performance of `SafeRE`, `JDK` (`java.util.regex`), `RE2J`, and native `RE2_FFM` on representative regex patterns and input sizes.

The benchmark defines 10 common real-world regex patterns (e.g. map field path lookups, markup entity replacements, wildcards, metadata blocks, tags) and tests them on both matching and non-matching inputs scaling from 1,000 to 10,000 characters.