### PR TITLE
Disable WorkCounters in production builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
           -Dtest.parallelism=4
           --batch-mode --no-transfer-progress
 
+      - name: Run work-counter scaling tests
+        run: >
+          mvn clean test -pl safere
+          -Pwork-counters
+          -Dtest.parallelism=4
+          --batch-mode --no-transfer-progress
+
   fuzz-regression:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Build and test
         run: mvn -pl safere verify -Dtest.parallelism=4 --batch-mode --no-transfer-progress
 
+      - name: Run work-counter scaling tests
+        run: >
+          mvn clean test -pl safere
+          -Pwork-counters
+          -Dtest.parallelism=4
+          --batch-mode --no-transfer-progress
+
       - name: Publish to Maven Central
         run: mvn -pl safere deploy -Prelease -DskipTests --batch-mode --no-transfer-progress
         env:

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -140,6 +140,7 @@
                         <exclude name="UnicodeTablesTest.java"/>
                         <exclude name="UtilsTest.java"/>
                         <exclude name="WalkerTest.java"/>
+                        <exclude name="WorkCounterTest.java"/>
                       </fileset>
                       <filterchain>
                         <replaceregex

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -19,6 +19,9 @@
 
   <properties>
     <test.parallelism>16</test.parallelism>
+    <workCounter.enabled>false</workCounter.enabled>
+    <test.groups></test.groups>
+    <test.excludedGroups>work-counter</test.excludedGroups>
   </properties>
 
   <dependencyManagement>
@@ -49,6 +52,58 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>generate-work-counter-config</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <mkdir dir="${project.build.directory}/generated-sources/work-counter/org/safere"/>
+                <echo file="${project.build.directory}/generated-sources/work-counter/org/safere/WorkCounterConfig.java"><![CDATA[// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Generated compile-time flag for deterministic test work accounting. */
+final class WorkCounterConfig {
+  static final boolean ENABLED = ${workCounter.enabled};
+
+  private WorkCounterConfig() {}
+}
+]]></echo>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <id>add-work-counter-config-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/work-counter</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -109,6 +164,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>
+          <groups>${test.groups}</groups>
+          <excludedGroups>${test.excludedGroups}</excludedGroups>
           <properties>
             <configurationParameters>
               junit.jupiter.execution.parallel.enabled = true
@@ -187,6 +244,14 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>work-counters</id>
+      <properties>
+        <workCounter.enabled>true</workCounter.enabled>
+        <test.groups>work-counter</test.groups>
+        <test.excludedGroups></test.excludedGroups>
+      </properties>
+    </profile>
     <profile>
       <id>coverage</id>
       <build>

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -400,7 +400,9 @@ final class BitState {
     }
 
     while (jobCount > 0) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       if (++stepCount > stepBudget) {
         budgetExceeded = true;
         return false;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1117,7 +1117,9 @@ final class Dfa {
 
     int pos = startPos;
     while (pos <= textLen) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       int cp;
       int nextPos;
       int cls;
@@ -1272,7 +1274,9 @@ final class Dfa {
 
     int pos = endPos;
     while (pos >= startLimit) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       int cp;
       int prevPos;
       int cls;

--- a/safere/src/main/java/org/safere/GraphemeSupport.java
+++ b/safere/src/main/java/org/safere/GraphemeSupport.java
@@ -114,7 +114,9 @@ final class GraphemeSupport {
       int runLength = 0;
       int pos = 0;
       while (pos < text.length()) {
-        WorkCounter.record();
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
         if (isRegionalIndicator(cp)) {
@@ -146,7 +148,9 @@ final class GraphemeSupport {
       boolean linkerSeen = false;
       int pos = 0;
       while (pos < text.length()) {
-        WorkCounter.record();
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
         if (isIndicConjunctConsonant(cp)) {
@@ -183,7 +187,9 @@ final class GraphemeSupport {
       int visiblePrependStart = -1;
       int pos = 0;
       while (pos < text.length()) {
-        WorkCounter.record();
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
         int cp = text.codePointAt(pos);
         int next = pos + Character.charCount(cp);
         if (containsCodePoint(EXTENDED_PICTOGRAPHIC, cp)) {
@@ -327,7 +333,9 @@ final class GraphemeSupport {
       int regionStart,
       boolean consumedInput,
       int boundaryEndPos) {
-    WorkCounter.record();
+    if (WorkCounterConfig.ENABLED) {
+      WorkCounter.record();
+    }
     int flags = 0;
     if (isGraphemeBoundaryContextEdge(pos, regionStart, boundaryEndPos)) {
       flags |= EmptyOp.GRAPHEME_CLUSTER_BOUNDARY | EmptyOp.EXPLICIT_GRAPHEME_CLUSTER_BOUNDARY;
@@ -400,7 +408,9 @@ final class GraphemeSupport {
 
   static boolean isGraphemeClusterBoundary(
       String text, int pos, int regionStart, Context graphemeContext) {
-    WorkCounter.record();
+    if (WorkCounterConfig.ENABLED) {
+      WorkCounter.record();
+    }
     if (pos < 0 || pos > text.length()) {
       return false;
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -390,7 +390,9 @@ public final class Matcher implements MatchResult {
     // Scan every code point.
     int i = 0;
     while (i < len) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       int cp = text.codePointAt(i);
       if (cp < 64) {
         if ((b0 & (1L << cp)) == 0) {
@@ -422,7 +424,9 @@ public final class Matcher implements MatchResult {
     int i = fromIndex;
     int len = text.length();
     while (i < len) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       int cp = text.codePointAt(i);
       if (charClassContains(ranges, b0, b1, cp)) {
         return applyEngineResult(new FullMatchResult(new int[] {i, i + Character.charCount(cp)}));
@@ -443,7 +447,9 @@ public final class Matcher implements MatchResult {
     int i = Math.max(0, fromIndex);
     int len = text.length();
     while (i < len) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       int cp = text.codePointAt(i);
       if (charClassContains(ranges, b0, b1, cp)) {
         return true;
@@ -1217,7 +1223,9 @@ public final class Matcher implements MatchResult {
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, literal, searchFrom);
       } else {
-        WorkCounter.record(Math.max(0, text.length() - searchFrom));
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(Math.max(0, text.length() - searchFrom));
+        }
         idx = text.indexOf(literal, searchFrom);
       }
       if (idx < 0) {
@@ -1294,7 +1302,9 @@ public final class Matcher implements MatchResult {
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, prefix, searchFrom);
       } else {
-        WorkCounter.record(Math.max(0, text.length() - searchFrom));
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(Math.max(0, text.length() - searchFrom));
+        }
         idx = text.indexOf(prefix, searchFrom);
       }
       if (idx < 0) {
@@ -1651,7 +1661,9 @@ public final class Matcher implements MatchResult {
   private boolean findKeywordAlternation(
       Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
     for (int i = Math.max(0, startPos); i < text.length(); i++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       char ch = text.charAt(i);
       if (ch < 128
           && keywordAlternation.firstAscii[asciiLower(ch)]
@@ -1701,7 +1713,9 @@ public final class Matcher implements MatchResult {
     int prefixLen = prefix.length();
     int limit = text.length() - prefixLen;
     for (int i = fromIndex; i <= limit; i++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       if (regionMatchesAsciiIgnoreCase(text, i, prefix, 0, prefixLen)) {
         return i;
       }
@@ -1719,7 +1733,9 @@ public final class Matcher implements MatchResult {
       return false;
     }
     for (int i = 0; i < length; i++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       if (asciiLower(text.charAt(textOffset + i)) != asciiLower(prefix.charAt(prefixOffset + i))) {
         return false;
       }
@@ -1734,7 +1750,9 @@ public final class Matcher implements MatchResult {
    */
   private static int indexOfCharClass(String text, boolean[] asciiMap, int fromIndex) {
     for (int i = fromIndex; i < text.length(); i++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       char ch = text.charAt(i);
       if (ch < 128 && asciiMap[ch]) {
         return i;
@@ -1747,7 +1765,9 @@ public final class Matcher implements MatchResult {
       String text, Pattern.StartAcceleration acceleration, int fromIndex, boolean unixLines) {
     int start = Math.max(0, fromIndex);
     for (int i = start; i < text.length(); i++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       if (matchesStartAcceleration(text, i, acceleration, unixLines)) {
         return i;
       }

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -560,7 +560,9 @@ final class Nfa {
 
     int engineEndPos = context.engineEndPos();
     for (int pos = start; pos < engineEndPos + 2; pos++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       if (prog.hasGraphemeSemantics()) {
         mergeDelayedQueue(delayedGrapheme, pos, runq);
       } else {
@@ -865,7 +867,9 @@ final class Nfa {
       int matchPos,
       int nextPos) {
     for (int threadIndex = 0; threadIndex < rq.size; threadIndex++) {
-      WorkCounter.record();
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       NfaThread t = rq.threads[threadIndex];
       int id = t.id;
       int[] capture = t.capture;

--- a/safere/src/main/java/org/safere/WorkCounter.java
+++ b/safere/src/main/java/org/safere/WorkCounter.java
@@ -8,7 +8,6 @@ package org.safere;
 /** Package-private deterministic work accounting for performance regression tests. */
 final class WorkCounter {
   private static final ThreadLocal<Counter> COUNTER = new ThreadLocal<>();
-  private static int activeCounters;
 
   private WorkCounter() {}
 
@@ -17,9 +16,11 @@ final class WorkCounter {
   }
 
   static long countForTesting(Runnable task) {
+    if (!WorkCounterConfig.ENABLED) {
+      throw new IllegalStateException("WorkCounter is disabled; run tests with -Pwork-counters");
+    }
     Counter previous = COUNTER.get();
     Counter current = new Counter();
-    activeCounters++;
     COUNTER.set(current);
     try {
       task.run();
@@ -30,7 +31,6 @@ final class WorkCounter {
       } else {
         COUNTER.set(previous);
       }
-      activeCounters--;
     }
   }
 
@@ -39,9 +39,6 @@ final class WorkCounter {
   }
 
   static void record(long units) {
-    if (activeCounters == 0) {
-      return;
-    }
     Counter counter = COUNTER.get();
     if (counter != null) {
       counter.units += units;

--- a/safere/src/test/java/org/safere/GraphemeLinearTimeTest.java
+++ b/safere/src/test/java/org/safere/GraphemeLinearTimeTest.java
@@ -9,10 +9,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Consumer;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Linear-time regression tests for grapheme cluster matching. */
 @DisabledForCrosscheck("java.util.regex is not the SafeRE linear-time engine")
+@Tag("work-counter")
 class GraphemeLinearTimeTest {
   @Test
   @DisplayName("repeated find() over grapheme clusters reuses per-input context")

--- a/safere/src/test/java/org/safere/PatternSetTest.java
+++ b/safere/src/test/java/org/safere/PatternSetTest.java
@@ -17,6 +17,7 @@ import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link PatternSet}. */
@@ -148,6 +149,7 @@ class PatternSetTest {
     }
 
     @Test
+    @Tag("work-counter")
     void regionalIndicatorGraphemeBoundaryMissesStayNearLinear() {
       PatternSet.Builder b = new PatternSet.Builder(PatternSet.Anchor.UNANCHORED);
       b.add("\\b{g}z");

--- a/safere/src/test/java/org/safere/WorkCounterTest.java
+++ b/safere/src/test/java/org/safere/WorkCounterTest.java
@@ -1,0 +1,133 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for deterministic work accounting. */
+class WorkCounterTest {
+  @Test
+  @DisplayName("countForTesting throws when work counters are disabled")
+  void countForTestingThrowsWhenCountersAreDisabled() {
+    assertThatThrownBy(() -> WorkCounter.countForTesting(() -> {}))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("WorkCounter is disabled");
+  }
+
+  @Test
+  @DisplayName("production bytecode has no work counter method or field references when disabled")
+  void productionBytecodeHasNoWorkCounterMethodOrFieldReferencesWhenDisabled()
+      throws IOException, URISyntaxException {
+    Path classesRoot =
+        Path.of(WorkCounter.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+    Path packageRoot = classesRoot.resolve("org/safere");
+    List<String> references = new ArrayList<>();
+
+    try (var classFiles = Files.walk(packageRoot)) {
+      List<Path> compiledClasses =
+          classFiles.filter(path -> path.toString().endsWith(".class")).toList();
+      for (Path classFile : compiledClasses) {
+        String classFileName = classFile.getFileName().toString();
+        if (classFileName.startsWith("WorkCounter")) {
+          continue;
+        }
+        references.addAll(workCounterMethodOrFieldReferences(classFile));
+      }
+    }
+
+    assertThat(references).isEmpty();
+  }
+
+  private static List<String> workCounterMethodOrFieldReferences(Path classFile)
+      throws IOException {
+    try (InputStream input = Files.newInputStream(classFile);
+        DataInputStream data = new DataInputStream(input)) {
+      int magic = data.readInt();
+      assertThat(magic).isEqualTo(0xCAFEBABE);
+      data.readUnsignedShort();
+      data.readUnsignedShort();
+
+      ConstantPool constantPool = ConstantPool.read(data);
+      List<String> references = new ArrayList<>();
+      for (ConstantPool.Ref ref : constantPool.refs) {
+        String owner = constantPool.className(ref.classIndex);
+        if (!owner.equals("org/safere/WorkCounter")
+            && !owner.equals("org/safere/WorkCounterConfig")) {
+          continue;
+        }
+        references.add(
+            classFile.getFileName() + " references " + owner + "." + constantPool.name(ref));
+      }
+      return references;
+    }
+  }
+
+  private static final class ConstantPool {
+    private final List<Ref> refs = new ArrayList<>();
+    private final String[] utf8s;
+    private final int[] classNameIndexes;
+    private final int[] nameAndTypeNameIndexes;
+
+    private ConstantPool(int size) {
+      utf8s = new String[size];
+      classNameIndexes = new int[size];
+      nameAndTypeNameIndexes = new int[size];
+    }
+
+    private static ConstantPool read(DataInputStream data) throws IOException {
+      int constantPoolCount = data.readUnsignedShort();
+      ConstantPool constantPool = new ConstantPool(constantPoolCount);
+      for (int index = 1; index < constantPoolCount; index++) {
+        int tag = data.readUnsignedByte();
+        switch (tag) {
+          case 1 -> constantPool.utf8s[index] = data.readUTF();
+          case 3, 4 -> data.skipBytes(4);
+          case 5, 6 -> {
+            data.skipBytes(8);
+            index++;
+          }
+          case 7 -> constantPool.classNameIndexes[index] = data.readUnsignedShort();
+          case 8, 16, 19, 20 -> data.skipBytes(2);
+          case 9, 10, 11 -> {
+            int classIndex = data.readUnsignedShort();
+            int nameAndTypeIndex = data.readUnsignedShort();
+            constantPool.refs.add(new Ref(classIndex, nameAndTypeIndex));
+          }
+          case 12 -> {
+            constantPool.nameAndTypeNameIndexes[index] = data.readUnsignedShort();
+            data.readUnsignedShort();
+          }
+          case 15 -> data.skipBytes(3);
+          case 17, 18 -> data.skipBytes(4);
+          default -> throw new IOException("Unsupported constant pool tag " + tag);
+        }
+      }
+      return constantPool;
+    }
+
+    private String className(int classIndex) {
+      return utf8s[classNameIndexes[classIndex]];
+    }
+
+    private String name(Ref ref) {
+      return utf8s[nameAndTypeNameIndexes[ref.nameAndTypeIndex]];
+    }
+
+    private record Ref(int classIndex, int nameAndTypeIndex) {}
+  }
+}

--- a/safere/src/test/java/org/safere/WorkCounterTest.java
+++ b/safere/src/test/java/org/safere/WorkCounterTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Tests for deterministic work accounting. */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class WorkCounterTest {
   @Test
   @DisplayName("countForTesting throws when work counters are disabled")


### PR DESCRIPTION
This is an alternative to #522 that completely removes WorkCounter instrumentation from production builds. I use a compile-time constant boolean that is set to false in the production config and true in a limited test config that applies only the the specific tests that need WorkCounters. javac optimizes any if (false) blocks away, so in the production build there is no more WorkCounter instrumentation.

I verified using javap that the generated bytecode in production config no longer contains any references to WorkCounter. I also added a test for this. Finally, I made it so that attempts to read work counters when they are disabled throw an exception.