### PR TITLE
Disable leftmost-first pruning during reverse DFA scan

### DIFF
--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -902,7 +902,7 @@ final class Dfa {
               isMatchValid = true;
             }
           }
-          if (isMatchValid) {
+          if (isMatchValid && !prog.reversed()) {
             break; // Prune all lower-priority branches!
           }
         } else {

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -387,4 +387,17 @@ class DfaTest {
       }
     }
   }
+
+  @Test
+  void reverseDfaPruningCorrectness() {
+    Pattern p = Pattern.compile("\\B([^a])*[^a][^a]");
+    Dfa revDfa = p.reverseDfa();
+    assertThat(revDfa).isNotNull();
+
+    String text = "bbbb";
+    Dfa.SearchResult r = revDfa.doSearchReverse(text, 4, 0, true, true);
+    assertThat(r).isNotNull();
+    assertThat(r.matched()).isTrue();
+    assertThat(r.pos()).isEqualTo(1);
+  }
 }


### PR DESCRIPTION
SafeRE's submatch extraction uses a forward DFA scan to find the match end position, followed by a reverse DFA scan (running on the reversed regex program) from that end position backward to locate the leftmost start position.

To optimize matching time and state space, the DFA implementation employs a leftmost-first state pruning strategy: once a match condition is found, any lower-priority alternation branches are immediately pruned. However, this pruning logic was incorrectly active during the reverse DFA scan. Discarding branches early during the backward scan can cause the engine to miss the actual leftmost starting boundary of a match, returning an incorrect, shortened starting index instead.

User-visible impact and dependencies:
- User-visible impact: None currently. SafeRE's compiler uses defensive semantic guards (`dfaStartReliable()`) to detect patterns vulnerable to start-boundary errors (such as those starting with assertions or overlapping alternations) and forces them to run on the NFA engine instead.
- Future dependency: This correctness fix is a strict blocker for removing those defensive semantic guards. Disabling these guards is required by future optimizations (allowing patterns like overlapping URL alternations to run on the fast DFA sandwich by default). Without this correctness fix, removing the guards would introduce user-visible correctness bugs.

Add a regression test in DfaTest exercising a suffix-repetition pattern `(\B([^a])*[^a][^a])` to verify reverse DFA start boundary correctness.