### PR TITLE
Add more real-world benchmarks

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -323,10 +323,12 @@
         "match": "  <Banana>  ",
         "nonMatch": "  <Orange>  ",
         "matchInput": {
-          "kind": "repeat"
+          "kind": "surroundWithSpaces",
+          "body": "<Banana>"
         },
         "nonMatchInput": {
-          "kind": "repeat"
+          "kind": "surroundWithSpaces",
+          "body": "<Orange>"
         }
       }
     ]

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -302,6 +302,32 @@
           "kind": "prefixedRepeat",
           "prefix": "12345 "
         }
+      },
+      {
+        "name": "fruitSearchQuery",
+        "pattern": "(?is).*\\b(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)\\b.*",
+        "op": "replaceAllGroup1",
+        "match": "Here are the apples to show for banana in this session.",
+        "nonMatch": "Orange lemon melon peach pear plum.",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
+      },
+      {
+        "name": "fruitMarkupTag",
+        "pattern": "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$",
+        "op": "replaceAllGroup1",
+        "match": "  <Banana>  ",
+        "nonMatch": "  <Orange>  ",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
       }
     ]
   },

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -245,6 +245,7 @@ std::string generated_sparse_real_world_input(const std::string& match_unit,
     if (static_cast<int>(text.size()) < size) {
       text += " ";
       text += match_unit;
+      text += " ";
     }
   }
   text.resize(size);

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -245,11 +245,19 @@ std::string generated_sparse_real_world_input(const std::string& match_unit,
     if (static_cast<int>(text.size()) < size) {
       text += " ";
       text += match_unit;
-      text += " ";
     }
   }
   text.resize(size);
   return text;
+}
+std::string generate_surround_with_spaces_input(const std::string& body, int size) {
+  if (static_cast<int>(body.size()) >= size) {
+    return body.substr(0, size);
+  }
+  int total_padding = size - static_cast<int>(body.size());
+  int leading_padding = total_padding / 2;
+  int trailing_padding = total_padding - leading_padding;
+  return std::string(leading_padding, ' ') + body + std::string(trailing_padding, ' ');
 }
 
 std::string generate_real_world_input(const json& input_spec,
@@ -275,6 +283,10 @@ std::string generate_real_world_input(const json& input_spec,
         match_unit, non_match_unit, size, seed,
         input_spec.at("nonMatchRepeats").get<int>(),
         input_spec.at("delimiterAlphabet").get<std::string>());
+  }
+  if (kind == "surroundWithSpaces") {
+    std::string body = input_spec.at("body").get<std::string>();
+    return generate_surround_with_spaces_input(body, size);
   }
   fprintf(stderr, "ERROR: invalid real-world input kind: %s\n", kind.c_str());
   exit(1);

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -583,7 +583,7 @@ void run_real_world_regex_benchmarks(
               c.name.c_str());
       exit(1);
     }
-    if (c.op != "find" && c.op != "replaceAllEmpty") {
+    if (c.op != "find" && c.op != "replaceAllEmpty" && c.op != "replaceAllGroup1") {
       fprintf(stderr, "ERROR: invalid real-world regex op: %s\n",
               c.op.c_str());
       exit(1);
@@ -607,10 +607,16 @@ void run_real_world_regex_benchmarks(
           print_json(measure(name, [&]() {
             do_not_optimize(RE2::PartialMatch(text, c.re));
           }));
-        } else {
+        } else if (c.op == "replaceAllEmpty") {
           print_json(measure(name, [&]() {
             std::string replaced = text;
             RE2::GlobalReplace(&replaced, c.re, "");
+            do_not_optimize(replaced);
+          }));
+        } else if (c.op == "replaceAllGroup1") {
+          print_json(measure(name, [&]() {
+            std::string replaced = text;
+            RE2::GlobalReplace(&replaced, c.re, "\\1");
             do_not_optimize(replaced);
           }));
         }

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -315,11 +315,24 @@ func generateRealWorldInput(
 		return generatedSparseRealWorldInput(
 			matchUnit, nonMatchUnit, size, seed, getInt(inputSpec, "nonMatchRepeats"),
 			getString(inputSpec, "delimiterAlphabet"))
+	case "surroundWithSpaces":
+		body := getString(inputSpec, "body")
+		return generateSurroundWithSpacesInput(body, size)
 	default:
 		fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex input kind: %s\n", kind)
 		os.Exit(1)
 	}
 	panic("unreachable")
+}
+
+func generateSurroundWithSpacesInput(body string, size int) string {
+	if len(body) >= size {
+		return body[:size]
+	}
+	totalPadding := size - len(body)
+	leadingPadding := totalPadding / 2
+	trailingPadding := totalPadding - leadingPadding
+	return strings.Repeat(" ", leadingPadding) + body + strings.Repeat(" ", trailingPadding)
 }
 
 func appendUTF8(b *strings.Builder, cp int) {

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -556,7 +556,7 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		op := getString(item, "op")
-		if op != "find" && op != "replaceAllEmpty" {
+		if op != "find" && op != "replaceAllEmpty" && op != "replaceAllGroup1" {
 			fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex op: %s\n", op)
 			os.Exit(1)
 		}
@@ -599,9 +599,13 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 					printJSON(measureNs(name, func() {
 						sink = c.re.FindStringIndex(text) != nil
 					}))
-				} else {
+				} else if c.op == "replaceAllEmpty" {
 					printJSON(measureNs(name, func() {
 						sink = c.re.ReplaceAllString(text, "")
+					}))
+				} else if c.op == "replaceAllGroup1" {
+					printJSON(measureNs(name, func() {
+						sink = c.re.ReplaceAllString(text, "$1")
 					}))
 				}
 			}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -203,9 +203,20 @@ public class RealWorldRegexBenchmark {
               seed,
               inputSpec.nonMatchRepeats,
               inputSpec.delimiterAlphabet);
+      case "surroundWithSpaces" -> generateSurroundWithSpacesInput(inputSpec.body, size);
       default ->
           throw new IllegalArgumentException("Unknown real-world input kind: " + inputSpec.kind);
     };
+  }
+
+  private String generateSurroundWithSpacesInput(String body, int size) {
+    if (body.length() >= size) {
+      return body.substring(0, size);
+    }
+    int totalPadding = size - body.length();
+    int leadingPadding = totalPadding / 2;
+    int trailingPadding = totalPadding - leadingPadding;
+    return " ".repeat(leadingPadding) + body + " ".repeat(trailingPadding);
   }
 
   private String generatePrefixedInput(

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -67,6 +67,7 @@ public class RealWorldRegexBenchmark {
             (input, replacement) -> p.matcher(input).replaceAll(replacement));
       }
     },
+
     JDK {
       @Override
       public RegexEngine compile(String patternStr) {
@@ -119,7 +120,9 @@ public class RealWorldRegexBenchmark {
     "boundedNameMatch",
     "templateTagMatch",
     "sparseUrl",
-    "unprefixedWordBoundary"
+    "unprefixedWordBoundary",
+    "fruitSearchQuery",
+    "fruitMarkupTag"
   })
   public String patternName;
 
@@ -148,6 +151,7 @@ public class RealWorldRegexBenchmark {
         switch (regexCase.op) {
           case "find" -> input -> regexEngine.finder().find(input);
           case "replaceAllEmpty" -> input -> regexEngine.replacer().replaceAll(input, "");
+          case "replaceAllGroup1" -> input -> regexEngine.replacer().replaceAll(input, "$1");
           default ->
               throw new IllegalArgumentException(
                   "Unknown real-world regex benchmark op: " + regexCase.op);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -67,7 +67,6 @@ public class RealWorldRegexBenchmark {
             (input, replacement) -> p.matcher(input).replaceAll(replacement));
       }
     },
-
     JDK {
       @Override
       public RegexEngine compile(String patternStr) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
@@ -41,7 +41,7 @@ final class RealWorldRegexCase {
     String pattern = requireString(obj, "pattern");
     String match = requireString(obj, "match");
     String nonMatch = requireString(obj, "nonMatch");
-    if (!"find".equals(op) && !"replaceAllEmpty".equals(op)) {
+    if (!"find".equals(op) && !"replaceAllEmpty".equals(op) && !"replaceAllGroup1".equals(op)) {
       throw new IllegalArgumentException("Unknown real-world regex benchmark op: " + op);
     }
     InputSpec matchInput = InputSpec.fromJson(obj, "matchInput");

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
@@ -60,18 +60,21 @@ final class RealWorldRegexCase {
 
     final String kind;
     final String prefix;
+    final String body;
     final int nonMatchRepeats;
     final String delimiterAlphabet;
 
-    private InputSpec(String kind, String prefix, int nonMatchRepeats, String delimiterAlphabet) {
+    private InputSpec(
+        String kind, String prefix, String body, int nonMatchRepeats, String delimiterAlphabet) {
       this.kind = kind;
       this.prefix = prefix;
+      this.body = body;
       this.nonMatchRepeats = nonMatchRepeats;
       this.delimiterAlphabet = delimiterAlphabet;
     }
 
     static InputSpec repeat() {
-      return new InputSpec("repeat", "", 0, "");
+      return new InputSpec("repeat", "", "", 0, "");
     }
 
     static InputSpec fromJson(JsonObject obj, String field) {
@@ -82,13 +85,15 @@ final class RealWorldRegexCase {
       String kind = requireString(spec, "kind");
       return switch (kind) {
         case "repeat" -> repeat();
-        case "prefixedRepeat" -> new InputSpec(kind, requireString(spec, "prefix"), 0, "");
+        case "prefixedRepeat" -> new InputSpec(kind, requireString(spec, "prefix"), "", 0, "");
         case "sparseMatch" ->
             new InputSpec(
                 kind,
                 "",
+                "",
                 requireInt(spec, "nonMatchRepeats"),
                 requireString(spec, "delimiterAlphabet"));
+        case "surroundWithSpaces" -> new InputSpec(kind, "", requireString(spec, "body"), 0, "");
         default -> throw new IllegalArgumentException("Unknown real-world input kind: " + kind);
       };
     }


### PR DESCRIPTION
This commit introduces two representative regex patterns :
- `fruitSearchQuery`: A search-heavy, wildcard-backtracking pattern.
- `fruitMarkupTag`: A short, anchored tags matching pattern.

These patterns are used to evaluate the comparative performance between SafeRE (iterative BitState) and native C++ RE2 (FFM). The new benchmarks resolve subgroups, forcing the use of `BitState`.

Comparative Performance Metrics (ns/op, lower is better):
- fruitSearchQuery (1000 chars, match=true):
  * SafeRE:           33,209 ns
  * RE2_FFM (C++):    13,711 ns (C++ is 2.42x faster)
- fruitMarkupTag (1000 chars, match=true):
  * SafeRE:              100 ns
  * RE2_FFM (C++):       629 ns (SafeRE is 6.26x faster due to avoiding FFM transition overhead)

https://github.com/eaftan/safere/issues/525