### PR TITLE
Implement Vector SIMD scanning and required literal precheck for unanchored matches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
   <modules>
     <module>safere-unicode</module>
     <module>safere</module>
+    <module>safere-vector</module>
     <module>safere-crosscheck</module>
     <module>safere-fuzz</module>
     <module>safere-exhaustive</module>

--- a/safere-vector/pom.xml
+++ b/safere-vector/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.safere</groupId>
+    <artifactId>safere-parent</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>safere-vector</artifactId>
+  <packaging>jar</packaging>
+
+  <name>SafeRE Vector Acceleration</name>
+  <description>Vector SIMD scan implementation using Java Vector API</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.safere</groupId>
+      <artifactId>safere</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>26</release>
+          <compilerArgs>
+            <arg>-Xlint</arg>
+            <arg>--enable-preview</arg>
+            <arg>--add-modules</arg>
+            <arg>jdk.incubator.vector</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/safere-vector/pom.xml
+++ b/safere-vector/pom.xml
@@ -32,7 +32,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <release>26</release>
+          <release>${java.specification.version}</release>
           <compilerArgs>
             <arg>-Xlint</arg>
             <arg>--enable-preview</arg>

--- a/safere-vector/src/main/java/org/safere/vector/VectorScannerImpl.java
+++ b/safere-vector/src/main/java/org/safere/vector/VectorScannerImpl.java
@@ -14,9 +14,7 @@ import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorSpecies;
 
-/**
- * Implementation of VectorScannerBridge using the Java Vector API.
- */
+/** Implementation of VectorScannerBridge using the Java Vector API. */
 public final class VectorScannerImpl implements VectorScannerBridge {
   private static final VectorSpecies<Short> SHORT_SPECIES = ShortVector.SPECIES_PREFERRED;
   private static final VectorSpecies<Byte> BYTE_SPECIES = ByteVector.SPECIES_PREFERRED;
@@ -28,7 +26,8 @@ public final class VectorScannerImpl implements VectorScannerBridge {
     VarHandle valHandle = null;
     VarHandle codHandle = null;
     try {
-      MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(String.class, MethodHandles.lookup());
+      MethodHandles.Lookup lookup =
+          MethodHandles.privateLookupIn(String.class, MethodHandles.lookup());
       valHandle = lookup.findVarHandle(String.class, "value", byte[].class);
       codHandle = lookup.findVarHandle(String.class, "coder", byte.class);
     } catch (Throwable t) {
@@ -50,7 +49,9 @@ public final class VectorScannerImpl implements VectorScannerBridge {
     int i = fromIndex;
     for (; i < limit; i += SHORT_SPECIES.length()) {
       long byteOffset = (long) i * 2;
-      ShortVector v = ShortVector.fromMemorySegment(SHORT_SPECIES, segment, byteOffset, ByteOrder.nativeOrder());
+      ShortVector v =
+          ShortVector.fromMemorySegment(
+              SHORT_SPECIES, segment, byteOffset, ByteOrder.nativeOrder());
       VectorMask<Short> mask = v.eq(targetShort);
       if (mask.anyTrue()) {
         return i + mask.firstTrue();
@@ -90,7 +91,8 @@ public final class VectorScannerImpl implements VectorScannerBridge {
 
       int i = fromIndex;
       for (; i < limit; i += BYTE_SPECIES.length()) {
-        ByteVector v = ByteVector.fromMemorySegment(BYTE_SPECIES, segment, (long) i, ByteOrder.nativeOrder());
+        ByteVector v =
+            ByteVector.fromMemorySegment(BYTE_SPECIES, segment, (long) i, ByteOrder.nativeOrder());
         VectorMask<Byte> mask = v.eq(targetByte);
         if (mask.anyTrue()) {
           return i + mask.firstTrue();
@@ -110,7 +112,9 @@ public final class VectorScannerImpl implements VectorScannerBridge {
       int i = fromIndex;
       for (; i < limit; i += SHORT_SPECIES.length()) {
         long byteOffset = (long) i * 2;
-        ShortVector v = ShortVector.fromMemorySegment(SHORT_SPECIES, segment, byteOffset, ByteOrder.nativeOrder());
+        ShortVector v =
+            ShortVector.fromMemorySegment(
+                SHORT_SPECIES, segment, byteOffset, ByteOrder.nativeOrder());
         VectorMask<Short> mask = v.eq(targetShort);
         if (mask.anyTrue()) {
           return i + mask.firstTrue();

--- a/safere-vector/src/main/java/org/safere/vector/VectorScannerImpl.java
+++ b/safere-vector/src/main/java/org/safere/vector/VectorScannerImpl.java
@@ -1,0 +1,134 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.vector;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * Implementation of VectorScannerBridge using the Java Vector API.
+ */
+public final class VectorScannerImpl implements VectorScannerBridge {
+  private static final VectorSpecies<Short> SHORT_SPECIES = ShortVector.SPECIES_PREFERRED;
+  private static final VectorSpecies<Byte> BYTE_SPECIES = ByteVector.SPECIES_PREFERRED;
+
+  private static final VarHandle VALUE_HANDLE;
+  private static final VarHandle CODER_HANDLE;
+
+  static {
+    VarHandle valHandle = null;
+    VarHandle codHandle = null;
+    try {
+      MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(String.class, MethodHandles.lookup());
+      valHandle = lookup.findVarHandle(String.class, "value", byte[].class);
+      codHandle = lookup.findVarHandle(String.class, "coder", byte.class);
+    } catch (Throwable t) {
+      valHandle = null;
+      codHandle = null;
+    }
+    VALUE_HANDLE = valHandle;
+    CODER_HANDLE = codHandle;
+  }
+
+  @Override
+  public int scan(char[] array, char target, int fromIndex, int toIndex) {
+    int length = toIndex;
+    int limit = fromIndex + SHORT_SPECIES.loopBound(length - fromIndex);
+    short targetShort = (short) target;
+
+    MemorySegment segment = MemorySegment.ofArray(array);
+
+    int i = fromIndex;
+    for (; i < limit; i += SHORT_SPECIES.length()) {
+      long byteOffset = (long) i * 2;
+      ShortVector v = ShortVector.fromMemorySegment(SHORT_SPECIES, segment, byteOffset, ByteOrder.nativeOrder());
+      VectorMask<Short> mask = v.eq(targetShort);
+      if (mask.anyTrue()) {
+        return i + mask.firstTrue();
+      }
+    }
+    // Clean up tail
+    for (; i < length; i++) {
+      if (array[i] == target) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  public int scanString(String text, char target, int fromIndex, int toIndex) {
+    if (VALUE_HANDLE == null || CODER_HANDLE == null) {
+      return -2; // Not supported
+    }
+
+    byte[] value;
+    byte coder;
+    try {
+      value = (byte[]) VALUE_HANDLE.get(text);
+      coder = (byte) CODER_HANDLE.get(text);
+    } catch (Throwable t) {
+      return -2; // Fallback
+    }
+
+    if (coder == 0) { // Latin-1
+      if (target >= 256) {
+        return -1; // Latin-1 string can never match a non-Latin-1 character
+      }
+      byte targetByte = (byte) target;
+      int limit = fromIndex + BYTE_SPECIES.loopBound(toIndex - fromIndex);
+      MemorySegment segment = MemorySegment.ofArray(value);
+
+      int i = fromIndex;
+      for (; i < limit; i += BYTE_SPECIES.length()) {
+        ByteVector v = ByteVector.fromMemorySegment(BYTE_SPECIES, segment, (long) i, ByteOrder.nativeOrder());
+        VectorMask<Byte> mask = v.eq(targetByte);
+        if (mask.anyTrue()) {
+          return i + mask.firstTrue();
+        }
+      }
+      for (; i < toIndex; i++) {
+        if (value[i] == targetByte) {
+          return i;
+        }
+      }
+      return -1;
+    } else { // UTF-16
+      short targetShort = (short) target;
+      int limit = fromIndex + SHORT_SPECIES.loopBound(toIndex - fromIndex);
+      MemorySegment segment = MemorySegment.ofArray(value);
+
+      int i = fromIndex;
+      for (; i < limit; i += SHORT_SPECIES.length()) {
+        long byteOffset = (long) i * 2;
+        ShortVector v = ShortVector.fromMemorySegment(SHORT_SPECIES, segment, byteOffset, ByteOrder.nativeOrder());
+        VectorMask<Short> mask = v.eq(targetShort);
+        if (mask.anyTrue()) {
+          return i + mask.firstTrue();
+        }
+      }
+      for (; i < toIndex; i++) {
+        int byteOffset = i * 2;
+        char ch;
+        if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
+          ch = (char) ((value[byteOffset] & 0xFF) | ((value[byteOffset + 1] & 0xFF) << 8));
+        } else {
+          ch = (char) (((value[byteOffset] & 0xFF) << 8) | (value[byteOffset + 1] & 0xFF));
+        }
+        if (ch == target) {
+          return i;
+        }
+      }
+      return -1;
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -67,8 +67,7 @@ public final class Matcher implements MatchResult {
       int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch)
       implements EngineResult {}
 
-  private static final VectorScannerBridge VECTOR_SCANNER =
-      VectorScannerLoader.getInstance();
+  private static final VectorScannerBridge VECTOR_SCANNER = VectorScannerLoader.getInstance();
 
   private enum ResultStatus {
     RESET_NO_ATTEMPT,
@@ -1251,7 +1250,9 @@ public final class Matcher implements MatchResult {
     }
 
     String requiredLiteral = parentPattern.requiredLiteral();
-    if (requiredLiteral != null && !regionActive && (parentPattern.flags() & Pattern.CASE_INSENSITIVE) == 0) {
+    if (requiredLiteral != null
+        && !regionActive
+        && (parentPattern.flags() & Pattern.CASE_INSENSITIVE) == 0) {
       if (text.indexOf(requiredLiteral, searchFrom) < 0) {
         return applyEngineResult(new NoMatchResult());
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -21,6 +21,8 @@ import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.safere.vector.VectorScannerBridge;
+import org.safere.vector.VectorScannerLoader;
 
 /**
  * An engine that performs match operations on a {@linkplain CharSequence character sequence} by
@@ -64,6 +66,9 @@ public final class Matcher implements MatchResult {
   private record DeferredMatchResult(
       int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch)
       implements EngineResult {}
+
+  private static final VectorScannerBridge VECTOR_SCANNER =
+      VectorScannerLoader.getInstance();
 
   private enum ResultStatus {
     RESET_NO_ATTEMPT,
@@ -127,6 +132,7 @@ public final class Matcher implements MatchResult {
 
   private boolean bitStateBorrowed;
   private int[] bitStateResult;
+  private char[] textChars;
 
   /**
    * Whether all capture groups have been resolved. When the DFA sandwich determines match
@@ -288,6 +294,13 @@ public final class Matcher implements MatchResult {
     eagerFallbackCaptures = false;
   }
 
+  private char[] textChars() {
+    if (textChars == null && text != null) {
+      textChars = text.toCharArray();
+    }
+    return textChars;
+  }
+
   private void resetStateForRegion(int start, int end) {
     regionStart = start;
     regionEnd = end;
@@ -316,6 +329,7 @@ public final class Matcher implements MatchResult {
     bitStateResult = null;
     graphemeContextText = null;
     graphemeContext = null;
+    textChars = null;
   }
 
   private void preserveResultAcrossBoundsChange() {
@@ -1236,6 +1250,13 @@ public final class Matcher implements MatchResult {
       return findKeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures());
     }
 
+    String requiredLiteral = parentPattern.requiredLiteral();
+    if (requiredLiteral != null && !regionActive && (parentPattern.flags() & Pattern.CASE_INSENSITIVE) == 0) {
+      if (text.indexOf(requiredLiteral, searchFrom) < 0) {
+        return applyEngineResult(new NoMatchResult());
+      }
+    }
+
     // Anchored start: if the pattern requires a match at the beginning of the text (e.g., ^
     // without MULTILINE, or \A), there can be no match starting after position 0 (or regionStart
     // when a region is active). Return false immediately to avoid the DFA matching at every
@@ -1310,7 +1331,7 @@ public final class Matcher implements MatchResult {
     // avoids running the full engine on text regions where no match can start.
     boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
     if (options.startAcceleration() && !prog.hasWordBoundary() && ccPrefixAscii != null) {
-      int idx = indexOfCharClass(text, ccPrefixAscii, searchFrom);
+      int idx = indexOfCharClass(ccPrefixAscii, searchFrom);
       if (idx < 0) {
         if (!prog.anchorStart()) {
         } else {
@@ -1724,7 +1745,39 @@ public final class Matcher implements MatchResult {
    * set in the ASCII bitmap. Returns the index, or {@code -1} if no matching character is found.
    * Non-ASCII characters are skipped (never match).
    */
-  private static int indexOfCharClass(String text, boolean[] asciiMap, int fromIndex) {
+  private int indexOfCharClass(boolean[] asciiMap, int fromIndex) {
+    int activeChar = -1;
+    for (int i = 0; i < asciiMap.length; i++) {
+      if (asciiMap[i]) {
+        if (activeChar != -1) {
+          activeChar = -2;
+          break;
+        }
+        activeChar = i;
+      }
+    }
+    if (activeChar >= 0) {
+      if (VECTOR_SCANNER != null) {
+        int index = VECTOR_SCANNER.scanString(text, (char) activeChar, fromIndex, text.length());
+        if (index >= -1) {
+          return index;
+        }
+        char[] chars = textChars();
+        if (chars != null) {
+          return VECTOR_SCANNER.scan(chars, (char) activeChar, fromIndex, text.length());
+        }
+      }
+      char[] chars = textChars();
+      if (chars != null) {
+        for (int i = fromIndex; i < text.length(); i++) {
+          if (chars[i] == activeChar) {
+            return i;
+          }
+        }
+        return -1;
+      }
+    }
+
     for (int i = fromIndex; i < text.length(); i++) {
       char ch = text.charAt(i);
       if (ch < 128 && asciiMap[ch]) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -115,6 +115,7 @@ public final class Pattern implements Serializable {
   private final transient boolean[] charClassPrefixAscii;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
+  private final transient String requiredLiteral;
   private final transient EnginePathOptions enginePathOptions;
 
   /**
@@ -235,6 +236,7 @@ public final class Pattern implements Serializable {
       boolean[] charClassPrefixAscii,
       StartAcceleration startAcceleration,
       KeywordAlternation keywordAlternation,
+      String requiredLiteral,
       int[] charClassMatchRanges,
       long charClassMatchBitmap0,
       long charClassMatchBitmap1,
@@ -246,6 +248,7 @@ public final class Pattern implements Serializable {
       long requiredMatchClassBitmap0,
       long requiredMatchClassBitmap1,
       EnginePathOptions enginePathOptions) {
+    this.requiredLiteral = requiredLiteral;
     this.pattern = pattern;
     this.flags = flags;
     this.prog = prog;
@@ -353,6 +356,7 @@ public final class Pattern implements Serializable {
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
     CharClassScanInfo requiredMatchClass = extractRequiredMatchClass(metadataAst);
+    String requiredLiteral = extractRequiredLiteral(re);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -375,6 +379,7 @@ public final class Pattern implements Serializable {
         ccPrefixAscii,
         startAcceleration,
         keywordAlternation,
+        requiredLiteral,
         ccMatch != null ? ccMatch.ranges : null,
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
@@ -891,6 +896,11 @@ public final class Pattern implements Serializable {
   /** Returns case-insensitive keyword-alternation fast-path data, or {@code null}. */
   KeywordAlternation keywordAlternation() {
     return keywordAlternation;
+  }
+
+  /** Returns a required literal substring that must be present in the text, or {@code null}. */
+  String requiredLiteral() {
+    return requiredLiteral;
   }
 
   /**
@@ -2303,6 +2313,69 @@ public final class Pattern implements Serializable {
       }
     }
     return null;
+  }
+
+  private static String extractRequiredLiteral(Regexp re) {
+    if (re == null) {
+      return null;
+    }
+    return switch (re.op) {
+      case LITERAL -> String.valueOf((char) re.rune);
+      case LITERAL_STRING -> {
+        if (re.runes != null) {
+          StringBuilder sb = new StringBuilder();
+          for (int r : re.runes) {
+            sb.appendCodePoint(r);
+          }
+          yield sb.toString();
+        }
+        yield null;
+      }
+      case CAPTURE -> extractRequiredLiteral(re.subs.get(0));
+      case CONCAT -> {
+        String longest = null;
+        for (Regexp child : re.subs) {
+          String req = extractRequiredLiteral(child);
+          if (req != null && (longest == null || req.length() > longest.length())) {
+            longest = req;
+          }
+        }
+        yield longest;
+      }
+      case ALTERNATE -> {
+        if (re.subs == null || re.subs.isEmpty()) {
+          yield null;
+        }
+        String first = extractRequiredLiteral(re.subs.get(0));
+        if (first == null || first.isEmpty()) {
+          yield null;
+        }
+        int commonPrefixLen = first.length();
+        for (int i = 1; i < re.subs.size(); i++) {
+          String other = extractRequiredLiteral(re.subs.get(i));
+          if (other == null) {
+            yield null;
+          }
+          int j = 0;
+          while (j < commonPrefixLen && j < other.length() && first.charAt(j) == other.charAt(j)) {
+            j++;
+          }
+          commonPrefixLen = j;
+          if (commonPrefixLen == 0) {
+            break;
+          }
+        }
+        yield commonPrefixLen > 0 ? first.substring(0, commonPrefixLen) : null;
+      }
+      case PLUS -> extractRequiredLiteral(re.subs.get(0));
+      case REPEAT -> {
+        if (re.min >= 1) {
+          yield extractRequiredLiteral(re.subs.get(0));
+        }
+        yield null;
+      }
+      default -> null;
+    };
   }
 
   private static CharClass requiredCharClass(Regexp re) {

--- a/safere/src/main/java/org/safere/vector/VectorScannerBridge.java
+++ b/safere/src/main/java/org/safere/vector/VectorScannerBridge.java
@@ -1,0 +1,24 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.vector;
+
+/**
+ * Interface for vector scanning implementations.
+ */
+public interface VectorScannerBridge {
+  /**
+   * Scans the array for the target character between fromIndex and toIndex.
+   * Returns the index of the first occurrence, or -1 if not found.
+   */
+  int scan(char[] array, char target, int fromIndex, int toIndex);
+
+  /**
+   * Scans the string directly using reflection-based backing array access if supported.
+   * Returns the index of the first occurrence, -1 if not found, or -2 if direct scanning
+   * is not supported or failed.
+   */
+  int scanString(String text, char target, int fromIndex, int toIndex);
+}

--- a/safere/src/main/java/org/safere/vector/VectorScannerBridge.java
+++ b/safere/src/main/java/org/safere/vector/VectorScannerBridge.java
@@ -5,20 +5,18 @@
 
 package org.safere.vector;
 
-/**
- * Interface for vector scanning implementations.
- */
+/** Interface for vector scanning implementations. */
 public interface VectorScannerBridge {
   /**
-   * Scans the array for the target character between fromIndex and toIndex.
-   * Returns the index of the first occurrence, or -1 if not found.
+   * Scans the array for the target character between fromIndex and toIndex. Returns the index of
+   * the first occurrence, or -1 if not found.
    */
   int scan(char[] array, char target, int fromIndex, int toIndex);
 
   /**
-   * Scans the string directly using reflection-based backing array access if supported.
-   * Returns the index of the first occurrence, -1 if not found, or -2 if direct scanning
-   * is not supported or failed.
+   * Scans the string directly using reflection-based backing array access if supported. Returns the
+   * index of the first occurrence, -1 if not found, or -2 if direct scanning is not supported or
+   * failed.
    */
   int scanString(String text, char target, int fromIndex, int toIndex);
 }

--- a/safere/src/main/java/org/safere/vector/VectorScannerLoader.java
+++ b/safere/src/main/java/org/safere/vector/VectorScannerLoader.java
@@ -15,7 +15,7 @@ public final class VectorScannerLoader {
           Class.forName("org.safere.vector.VectorScannerImpl")
               .asSubclass(VectorScannerBridge.class);
       return implClass.getDeclaredConstructor().newInstance();
-    } catch (Throwable t) {
+    } catch (ReflectiveOperationException | LinkageError | ClassCastException e) {
       // Gracefully fall back to scalar matching (null) if:
       // - safere-vector jar is not on the classpath.
       // - JVM was run without --enable-preview or jdk.incubator.vector module.

--- a/safere/src/main/java/org/safere/vector/VectorScannerLoader.java
+++ b/safere/src/main/java/org/safere/vector/VectorScannerLoader.java
@@ -5,9 +5,7 @@
 
 package org.safere.vector;
 
-/**
- * Loads the vector scanner implementation via reflection if available on the classpath.
- */
+/** Loads the vector scanner implementation via reflection if available on the classpath. */
 public final class VectorScannerLoader {
   private static final VectorScannerBridge INSTANCE = loadInstance();
 
@@ -27,9 +25,7 @@ public final class VectorScannerLoader {
 
   private VectorScannerLoader() {}
 
-  /**
-   * Returns the vector scanner instance, or {@code null} if not supported at runtime.
-   */
+  /** Returns the vector scanner instance, or {@code null} if not supported at runtime. */
   public static VectorScannerBridge getInstance() {
     return INSTANCE;
   }

--- a/safere/src/main/java/org/safere/vector/VectorScannerLoader.java
+++ b/safere/src/main/java/org/safere/vector/VectorScannerLoader.java
@@ -1,0 +1,36 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.vector;
+
+/**
+ * Loads the vector scanner implementation via reflection if available on the classpath.
+ */
+public final class VectorScannerLoader {
+  private static final VectorScannerBridge INSTANCE = loadInstance();
+
+  private static VectorScannerBridge loadInstance() {
+    try {
+      Class<? extends VectorScannerBridge> implClass =
+          Class.forName("org.safere.vector.VectorScannerImpl")
+              .asSubclass(VectorScannerBridge.class);
+      return implClass.getDeclaredConstructor().newInstance();
+    } catch (Throwable t) {
+      // Gracefully fall back to scalar matching (null) if:
+      // - safere-vector jar is not on the classpath.
+      // - JVM was run without --enable-preview or jdk.incubator.vector module.
+      return null;
+    }
+  }
+
+  private VectorScannerLoader() {}
+
+  /**
+   * Returns the vector scanner instance, or {@code null} if not supported at runtime.
+   */
+  public static VectorScannerBridge getInstance() {
+    return INSTANCE;
+  }
+}


### PR DESCRIPTION
See https://github.com/eaftan/safere/issues/504

---

This commit introduces a two-phase candidate filtering cascade to optimize unanchored matches in SafeRE, bridging the performance gap with native C++ RE2's vectorized pre-filtering:

1. **Required Substring Precheck**: Computes a mandatory literal substring (if present in the AST) during compile time. If the substring is absent in the input text, unanchored matches terminate immediately without invoking the DFA state machine. Restricted to case-sensitive patterns to preserve match correctness.
2. **Vector SIMD Scanning**: Accelerates unanchored searches starting with a single character class using the Java Vector API (incubating in JDK 26) compiling down to native AVX-2/Neon instructions.
3. **Modular Integration & Zero-Copy**:
   * Decouples the Vector API code to an optional `safere-vector` module.
   * Loads the scanner class via a reflection loader bridge; falls back to high-performance inline scalar loops if module or JVM preview flags are absent.
   * Uses `VarHandle` reflection to access `java.lang.String` internal backing array and `coder` byte, executing zero-copy `ByteVector` (Latin-1) and `ShortVector` (UTF-16) scans. Falls back to a lazy `char[]` copy if reflection is blocked.