### PR TITLE
Rewrite Bash regular expressions to avoid issues.

### DIFF
--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -128,8 +128,9 @@ is_pathological() {
 normalize_benchmark_filter() {
   local bench="$1"
   local package_regex="org\\.safere\\.benchmark"
+  local regex='[][^$()|*+?\]'
 
-  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ [\^\$\[\]\(\)\|\*\+\?] ]]; then
+  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ $regex ]]; then
     printf '%s\n' "$bench"
   elif [[ "$bench" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
     printf '^%s\\.%s\\.\n' "$package_regex" "$bench"

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -59,8 +59,9 @@ mvn install -DskipTests -q -f "$SCRIPT_DIR/pom.xml"
 normalize_benchmark_filter() {
   local bench="$1"
   local package_regex="org\\.safere\\.benchmark"
+  local regex='[][^$()|*+?\]'
 
-  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ [\^\$\[\]\(\)\|\*\+\?] ]]; then
+  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ $regex ]]; then
     printf '%s\n' "$bench"
   elif [[ "$bench" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
     printf '^%s\\.%s\\.\n' "$package_regex" "$bench"


### PR DESCRIPTION
This might depend on the version of Bash, but I was getting this error:
```
run-java-benchmarks.sh: line 132: [[: invalid regular expression `[^$[]()|*+?]': Invalid preceding regular expression
```
Extracting the regular expression in question into a variable made the error go away.