### PR TITLE
Fix libre2_shim path to use .dylib on macos

### DIFF
--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/Re2Shim.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/Re2Shim.java
@@ -13,6 +13,7 @@ import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.file.Path;
+import java.util.Locale;
 
 /**
  * Low-level FFM bindings to the re2_shim native library. Each static method corresponds to a C
@@ -35,7 +36,9 @@ final class Re2Shim {
     String libPath = System.getProperty("re2shim.library.path");
     SymbolLookup lookup;
     if (libPath != null) {
-      lookup = SymbolLookup.libraryLookup(Path.of(libPath, "libre2_shim.so"), Arena.global());
+      String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+      String libName = osName.contains("mac") ? "libre2_shim.dylib" : "libre2_shim.so";
+      lookup = SymbolLookup.libraryLookup(Path.of(libPath, libName), Arena.global());
     } else {
       // Fall back to system library path
       System.loadLibrary("re2_shim");


### PR DESCRIPTION
This fixes an problem I was having running the benchmarks on mac

```
./run-java-benchmarks.sh '^org\.safere\.benchmark\.Issue488ReplaceAllBenchmark\.lazyAlt_safere$' --     -p textSize=100000
...
Caused by: java.lang.IllegalArgumentException: Cannot open library: ~/src/safere/safere-ffm-re2/build/libre2_shim.so
	at java.base/java.lang.foreign.SymbolLookup.libraryLookup(SymbolLookup.java:350)
	at java.base/java.lang.foreign.SymbolLookup.libraryLookup(SymbolLookup.java:335)
	at org.safere.re2ffm.Re2Shim.<clinit>(Re2Shim.java:38)
	... 15 more
```