### PR TITLE
Add more cases to RealWorldRegexBenchmark

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -286,6 +286,13 @@
         "op": "replaceAllEmpty",
         "match": "https://www.example.com/search?q=testing&hl=en",
         "nonMatch": "some-random-domain-name"
+      },
+      {
+        "name": "unprefixedWordBoundary",
+        "pattern": "\\b[a-zA-Z]{3,5}\\b",
+        "op": "find",
+        "match": "hello",
+        "nonMatch": "12345"
       }
     ]
   },

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -285,14 +285,23 @@
         "pattern": "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
         "op": "replaceAllEmpty",
         "match": "https://www.example.com/search?q=testing&hl=en",
-        "nonMatch": "some-random-domain-name"
+        "nonMatch": "some-random-domain-name",
+        "matchInput": {
+          "kind": "sparseMatch",
+          "nonMatchRepeats": 20,
+          "delimiterAlphabet": "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789"
+        }
       },
       {
         "name": "unprefixedWordBoundary",
         "pattern": "\\b[a-zA-Z]{3,5}\\b",
         "op": "find",
         "match": "hello",
-        "nonMatch": "12345"
+        "nonMatch": "12345",
+        "matchInput": {
+          "kind": "prefixedRepeat",
+          "prefix": "12345 "
+        }
       }
     ]
   },

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -279,6 +279,13 @@
         "op": "replaceAllEmpty",
         "match": "<template name>content to match</template",
         "nonMatch": "plain text without template tag"
+      },
+      {
+        "name": "sparseUrl",
+        "pattern": "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
+        "op": "replaceAllEmpty",
+        "match": "https://www.example.com/search?q=testing&hl=en",
+        "nonMatch": "some-random-domain-name"
       }
     ]
   },

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -225,6 +225,61 @@ std::string generated_real_world_input(const std::string& unit, int size,
   return text;
 }
 
+std::string generated_sparse_real_world_input(const std::string& match_unit,
+                                              const std::string& non_match_unit,
+                                              int size, int seed,
+                                              int non_match_repeats,
+                                              const std::string& alphabet) {
+  std::string text;
+  text.reserve(size + match_unit.size() + non_match_unit.size());
+  int delimiter_index = seed;
+  while (static_cast<int>(text.size()) < size) {
+    for (int i = 0; i < non_match_repeats &&
+                    static_cast<int>(text.size()) < size; ++i) {
+      text += non_match_unit;
+      if (static_cast<int>(text.size()) < size) {
+        text += alphabet[delimiter_index % alphabet.size()];
+        ++delimiter_index;
+      }
+    }
+    if (static_cast<int>(text.size()) < size) {
+      text += " ";
+      text += match_unit;
+      text += " ";
+    }
+  }
+  text.resize(size);
+  return text;
+}
+
+std::string generate_real_world_input(const json& input_spec,
+                                      const std::string& match_unit,
+                                      const std::string& non_match_unit,
+                                      bool match, int size,
+                                      const std::string& alphabet, int seed) {
+  std::string unit = match ? match_unit : non_match_unit;
+  std::string kind = input_spec.value("kind", "repeat");
+  if (kind == "repeat") {
+    return generated_real_world_input(unit, size, alphabet, seed);
+  }
+  if (kind == "prefixedRepeat") {
+    std::string prefix = input_spec.at("prefix").get<std::string>();
+    if (static_cast<int>(prefix.size()) >= size) {
+      return prefix.substr(0, size);
+    }
+    int body_size = size - static_cast<int>(prefix.size());
+    return prefix + generated_real_world_input(unit, body_size, alphabet, seed);
+  }
+  if (kind == "sparseMatch") {
+    return generated_sparse_real_world_input(
+        match_unit, non_match_unit, size, seed,
+        input_spec.at("nonMatchRepeats").get<int>(),
+        input_spec.at("delimiterAlphabet").get<std::string>());
+  }
+  fprintf(stderr, "ERROR: invalid real-world input kind: %s\n", kind.c_str());
+  exit(1);
+}
+
 // Encode a Unicode code point as UTF-8 and append to the string.
 void append_utf8(std::string& s, int cp) {
   if (cp < 0x80) {
@@ -501,6 +556,8 @@ void run_real_world_regex_benchmarks(
     std::string pattern;
     std::string match;
     std::string non_match;
+    json match_input;
+    json non_match_input;
     RE2 re;
 
     explicit RealWorldCase(const json& item)
@@ -509,6 +566,8 @@ void run_real_world_regex_benchmarks(
           pattern(item.at("pattern").get<std::string>()),
           match(item.at("match").get<std::string>()),
           non_match(item.at("nonMatch").get<std::string>()),
+          match_input(item.value("matchInput", json::object())),
+          non_match_input(item.value("nonMatchInput", json::object())),
           re(pattern) {}
   };
 
@@ -534,10 +593,11 @@ void run_real_world_regex_benchmarks(
   for (const auto& case_ptr : cases) {
     const RealWorldCase& c = *case_ptr;
     for (bool match : {true, false}) {
-      const std::string& unit = match ? c.match : c.non_match;
+      const json& input_spec = match ? c.match_input : c.non_match_input;
       std::string match_label = match ? "match" : "noMatch";
       for (int size : sizes) {
-        std::string text = generated_real_world_input(unit, size, alphabet, seed);
+        std::string text = generate_real_world_input(
+            input_spec, c.match, c.non_match, match, size, alphabet, seed);
         std::string name = "RealWorldRegexBenchmark.runBenchmark." + c.name +
                            "." + match_label + "." + std::to_string(size);
         if (!matches_filter(name, filters)) {

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -265,6 +265,63 @@ func generatedRealWorldInput(unit string, size int, alphabet string, seed int) s
 	return b.String()[:size]
 }
 
+func generatedSparseRealWorldInput(
+	matchUnit string, nonMatchUnit string, size int, seed int, nonMatchRepeats int,
+	alphabet string,
+) string {
+	var b strings.Builder
+	b.Grow(size + len(matchUnit) + len(nonMatchUnit))
+	delimiterIndex := seed
+	for b.Len() < size {
+		for i := 0; i < nonMatchRepeats && b.Len() < size; i++ {
+			b.WriteString(nonMatchUnit)
+			if b.Len() < size {
+				b.WriteByte(alphabet[delimiterIndex%len(alphabet)])
+				delimiterIndex++
+			}
+		}
+		if b.Len() < size {
+			b.WriteByte(' ')
+			b.WriteString(matchUnit)
+			b.WriteByte(' ')
+		}
+	}
+	return b.String()[:size]
+}
+
+func generateRealWorldInput(
+	inputSpec map[string]any, matchUnit string, nonMatchUnit string, match bool, size int,
+	alphabet string, seed int,
+) string {
+	unit := nonMatchUnit
+	if match {
+		unit = matchUnit
+	}
+	kind := "repeat"
+	if rawKind, ok := inputSpec["kind"]; ok {
+		kind = rawKind.(string)
+	}
+	switch kind {
+	case "repeat":
+		return generatedRealWorldInput(unit, size, alphabet, seed)
+	case "prefixedRepeat":
+		prefix := getString(inputSpec, "prefix")
+		if len(prefix) >= size {
+			return prefix[:size]
+		}
+		bodySize := size - len(prefix)
+		return prefix + generatedRealWorldInput(unit, bodySize, alphabet, seed)
+	case "sparseMatch":
+		return generatedSparseRealWorldInput(
+			matchUnit, nonMatchUnit, size, seed, getInt(inputSpec, "nonMatchRepeats"),
+			getString(inputSpec, "delimiterAlphabet"))
+	default:
+		fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex input kind: %s\n", kind)
+		os.Exit(1)
+	}
+	panic("unreachable")
+}
+
 func appendUTF8(b *strings.Builder, cp int) {
 	var buf [4]byte
 	n := utf8.EncodeRune(buf[:], rune(cp))
@@ -476,12 +533,14 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 	seed := getInt(sec, "seed")
 
 	type realWorldCase struct {
-		name     string
-		op       string
-		pattern  string
-		match    string
-		nonMatch string
-		re       *regexp.Regexp
+		name          string
+		op            string
+		pattern       string
+		match         string
+		nonMatch      string
+		matchInput    map[string]any
+		nonMatchInput map[string]any
+		re            *regexp.Regexp
 	}
 
 	rawCases, ok := sec["cases"].([]any)
@@ -502,27 +561,34 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		pattern := getString(item, "pattern")
+		matchInput, _ := item["matchInput"].(map[string]any)
+		nonMatchInput, _ := item["nonMatchInput"].(map[string]any)
 		cases = append(cases, realWorldCase{
-			name:     getString(item, "name"),
-			op:       op,
-			pattern:  pattern,
-			match:    getString(item, "match"),
-			nonMatch: getString(item, "nonMatch"),
-			re:       regexp.MustCompile(pattern),
+			name:          getString(item, "name"),
+			op:            op,
+			pattern:       pattern,
+			match:         getString(item, "match"),
+			nonMatch:      getString(item, "nonMatch"),
+			matchInput:    matchInput,
+			nonMatchInput: nonMatchInput,
+			re:            regexp.MustCompile(pattern),
 		})
 	}
 
 	for _, c := range cases {
 		c := c
 		for _, match := range []bool{true, false} {
-			unit := c.nonMatch
 			matchLabel := "noMatch"
 			if match {
-				unit = c.match
 				matchLabel = "match"
 			}
 			for _, size := range sizes {
-				text := generatedRealWorldInput(unit, size, alphabet, seed)
+				inputSpec := c.nonMatchInput
+				if match {
+					inputSpec = c.matchInput
+				}
+				text := generateRealWorldInput(
+					inputSpec, c.match, c.nonMatch, match, size, alphabet, seed)
 				name := fmt.Sprintf(
 					"RealWorldRegexBenchmark.runBenchmark.%s.%s.%d",
 					c.name, matchLabel, size)

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -153,16 +153,10 @@ public class RealWorldRegexBenchmark {
                   "Unknown real-world regex benchmark op: " + regexCase.op);
         };
 
-    String template = match ? regexCase.match : regexCase.nonMatch;
+    RealWorldRegexCase.InputSpec inputSpec = match ? regexCase.matchInput : regexCase.nonMatchInput;
     String alphabet = data.getString("realWorldRegex.safeDelimiterAlphabet");
     int seed = data.getInt("realWorldRegex.seed");
-    if (patternName.equals("sparseUrl") && match) {
-      testInput = generateSparseInput(regexCase.match, regexCase.nonMatch, inputSize, seed);
-    } else if (patternName.equals("unprefixedWordBoundary") && match) {
-      testInput = "12345 " + generateInput(template, inputSize - 6, alphabet, seed);
-    } else {
-      testInput = generateInput(template, inputSize, alphabet, seed);
-    }
+    testInput = generateInput(regexCase, inputSpec, match, inputSize, alphabet, seed);
   }
 
   @TearDown
@@ -186,20 +180,57 @@ public class RealWorldRegexBenchmark {
     return sb.substring(0, size);
   }
 
-  private String generateSparseInput(String matchPart, String nonMatchPart, int size, int seed) {
+  private String generateInput(
+      RealWorldRegexCase regexCase,
+      RealWorldRegexCase.InputSpec inputSpec,
+      boolean match,
+      int size,
+      String alphabet,
+      int seed) {
+    String template = match ? regexCase.match : regexCase.nonMatch;
+    return switch (inputSpec.kind) {
+      case "repeat" -> generateInput(template, size, alphabet, seed);
+      case "prefixedRepeat" ->
+          generatePrefixedInput(inputSpec.prefix, template, size, alphabet, seed);
+      case "sparseMatch" ->
+          generateSparseInput(
+              regexCase.match,
+              regexCase.nonMatch,
+              size,
+              seed,
+              inputSpec.nonMatchRepeats,
+              inputSpec.delimiterAlphabet);
+      default ->
+          throw new IllegalArgumentException("Unknown real-world input kind: " + inputSpec.kind);
+    };
+  }
+
+  private String generatePrefixedInput(
+      String prefix, String template, int size, String alphabet, int seed) {
+    if (prefix.length() >= size) {
+      return prefix.substring(0, size);
+    }
+    return prefix + generateInput(template, size - prefix.length(), alphabet, seed);
+  }
+
+  private String generateSparseInput(
+      String matchPart,
+      String nonMatchPart,
+      int size,
+      int seed,
+      int nonMatchRepeats,
+      String delimiterAlphabet) {
     StringBuilder sb = new StringBuilder(size);
     int delimiterIndex = seed;
-    String alphabet = "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789";
     while (sb.length() < size) {
-      // Insert 20 non-matching segments
-      for (int i = 0; i < 20 && sb.length() < size; i++) {
+      for (int i = 0; i < nonMatchRepeats && sb.length() < size; i++) {
         sb.append(nonMatchPart);
         if (sb.length() < size) {
-          sb.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
+          sb.append(
+              delimiterAlphabet.charAt(Math.floorMod(delimiterIndex, delimiterAlphabet.length())));
           delimiterIndex++;
         }
       }
-      // Insert 1 matching segment with non-word boundaries (spaces)
       if (sb.length() < size) {
         sb.append(" ");
         sb.append(matchPart);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -118,7 +118,8 @@ public class RealWorldRegexBenchmark {
     "caseInsensitiveKeyword",
     "boundedNameMatch",
     "templateTagMatch",
-    "sparseUrl"
+    "sparseUrl",
+    "unprefixedWordBoundary"
   })
   public String patternName;
 
@@ -157,6 +158,8 @@ public class RealWorldRegexBenchmark {
     int seed = data.getInt("realWorldRegex.seed");
     if (patternName.equals("sparseUrl") && match) {
       testInput = generateSparseInput(regexCase.match, regexCase.nonMatch, inputSize, seed);
+    } else if (patternName.equals("unprefixedWordBoundary") && match) {
+      testInput = "12345 " + generateInput(template, inputSize - 6, alphabet, seed);
     } else {
       testInput = generateInput(template, inputSize, alphabet, seed);
     }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -117,7 +117,8 @@ public class RealWorldRegexBenchmark {
     "overlappingUrl",
     "caseInsensitiveKeyword",
     "boundedNameMatch",
-    "templateTagMatch"
+    "templateTagMatch",
+    "sparseUrl"
   })
   public String patternName;
 
@@ -154,7 +155,11 @@ public class RealWorldRegexBenchmark {
     String template = match ? regexCase.match : regexCase.nonMatch;
     String alphabet = data.getString("realWorldRegex.safeDelimiterAlphabet");
     int seed = data.getInt("realWorldRegex.seed");
-    testInput = generateInput(template, inputSize, alphabet, seed);
+    if (patternName.equals("sparseUrl") && match) {
+      testInput = generateSparseInput(regexCase.match, regexCase.nonMatch, inputSize, seed);
+    } else {
+      testInput = generateInput(template, inputSize, alphabet, seed);
+    }
   }
 
   @TearDown
@@ -173,6 +178,29 @@ public class RealWorldRegexBenchmark {
       if (sb.length() < size) {
         sb.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
         delimiterIndex++;
+      }
+    }
+    return sb.substring(0, size);
+  }
+
+  private String generateSparseInput(String matchPart, String nonMatchPart, int size, int seed) {
+    StringBuilder sb = new StringBuilder(size);
+    int delimiterIndex = seed;
+    String alphabet = "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789";
+    while (sb.length() < size) {
+      // Insert 20 non-matching segments
+      for (int i = 0; i < 20 && sb.length() < size; i++) {
+        sb.append(nonMatchPart);
+        if (sb.length() < size) {
+          sb.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
+          delimiterIndex++;
+        }
+      }
+      // Insert 1 matching segment with non-word boundaries (spaces)
+      if (sb.length() < size) {
+        sb.append(" ");
+        sb.append(matchPart);
+        sb.append(" ");
       }
     }
     return sb.substring(0, size);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
@@ -15,14 +15,24 @@ final class RealWorldRegexCase {
   final String pattern;
   final String match;
   final String nonMatch;
+  final InputSpec matchInput;
+  final InputSpec nonMatchInput;
 
   private RealWorldRegexCase(
-      String name, String op, String pattern, String match, String nonMatch) {
+      String name,
+      String op,
+      String pattern,
+      String match,
+      String nonMatch,
+      InputSpec matchInput,
+      InputSpec nonMatchInput) {
     this.name = name;
     this.op = op;
     this.pattern = pattern;
     this.match = match;
     this.nonMatch = nonMatch;
+    this.matchInput = matchInput;
+    this.nonMatchInput = nonMatchInput;
   }
 
   static RealWorldRegexCase fromJson(JsonObject obj) {
@@ -34,7 +44,9 @@ final class RealWorldRegexCase {
     if (!"find".equals(op) && !"replaceAllEmpty".equals(op)) {
       throw new IllegalArgumentException("Unknown real-world regex benchmark op: " + op);
     }
-    return new RealWorldRegexCase(name, op, pattern, match, nonMatch);
+    InputSpec matchInput = InputSpec.fromJson(obj, "matchInput");
+    InputSpec nonMatchInput = InputSpec.fromJson(obj, "nonMatchInput");
+    return new RealWorldRegexCase(name, op, pattern, match, nonMatch, matchInput, nonMatchInput);
   }
 
   private static String requireString(JsonObject obj, String field) {
@@ -42,5 +54,50 @@ final class RealWorldRegexCase {
       throw new IllegalArgumentException("Real-world regex case requires " + field);
     }
     return obj.get(field).getAsString();
+  }
+
+  static final class InputSpec {
+
+    final String kind;
+    final String prefix;
+    final int nonMatchRepeats;
+    final String delimiterAlphabet;
+
+    private InputSpec(String kind, String prefix, int nonMatchRepeats, String delimiterAlphabet) {
+      this.kind = kind;
+      this.prefix = prefix;
+      this.nonMatchRepeats = nonMatchRepeats;
+      this.delimiterAlphabet = delimiterAlphabet;
+    }
+
+    static InputSpec repeat() {
+      return new InputSpec("repeat", "", 0, "");
+    }
+
+    static InputSpec fromJson(JsonObject obj, String field) {
+      if (!obj.has(field) || obj.get(field).isJsonNull()) {
+        return repeat();
+      }
+      JsonObject spec = obj.getAsJsonObject(field);
+      String kind = requireString(spec, "kind");
+      return switch (kind) {
+        case "repeat" -> repeat();
+        case "prefixedRepeat" -> new InputSpec(kind, requireString(spec, "prefix"), 0, "");
+        case "sparseMatch" ->
+            new InputSpec(
+                kind,
+                "",
+                requireInt(spec, "nonMatchRepeats"),
+                requireString(spec, "delimiterAlphabet"));
+        default -> throw new IllegalArgumentException("Unknown real-world input kind: " + kind);
+      };
+    }
+
+    private static int requireInt(JsonObject obj, String field) {
+      if (!obj.has(field) || obj.get(field).isJsonNull()) {
+        throw new IllegalArgumentException("Real-world regex input spec requires " + field);
+      }
+      return obj.get(field).getAsInt();
+    }
   }
 }


### PR DESCRIPTION
Some of the regexes in RealWorldRegexBenchmark were adapted from examples, and in the process of doing that stopped showing the benefit of the optimizations they inspired.

* `sparseUrl` shows a 8.86x speedup with #506
* `unprefixedWordBoundary` shows a 2.16x speedup with #493