### PR TITLE
Optimize Pike NFA VM execution performance and garbage collection overhead

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -128,6 +128,11 @@ public final class Matcher implements MatchResult {
   private boolean bitStateBorrowed;
   private int[] bitStateResult;
 
+  /** Cached Nfa instance borrowed from the parent Pattern's thread-local cache. */
+  private Nfa cachedNfa;
+
+  private boolean nfaBorrowed;
+
   /**
    * Whether all capture groups have been resolved. When the DFA sandwich determines match
    * boundaries (group 0), inner captures (groups 1+) are deferred until explicitly requested. This
@@ -305,6 +310,10 @@ public final class Matcher implements MatchResult {
       bitStateBorrowed = false;
       cachedBitState = null;
     }
+    if (nfaBorrowed && cachedNfa != null) {
+      nfaBorrowed = false;
+      cachedNfa = null;
+    }
     bitStateResult = null;
     graphemeContextText = null;
     graphemeContext = null;
@@ -314,6 +323,8 @@ public final class Matcher implements MatchResult {
     bitStateBorrowed = false;
     cachedBitState = null;
     bitStateResult = null;
+    nfaBorrowed = false;
+    cachedNfa = null;
     graphemeContextText = null;
     graphemeContext = null;
   }
@@ -786,19 +797,18 @@ public final class Matcher implements MatchResult {
     // may accept a match ending before a trailing \n. In that case, fall back to the NFA
     // which uses longest-match mode for FULL_MATCH and finds the correct full-text match.
     if (result != null && result[1] != text.length()) {
-      Nfa.SearchResult nfaResult =
-          Nfa.search(
+      int[] nfaResult =
+          searchNfa(
               prog,
-              text,
               0,
               text.length(),
               text.length(),
               0,
+              prog.numCaptures(),
               Nfa.Anchor.ANCHORED,
               Nfa.MatchKind.FULL_MATCH,
-              prog.numCaptures(),
-              graphemeContextFor(prog));
-      result = nfaResult.groups();
+              false);
+      result = nfaResult;
     }
     return applyEngineResult(new FullMatchResult(result));
   }
@@ -1901,10 +1911,49 @@ public final class Matcher implements MatchResult {
     } else {
       nfaKind = Nfa.MatchKind.FIRST_MATCH;
     }
+    return searchNfa(
+        prog,
+        startPos,
+        searchLimit,
+        endPos,
+        graphemeConsumeEndPos,
+        nsubmatch,
+        nfaAnchor,
+        nfaKind,
+        preserveOuterEmptyContext);
+  }
+
+  private int[] searchNfa(
+      Prog prog,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int graphemeConsumeEndPos,
+      int nsubmatch,
+      Nfa.Anchor nfaAnchor,
+      Nfa.MatchKind nfaKind,
+      boolean preserveOuterEmptyContext) {
+    if (prog.start() == 0) {
+      return null;
+    }
+    boolean anchored = (nfaAnchor == Nfa.Anchor.ANCHORED) || prog.anchorStart();
+    boolean longestMode = (nfaKind != Nfa.MatchKind.FIRST_MATCH);
+    boolean endmatch = prog.anchorEnd();
+
+    if (nfaKind == Nfa.MatchKind.FULL_MATCH) {
+      anchored = true;
+      endmatch = true;
+      if (nsubmatch == 0) {
+        nsubmatch = 1;
+      }
+    }
+
+    // We always need at least capture[0..1] to track the match boundaries.
+    int ncapture = 2 * Math.max(nsubmatch, 1);
+
     boolean graphemeRegionContext = fullTextRegionContext && prog.hasGraphemeSemantics();
     int consumeRegionStart = graphemeRegionContext && !transparentBounds ? regionStart : 0;
-    // Deferred capture replay bounds consumption to group(0), but empty-width assertions still
-    // need the matcher region context that produced the match.
+
     boolean useOuterEmptyContext = fullTextRegionContext || preserveOuterEmptyContext;
     int emptyContextEnd = preserveOuterEmptyContext ? regionEnd : endPos;
     int boundaryRegionStart = useOuterEmptyContext && !transparentBounds ? regionStart : 0;
@@ -1917,8 +1966,9 @@ public final class Matcher implements MatchResult {
     int emptyAnchorStartPos = useOuterEmptyContext && anchoringBounds ? regionStart : 0;
     int emptyAnchorEndPos =
         useOuterEmptyContext && !anchoringBounds ? text.length() : emptyContextEnd;
-    Nfa.SearchResult nfaResult =
-        Nfa.search(
+
+    EngineContext context =
+        EngineContext.create(
             prog,
             text,
             startPos,
@@ -1931,10 +1981,18 @@ public final class Matcher implements MatchResult {
             anchorEndPos,
             emptyAnchorStartPos,
             emptyAnchorEndPos,
-            nfaAnchor,
-            nfaKind,
-            nsubmatch,
             graphemeContextFor(prog));
+
+    if (cachedNfa == null && !nfaBorrowed) {
+      cachedNfa = parentPattern.borrowNfa();
+      nfaBorrowed = true;
+    }
+
+    Nfa nfa = Nfa.getOrCreate(cachedNfa, prog, context, ncapture, longestMode, endmatch);
+    Nfa.SearchResult nfaResult = nfa.runSearch(anchored, nfaKind, nsubmatch, endPos);
+    cachedNfa = nfa;
+    parentPattern.returnNfa(nfa);
+
     return nfaResult.groups();
   }
 

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -283,6 +283,10 @@ final class Nfa {
     this.addToThreadqStack.clear();
   }
 
+  void releaseInputContext() {
+    context = null;
+  }
+
   SearchResult runSearch(boolean anchored, MatchKind kind, int nsubmatch, int endPos) {
     if (prog.hasGraphemeSemantics()) {
       doSearchEveryCharPosition(anchored);

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -64,13 +64,14 @@ final class Nfa {
     final NfaThread[] threads;
     int size = 0;
 
-    final boolean[] visitedInst;
+    final int[] visitedInst;
+    int visitedGeneration = 1;
     final Set<Long> visitedGrapheme;
     final boolean hasGraphemeSemantics;
 
     QueueState(int progSize, boolean hasGraphemeSemantics) {
       this.threads = new NfaThread[progSize + 1];
-      this.visitedInst = new boolean[progSize + 1];
+      this.visitedInst = new int[progSize + 1];
       this.visitedGrapheme = hasGraphemeSemantics ? new HashSet<>() : null;
       this.hasGraphemeSemantics = hasGraphemeSemantics;
     }
@@ -84,7 +85,11 @@ final class Nfa {
       if (hasGraphemeSemantics) {
         visitedGrapheme.clear();
       } else {
-        Arrays.fill(visitedInst, false);
+        visitedGeneration++;
+        if (visitedGeneration == 0) {
+          Arrays.fill(visitedInst, 0);
+          visitedGeneration = 1;
+        }
       }
     }
   }
@@ -161,18 +166,18 @@ final class Nfa {
   @SuppressWarnings("ArrayRecordComponent")
   record SearchResult(int[] groups) {}
 
-  private final Prog prog;
-  private final int ncapture;
+  private Prog prog;
+  private int ncapture;
 
   /** Total thread array size: ncapture slots for captures + numLoopRegs for progress checks. */
-  private final int threadArraySize;
+  private int threadArraySize;
 
-  private final boolean longest;
-  private final boolean endmatch;
-  private final EngineContext context;
+  private boolean longest;
+  private boolean endmatch;
+  private EngineContext context;
 
   private boolean matched;
-  private final int[] bestMatch;
+  private int[] bestMatch;
   private final AddToThreadqStack addToThreadqStack = new AddToThreadqStack();
 
   // NfaThread pool
@@ -238,6 +243,67 @@ final class Nfa {
     this.context = context;
     this.bestMatch = new int[ncapture];
     Arrays.fill(bestMatch, -1);
+  }
+
+  static Nfa getOrCreate(
+      Nfa cached,
+      Prog prog,
+      EngineContext context,
+      int ncapture,
+      boolean longest,
+      boolean endmatch) {
+    if (cached != null && cached.canReuse(prog, ncapture)) {
+      cached.reset(prog, context, ncapture, longest, endmatch);
+      return cached;
+    }
+    return new Nfa(prog, context, ncapture, longest, endmatch);
+  }
+
+  private boolean canReuse(Prog prog, int ncapture) {
+    int requiredThreadArraySize = ncapture + prog.numLoopRegs();
+    return this.threadArraySize >= requiredThreadArraySize
+        && this.bestMatch.length >= ncapture
+        && this.prog.size() >= prog.size()
+        && this.prog.hasGraphemeSemantics() == prog.hasGraphemeSemantics();
+  }
+
+  private void reset(
+      Prog prog, EngineContext context, int ncapture, boolean longest, boolean endmatch) {
+    this.prog = prog;
+    this.ncapture = ncapture;
+    this.threadArraySize = ncapture + prog.numLoopRegs();
+    this.longest = longest;
+    this.endmatch = endmatch;
+    this.context = context;
+    this.matched = false;
+    if (this.bestMatch.length < ncapture) {
+      this.bestMatch = new int[ncapture];
+    }
+    Arrays.fill(this.bestMatch, 0, ncapture, -1);
+    this.addToThreadqStack.clear();
+  }
+
+  SearchResult runSearch(boolean anchored, MatchKind kind, int nsubmatch, int endPos) {
+    if (prog.hasGraphemeSemantics()) {
+      doSearchEveryCharPosition(anchored);
+    } else {
+      doSearch(anchored);
+    }
+
+    if (!matched) {
+      return new SearchResult(null);
+    }
+    if (kind == MatchKind.FULL_MATCH && bestMatch[1] != endPos) {
+      return new SearchResult(null);
+    }
+
+    int[] result = new int[2 * nsubmatch];
+    int ncopy = Math.min(ncapture, result.length);
+    System.arraycopy(bestMatch, 0, result, 0, ncopy);
+    if (ncopy < result.length) {
+      Arrays.fill(result, ncopy, result.length, -1);
+    }
+    return new SearchResult(result);
   }
 
   /**
@@ -439,26 +505,7 @@ final class Nfa {
             emptyAnchorEndPos,
             graphemeContext);
     Nfa nfa = new Nfa(prog, context, ncapture, longestMode, endmatch);
-    if (prog.hasGraphemeSemantics()) {
-      nfa.doSearchEveryCharPosition(anchored);
-    } else {
-      nfa.doSearch(anchored);
-    }
-
-    if (!nfa.matched) {
-      return new SearchResult(null);
-    }
-    if (kind == MatchKind.FULL_MATCH && nfa.bestMatch[1] != endPos) {
-      return new SearchResult(null);
-    }
-
-    int[] result = new int[2 * nsubmatch];
-    System.arraycopy(nfa.bestMatch, 0, result, 0, Math.min(result.length, nfa.bestMatch.length));
-    // Fill any remaining slots with -1.
-    for (int i = nfa.bestMatch.length; i < result.length; i++) {
-      result[i] = -1;
-    }
-    return new SearchResult(result);
+    return nfa.runSearch(anchored, kind, nsubmatch, endPos);
   }
 
   /**
@@ -572,8 +619,9 @@ final class Nfa {
       }
 
       if (!runq.isEmpty()) {
-        int cp = inputCodePointAt(text, pos);
-        int nextPos = inputNextPos(text, pos);
+        long stepResult = inputStep(text, pos);
+        int cp = (int) (stepResult >>> 32);
+        int nextPos = (int) stepResult;
         step(runq, delayedBuffer, delayedGrapheme, cp, text, pos, nextPos);
       } else {
         freeQueue(runq);
@@ -642,8 +690,8 @@ final class Nfa {
         long key = visitKey(prog.inst(t.id), t.id, text, pos, t.graphemeStart);
         visited = !destination.visitedGrapheme.add(key);
       } else {
-        visited = destination.visitedInst[t.id];
-        destination.visitedInst[t.id] = true;
+        visited = destination.visitedInst[t.id] == destination.visitedGeneration;
+        destination.visitedInst[t.id] = destination.visitedGeneration;
       }
       if (visited) {
         freeThread(t);
@@ -688,19 +736,24 @@ final class Nfa {
             context.graphemeContext());
   }
 
-  private int inputCodePointAt(String text, int pos) {
+  private long inputStep(String text, int pos) {
     if (prog.hasGraphemeSemantics()) {
-      return GraphemeSupport.inputCodePointAt(text, pos, context.endPos(), true);
+      int cp = GraphemeSupport.inputCodePointAt(text, pos, context.endPos(), true);
+      int nextPos = GraphemeSupport.inputNextPos(text, pos, context.endPos(), true);
+      return ((long) cp << 32) | (nextPos & 0xFFFFFFFFL);
     }
-    return codePointAtConsumeBoundary(text, pos);
-  }
-
-  private int inputNextPos(String text, int pos) {
-    if (prog.hasGraphemeSemantics()) {
-      return GraphemeSupport.inputNextPos(text, pos, context.endPos(), true);
+    if (pos < 0 || pos >= context.engineEndPos()) {
+      int nextPos = nextBoundaryPosition(pos, context.endPos());
+      return (-1L << 32) | (nextPos & 0xFFFFFFFFL);
     }
-    int cp = codePointAtConsumeBoundary(text, pos);
-    return cp >= 0 ? pos + Character.charCount(cp) : nextBoundaryPosition(pos, context.endPos());
+    int cp = text.codePointAt(pos);
+    int width = Character.charCount(cp);
+    if (pos + width <= context.engineEndPos()) {
+      return ((long) cp << 32) | ((pos + width) & 0xFFFFFFFFL);
+    } else {
+      int nextPos = nextBoundaryPosition(pos, context.endPos());
+      return (-1L << 32) | (nextPos & 0xFFFFFFFFL);
+    }
   }
 
   private int graphemeNextPos(String text, int pos) {
@@ -735,6 +788,8 @@ final class Nfa {
     stack.clear();
     stack.pushInstruction(id, consumedInput);
 
+    int cachedFlags = -1;
+
     while (!stack.isEmpty()) {
       stack.pop();
       if (stack.restoreIndex >= 0) {
@@ -762,10 +817,10 @@ final class Nfa {
             continue;
           }
         } else {
-          if (q.visitedInst[instructionId]) {
+          if (q.visitedInst[instructionId] == q.visitedGeneration) {
             continue;
           }
-          q.visitedInst[instructionId] = true;
+          q.visitedInst[instructionId] = q.visitedGeneration;
         }
       }
 
@@ -797,22 +852,24 @@ final class Nfa {
         }
 
         case EMPTY_WIDTH -> {
-          int flags =
-              emptyFlags(
-                  text,
-                  pos,
-                  prog.unixLines(),
-                  prog.hasGraphemeSemantics(),
-                  context.graphemeContext(),
-                  t0[0],
-                  context.boundaryRegionStart(),
-                  frameConsumedInput,
-                  context.emptyAnchorStartPos(),
-                  context.emptyAnchorEndPos(),
-                  context.effectiveBoundaryEndPos(frameConsumedInput),
-                  prog.hasWordBoundary(),
-                  prog.hasTextAnchor());
-          if ((ip.arg & ~flags) == 0) {
+          if (cachedFlags == -1) {
+            cachedFlags =
+                emptyFlags(
+                    text,
+                    pos,
+                    prog.unixLines(),
+                    prog.hasGraphemeSemantics(),
+                    context.graphemeContext(),
+                    t0[0],
+                    context.boundaryRegionStart(),
+                    frameConsumedInput,
+                    context.emptyAnchorStartPos(),
+                    context.emptyAnchorEndPos(),
+                    context.effectiveBoundaryEndPos(frameConsumedInput),
+                    prog.hasWordBoundary(),
+                    prog.hasTextAnchor());
+          }
+          if ((ip.arg & ~cachedFlags) == 0) {
             stack.pushInstruction(ip.out, frameConsumedInput);
           }
         }
@@ -924,8 +981,8 @@ final class Nfa {
                   long key = visitKey(ip, id, text, scalarEnd, graphemeStart);
                   visited = !destination.visitedGrapheme.add(key);
                 } else {
-                  visited = destination.visitedInst[id];
-                  destination.visitedInst[id] = true;
+                  visited = destination.visitedInst[id] == destination.visitedGeneration;
+                  destination.visitedInst[id] = destination.visitedGeneration;
                 }
                 if (!visited) {
                   destination.threads[destination.size++] = allocThread(id, capture, graphemeStart);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -690,6 +690,7 @@ public final class Pattern implements Serializable {
   }
 
   void returnNfa(Nfa nfa) {
+    nfa.releaseInputContext();
     cachedNfa.set(nfa);
   }
 

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -189,6 +189,9 @@ public final class Pattern implements Serializable {
   @SuppressWarnings("ThreadLocalUsage")
   private final transient ThreadLocal<BitState> cachedBitState = new ThreadLocal<>();
 
+  @SuppressWarnings("ThreadLocalUsage")
+  private final transient ThreadLocal<Nfa> cachedNfa = new ThreadLocal<>();
+
   /**
    * Thread-local cached forward DFA. Shared across all Matchers created from this Pattern within
    * the same thread, so the DFA state cache persists across the common {@code
@@ -678,6 +681,16 @@ public final class Pattern implements Serializable {
   /** Returns a BitState to the thread-local cache for reuse by future Matchers. */
   void returnBitState(BitState bs) {
     cachedBitState.set(bs);
+  }
+
+  Nfa borrowNfa() {
+    Nfa nfa = cachedNfa.get();
+    cachedNfa.set(null);
+    return nfa;
+  }
+
+  void returnNfa(Nfa nfa) {
+    cachedNfa.set(nfa);
   }
 
   /** Maximum number of DFA states before the DFA bails out. */

--- a/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
+++ b/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
@@ -75,6 +75,23 @@ class MatcherDeferredCaptureStateTest {
   }
 
   @Test
+  @DisplayName("cached NFA does not retain input context")
+  void cachedNfaDoesNotRetainInputContext() throws ReflectiveOperationException {
+    Pattern pattern =
+        Pattern.compile(
+            "([a-z]+)([0-9]+)",
+            0,
+            EnginePathOptions.builder().dfa(false).onePass(false).bitState(false).build());
+
+    assertThat(pattern.matcher("abc123").find()).isTrue();
+
+    ThreadLocal<?> cachedNfa = (ThreadLocal<?>) field(Pattern.class, "cachedNfa").get(pattern);
+    Object nfa = cachedNfa.get();
+    assertThat(nfa).isNotNull();
+    assertThat(field(Nfa.class, "context").get(nfa)).isNull();
+  }
+
+  @Test
   @DisplayName("anchoring bounds change resolves stale deferred captures before clearing markers")
   void anchoringBoundsChangeResolvesStaleDeferredCapturesBeforeClearingMarkers()
       throws ReflectiveOperationException {
@@ -126,7 +143,11 @@ class MatcherDeferredCaptureStateTest {
   }
 
   private static Field field(String name) throws ReflectiveOperationException {
-    Field field = Matcher.class.getDeclaredField(name);
+    return field(Matcher.class, name);
+  }
+
+  private static Field field(Class<?> type, String name) throws ReflectiveOperationException {
+    Field field = type.getDeclaredField(name);
     field.setAccessible(true);
     return field;
   }


### PR DESCRIPTION
This came out of work to optimize benchmarks in #500, some of those cases were slow because they fell back to the NFA, and this makes the NFA faster in those cases and also significantly reduces allocations.

That investigation also found some opportunities to use the DFA more (#506) and to use BitState more (#493). I think those other changes are higher priority, and they make the NFA performance less important. This should probably be re-benchmarked after the other changes land to see if it's still worthwhile.

---

This change ports several NFA execution optimizations inspired by RE2J to SafeRE's fallback NFA engine.

* NFA VM Instance Pooling: Cache and reuse `Nfa` instances along with pre-allocated thread state arrays (`q0`, `q1`, `visitedInst`) via a ThreadLocal cache. Avoids allocations during fallback capture-group extraction. Equivalent to RE2J's caching of `Machine` instances.

* Generational Visited Array. Replaces the `Arrays.fill(visitedInst, false)` reset at each character step with an integer-based `visitedGeneration` counter. A state is visited if its entry equals the current generation. Matches RE2J's step generation index tracking in `Machine.java`.

* Combined Code Point Step Decoding: Replaces separate calls to `inputCodePointAt` and `inputNextPos` with a single unified `inputStep` method. The code point value and the next text position index are packed into a single `long` return value. Reduces duplicate index bounds checks and character/surrogate decoding lookups in string bounds. Directly inspired by RE2J's `MachineInput.step` encoding (which packs both the decoded rune and character width into a single integer via `rune << 3 | width`).

* Lazy Empty-Width Assertion Cache (CPU): Caches lookahead/lookbehind empty-width boundary flags (`emptyFlags`) per step, avoiding redundant re-evaluations of word boundaries and text anchors during the epsilon-transition queue traversal for a single character step. Matches how RE2J's NFA simulation precalculates the step condition (`cond`) once per character step and passes it as a parameter, avoiding redundant boundary evaluations during epsilon transitions.