### PR TITLE
Optimize DFA transitions using a flat 1D array layout

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -354,6 +354,7 @@
           "kind": "sparseMatch",
           "nonMatchRepeats": 5,
           "delimiterAlphabet": " "
+        }
       },
       {
         "name": "cjkSearch",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -354,6 +354,31 @@
           "kind": "sparseMatch",
           "nonMatchRepeats": 5,
           "delimiterAlphabet": " "
+      },
+      {
+        "name": "cjkSearch",
+        "pattern": "[一-龥]{3,}",
+        "op": "find",
+        "match": "这是一个中文测试句子",
+        "nonMatch": "This is a sentence containing only English characters.",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
+      },
+      {
+        "name": "emojiSearch",
+        "pattern": "[😀-😇]",
+        "op": "find",
+        "match": "Today is a beautiful day 😇 with warm sunshine.",
+        "nonMatch": "Today is a beautiful day with warm sunshine.",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
         }
       }
     ]

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -123,7 +123,9 @@ public class RealWorldRegexBenchmark {
     "fruitSearchQuery",
     "fruitMarkupTag",
     "charReplace",
-    "layoutBlock"
+    "layoutBlock",
+    "cjkSearch",
+    "emojiSearch"
   })
   public String patternName;
 

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -5,9 +5,11 @@
 
 package org.safere;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -73,6 +75,8 @@ final class Dfa {
    */
   private static final int FLAG_LAST_UNICODE_WORD = 1 << 14;
 
+  private static final int FLAG_HIGHEST_PRIORITY_MATCH = 1 << 15;
+
   /** Maximum number of DFA states before bailing out to NFA. */
   private static final int DEFAULT_MAX_STATES = 10_000;
 
@@ -86,6 +90,7 @@ final class Dfa {
    * recomputation.
    */
   private static final class State {
+    final int id;
     final int[] insts; // sorted NFA instruction IDs (CHAR_RANGE, EMPTY_WIDTH, and MATCH only)
     final int flags;
     final boolean isHighestPriorityMatch;
@@ -98,16 +103,18 @@ final class Dfa {
     /** Transitions indexed by equivalence class; null entry = not yet computed. */
     final State[] next;
 
-    State(int[] insts, int flags, int[] wordBoundaryMatchIds, int numClasses) {
-      this(insts, flags, wordBoundaryMatchIds, numClasses, false);
+    State(int id, int[] insts, int flags, int[] wordBoundaryMatchIds, int numClasses) {
+      this(id, insts, flags, wordBoundaryMatchIds, numClasses, false);
     }
 
     State(
+        int id,
         int[] insts,
         int flags,
         int[] wordBoundaryMatchIds,
         int numClasses,
         boolean isHighestPriorityMatch) {
+      this.id = id;
       this.insts = insts;
       this.flags = flags;
       this.wordBoundaryMatchIds = wordBoundaryMatchIds;
@@ -224,6 +231,10 @@ final class Dfa {
   /** Per-search grapheme context. Set only while a search method is active. */
   private GraphemeSupport.Context graphemeContext;
 
+  private final List<State> statesList = new ArrayList<>();
+  private int[] transitions;
+  private int[] stateFlags;
+
   // ---------------------------------------------------------------------------
   // Construction
   // ---------------------------------------------------------------------------
@@ -272,7 +283,38 @@ final class Dfa {
     this.expandStack = new int[prog.size()];
     this.expandFrontier = new int[prog.size()];
     this.computeBuf = new int[prog.size()];
-    this.deadState = new State(new int[0], 0, null, numClasses);
+    this.deadState = new State(0, new int[0], 0, null, numClasses);
+    this.statesList.add(deadState);
+    this.transitions = new int[1024];
+    this.stateFlags = new int[64];
+    addStateToFlatArrays(deadState);
+  }
+
+  private void addStateToFlatArrays(State s) {
+    if (s.id >= stateFlags.length) {
+      int newLen = Math.max(stateFlags.length * 2, s.id + 1);
+      stateFlags = Arrays.copyOf(stateFlags, newLen);
+    }
+    int flags = s.flags;
+    if (s.isHighestPriorityMatch) {
+      flags |= FLAG_HIGHEST_PRIORITY_MATCH;
+    }
+    stateFlags[s.id] = flags;
+
+    int minTransLen = (s.id + 1) * numClasses;
+    if (minTransLen > transitions.length) {
+      int newLen = Math.max(transitions.length * 2, minTransLen);
+      transitions = Arrays.copyOf(transitions, newLen);
+    }
+  }
+
+  private void setTransition(int fromId, int cls, int toId) {
+    transitions[fromId * numClasses + cls] = toId;
+  }
+
+  private void addTransition(State from, int cls, State to) {
+    from.next[cls] = to;
+    setTransition(from.id, cls, to.id);
   }
 
   /**
@@ -632,7 +674,16 @@ final class Dfa {
     }
     boolean isHighestPriorityMatch =
         insts.length > 0 && prog.inst(insts[0]).opCode == InstOp.OP_MATCH;
-    s = new State(insts, flags, wordBoundaryMatchIds, numClasses, isHighestPriorityMatch);
+    s =
+        new State(
+            statesList.size(),
+            insts,
+            flags,
+            wordBoundaryMatchIds,
+            numClasses,
+            isHighestPriorityMatch);
+    statesList.add(s);
+    addStateToFlatArrays(s);
     cache.put(lookupKey.copy(), s);
     return s;
   }
@@ -1162,29 +1213,33 @@ final class Dfa {
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
       int limit = Math.min(textLen, posDepThreshold - 1);
+      int sId = s.id;
       while (pos < limit) {
         char ch = text.charAt(pos);
         if (ch >= 128) {
           break;
         }
         int cls = asciiClassMap[ch];
-        State ns = s.next[cls];
-        if (ns == null || ns == deadState) {
+        int nsId = transitions[sId * numClasses + cls];
+        if (nsId == 0) {
           break;
         }
-        if (ns.isMatch() && !needEndMatch) {
+        int nsFlags = stateFlags[nsId];
+        if ((nsFlags & FLAG_MATCH) != 0 && !needEndMatch) {
           boolean useBefore =
-              (ns.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+              (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
           int endPos = useBefore ? pos : pos + 1;
-          if (!longest && ns.isHighestPriorityMatch) {
+          boolean nsHighestPriorityMatch = (nsFlags & FLAG_HIGHEST_PRIORITY_MATCH) != 0;
+          if (!longest && nsHighestPriorityMatch) {
             return new SearchResult(true, endPos);
           }
           matched = true;
           matchEnd = endPos;
         }
-        s = ns;
+        sId = nsId;
         pos++;
       }
+      s = statesList.get(sId);
 
       if (pos >= textLen) {
         break;
@@ -1205,7 +1260,7 @@ final class Dfa {
         if (ns == null) {
           return null; // budget exceeded
         }
-        s.next[cls] = ns;
+        addTransition(s, cls, ns);
       }
       s = ns;
       if (s == deadState) {
@@ -1277,7 +1332,7 @@ final class Dfa {
           if (ns == null) {
             return null; // budget exceeded
           }
-          s.next[cls] = ns;
+          addTransition(s, cls, ns);
         }
       }
 
@@ -1389,46 +1444,49 @@ final class Dfa {
     while (pos > startLimit) {
       if (pos <= posDepThreshold) {
         int limit = startLimit;
+        int sId = s.id;
         while (pos > limit) {
           char ch = text.charAt(pos - 1);
           if (ch >= 128) {
             break;
           }
           int cls = asciiClassMap[ch];
-          State ns = s.next[cls];
-          if (ns == null || ns == deadState) {
+          int nsId = transitions[sId * numClasses + cls];
+          if (nsId == 0) {
             break;
           }
-          if (ns.isMatch()) {
-            if ((ns.flags & FLAG_MATCH_BEFORE) != 0) {
+          int nsFlags = stateFlags[nsId];
+          if ((nsFlags & FLAG_MATCH) != 0) {
+            if ((nsFlags & FLAG_MATCH_BEFORE) != 0) {
               if (pos >= startLimit && (!needEndMatch || pos == startLimit)) {
                 boolean alreadyMatched = matched;
                 matched = true;
                 matchStart = longest && alreadyMatched ? Math.min(matchStart, pos) : pos;
-                ambiguous |= (ns.flags & FLAG_MATCH_AFTER_DEFERRED) != 0;
+                ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
                 if (!longest && !needEndMatch) {
                   return new SearchResult(true, matchStart, ambiguous);
                 }
               }
             }
             boolean hasOnlyBeforeMatch =
-                (ns.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+                (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
             int prevPos = pos - 1;
             if (!hasOnlyBeforeMatch) {
               if (prevPos >= startLimit && (!needEndMatch || prevPos == startLimit)) {
                 boolean alreadyMatched = matched;
                 matched = true;
                 matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
-                ambiguous |= (ns.flags & FLAG_MATCH_AFTER_DEFERRED) != 0;
+                ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
                 if (!longest && !needEndMatch) {
                   return new SearchResult(true, matchStart, ambiguous);
                 }
               }
             }
           }
-          s = ns;
+          sId = nsId;
           pos--;
         }
+        s = statesList.get(sId);
       }
 
       if (pos <= startLimit) {
@@ -1450,7 +1508,7 @@ final class Dfa {
         if (ns == null) {
           return null; // budget exceeded
         }
-        s.next[cls] = ns;
+        addTransition(s, cls, ns);
       }
       s = ns;
       if (s == deadState) {
@@ -1536,7 +1594,7 @@ final class Dfa {
           if (ns == null) {
             return null; // budget exceeded
           }
-          s.next[cls] = ns;
+          addTransition(s, cls, ns);
         }
       }
       s = ns;
@@ -1642,6 +1700,7 @@ final class Dfa {
     if (s != deadState) {
       int pos = 0;
       // Fast path: scan forward through ASCII characters
+      int sId = s.id;
       while (pos < textLen) {
         if (pos + 1 >= posDepThreshold) {
           break; // fall back to general loop for position-dependent context
@@ -1651,39 +1710,45 @@ final class Dfa {
           break; // fall back
         }
         int cls = asciiClassMap[ch];
-        State ns = s.next[cls];
-        if (ns == null) {
+        int nsId = transitions[sId * numClasses + cls];
+        if (nsId == 0) {
+          s = statesList.get(sId);
           int effectiveNextPos = pos + 1;
-          ns = computeNext(s, ch, text, effectiveNextPos);
+          State ns = computeNext(s, ch, text, effectiveNextPos);
           if (ns == null) {
             return null; // budget exceeded
           }
-          s.next[cls] = ns;
+          addTransition(s, cls, ns);
+          nsId = ns.id;
         }
-        s = ns;
-        if (s == deadState) {
+        if (nsId == 0) { // deadState
           break;
         }
-        if (s.isMatch()) {
-          boolean useBefore =
-              (s.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
-          int endPos = useBefore ? pos : pos + 1;
+        int nsFlags = stateFlags[nsId];
+        if ((nsFlags & FLAG_MATCH) != 0) {
+          int endPos =
+              ((nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE)
+                  ? pos
+                  : pos + 1;
           if (!needEndMatch
               || endPos == textLen
               || (trailingTermStart < textLen && endPos == trailingTermStart)) {
             // Collect match IDs from the state's instructions.
-            for (int id : collectMatchIds(s.insts)) {
+            State ns = statesList.get(nsId);
+            for (int id : collectMatchIds(ns.insts)) {
               seen.set(id);
             }
-            if (s.wordBoundaryMatchIds != null) {
-              for (int id : s.wordBoundaryMatchIds) {
+            if (ns.wordBoundaryMatchIds != null) {
+              for (int id : ns.wordBoundaryMatchIds) {
                 seen.set(id);
               }
             }
           }
         }
+        sId = nsId;
         pos++;
       }
+      s = statesList.get(sId);
 
       // General loop
       while (pos <= textLen) {
@@ -1728,7 +1793,7 @@ final class Dfa {
             if (ns == null) {
               return null; // budget exceeded
             }
-            s.next[cls] = ns;
+            addTransition(s, cls, ns);
           }
         }
         s = ns;


### PR DESCRIPTION
This change introduces a flat 1D transition array (`int[] transitions`) and state flags cache (`int[] stateFlags`) to optimize the tight DFA loops.

1. As demonstrated by https://github.com/eaftan/safere/pull/498, flattening the transition table and applying it to general loops introduces a performance regression (up to 76% slower) due to the overhead of looking up state objects from the state index map (`statesList.get(nsId)`) and index multiplication bounds checks.

2. This optimization is designed to be stacked on top of the ASCII fast path loops (https://github.com/eaftan/safere/pull/517). In those loops, the engine keeps the state represented entirely as a primitive `int sId`, avoiding `State` object lookups altogether and resolving transitions directly from the flat array.

3. To avoid performance regressions, the general loops are kept unflattened, using the baseline `s.next[cls]` pointer layout for Unicode code point fallbacks, while the ASCII fast paths are optimized using the flat table.

Benchmark Results (stacked on top of https://github.com/eaftan/safere/pull/517, matching blockFind_safere):
- 1,024 bytes:   5.781 us/op (vs. 7.639 us/op on PR 517, a 32% speedup)
- 102,400 bytes: 576.886 us/op (vs. 747.036 us/op on PR 517, a 29% speedup)
- 1,048,576 bytes: 5905.135 us/op (vs. 7685.546 us/op on PR 517, a 30% speedup)

---

I also investigated using `Unsafe` or FFM `MemorySegment`s to avoid bounds-checking overhead inside the hot loops. However that benchmarked worse, using those features inside the loops may have inhibited loop unrolling and other optimizations, and the new flattened array for the ASCII fast path may be easier to optimize and avoid bounds check for when using an array.