### PR TITLE
Simplify Java benchmark filter handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
           cache: maven
 
       - name: Smoke test Java benchmarks
-        run: ./run-java-benchmarks.sh --smoke RegexBenchmark
+        run: ./run-java-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.'
 
       - name: Smoke test Java memory benchmarks (GC profiler)
-        run: ./run-java-memory-benchmarks.sh --smoke RegexBenchmark
+        run: ./run-java-memory-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.'
 
       - name: Smoke test Java memory benchmarks (pattern sizes)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ mvn -pl safere test -q
 mvn install -DskipTests -q
 
 # Run benchmarks (see Benchmarking section below)
-./run-java-benchmarks.sh RegexBenchmark
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
 ```
 
 ## Code Style
@@ -294,26 +294,38 @@ Benchmark classes have no `@Fork`, `@Warmup`, or `@Measurement` annotations
 
 ```bash
 # BENCHMARKS.md updates and routine benchmark evidence
-./run-java-benchmarks.sh RegexBenchmark
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
 
 # Longer confirmation run for close, surprising, or important comparisons
-./run-java-benchmarks.sh --long RegexBenchmark
+./run-java-benchmarks.sh --long '^org\.safere\.benchmark\.RegexBenchmark\.'
 ```
+
+Arguments after the mode flag are passed directly to JMH as benchmark regex
+filters.
 
 **Run benchmarks in batches, not all at once.** Run 2–3 benchmark classes
 per invocation and collect results incrementally:
 
 ```bash
-./run-java-benchmarks.sh RegexBenchmark CompileBenchmark
-./run-java-benchmarks.sh SearchScalingBenchmark CaptureScalingBenchmark
-./run-java-benchmarks.sh HttpBenchmark ReplaceBenchmark FanoutBenchmark
-./run-java-benchmarks.sh PathologicalBenchmark PathologicalComparisonBenchmark
+./run-java-benchmarks.sh \
+  '^org\.safere\.benchmark\.RegexBenchmark\.' \
+  '^org\.safere\.benchmark\.CompileBenchmark\.'
+./run-java-benchmarks.sh \
+  '^org\.safere\.benchmark\.SearchScalingBenchmark\.' \
+  '^org\.safere\.benchmark\.CaptureScalingBenchmark\.'
+./run-java-benchmarks.sh \
+  '^org\.safere\.benchmark\.HttpBenchmark\.' \
+  '^org\.safere\.benchmark\.ReplaceBenchmark\.' \
+  '^org\.safere\.benchmark\.FanoutBenchmark\.'
+./run-java-benchmarks.sh \
+  '^org\.safere\.benchmark\.PathologicalBenchmark\.' \
+  '^org\.safere\.benchmark\.PathologicalComparisonBenchmark\.'
 ```
 
 **Extract summary tables from JMH output** using grep:
 
 ```bash
-./run-java-benchmarks.sh RegexBenchmark 2>&1 \
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.' 2>&1 \
   | grep -E '^(Benchmark|[A-Z][a-zA-Z]+Benchmark\.)'
 ```
 

--- a/README.md
+++ b/README.md
@@ -457,21 +457,24 @@ development iteration or focused investigation; use
 ```bash
 # Java benchmarks (throughput)
 ./run-java-benchmarks.sh                        # standard benchmarks
-./run-java-benchmarks.sh RegexBenchmark         # specific class
-./run-java-benchmarks.sh ApplicationBenchmark   # application workloads
-./run-java-benchmarks.sh --long RegexBenchmark  # longer confirmation run
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.ApplicationBenchmark\.'
+./run-java-benchmarks.sh --long '^org\.safere\.benchmark\.RegexBenchmark\.'
 
 # Java memory profiling (allocation rates via JMH GC profiler)
 ./run-java-memory-benchmarks.sh                 # all benchmarks
-./run-java-memory-benchmarks.sh RegexBenchmark  # specific class
+./run-java-memory-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
 ```
+
+Arguments to the Java wrapper scripts are passed directly to JMH as benchmark
+regex filters.
 
 `CrosscheckOverheadBenchmark` is excluded from the no-argument Java benchmark
 run. It measures overhead in the `safere-crosscheck` facade and should be run
 explicitly only when optimizing crosscheck:
 
 ```bash
-./run-java-benchmarks.sh CrosscheckOverheadBenchmark
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.CrosscheckOverheadBenchmark\.'
 ```
 
 ### C++ RE2 and Go Benchmarks

--- a/TESTING.md
+++ b/TESTING.md
@@ -189,11 +189,11 @@ The Unicode table-generation work uses three benchmark shapes:
 
 ```bash
 # Warm repeated compile throughput.
-./run-java-benchmarks.sh UnicodeCompileBenchmark
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.UnicodeCompileBenchmark\.'
 
 # Fresh-fork first compile. This preserves lazy Unicode table initialization
 # costs that ordinary JMH warmup would hide.
-./run-java-benchmarks.sh --first-compile UnicodeFirstCompileBenchmark
+./run-java-benchmarks.sh --first-compile '^org\.safere\.benchmark\.UnicodeFirstCompileBenchmark\.'
 
 # Plain JVM cold-start harness for short-lived CLI-style workloads.
 mvn install -DskipTests -q

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -120,30 +120,45 @@ fi
 
 if [ "$MODE" = "smoke" ]; then
   run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
-    ./run-java-benchmarks.sh --smoke RegexBenchmark.literalMatch
+    ./run-java-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.literalMatch_'
 
   log "Combining Java JMH output"
   cp "$OUTPUT_DIR/java-01-core.txt" "$OUTPUT_DIR/jmh-output.txt"
 
   clean_benchmark_module
   run_and_capture "$OUTPUT_DIR/java-memory.txt" \
-    ./run-java-memory-benchmarks.sh --smoke RegexBenchmark.literalMatch
+    ./run-java-memory-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.literalMatch_'
 else
   run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
     ./run-java-benchmarks.sh \
-      "${JAVA_MODE_ARGS[@]}" RegexBenchmark ApplicationBenchmark RealWorldRegexBenchmark CompileBenchmark
+      "${JAVA_MODE_ARGS[@]}" \
+      '^org\.safere\.benchmark\.RegexBenchmark\.' \
+      '^org\.safere\.benchmark\.ApplicationBenchmark\.' \
+      '^org\.safere\.benchmark\.RealWorldRegexBenchmark\.' \
+      '^org\.safere\.benchmark\.CompileBenchmark\.'
 
   run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
-    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" SearchScalingBenchmark Issue481ScalingBenchmark CaptureScalingBenchmark
+    ./run-java-benchmarks.sh \
+      "${JAVA_MODE_ARGS[@]}" \
+      '^org\.safere\.benchmark\.SearchScalingBenchmark\.' \
+      '^org\.safere\.benchmark\.Issue481ScalingBenchmark\.' \
+      '^org\.safere\.benchmark\.CaptureScalingBenchmark\.'
 
   run_and_capture "$OUTPUT_DIR/java-03-http-replace-fanout.txt" \
-    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" HttpBenchmark ReplaceBenchmark FanoutBenchmark
+    ./run-java-benchmarks.sh \
+      "${JAVA_MODE_ARGS[@]}" \
+      '^org\.safere\.benchmark\.HttpBenchmark\.' \
+      '^org\.safere\.benchmark\.ReplaceBenchmark\.' \
+      '^org\.safere\.benchmark\.FanoutBenchmark\.'
 
   run_and_capture "$OUTPUT_DIR/java-04-pathological.txt" \
-    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" PathologicalBenchmark PathologicalComparisonBenchmark
+    ./run-java-benchmarks.sh \
+      "${JAVA_MODE_ARGS[@]}" \
+      '^org\.safere\.benchmark\.PathologicalBenchmark\.' \
+      '^org\.safere\.benchmark\.PathologicalComparisonBenchmark\.'
 
   run_and_capture "$OUTPUT_DIR/java-05-patternset.txt" \
-    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" PatternSetBenchmark
+    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" '^org\.safere\.benchmark\.PatternSetBenchmark\.'
 
   log "Combining Java JMH output"
   cat \
@@ -156,7 +171,10 @@ else
 
   clean_benchmark_module
   run_and_capture "$OUTPUT_DIR/java-memory.txt" \
-    ./run-java-memory-benchmarks.sh RegexBenchmark SearchScalingBenchmark MemoryScalingBenchmark
+    ./run-java-memory-benchmarks.sh \
+      '^org\.safere\.benchmark\.RegexBenchmark\.' \
+      '^org\.safere\.benchmark\.SearchScalingBenchmark\.' \
+      '^org\.safere\.benchmark\.MemoryScalingBenchmark\.'
 fi
 
 run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -5,10 +5,11 @@
 # Run SafeRE JMH benchmarks.
 #
 # Usage:
-#   ./run-java-benchmarks.sh RegexBenchmark         # standard benchmark run
-#   ./run-java-benchmarks.sh --long RegexBenchmark  # longer confirmation run
-#   ./run-java-benchmarks.sh --smoke RegexBenchmark  # CI smoke test (minimal)
-#   ./run-java-benchmarks.sh --first-compile UnicodeFirstCompileBenchmark
+#   ./run-java-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
+#   ./run-java-benchmarks.sh --long '^org\.safere\.benchmark\.RegexBenchmark\.'
+#   ./run-java-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.'
+#   ./run-java-benchmarks.sh --first-compile \
+#     '^org\.safere\.benchmark\.UnicodeFirstCompileBenchmark\.'
 #   ./run-java-benchmarks.sh                         # run all benchmarks
 #
 # The script builds a shaded (fat) JAR containing all dependencies and runs
@@ -40,6 +41,9 @@
 #
 # CrosscheckOverheadBenchmark is excluded from default no-argument runs. Run it
 # explicitly when working on safere-crosscheck performance.
+#
+# Arguments after the mode flag are passed directly to JMH as benchmark regex
+# filters.
 
 set -euo pipefail
 
@@ -63,7 +67,7 @@ PATHOLOGICAL_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 usage() {
   cat <<EOF
 Usage:
-  ./run-java-benchmarks.sh [--long|--smoke|--first-compile] [BenchmarkClass ...]
+  ./run-java-benchmarks.sh [--long|--smoke|--first-compile] [JmhBenchmarkRegex ...]
 
 Modes:
   default          Standard benchmark run.
@@ -125,32 +129,14 @@ is_pathological() {
   esac
 }
 
-normalize_benchmark_filter() {
-  local bench="$1"
-  local package_regex="org\\.safere\\.benchmark"
-  local regex='[][^$()|*+?\]'
-
-  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ $regex ]]; then
-    printf '%s\n' "$bench"
-  elif [[ "$bench" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-    printf '^%s\\.%s\\.\n' "$package_regex" "$bench"
-  elif [[ "$bench" =~ ^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$ ]]; then
-    printf '^%s\\.%s\\.%s($|_)\n' "$package_regex" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
-  else
-    printf '%s\n' "$bench"
-  fi
-}
-
 run_benchmark() {
   local bench="$1"
-  local filter
   local opts="$JMH_OPTS"
   if is_pathological "$bench"; then
     opts="$PATHOLOGICAL_JMH_OPTS"
   fi
-  filter="$(normalize_benchmark_filter "$bench")"
   echo "=== Running $bench ($opts) ==="
-  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "$filter"
+  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "$bench"
 }
 
 if [ $# -eq 0 ]; then

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -5,9 +5,9 @@
 # Run SafeRE JMH benchmarks with GC profiling to measure allocation rates.
 #
 # Usage:
-#   ./run-java-memory-benchmarks.sh RegexBenchmark         # publication-quality (default)
-#   ./run-java-memory-benchmarks.sh --quick RegexBenchmark  # fast dev iteration
-#   ./run-java-memory-benchmarks.sh --smoke RegexBenchmark  # CI smoke test
+#   ./run-java-memory-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
+#   ./run-java-memory-benchmarks.sh --quick '^org\.safere\.benchmark\.RegexBenchmark\.'
+#   ./run-java-memory-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.'
 #   ./run-java-memory-benchmarks.sh                         # run all benchmarks
 #
 # This runs the same benchmarks as run-java-benchmarks.sh but adds JMH's
@@ -16,6 +16,9 @@
 # and is not affected by other processes on the machine.
 #
 # See run-java-benchmarks.sh for details on modes and settings.
+#
+# Arguments after the mode flag are passed directly to JMH as benchmark regex
+# filters.
 
 set -euo pipefail
 
@@ -56,29 +59,12 @@ JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DI
 echo "=== Building safere + benchmark JAR ==="
 mvn install -DskipTests -q -f "$SCRIPT_DIR/pom.xml"
 
-normalize_benchmark_filter() {
-  local bench="$1"
-  local package_regex="org\\.safere\\.benchmark"
-  local regex='[][^$()|*+?\]'
-
-  if [[ "$bench" == org.safere.benchmark.* ]] || [[ "$bench" =~ $regex ]]; then
-    printf '%s\n' "$bench"
-  elif [[ "$bench" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-    printf '^%s\\.%s\\.\n' "$package_regex" "$bench"
-  elif [[ "$bench" =~ ^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$ ]]; then
-    printf '^%s\\.%s\\.%s($|_)\n' "$package_regex" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
-  else
-    printf '%s\n' "$bench"
-  fi
-}
-
 if [ $# -eq 0 ]; then
   echo "=== Running all benchmarks with GC profiling ==="
   java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" -prof gc $JMH_OPTS
 else
   for bench in "$@"; do
-    filter="$(normalize_benchmark_filter "$bench")"
     echo "=== Running $bench with GC profiling ==="
-    java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" -prof gc $JMH_OPTS "$filter"
+    java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" -prof gc $JMH_OPTS "$bench"
   done
 fi

--- a/safere-benchmarks/CONFIGURATION_EVALUATION.md
+++ b/safere-benchmarks/CONFIGURATION_EVALUATION.md
@@ -180,8 +180,8 @@ important enough to justify roughly doubling the runtime:
 The benchmark runner exposes these as:
 
 ```bash
-./run-java-benchmarks.sh RegexBenchmark
-./run-java-benchmarks.sh --long RegexBenchmark
+./run-java-benchmarks.sh '^org\.safere\.benchmark\.RegexBenchmark\.'
+./run-java-benchmarks.sh --long '^org\.safere\.benchmark\.RegexBenchmark\.'
 ```
 
 ## Reproducing


### PR DESCRIPTION
## Summary

This removes the Java benchmark wrapper's custom benchmark filter normalization and passes user-supplied benchmark arguments directly through to JMH as regex filters.

To preserve the CI and collection behavior that motivated the normalization, this updates the Java benchmark smoke tests and benchmark collection scripts to use explicit anchored JMH filters such as `^org\.safere\.benchmark\.RegexBenchmark\.`. The documentation now describes Java wrapper arguments as JMH benchmark regex filters instead of class-name shorthands.

## Root Cause

The previous helper tried to infer whether an argument was shorthand or an existing regex. That added a fragile Bash `[[ ... =~ ... ]]` expression and made the script maintain a second benchmark-selection language on top of JMH's own regex filters.

## Validation

Ran:

- `bash -n run-java-benchmarks.sh run-java-memory-benchmarks.sh collect-benchmark-results.sh`
- `git diff --check`
- `./run-java-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.'`
- `./run-java-memory-benchmarks.sh --smoke '^org\.safere\.benchmark\.RegexBenchmark\.'`
- `codex exec review --base main --json --output-last-message "$tmpdir/review.md" --ephemeral`

Both smoke runs completed and only ran `RegexBenchmark.*`, not `RealWorldRegexBenchmark.*`. The Codex review pass reported no findings.
