### PR TITLE
Fix forward and reverse DFA priority inversion for boundary matches

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -142,11 +142,18 @@ final class MatchFuzzer {
 
   private static void assertDfaSandwichLeftmostStartCasesMatchJdk() {
     List<String> regexes =
-        List.of("\\B([^a])*[^a][^a]", "\\B(?:[^a])*[^a][^a]", "\\B[^a]*[^a][^a]", "\\B(?:b|bb)*bb");
+        List.of(
+            "\\B([^a])*[^a][^a]",
+            "\\B(?:[^a])*[^a][^a]",
+            "\\B[^a]*[^a][^a]",
+            "\\B(?:b|bb)*bb",
+            "(?:(?:\\ba?)|\\B|[^a])a?",
+            "(?:(?:\\ba?)|\\B|b)a?");
     for (String regex : regexes) {
       FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
       if (pattern != null) {
         pattern.matcher("bbbb").find();
+        pattern.matcher("ba").find();
       }
     }
   }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1180,7 +1180,7 @@ final class Dfa {
         // FLAG_MATCH_BEFORE indicates a deferred assertion (\b, multiline $) fired before
         // consuming the current character and reached MATCH. Try the before-consume position
         // first (it's at an earlier position, preserving leftmost-first semantics).
-        if ((s.flags & FLAG_MATCH_BEFORE) != 0) {
+        if ((s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE) {
           int endPos = pos;
           if (isRequiredEndMatch(endPos, needEndMatch, textLen, trailingTermStart)) {
             matched = true;
@@ -1193,7 +1193,7 @@ final class Dfa {
         // Try the after-consume position: either no before-consume match exists, or it was
         // rejected (e.g., needEndMatch but pos != textLen) and an after-consume match also
         // exists (FLAG_MATCH_AFTER_DEFERRED).
-        if ((s.flags & FLAG_MATCH_BEFORE) == 0 || (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0) {
+        if ((s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) != FLAG_MATCH_BEFORE) {
           int endPos = Math.min(nextPos, textLen);
           if (isRequiredEndMatch(endPos, needEndMatch, textLen, trailingTermStart)) {
             matched = true;
@@ -1465,7 +1465,10 @@ final class Dfa {
         }
 
         if (s.isMatch()) {
-          int endPos = (s.flags & FLAG_MATCH_BEFORE) != 0 ? pos : Math.min(nextPos, textLen);
+          int endPos =
+              ((s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE)
+                  ? pos
+                  : Math.min(nextPos, textLen);
           if (!needEndMatch
               || endPos == textLen
               || (trailingTermStart < textLen && endPos == trailingTermStart)) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1332,10 +1332,18 @@ final class Dfa {
       }
 
       if (s.isMatch()) {
-        boolean matchValid = (s.flags & FLAG_MATCH_BEFORE) != 0 || prevPos >= startLimit;
-        if (matchValid) {
-          int startPos = (s.flags & FLAG_MATCH_BEFORE) != 0 ? pos : prevPos;
-          if (!needEndMatch || startPos == startLimit) {
+        if ((s.flags & FLAG_MATCH_BEFORE) == 0 || (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0) {
+          int startPos = prevPos;
+          if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
+            matched = true;
+            matchStart = startPos;
+            if (!longest && !needEndMatch) {
+              return new SearchResult(true, matchStart);
+            }
+          }
+        } else {
+          int startPos = pos;
+          if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
             matched = true;
             matchStart = startPos;
             if (!longest && !needEndMatch) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1332,14 +1332,26 @@ final class Dfa {
       }
 
       if (s.isMatch()) {
-        boolean useBefore =
+        if ((s.flags & FLAG_MATCH_BEFORE) != 0) {
+          if (pos >= startLimit && (!needEndMatch || pos == startLimit)) {
+            boolean alreadyMatched = matched;
+            matched = true;
+            matchStart = longest && alreadyMatched ? Math.min(matchStart, pos) : pos;
+            if (!longest && !needEndMatch) {
+              return new SearchResult(true, matchStart);
+            }
+          }
+        }
+        boolean hasOnlyBeforeMatch =
             (s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
-        int startPos = useBefore ? pos : prevPos;
-        if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
-          matched = true;
-          matchStart = startPos;
-          if (!longest && !needEndMatch) {
-            return new SearchResult(true, matchStart);
+        if (!hasOnlyBeforeMatch) {
+          if (prevPos >= startLimit && (!needEndMatch || prevPos == startLimit)) {
+            boolean alreadyMatched = matched;
+            matched = true;
+            matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
+            if (!longest && !needEndMatch) {
+              return new SearchResult(true, matchStart);
+            }
           }
         }
       }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1332,7 +1332,8 @@ final class Dfa {
       }
 
       if (s.isMatch()) {
-        boolean useBefore = (s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+        boolean useBefore =
+            (s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
         int startPos = useBefore ? pos : prevPos;
         if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
           matched = true;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1332,23 +1332,13 @@ final class Dfa {
       }
 
       if (s.isMatch()) {
-        if ((s.flags & FLAG_MATCH_BEFORE) == 0 || (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0) {
-          int startPos = prevPos;
-          if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
-            matched = true;
-            matchStart = startPos;
-            if (!longest && !needEndMatch) {
-              return new SearchResult(true, matchStart);
-            }
-          }
-        } else {
-          int startPos = pos;
-          if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
-            matched = true;
-            matchStart = startPos;
-            if (!longest && !needEndMatch) {
-              return new SearchResult(true, matchStart);
-            }
+        boolean useBefore = (s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+        int startPos = useBefore ? pos : prevPos;
+        if (startPos >= startLimit && (!needEndMatch || startPos == startLimit)) {
+          matched = true;
+          matchStart = startPos;
+          if (!longest && !needEndMatch) {
+            return new SearchResult(true, matchStart);
           }
         }
       }

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -419,4 +419,17 @@ class DfaTest {
     assertThat(r2.matched()).isTrue();
     assertThat(r2.pos()).isEqualTo(1);
   }
+
+  @Test
+  void reverseDfaMixedDeferredAndConsumingMatchPreservesDeferredStart() {
+    Pattern p = Pattern.compile("(?:(?:\\ba?)|\\B|[^a])a?");
+    Dfa revDfa = p.reverseDfa();
+    assertThat(revDfa).isNotNull();
+
+    Dfa.SearchResult r = revDfa.doSearchReverse("ba", 2, 1, true, true);
+
+    assertThat(r).isNotNull();
+    assertThat(r.matched()).isTrue();
+    assertThat(r.pos()).isEqualTo(1);
+  }
 }

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -400,4 +400,23 @@ class DfaTest {
     assertThat(r.matched()).isTrue();
     assertThat(r.pos()).isEqualTo(1);
   }
+
+  @Test
+  void reverseDfaDeferredMatchCorrectness() {
+    Pattern p = Pattern.compile("\\ba|a");
+    Dfa revDfa = p.reverseDfa();
+    assertThat(revDfa).isNotNull();
+
+    String text = "a";
+    Dfa.SearchResult r = revDfa.doSearchReverse(text, 1, 0, true, true);
+    assertThat(r).isNotNull();
+    assertThat(r.matched()).isTrue();
+    assertThat(r.pos()).isEqualTo(0);
+
+    String text2 = "aa";
+    Dfa.SearchResult r2 = revDfa.doSearchReverse(text2, 2, 1, true, true);
+    assertThat(r2).isNotNull();
+    assertThat(r2.matched()).isTrue();
+    assertThat(r2.pos()).isEqualTo(1);
+  }
 }

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -92,8 +92,8 @@ class EnginePathEquivalenceTest {
   @Test
   @DisplayName("DFA start-reliability guard has semantic content")
   void dfaStartReliabilityGuardHasSemanticContent() {
-    String regex = "(?:\\B{1}|a).";
-    String input = "ab";
+    String regex = "\\[.*?\\]\\((.*?)\\)|(\\b\\w+\\.md\\b)";
+    String input = "abc [def](xyz.md) ghi";
     Pattern canonical = Pattern.compile(regex);
     Pattern unguarded =
         Pattern.compile(

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -89,8 +89,6 @@ class EnginePathEquivalenceTest {
         .isNotEqualTo(findTrace(canonical.matcher(input)));
   }
 
-
-
   @Test
   @DisplayName("literal fast paths match the canonical engine trace")
   void literalFastPathsMatchCanonicalTrace() {
@@ -256,13 +254,7 @@ class EnginePathEquivalenceTest {
             .bitState(false)
             .build());
     // Assert BitState vs canonical (NFA)
-    assertEquivalent(
-        regex1,
-        input1,
-        EnginePathOptions.builder()
-            .dfa(false)
-            .onePass(false)
-            .build());
+    assertEquivalent(regex1, input1, EnginePathOptions.builder().dfa(false).onePass(false).build());
 
     // 2. Lazy quantifier priority inversion
     String regex2 = "\\[.*?\\]\\((.*?)\\)|(\\b\\w+\\.md\\b)";
@@ -271,19 +263,9 @@ class EnginePathEquivalenceTest {
     assertEquivalent(
         regex2,
         input2,
-        EnginePathOptions.builder()
-            .semanticGuards(false)
-            .onePass(false)
-            .bitState(false)
-            .build());
+        EnginePathOptions.builder().semanticGuards(false).onePass(false).bitState(false).build());
     // Assert BitState vs canonical (NFA)
-    assertEquivalent(
-        regex2,
-        input2,
-        EnginePathOptions.builder()
-            .dfa(false)
-            .onePass(false)
-            .build());
+    assertEquivalent(regex2, input2, EnginePathOptions.builder().dfa(false).onePass(false).build());
   }
 
   private static MatchTrace operationTrace(Matcher matcher, Operation operation) {

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -268,6 +268,17 @@ class EnginePathEquivalenceTest {
     assertEquivalent(regex2, input2, EnginePathOptions.builder().dfa(false).onePass(false).build());
   }
 
+  @Test
+  @DisplayName("reverse DFA preserves deferred starts at consuming boundaries")
+  void reverseDfaPreservesDeferredStartsAtConsumingBoundaries() {
+    String regex = "(?:(?:\\ba?)|\\B|[^a])a?";
+    String input = "ba";
+    EnginePathOptions forcedDfa =
+        EnginePathOptions.builder().semanticGuards(false).onePass(false).bitState(false).build();
+
+    assertEquivalent(regex, input, forcedDfa);
+  }
+
   private static MatchTrace operationTrace(Matcher matcher, Operation operation) {
     boolean matched =
         switch (operation) {

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -89,27 +89,7 @@ class EnginePathEquivalenceTest {
         .isNotEqualTo(findTrace(canonical.matcher(input)));
   }
 
-  @Test
-  @DisplayName("DFA start-reliability guard has semantic content")
-  void dfaStartReliabilityGuardHasSemanticContent() {
-    String regex = "\\[.*?\\]\\((.*?)\\)|(\\b\\w+\\.md\\b)";
-    String input = "abc [def](xyz.md) ghi";
-    Pattern canonical = Pattern.compile(regex);
-    Pattern unguarded =
-        Pattern.compile(
-            regex,
-            0,
-            EnginePathOptions.builder()
-                .semanticGuards(false)
-                .onePass(false)
-                .bitState(false)
-                .build());
 
-    assertThat(canonical.dfaStartReliable()).isFalse();
-    assertThat(findTrace(unguarded.matcher(input)))
-        .as("unguarded DFA sandwich should expose why the start-reliability guard exists")
-        .isNotEqualTo(findTrace(canonical.matcher(input)));
-  }
 
   @Test
   @DisplayName("literal fast paths match the canonical engine trace")
@@ -257,6 +237,52 @@ class EnginePathEquivalenceTest {
             .dfa(false)
             .reverseDfa(false)
             .bitState(false)
+            .build());
+  }
+
+  @Test
+  @DisplayName("priority inversion boundary patterns match across all engine paths")
+  void priorityInversionEquivalence() {
+    // 1. Alternation priority inversion
+    String regex1 = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*')|(\\btype\\b)";
+    String input1 = "x = \"type\"";
+    // Assert DFA vs canonical (NFA)
+    assertEquivalent(
+        regex1,
+        input1,
+        EnginePathOptions.builder()
+            .semanticGuards(false) // Bypasses guards to force DFA execution!
+            .onePass(false)
+            .bitState(false)
+            .build());
+    // Assert BitState vs canonical (NFA)
+    assertEquivalent(
+        regex1,
+        input1,
+        EnginePathOptions.builder()
+            .dfa(false)
+            .onePass(false)
+            .build());
+
+    // 2. Lazy quantifier priority inversion
+    String regex2 = "\\[.*?\\]\\((.*?)\\)|(\\b\\w+\\.md\\b)";
+    String input2 = "abc [def](xyz.md) ghi";
+    // Assert DFA vs canonical (NFA)
+    assertEquivalent(
+        regex2,
+        input2,
+        EnginePathOptions.builder()
+            .semanticGuards(false)
+            .onePass(false)
+            .bitState(false)
+            .build());
+    // Assert BitState vs canonical (NFA)
+    assertEquivalent(
+        regex2,
+        input2,
+        EnginePathOptions.builder()
+            .dfa(false)
+            .onePass(false)
             .build());
   }
 

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -736,6 +736,31 @@ class MatcherTest {
       assertThat(m.end()).isEqualTo(3);
       assertThat(m.find()).isFalse();
     }
+
+    @Test
+    @DisplayName(
+        "find() preserves leftmost start for overlapping alternation branches (b/528687345)")
+    void testAlternationPriorityInversion() {
+      String regex = "(?:\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*')|(\\btype\\b)";
+      String input = "x = \"type\"";
+      Matcher m = Pattern.compile(regex).matcher(input);
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("\"type\"");
+      assertThat(m.group(1)).isNull();
+    }
+
+    @Test
+    @DisplayName("find() preserves leftmost start for overlapping lazy quantifiers (b/528722782)")
+    void testLazyQuantifierPriorityInversion() {
+      String regex = "\\[.*?\\]\\((.*?)\\)|(\\b\\w+\\.md\\b)";
+      String input = "abc [def](xyz.md) ghi";
+      Matcher m = Pattern.compile(regex).matcher(input);
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("[def](xyz.md)");
+      assertThat(m.group(1)).isEqualTo("xyz.md");
+    }
   }
 
   @Nested


### PR DESCRIPTION
When a DFA state contains both a deferred boundary match (`FLAG_MATCH_BEFORE`) and a standard consuming match, the engine must distinguish between them to preserve leftmost-first priority. Without this, overlapping alternation branches or lazy quantifiers can suffer from priority inversion or false-negative mismatches.

This PR integrates the `FLAG_MATCH_AFTER_DEFERRED` flag into both the forward (`doSearch`/`doSearchMany`) and reverse (`doSearchReverse`) DFA loops to enforce correct leftmost-first priority.

Resolves bugs on patterns such as:

1. `\ba|a` (reverse DFA boundary match)
2. `(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|(\btype\b)`
3. `\[.*?\]\((.*?)\)|(\b\w+\.md\b)`

These correctness fixes were originally bundled inside #506 because removing the guards exposed the forward DFA bug. This extracts the fixes into a separate change to prepare for #506.

* `Dfa.java`:
  * Forward loops check `FLAG_MATCH_AFTER_DEFERRED` to record matches at the correct position when both deferred and consuming matches exist.
  * Reverse loop prioritizes `prevPos` over `pos` when both match types exist.
* `MatcherTest.java` / `DfaTest.java`: Added tests for alternation, lazy quantifier, and reverse DFA boundary correctness.
* `EnginePathEquivalenceTest.java`: Added cross-engine differential tests comparing NFA, BitState, and DFA traces on these patterns. Removed the obsolete `dfaStartReliabilityGuardHasSemanticContent` check since it asserts that the DFA start position is unreliable in the case fixed by this PR.