### PR TITLE
Run fuzz regression seeds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,32 @@ jobs:
           -Dtest.parallelism=4
           --batch-mode --no-transfer-progress
 
+  fuzz-regression:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build SafeRE for fuzz tests
+        run: >
+          mvn -pl safere -am install
+          -DskipTests
+          --batch-mode --no-transfer-progress
+
+      - name: Run fuzz regression seeds
+        run: >
+          mvn -pl safere-fuzz test
+          --batch-mode --no-transfer-progress
+
   benchmark-smoke-test-java:
     needs: changes
     if: needs.changes.outputs.code == 'true'


### PR DESCRIPTION
## Summary

- add a dedicated CI job for fuzz regression seed tests
- build and install the SafeRE dependency with tests skipped before running the fuzz module
- run `safere-fuzz` tests without `-am` so the job does not duplicate the full SafeRE test suite

## Verification

- `mvn -pl safere-fuzz -am test` passed before the CI change
  - SafeRE Fuzz Tests: 36 tests, 0 failures, 0 errors
  - Total time: 18:54 min
- `mvn -pl safere -am install -DskipTests --batch-mode --no-transfer-progress`
  - passed in 33.043 s
- `mvn -pl safere-fuzz test --batch-mode --no-transfer-progress`
  - passed, 36 tests, 0 failures, 0 errors, 17.536 s

The existing CI build job still runs the full SafeRE, crosscheck, and exhaustive module verification.
