### PR TITLE
Reduce WorkCounter instrumentation overhead

### DIFF
--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -400,7 +400,9 @@ final class BitState {
     }
 
     while (jobCount > 0) {
-      WorkCounter.record();
+      if (WorkCounter.activeCounters != 0) {
+        WorkCounter.record();
+      }
       if (++stepCount > stepBudget) {
         budgetExceeded = true;
         return false;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1117,7 +1117,9 @@ final class Dfa {
 
     int pos = startPos;
     while (pos <= textLen) {
-      WorkCounter.record();
+      if (WorkCounter.activeCounters != 0) {
+        WorkCounter.record();
+      }
       int cp;
       int nextPos;
       int cls;
@@ -1272,7 +1274,9 @@ final class Dfa {
 
     int pos = endPos;
     while (pos >= startLimit) {
-      WorkCounter.record();
+      if (WorkCounter.activeCounters != 0) {
+        WorkCounter.record();
+      }
       int cp;
       int prevPos;
       int cls;

--- a/safere/src/main/java/org/safere/WorkCounter.java
+++ b/safere/src/main/java/org/safere/WorkCounter.java
@@ -8,7 +8,7 @@ package org.safere;
 /** Package-private deterministic work accounting for performance regression tests. */
 final class WorkCounter {
   private static final ThreadLocal<Counter> COUNTER = new ThreadLocal<>();
-  private static int activeCounters;
+  static int activeCounters;
 
   private WorkCounter() {}
 


### PR DESCRIPTION
Guard calls to WorkCounter APIs in some core loops to avoid overhead.

https://github.com/eaftan/safere/issues/521
