### PR TITLE
Fix ArrayIndexOutOfBoundsException in Dfa.computeNext after 7889a3bd2234d75f7185f59e0b9724dbcafbc4f9

### DIFF
--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -909,6 +909,9 @@ final class Dfa {
           // Add non-MATCH instructions from this expansion.
           for (int x : expanded) {
             if (prog.inst(x).opCode != InstOp.OP_MATCH) {
+              if (tempCount == tempExpanded.length) {
+                tempExpanded = Arrays.copyOf(tempExpanded, tempExpanded.length * 2);
+              }
               tempExpanded[tempCount++] = x;
             }
           }
@@ -927,10 +930,16 @@ final class Dfa {
           }
         } else {
           for (int x : expanded) {
+            if (tempCount == tempExpanded.length) {
+              tempExpanded = Arrays.copyOf(tempExpanded, tempExpanded.length * 2);
+            }
             tempExpanded[tempCount++] = x;
           }
         }
       } else {
+        if (tempCount == tempExpanded.length) {
+          tempExpanded = Arrays.copyOf(tempExpanded, tempExpanded.length * 2);
+        }
         tempExpanded[tempCount++] = id;
       }
     }

--- a/safere/src/test/java/org/safere/RE2RegressionTest.java
+++ b/safere/src/test/java/org/safere/RE2RegressionTest.java
@@ -426,7 +426,10 @@ class RE2RegressionTest {
     @DisplayName("b/529118477: ArrayIndexOutOfBoundsException in DFA computeNext")
     void bug529118477DfaArrayIndexOutOfBounds() {
       String regex = "(\u0000A\u0000||(?Um)$|\uFFFF){741}^NA^ .?K";
-      String input = "\rA\u0000|(?Um)~\rA\u0000|(?Um)+?\u0002u\u0225C\uFFFF\uFFFF\uFFFF\uF007\u0183\u011A\u00A3###j";
+      String input =
+          "\r"
+              + "A\u0000|(?Um)~\r"
+              + "A\u0000|(?Um)+?\u0002u\u0225C\uFFFF\uFFFF\uFFFF\uF007\u0183\u011A\u00A3###j";
       Pattern pattern = Pattern.compile(regex);
       Matcher matcher = pattern.matcher(input);
       while (matcher.find()) {

--- a/safere/src/test/java/org/safere/RE2RegressionTest.java
+++ b/safere/src/test/java/org/safere/RE2RegressionTest.java
@@ -421,6 +421,24 @@ class RE2RegressionTest {
       Matcher m = p.matcher("llx-3;llx4");
       assertThat(m.find()).isTrue();
     }
+
+    @Test
+    @DisplayName("b/529118477: ArrayIndexOutOfBoundsException in DFA computeNext")
+    void bug529118477DfaArrayIndexOutOfBounds() {
+      String regex = "(\u0000A\u0000||(?Um)$|\uFFFF){741}^NA^ .?K";
+      String input = "\rA\u0000|(?Um)~\rA\u0000|(?Um)+?\u0002u\u0225C\uFFFF\uFFFF\uFFFF\uF007\u0183\u011A\u00A3###j";
+      Pattern pattern = Pattern.compile(regex);
+      Matcher matcher = pattern.matcher(input);
+      while (matcher.find()) {
+        var unused = matcher.group();
+        for (int i = 0; i <= matcher.groupCount(); i++) {
+          matcher.start(i);
+          matcher.end(i);
+        }
+      }
+      matcher.matches();
+      pattern.split(input);
+    }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
During empty-width assertion re-expansion in computeNext, we collect NFA states in priority order. When resolving empty transitions, multiple active states can expand to overlapping sets of reachable states. These transient duplicates are temporarily stored in `tempExpanded` before being deduplicated by `stableDedup`.

For complex patterns with large loops (e.g. unrolled loops of empty assertions), the number of duplicates can exceed the NFA program size, causing `tempExpanded` (which was allocated with size `prog.instructions.size()`) to overflow with an `ArrayIndexOutOfBoundsException`.

This fix dynamically resizes the `tempExpanded` array if it reaches capacity. Because the final unique state count is bounded by the program size, the array will grow only as needed to accommodate transient duplicates and is safely deduplicated immediately after.

This bug regressed in 7889a3bd2234d75f7185f59e0b9724dbcafbc4f9, which replaced the previous `mergeInsts` state deduplication logic with the pre-allocated flat array and `stableDedup` collection approach.