### PR TITLE
Optimize DFA cache lookups to be allocation-free on cache hits

### DIFF
--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -110,9 +110,26 @@ final class Dfa {
   }
 
   /** Cache key for state deduplication. */
-  // TODO(#98): Replace int[] with Guava ImmutableIntArray to get proper value semantics.
-  @SuppressWarnings("ArrayRecordComponent")
-  private record StateKey(int[] insts, int flags) {
+  private static final class StateKey {
+    private int[] insts;
+    private int flags;
+
+    StateKey() {}
+
+    StateKey(int[] insts, int flags) {
+      this.insts = insts;
+      this.flags = flags;
+    }
+
+    void reset(int[] insts, int flags) {
+      this.insts = insts;
+      this.flags = flags;
+    }
+
+    StateKey copy() {
+      return new StateKey(insts, flags);
+    }
+
     @Override
     public int hashCode() {
       return Arrays.hashCode(insts) * 31 + flags;
@@ -154,6 +171,9 @@ final class Dfa {
 
   /** State cache: maps instruction-set + flags to canonical State instance. */
   private final Map<StateKey, State> cache = new HashMap<>();
+
+  /** Pre-allocated mutable key to perform allocation-free cache lookups. */
+  private final StateKey lookupKey = new StateKey();
 
   /** Sentinel dead state: no instructions, no transitions possible. */
   private final State deadState = new State(new int[0], 0, 0);
@@ -590,8 +610,8 @@ final class Dfa {
     if (insts.length == 0 && (flags & FLAG_MATCH) == 0) {
       return deadState;
     }
-    StateKey key = new StateKey(insts, flags);
-    State s = cache.get(key);
+    lookupKey.reset(insts, flags);
+    State s = cache.get(lookupKey);
     if (s != null) {
       return s;
     }
@@ -599,7 +619,7 @@ final class Dfa {
       return null;
     }
     s = new State(insts, flags, wordBoundaryMatchIds, numClasses);
-    cache.put(key, s);
+    cache.put(lookupKey.copy(), s);
     return s;
   }
 


### PR DESCRIPTION
This PR optimizes the DFA state transition caching logic to avoid object allocations during cache hits. 

This doesn't improve benchmark performance after warmup, the hope is that it might improve performance while the DFA is warming up, and it also reduces allocations.

---

Previously, `Dfa.getOrCreate()` allocated a new `StateKey` record on every transition lookup. In hot matching loops where transition lookups frequently hit the cache, this generated substantial GC allocation pressure.

This change:
1. Converts the internal `StateKey` from a record to a mutable class with `reset()` and `copy()` methods.
2. Adds a private instance-local `lookupKey` to the `Dfa` class.
3. Rewrites `getOrCreate()` to reuse `lookupKey.reset(insts, flags)` for the cache query. We only allocate a persistent `StateKey` object on a cache miss by calling `lookupKey.copy()`.

Because `Dfa` instances are cached inside a `ThreadLocal` wrapper, reusing an instance-level key is completely thread-safe and requires no synchronization.