### PR TITLE
Remove obsolete dfaGroupZeroReliable and groupZeroResolved dead code

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -61,8 +61,7 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  private record DeferredMatchResult(
-      int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch)
+  private record DeferredMatchResult(int start, int end, int ncap, boolean endMatch)
       implements EngineResult {}
 
   private enum ResultStatus {
@@ -135,13 +134,6 @@ public final class Matcher implements MatchResult {
    * existence or read group 0.
    */
   private boolean capturesResolved = true;
-
-  /**
-   * Whether {@code groups[0..1]} are authoritative while inner captures are deferred. Some DFA
-   * paths only narrow the candidate range, so group 0 must still be resolved by the submatch engine
-   * before it is exposed.
-   */
-  private boolean groupZeroResolved = true;
 
   /** Stashed match boundaries for deferred capture resolution. */
   private int deferredMatchStart;
@@ -242,8 +234,7 @@ public final class Matcher implements MatchResult {
     deferredMatchStart = deferred.start();
     deferredMatchEnd = deferred.end();
     deferredEndMatch = deferred.endMatch();
-    groupZeroResolved = deferred.groupZeroResolved();
-    capturesResolved = deferred.groupZeroResolved() && deferred.ncap() <= 1;
+    capturesResolved = deferred.ncap() <= 1;
     hasMatch = true;
     resultStatus = ResultStatus.MATCHED;
   }
@@ -258,7 +249,6 @@ public final class Matcher implements MatchResult {
 
   private void clearDeferredCaptureState() {
     capturesResolved = true;
-    groupZeroResolved = true;
     deferredMatchStart = 0;
     deferredMatchEnd = 0;
     deferredEndMatch = false;
@@ -723,7 +713,6 @@ public final class Matcher implements MatchResult {
   /** Core matches logic, operates on the (possibly substituted) {@code text} field. */
   private boolean matchesCore() {
     capturesResolved = true;
-    groupZeroResolved = true;
 
     // Literal fast path: for fully literal patterns with no user capture groups.
     String literal = parentPattern.literalMatch();
@@ -783,7 +772,7 @@ public final class Matcher implements MatchResult {
       }
       if (dfaResult != null && prog.numLoopRegs() == 0) {
         return applyEngineResult(
-            new DeferredMatchResult(0, text.length(), prog.numCaptures(), true, true));
+            new DeferredMatchResult(0, text.length(), prog.numCaptures(), true));
       }
     }
 
@@ -864,7 +853,6 @@ public final class Matcher implements MatchResult {
   /** Core lookingAt logic, operates on the (possibly substituted) {@code text} field. */
   private boolean lookingAtCore() {
     capturesResolved = true;
-    groupZeroResolved = true;
 
     // Literal fast path: for fully literal patterns with no user capture groups.
     String literal = parentPattern.literalMatch();
@@ -941,9 +929,6 @@ public final class Matcher implements MatchResult {
       // Only resolve deferred captures before advancing when group 0 itself is not authoritative.
       // If group 0 is already exact, find-all loops that never read inner captures should not pay
       // the capture-extraction cost for the previous match.
-      if (!groupZeroResolved) {
-        resolveCaptures();
-      }
       searchFrom = groups[1];
       if (groups[0] == groups[1]) { // empty match
         if (searchFrom >= regionEnd) {
@@ -1131,7 +1116,6 @@ public final class Matcher implements MatchResult {
 
   private boolean matchesTransparentRegion() {
     capturesResolved = true;
-    groupZeroResolved = true;
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
@@ -1152,7 +1136,6 @@ public final class Matcher implements MatchResult {
 
   private boolean lookingAtTransparentRegion() {
     capturesResolved = true;
-    groupZeroResolved = true;
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
@@ -1176,7 +1159,6 @@ public final class Matcher implements MatchResult {
       return applyEngineResult(new NoMatchResult());
     }
     capturesResolved = true;
-    groupZeroResolved = true;
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     if (prog.anchorStart() && searchFrom > regionStart) {
@@ -1210,7 +1192,6 @@ public final class Matcher implements MatchResult {
 
     // Reset deferred-capture state; DFA sandwich path may set it to false.
     capturesResolved = true;
-    groupZeroResolved = true;
 
     Prog prog = parentPattern.prog();
 
@@ -1441,12 +1422,7 @@ public final class Matcher implements MatchResult {
           if (fwdAnchored != null && fwdAnchored.matched()) {
             int matchEnd = fwdAnchored.pos();
             return applyEngineResult(
-                new DeferredMatchResult(
-                    matchStart,
-                    matchEnd,
-                    prog.numCaptures(),
-                    !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
-                    false));
+                new DeferredMatchResult(matchStart, matchEnd, prog.numCaptures(), false));
           }
         }
         // DFA budget exceeded or forward DFA disagreed — fall through to normal path.
@@ -1457,7 +1433,6 @@ public final class Matcher implements MatchResult {
         !regionActive
             && !parentPattern.dfaStartReliable()
             && options.startAcceleration()
-            && !prog.hasWordBoundary()
             && (prefix != null || ccPrefixAscii != null)
             && text.length() <= DIRECT_FALLBACK_TEXT_LIMIT
             && BitState.maxTextSize(prog) >= text.length();
@@ -1515,12 +1490,7 @@ public final class Matcher implements MatchResult {
         if (fwdFirst != null && fwdFirst.matched()) {
           int matchEnd = fwdFirst.pos();
           return applyEngineResult(
-              new DeferredMatchResult(
-                  effectiveStart,
-                  matchEnd,
-                  prog.numCaptures(),
-                  !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
-                  false));
+              new DeferredMatchResult(effectiveStart, matchEnd, prog.numCaptures(), false));
         }
       } else if (literalPrefixCandidateStart) {
         // A literal prefix occurrence is a candidate match start, even when the prefix is preceded
@@ -1530,12 +1500,7 @@ public final class Matcher implements MatchResult {
         if (fwdFirst != null && fwdFirst.matched()) {
           int matchEnd = fwdFirst.pos();
           return applyEngineResult(
-              new DeferredMatchResult(
-                  effectiveStart,
-                  matchEnd,
-                  prog.numCaptures(),
-                  !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
-                  false));
+              new DeferredMatchResult(effectiveStart, matchEnd, prog.numCaptures(), false));
         }
       } else {
         Dfa revDfa = reverseDfa();
@@ -1608,12 +1573,7 @@ public final class Matcher implements MatchResult {
                 int matchEnd = fwdFirst.pos();
                 // Step 4: Store group(0) boundaries, defer inner captures until requested.
                 return applyEngineResult(
-                    new DeferredMatchResult(
-                        matchStart,
-                        matchEnd,
-                        prog.numCaptures(),
-                        !options.semanticGuards() || parentPattern.dfaGroupZeroReliable(),
-                        false));
+                    new DeferredMatchResult(matchStart, matchEnd, prog.numCaptures(), false));
               }
             }
             // If anchored forward DFA fails, fall through to full search.
@@ -1654,7 +1614,7 @@ public final class Matcher implements MatchResult {
       return applyEngineResult(new FullMatchResult(result));
     } else {
       return applyEngineResult(
-          new DeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false));
+          new DeferredMatchResult(result[0], result[1], prog.numCaptures(), false));
     }
   }
 
@@ -2059,10 +2019,8 @@ public final class Matcher implements MatchResult {
   public int start(int group) {
     checkMatch();
     checkGroup(group);
-    if (group != 0 || !groupZeroResolved) {
-      if (group != 0) {
-        eagerFallbackCaptures = true;
-      }
+    if (group != 0) {
+      eagerFallbackCaptures = true;
       resolveCaptures();
     }
     return groups[2 * group];
@@ -2094,10 +2052,8 @@ public final class Matcher implements MatchResult {
   public int end(int group) {
     checkMatch();
     checkGroup(group);
-    if (group != 0 || !groupZeroResolved) {
-      if (group != 0) {
-        eagerFallbackCaptures = true;
-      }
+    if (group != 0) {
+      eagerFallbackCaptures = true;
       resolveCaptures();
     }
     return groups[2 * group + 1];
@@ -2219,7 +2175,7 @@ public final class Matcher implements MatchResult {
     StringBuilder sb = new StringBuilder();
     boolean needsCaptures = templateNeedsCaptures(template);
     do {
-      if (needsCaptures || !groupZeroResolved) {
+      if (needsCaptures) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
@@ -2454,9 +2410,6 @@ public final class Matcher implements MatchResult {
     }
     modCount++;
     if (hasMatch && groups != null) {
-      if (!groupZeroResolved) {
-        resolveCaptures();
-      }
       searchFrom = groups[1];
       if (groups[0] == groups[1] && searchFrom < regionEnd) {
         searchFrom++;
@@ -2592,7 +2545,6 @@ public final class Matcher implements MatchResult {
       groups = result;
     }
     capturesResolved = true;
-    groupZeroResolved = true;
   }
 
   private void checkMatch() {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -800,17 +800,9 @@ public final class Pattern implements Serializable {
    *       maximizes each iteration.
    * </ol>
    *
-   * <p>When this returns {@code false}, the DFA sandwich is skipped and the submatch engine
-   * (BitState/NFA) determines the correct match boundaries.
-   */
-  boolean dfaGroupZeroReliable() {
-    return true;
-  }
-
-  /**
-   * Returns {@code true} if the pattern contains alternation ({@code |}). Used by the Matcher to
-   * skip OnePass primary for find() — OnePass always uses longest-match semantics, which can pick
-   * the wrong alternative when a zero-width branch competes with a consuming branch.
+   * /** Returns {@code true} if the pattern contains alternation ({@code |}). Used by the Matcher
+   * to skip OnePass primary for find() — OnePass always uses longest-match semantics, which can
+   * pick the wrong alternative when a zero-width branch competes with a consuming branch.
    */
   boolean hasAlternation() {
     return hasAlternation;
@@ -831,10 +823,9 @@ public final class Pattern implements Serializable {
 
   /**
    * Returns {@code true} when the DFA sandwich correctly identifies the leftmost match
-   * <em>start</em> position, even if the match end may be wrong. This is a weaker guarantee than
-   * {@link #dfaGroupZeroReliable()}: the sandwich can narrow the search range for the submatch
-   * engine, but captures must still be resolved (with {@code endMatch=false}) to determine the
-   * correct match end.
+   * <em>start</em> position, even if the match end may be wrong. The sandwich can narrow the search
+   * range for the submatch engine, but captures must still be resolved (with {@code
+   * endMatch=false}) to determine the correct match end.
    *
    * <p>The DFA start is reliable when the leftmost-starting match is the only match ending at the
    * forward DFA's earliest end. This fails for:

--- a/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
+++ b/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
@@ -111,7 +111,6 @@ class MatcherDeferredCaptureStateTest {
   private static void assertDeferredCaptureStateClear(Matcher matcher)
       throws ReflectiveOperationException {
     assertThat(booleanField(matcher, "capturesResolved")).isTrue();
-    assertThat(booleanField(matcher, "groupZeroResolved")).isTrue();
     assertThat(intField(matcher, "deferredMatchStart")).isZero();
     assertThat(intField(matcher, "deferredMatchEnd")).isZero();
     assertThat(booleanField(matcher, "deferredEndMatch")).isFalse();


### PR DESCRIPTION
This became dead code after 7889a3bd, which made `dfaGroupZeroReliable()` always return `true`. `groupZeroResolved` was used to track whether the NFA needed to be run to find `group(0)` end positions if the DFA positions weren't reliable, but that logic is now also unused.

This was included in #506, which needs more work, I'm moving it to a separate PR.