### PR TITLE
Implement compile-time case folding expansion for Unicode case-insensitive literals

### DIFF
--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -946,16 +946,58 @@ final class Compiler extends Walker<Compiler.Frag> {
 
   private Frag literal(int rune, int flags) {
     boolean foldCase = (flags & ParseFlags.FOLD_CASE) != 0;
-    if (foldCase && (flags & ParseFlags.UNICODE_CASE) == 0) {
-      if (isAsciiLetter(rune)) {
-        // Parser keeps these as folded literals so literal/prefix accelerators can see them.
-        // Lower to an explicit ASCII class here to avoid Unicode simple-fold matching.
-        return asciiFoldedLiteral(rune);
+    if (foldCase) {
+      if ((flags & ParseFlags.UNICODE_CASE) == 0) {
+        if (isAsciiLetter(rune)) {
+          // Parser keeps these as folded literals so literal/prefix accelerators can see them.
+          // Lower to an explicit ASCII class here to avoid Unicode simple-fold matching.
+          return asciiFoldedLiteral(rune);
+        }
+        foldCase = false;
+      } else {
+        // Expand Unicode case fold orbit at compile-time to avoid runtime simpleFold lookups.
+        return unicodeFoldedLiteral(rune);
       }
-      foldCase = false;
     }
     // In our code-point model, a literal is just a single CHAR_RANGE.
     return charRange(rune, rune, foldCase);
+  }
+
+  private Frag unicodeFoldedLiteral(int rune) {
+    List<Integer> orbit = new ArrayList<>();
+    orbit.add(rune);
+    int folded = Inst.simpleFold(rune);
+    while (folded != rune) {
+      orbit.add(folded);
+      folded = Inst.simpleFold(folded);
+    }
+    orbit.sort(null);
+
+    List<Integer> rangesList = new ArrayList<>();
+    int i = 0;
+    while (i < orbit.size()) {
+      int start = orbit.get(i);
+      int end = start;
+      while (i + 1 < orbit.size() && orbit.get(i + 1) == end + 1) {
+        end = orbit.get(i + 1);
+        i++;
+      }
+      rangesList.add(start);
+      rangesList.add(end);
+      i++;
+    }
+
+    int[] ranges = new int[rangesList.size()];
+    for (int j = 0; j < ranges.length; j++) {
+      ranges[j] = rangesList.get(j);
+    }
+
+    int id = allocInst();
+    if (id < 0) {
+      return Frag.NO_MATCH;
+    }
+    prog.mutableInst(id).initCharClass(0, ranges);
+    return new Frag(id, PatchList.mk(id << 1), false);
   }
 
   private Frag asciiFoldedLiteral(int rune) {

--- a/safere/src/test/java/org/safere/CompilerTest.java
+++ b/safere/src/test/java/org/safere/CompilerTest.java
@@ -7,6 +7,7 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,33 @@ class CompilerTest {
       assertThat(prog.size()).isGreaterThan(1);
       assertHasInstOp(prog, InstOp.CHAR_RANGE);
       assertHasInstOp(prog, InstOp.MATCH);
+    }
+
+    @Test
+    void compileSingleLiteralCaseInsensitiveAscii() {
+      // With UNICODE_CASE disabled, ASCII letters fold to a character class containing upper/lower.
+      Prog prog = compile("(?i)a", ParseFlags.PERL_X | ParseFlags.PERL_CLASSES);
+      assertThat(prog).isNotNull();
+      assertHasInstOp(prog, InstOp.CHAR_CLASS);
+      assertHasCharClass(prog, new int[] {'A', 'A', 'a', 'a'});
+    }
+
+    @Test
+    void compileSingleLiteralCaseInsensitiveUnicode() {
+      // With UNICODE_CASE enabled, 'a' folds to 'a' and 'A'.
+      Prog prog = compile("(?iu)a");
+      assertThat(prog).isNotNull();
+      assertHasInstOp(prog, InstOp.CHAR_CLASS);
+      assertHasCharClass(prog, new int[] {'A', 'A', 'a', 'a'});
+    }
+
+    @Test
+    void compileKelvinSignCaseInsensitive() {
+      // Kelvin sign K (0x212A) case folds to 'K' (0x4B) and 'k' (0x6B).
+      Prog prog = compile("(?iu)\u212A");
+      assertThat(prog).isNotNull();
+      assertHasInstOp(prog, InstOp.CHAR_CLASS);
+      assertHasCharClass(prog, new int[] {'K', 'K', 'k', 'k', 0x212A, 0x212A});
     }
 
     @Test
@@ -462,6 +490,22 @@ class CompilerTest {
     assertThat(found)
         .withFailMessage(
             "Expected CHAR_RANGE [0x%X-0x%X] not found in prog:\n%s", lo, hi, prog.dump())
+        .isTrue();
+  }
+
+  private static void assertHasCharClass(Prog prog, int[] expectedRanges) {
+    boolean found = false;
+    for (int i = 0; i < prog.size(); i++) {
+      Inst inst = prog.inst(i);
+      if (inst.op == InstOp.CHAR_CLASS && Arrays.equals(inst.ranges, expectedRanges)) {
+        found = true;
+        break;
+      }
+    }
+    assertThat(found)
+        .withFailMessage(
+            "Expected CHAR_CLASS with ranges %s not found in prog:\n%s",
+            Arrays.toString(expectedRanges), prog.dump())
         .isTrue();
   }
 }


### PR DESCRIPTION
Previously, a case-insensitive literal character range with UNICODE_CASE enabled was compiled to a CHAR_RANGE instruction with `foldCase=true`. At runtime, every character check evaluated the case-insensitive orbit dynamically by binary searching on Unicode tables (`simpleFold`), slowing down NFA/DFA transitions.

This change modifies the literal compilation path in `Compiler.java` to precompute the full case-folding orbit of a rune at compile-time when FOLD_CASE and UNICODE_CASE flags are set. The compiler compiles these orbits to static character class instructions (`InstOp.CHAR_CLASS`).

Because character class instructions use O(1) ASCII bitmaps for characters 0-127 and compact sorted binary search arrays for non-ASCII characters, matching is significantly faster and completely avoids dynamic simpleFold lookups.

This helps with the CASE_INSENSITIVE_KEYWORD and OVERLAPPING_URL cases in #500