### PR TITLE
BitState stack consolidation optimization

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -30,6 +30,11 @@
       "pattern": "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}",
       "text": "contact user.name+tag@example.co.uk for info",
       "op": "find"
+    },
+    "lazyWildcardFind": {
+      "pattern": "(?s)<markerA>.*?<markerB>",
+      "text": "<markerA>Lorem ipsum dolor sit amet, consectetur adipiscing elit.<markerB>",
+      "op": "find"
     }
   },
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexBenchmark.java
@@ -95,6 +95,16 @@ public class RegexBenchmark {
   private org.safere.re2ffm.RE2FfmPattern re2ffmEmail;
   private String emailText;
 
+  // ---------------------------------------------------------------------------
+  // Lazy wildcard find
+  // ---------------------------------------------------------------------------
+
+  private org.safere.Pattern safeLazyWildcard;
+  private java.util.regex.Pattern jdkLazyWildcard;
+  private com.google.re2j.Pattern re2jLazyWildcard;
+  private org.safere.re2ffm.RE2FfmPattern re2ffmLazyWildcard;
+  private String lazyWildcardText;
+
   @Setup
   public void setup() {
     BenchmarkData data = BenchmarkData.get();
@@ -146,6 +156,14 @@ public class RegexBenchmark {
     jdkEmail = java.util.regex.Pattern.compile(emailPattern);
     re2jEmail = com.google.re2j.Pattern.compile(emailPattern);
     re2ffmEmail = org.safere.re2ffm.RE2FfmPattern.compile(emailPattern);
+
+    // Lazy wildcard
+    String lazyWildcardPattern = data.getString("regex.lazyWildcardFind.pattern");
+    lazyWildcardText = data.getString("regex.lazyWildcardFind.text");
+    safeLazyWildcard = org.safere.Pattern.compile(lazyWildcardPattern);
+    jdkLazyWildcard = java.util.regex.Pattern.compile(lazyWildcardPattern);
+    re2jLazyWildcard = com.google.re2j.Pattern.compile(lazyWildcardPattern);
+    re2ffmLazyWildcard = org.safere.re2ffm.RE2FfmPattern.compile(lazyWildcardPattern);
   }
 
   // ===== Literal match =====
@@ -326,5 +344,27 @@ public class RegexBenchmark {
   @Benchmark
   public boolean emailFind_re2ffm() {
     return re2ffmEmail.matcher(emailText).find();
+  }
+
+  // ===== Lazy wildcard find =====
+
+  @Benchmark
+  public boolean lazyWildcardFind_safere() {
+    return safeLazyWildcard.matcher(lazyWildcardText).find();
+  }
+
+  @Benchmark
+  public boolean lazyWildcardFind_jdk() {
+    return jdkLazyWildcard.matcher(lazyWildcardText).find();
+  }
+
+  @Benchmark
+  public boolean lazyWildcardFind_re2j() {
+    return re2jLazyWildcard.matcher(lazyWildcardText).find();
+  }
+
+  @Benchmark
+  public boolean lazyWildcardFind_re2ffm() {
+    return re2ffmLazyWildcard.matcher(lazyWildcardText).find();
   }
 }

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -289,9 +289,7 @@ final class BitState {
   private boolean budgetExceeded;
 
   /** Explicit job stack for backtracking. */
-  private int[] jobInstId;
-
-  private int[] jobPos;
+  private long[] jobStack;
   private int jobCount;
 
   private BitState(Prog prog, String text, int ncap, boolean longest, boolean endMatch) {
@@ -319,8 +317,7 @@ final class BitState {
     }
 
     int maxJobs = Math.min(totalBits, 4096);
-    this.jobInstId = new int[maxJobs];
-    this.jobPos = new int[maxJobs];
+    this.jobStack = new long[maxJobs];
     this.jobCount = 0;
     this.stepBudget = Math.max(4096L, (long) MAX_WORK_PER_SLOT * prog.size() * (textLen + 1));
     this.stepCount = 0;
@@ -365,16 +362,12 @@ final class BitState {
     return true;
   }
 
-  /** Pushes a job onto the stack, growing if needed. */
   private void push(int instId, int pos) {
-    if (jobCount >= jobInstId.length) {
-      int newLen = jobInstId.length * 2;
-      jobInstId = Arrays.copyOf(jobInstId, newLen);
-      jobPos = Arrays.copyOf(jobPos, newLen);
+    if (jobCount >= jobStack.length) {
+      int newLen = jobStack.length * 2;
+      jobStack = Arrays.copyOf(jobStack, newLen);
     }
-    jobInstId[jobCount] = instId;
-    jobPos[jobCount] = pos;
-    jobCount++;
+    jobStack[jobCount++] = ((long) pos << 32) | (instId & 0xFFFFFFFFL);
   }
 
   /**
@@ -406,8 +399,9 @@ final class BitState {
         return false;
       }
       jobCount--;
-      int id = jobInstId[jobCount];
-      int pos = jobPos[jobCount];
+      long job = jobStack[jobCount];
+      int id = (int) job;
+      int pos = (int) (job >>> 32);
 
       // Negative IDs are restore sentinels: cap or loopReg restore on backtrack.
       // Capture sentinels use -(reg+1) where reg < ncap.
@@ -580,7 +574,7 @@ final class BitState {
     int requiredVisitedLen = (totalBits + 63) / 64;
     return visited.length >= requiredVisitedLen
         && cap.length >= ncap
-        && jobInstId.length >= Math.min(totalBits, 4096);
+        && jobStack.length >= Math.min(totalBits, 4096);
   }
 
   /**

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -290,6 +290,7 @@ final class BitState {
 
   /** Explicit job stack for backtracking. */
   private long[] jobStack;
+
   private int jobCount;
 
   private BitState(Prog prog, String text, int ncap, boolean longest, boolean endMatch) {


### PR DESCRIPTION
For a regex like `(?s)<markerA>.*?<markerB>` with lazy wildcard repetitions and a short 100-character input matching the pattern like `<markerA>Lorem ipsum dolor sit amet, consectetur adipiscing elit.<markerB>`, packing the `jobInstId` and `jobPos` into a single `long[]` in `BitState` improves cache locality and reduces the number of array bounds checks, and improved latency by ~17% for that benchmark.

I noticed this looking at cases where RE2 outperforms SafeRE for short ~100 character inputs.