### PR TITLE
Enable BitState execution for patterns containing word boundary assertions

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1860,7 +1860,6 @@ public final class Matcher implements MatchResult {
             && !fullTextRegionContext
             && !(prog.hasGraphemeSemantics() && !anchored)
             && !prog.hasGraphemeSemantics()
-            && !prog.hasWordBoundary()
             && (!enginePathOptions().semanticGuards()
                 || !prog.requiresPikeNfaCaptureSemantics()
                 || nsubmatch <= 1);

--- a/safere/src/test/java/org/safere/BitStateTest.java
+++ b/safere/src/test/java/org/safere/BitStateTest.java
@@ -347,6 +347,9 @@ class BitStateTest {
     cases.add(new TestCase("[a-z]+@[a-z]+", "user@host"));
     cases.add(new TestCase("\\bfoo\\b", "foo bar"));
     cases.add(new TestCase("\\bfoo\\b", "foobar"));
+    cases.add(new TestCase("(\\bfoo\\b)", "foo bar"));
+    cases.add(new TestCase("(\\Bfoo\\B)", "afoob"));
+    cases.add(new TestCase("\\b(cat|dog|bird)\\b", "The quick brown cat and the lazy dog"));
     cases.add(new TestCase("(a(b)c)", "abc"));
     cases.add(new TestCase("x(y|z)w", "xyw"));
     cases.add(new TestCase("(.*)x", "abcx"));


### PR DESCRIPTION
This is related to the comment in https://github.com/eaftan/safere/pull/493#pullrequestreview-4540041896

> This came out of a correctness sweep in PR #463, and then there was a round of optimization in PR #466 that restored DFA support for word-boundary patterns.

I think #466 already made the decision to accept an intentional divergence around not splitting surrogate pairs on word boundaries for `java.util.regex` bug compatibility, so there's no reason not to remove this case and allow using BitState here.

This results in a ~8x speedup for capture group patterns containing word boundaries in #500. This also dovetails with #507, which specializes empty-width checking in `BitState`.