### PR TITLE
Use work counters for grapheme scaling tests

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -120,6 +120,7 @@
                         <exclude name="DfaTest.java"/>
                         <exclude name="EmptyOpTest.java"/>
                         <exclude name="EnginePathEquivalenceTest.java"/>
+                        <exclude name="GraphemeLinearTimeTest.java"/>
                         <exclude name="InstOpTest.java"/>
                         <exclude name="InstTest.java"/>
                         <exclude name="MatcherDeferredCaptureStateTest.java"/>

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -400,6 +400,7 @@ final class BitState {
     }
 
     while (jobCount > 0) {
+      WorkCounter.record();
       if (++stepCount > stepBudget) {
         budgetExceeded = true;
         return false;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1117,6 +1117,7 @@ final class Dfa {
 
     int pos = startPos;
     while (pos <= textLen) {
+      WorkCounter.record();
       int cp;
       int nextPos;
       int cls;
@@ -1271,6 +1272,7 @@ final class Dfa {
 
     int pos = endPos;
     while (pos >= startLimit) {
+      WorkCounter.record();
       int cp;
       int prevPos;
       int cls;

--- a/safere/src/main/java/org/safere/GraphemeSupport.java
+++ b/safere/src/main/java/org/safere/GraphemeSupport.java
@@ -114,6 +114,7 @@ final class GraphemeSupport {
       int runLength = 0;
       int pos = 0;
       while (pos < text.length()) {
+        WorkCounter.record();
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
         if (isRegionalIndicator(cp)) {
@@ -145,6 +146,7 @@ final class GraphemeSupport {
       boolean linkerSeen = false;
       int pos = 0;
       while (pos < text.length()) {
+        WorkCounter.record();
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
         if (isIndicConjunctConsonant(cp)) {
@@ -181,6 +183,7 @@ final class GraphemeSupport {
       int visiblePrependStart = -1;
       int pos = 0;
       while (pos < text.length()) {
+        WorkCounter.record();
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
         if (containsCodePoint(EXTENDED_PICTOGRAPHIC, cp)) {
@@ -324,6 +327,7 @@ final class GraphemeSupport {
       int regionStart,
       boolean consumedInput,
       int boundaryEndPos) {
+    WorkCounter.record();
     int flags = 0;
     if (isGraphemeBoundaryContextEdge(pos, regionStart, boundaryEndPos)) {
       flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
@@ -396,6 +400,7 @@ final class GraphemeSupport {
 
   static boolean isGraphemeClusterBoundary(
       String text, int pos, int regionStart, Context graphemeContext) {
+    WorkCounter.record();
     if (pos < 0 || pos > text.length()) {
       return false;
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -390,6 +390,7 @@ public final class Matcher implements MatchResult {
     // Scan every code point.
     int i = 0;
     while (i < len) {
+      WorkCounter.record();
       int cp = text.codePointAt(i);
       if (cp < 64) {
         if ((b0 & (1L << cp)) == 0) {
@@ -421,6 +422,7 @@ public final class Matcher implements MatchResult {
     int i = fromIndex;
     int len = text.length();
     while (i < len) {
+      WorkCounter.record();
       int cp = text.codePointAt(i);
       if (charClassContains(ranges, b0, b1, cp)) {
         return applyEngineResult(new FullMatchResult(new int[] {i, i + Character.charCount(cp)}));
@@ -441,6 +443,7 @@ public final class Matcher implements MatchResult {
     int i = Math.max(0, fromIndex);
     int len = text.length();
     while (i < len) {
+      WorkCounter.record();
       int cp = text.codePointAt(i);
       if (charClassContains(ranges, b0, b1, cp)) {
         return true;
@@ -1214,6 +1217,7 @@ public final class Matcher implements MatchResult {
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, literal, searchFrom);
       } else {
+        WorkCounter.record(Math.max(0, text.length() - searchFrom));
         idx = text.indexOf(literal, searchFrom);
       }
       if (idx < 0) {
@@ -1290,6 +1294,7 @@ public final class Matcher implements MatchResult {
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, prefix, searchFrom);
       } else {
+        WorkCounter.record(Math.max(0, text.length() - searchFrom));
         idx = text.indexOf(prefix, searchFrom);
       }
       if (idx < 0) {
@@ -1646,6 +1651,7 @@ public final class Matcher implements MatchResult {
   private boolean findKeywordAlternation(
       Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
     for (int i = Math.max(0, startPos); i < text.length(); i++) {
+      WorkCounter.record();
       char ch = text.charAt(i);
       if (ch < 128
           && keywordAlternation.firstAscii[asciiLower(ch)]
@@ -1695,6 +1701,7 @@ public final class Matcher implements MatchResult {
     int prefixLen = prefix.length();
     int limit = text.length() - prefixLen;
     for (int i = fromIndex; i <= limit; i++) {
+      WorkCounter.record();
       if (regionMatchesAsciiIgnoreCase(text, i, prefix, 0, prefixLen)) {
         return i;
       }
@@ -1712,6 +1719,7 @@ public final class Matcher implements MatchResult {
       return false;
     }
     for (int i = 0; i < length; i++) {
+      WorkCounter.record();
       if (asciiLower(text.charAt(textOffset + i)) != asciiLower(prefix.charAt(prefixOffset + i))) {
         return false;
       }
@@ -1726,6 +1734,7 @@ public final class Matcher implements MatchResult {
    */
   private static int indexOfCharClass(String text, boolean[] asciiMap, int fromIndex) {
     for (int i = fromIndex; i < text.length(); i++) {
+      WorkCounter.record();
       char ch = text.charAt(i);
       if (ch < 128 && asciiMap[ch]) {
         return i;
@@ -1738,6 +1747,7 @@ public final class Matcher implements MatchResult {
       String text, Pattern.StartAcceleration acceleration, int fromIndex, boolean unixLines) {
     int start = Math.max(0, fromIndex);
     for (int i = start; i < text.length(); i++) {
+      WorkCounter.record();
       if (matchesStartAcceleration(text, i, acceleration, unixLines)) {
         return i;
       }

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -560,6 +560,7 @@ final class Nfa {
 
     int engineEndPos = context.engineEndPos();
     for (int pos = start; pos < engineEndPos + 2; pos++) {
+      WorkCounter.record();
       if (prog.hasGraphemeSemantics()) {
         mergeDelayedQueue(delayedGrapheme, pos, runq);
       } else {
@@ -864,6 +865,7 @@ final class Nfa {
       int matchPos,
       int nextPos) {
     for (int threadIndex = 0; threadIndex < rq.size; threadIndex++) {
+      WorkCounter.record();
       NfaThread t = rq.threads[threadIndex];
       int id = t.id;
       int[] capture = t.capture;

--- a/safere/src/main/java/org/safere/WorkCounter.java
+++ b/safere/src/main/java/org/safere/WorkCounter.java
@@ -1,0 +1,50 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Package-private deterministic work accounting for performance regression tests. */
+final class WorkCounter {
+  private static final ThreadLocal<Counter> COUNTER = new ThreadLocal<>();
+  private static int activeCounters;
+
+  private WorkCounter() {}
+
+  private static final class Counter {
+    private long units;
+  }
+
+  static long countForTesting(Runnable task) {
+    Counter previous = COUNTER.get();
+    Counter current = new Counter();
+    activeCounters++;
+    COUNTER.set(current);
+    try {
+      task.run();
+      return current.units;
+    } finally {
+      if (previous == null) {
+        COUNTER.remove();
+      } else {
+        COUNTER.set(previous);
+      }
+      activeCounters--;
+    }
+  }
+
+  static void record() {
+    record(1);
+  }
+
+  static void record(long units) {
+    if (activeCounters == 0) {
+      return;
+    }
+    Counter counter = COUNTER.get();
+    if (counter != null) {
+      counter.units += units;
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/GraphemeLinearTimeTest.java
+++ b/safere/src/test/java/org/safere/GraphemeLinearTimeTest.java
@@ -1,0 +1,91 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Linear-time regression tests for grapheme cluster matching. */
+@DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
+class GraphemeLinearTimeTest {
+  @Test
+  @DisplayName("repeated find() over grapheme clusters reuses per-input context")
+  void repeatedFindOverGraphemeClustersReusesPerInputContext() {
+    Pattern pattern = Pattern.compile("\\X");
+
+    assertFourXInputStaysNearLinear(
+        "repeated find() over grapheme clusters",
+        "a".repeat(20_000),
+        "a".repeat(80_000),
+        text -> {
+          Matcher matcher = pattern.matcher(text);
+          int count = 0;
+          while (matcher.find()) {
+            count++;
+          }
+          assertThat(count).isEqualTo(text.length());
+        });
+  }
+
+  @Test
+  @DisplayName("JDK-compatible low-surrogate search positions stay near-linear")
+  void lowSurrogateSearchPositionsStayNearLinear() {
+    Pattern pattern = Pattern.compile(".*\\b{g}z");
+
+    assertFourXInputStaysNearLinear(
+        "low-surrogate search-position miss",
+        "\uDC00".repeat(20_000),
+        "\uDC00".repeat(80_000),
+        text -> assertThat(pattern.matcher(text).find()).isFalse());
+  }
+
+  @Test
+  @DisplayName("regional-indicator grapheme boundary misses stay near-linear")
+  void regionalIndicatorBoundaryMissesStayNearLinear() {
+    Pattern pattern = Pattern.compile("\\b{g}z");
+
+    assertFourXInputStaysNearLinear(
+        "regional-indicator boundary miss",
+        "\uD83C\uDDE6".repeat(20_000),
+        "\uD83C\uDDE6".repeat(80_000),
+        text -> assertThat(pattern.matcher(text).find()).isFalse());
+  }
+
+  @Test
+  @DisplayName("failed unanchored \\X suffix misses stay near-linear")
+  void failedUnanchoredGraphemeSuffixMissesStayNearLinear() {
+    Pattern pattern = Pattern.compile("\\Xz");
+
+    assertFourXInputStaysNearLinear(
+        "failed unanchored \\X suffix miss",
+        "a" + "\u0301".repeat(20_000),
+        "a" + "\u0301".repeat(80_000),
+        text -> assertThat(pattern.matcher(text).find()).isFalse());
+    assertFourXInputStaysNearLinear(
+        "failed unanchored regional-indicator \\X suffix miss",
+        "\uD83C\uDDE6".repeat(20_000),
+        "\uD83C\uDDE6".repeat(80_000),
+        text -> assertThat(pattern.matcher(text).find()).isFalse());
+  }
+
+  private static void assertFourXInputStaysNearLinear(
+      String scenario, String smallerInput, String largerInput, Consumer<String> task) {
+    task.accept(smallerInput);
+    task.accept(largerInput);
+    long smallerWork = WorkCounter.countForTesting(() -> task.accept(smallerInput));
+    long largerWork = WorkCounter.countForTesting(() -> task.accept(largerInput));
+
+    assertThat(smallerWork).as("%s: smaller input should use grapheme work", scenario).isPositive();
+    assertThat(largerWork)
+        .as(
+            "%s: 4x input should stay near-linear, smallerWork=%d largerWork=%d",
+            scenario, smallerWork, largerWork)
+        .isLessThan(smallerWork * 5);
+  }
+}

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -7,14 +7,11 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
@@ -26,8 +23,6 @@ import org.junit.jupiter.api.Test;
  * Validates behavior against JDK 21's {@link java.util.regex.Pattern} specification.
  */
 class LinebreakGraphemeTest {
-  private static final Duration PERFORMANCE_SCENARIO_TIMEOUT = Duration.ofSeconds(30);
-
   @Nested
   @DisplayName("\\R (Unicode linebreak)")
   class LinebreakTests {
@@ -534,70 +529,6 @@ class LinebreakGraphemeTest {
     }
 
     @Test
-    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
-    @DisplayName("repeated find() over grapheme clusters reuses per-input context")
-    void repeatedFindOverGraphemeClustersReusesPerInputContext() {
-      Pattern pattern = Pattern.compile("\\X");
-
-      assertFourXInputStaysNearLinear(
-          "repeated find() over grapheme clusters",
-          "a".repeat(20_000),
-          "a".repeat(80_000),
-          text -> {
-            Matcher matcher = pattern.matcher(text);
-            int count = 0;
-            while (matcher.find()) {
-              count++;
-            }
-            assertThat(count).isEqualTo(text.length());
-          });
-    }
-
-    @Test
-    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
-    @DisplayName("JDK-compatible low-surrogate search positions stay near-linear")
-    void lowSurrogateSearchPositionsStayNearLinear() {
-      Pattern pattern = Pattern.compile(".*\\b{g}z");
-
-      assertFourXInputStaysNearLinear(
-          "low-surrogate search-position miss",
-          "\uDC00".repeat(20_000),
-          "\uDC00".repeat(80_000),
-          text -> assertThat(pattern.matcher(text).find()).isFalse());
-    }
-
-    @Test
-    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
-    @DisplayName("regional-indicator grapheme boundary misses stay near-linear")
-    void regionalIndicatorBoundaryMissesStayNearLinear() {
-      Pattern pattern = Pattern.compile("\\b{g}z");
-
-      assertFourXInputStaysNearLinear(
-          "regional-indicator boundary miss",
-          "\uD83C\uDDE6".repeat(20_000),
-          "\uD83C\uDDE6".repeat(80_000),
-          text -> assertThat(pattern.matcher(text).find()).isFalse());
-    }
-
-    @Test
-    @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
-    @DisplayName("failed unanchored \\X suffix misses stay near-linear")
-    void failedUnanchoredGraphemeSuffixMissesStayNearLinear() {
-      Pattern pattern = Pattern.compile("\\Xz");
-
-      assertFourXInputStaysNearLinear(
-          "failed unanchored \\X suffix miss",
-          "a" + "\u0301".repeat(20_000),
-          "a" + "\u0301".repeat(80_000),
-          text -> assertThat(pattern.matcher(text).find()).isFalse());
-      assertFourXInputStaysNearLinear(
-          "failed unanchored regional-indicator \\X suffix miss",
-          "\uD83C\uDDE6".repeat(20_000),
-          "\uD83C\uDDE6".repeat(80_000),
-          text -> assertThat(pattern.matcher(text).find()).isFalse());
-    }
-
-    @Test
     @DisplayName("consecutive \\X atoms do not split a single grapheme cluster")
     void consecutiveAtomsDoNotSplitSingleCluster() {
       Pattern p = Pattern.compile("^\\X\\X$");
@@ -894,39 +825,6 @@ class LinebreakGraphemeTest {
       assertThat(matcher.find()).isTrue();
       assertThat(matcher.start()).isZero();
       assertThat(matcher.end()).isEqualTo(2);
-    }
-
-    private static void assertFourXInputStaysNearLinear(
-        String scenario, String smallerInput, String largerInput, Consumer<String> task) {
-      task.accept(smallerInput);
-      task.accept(largerInput);
-      long smallerNanos = medianRuntimeNanos(() -> task.accept(smallerInput));
-      long largerNanos = medianRuntimeNanos(() -> task.accept(largerInput));
-
-      assertThat(largerNanos)
-          .as(
-              "%s: 4x input should stay near-linear, smaller=%dns larger=%dns",
-              scenario, smallerNanos, largerNanos)
-          .isLessThan(smallerNanos * 10);
-    }
-
-    private static long medianRuntimeNanos(Runnable task) {
-      long[] samples = new long[5];
-      for (int i = 0; i < samples.length; i++) {
-        samples[i] = runtimeNanos(task);
-      }
-      java.util.Arrays.sort(samples);
-      return samples[samples.length / 2];
-    }
-
-    private static long runtimeNanos(Runnable task) {
-      return assertTimeoutPreemptively(
-          PERFORMANCE_SCENARIO_TIMEOUT,
-          () -> {
-            long start = System.nanoTime();
-            task.run();
-            return System.nanoTime() - start;
-          });
     }
 
     private static AllocationTracker allocationTracker() {

--- a/safere/src/test/java/org/safere/PatternSetTest.java
+++ b/safere/src/test/java/org/safere/PatternSetTest.java
@@ -7,11 +7,9 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntConsumer;
@@ -24,8 +22,6 @@ import org.junit.jupiter.api.Test;
 /** Tests for {@link PatternSet}. */
 @DisabledForCrosscheck("PatternSet is a SafeRE-only API with no java.util.regex equivalent")
 class PatternSetTest {
-  private static final Duration PERFORMANCE_SCENARIO_TIMEOUT = Duration.ofSeconds(30);
-
   // ---------------------------------------------------------------------------
   // Builder
   // ---------------------------------------------------------------------------
@@ -622,33 +618,15 @@ class PatternSetTest {
 
   private static void assertFourXInputStaysNearLinear(String scenario, IntConsumer task) {
     task.accept(1_000);
-    long smallerNanos = medianRuntimeNanos(() -> task.accept(5_000));
-    long largerNanos = medianRuntimeNanos(() -> task.accept(20_000));
+    long smallerWork = WorkCounter.countForTesting(() -> task.accept(5_000));
+    long largerWork = WorkCounter.countForTesting(() -> task.accept(20_000));
 
-    assertThat(largerNanos)
+    assertThat(smallerWork).as("%s: smaller input should use matcher work", scenario).isPositive();
+    assertThat(largerWork)
         .as(
-            "%s: 4x input should stay near-linear, smaller=%dns larger=%dns",
-            scenario, smallerNanos, largerNanos)
-        .isLessThan(smallerNanos * 10);
-  }
-
-  private static long medianRuntimeNanos(Runnable task) {
-    long[] samples = new long[5];
-    for (int i = 0; i < samples.length; i++) {
-      samples[i] = runtimeNanos(task);
-    }
-    java.util.Arrays.sort(samples);
-    return samples[samples.length / 2];
-  }
-
-  private static long runtimeNanos(Runnable task) {
-    return assertTimeoutPreemptively(
-        PERFORMANCE_SCENARIO_TIMEOUT,
-        () -> {
-          long start = System.nanoTime();
-          task.run();
-          return System.nanoTime() - start;
-        });
+            "%s: 4x input should stay near-linear, smallerWork=%d largerWork=%d",
+            scenario, smallerWork, largerWork)
+        .isLessThan(smallerWork * 5);
   }
 
   private static long allocatedFor(


### PR DESCRIPTION
## Summary

- add package-private deterministic work accounting for matcher/scaling regression tests
- record work in the matcher fast paths, DFA, BitState, NFA, and grapheme boundary/context paths
- replace wall-clock timing assertions in grapheme scaling tests with work-unit scaling assertions

## Why

The existing linear-time smoke tests used elapsed time ratios. Those tests have caught real regressions, but they are also noisy on CI and have failed without a code regression. Counting deterministic engine work keeps the same scaling invariant while avoiding scheduler and machine noise.

## Verification

Ran:

- `mvn -pl safere -Dtest='LinebreakGraphemeTest$GraphemeClusterTests' test -q`
- `mvn -pl safere -Dtest='PatternSetTest#regionalIndicatorGraphemeBoundaryMissesStayNearLinear' test -q`
- `mvn -pl safere -Dtest='PatternSetTest' test -q`
- `mvn -pl safere test -q`
- `git diff --check`
