### PR TITLE
Fix ambiguous reverse DFA starts

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -19,12 +19,23 @@ final class FindSequenceFuzzer {
     pattern.matcher("Foo '{0}' Bar: {0}").find();
   }
 
+  @Test
+  void dfaBoundSemanticsRegressions() {
+    assertFindSequence("$", "x".repeat(512) + "a\n");
+    assertFindSequence("$", "x".repeat(512) + "a\r\n");
+    assertFindSequence("$", "x".repeat(512) + "a\u2028");
+    assertFindSequence("(?:\\B{1}|a).a?", "ab".repeat(300) + "c");
+    assertFindSequence("(?:\\B{1}|a).a?$", "x".repeat(512) + "ab");
+    assertFindSequence("(?:a+?|(?:[^x])*)$", "x".repeat(512) + "a\n");
+    assertFindSequence("(?:a{2,}|(?:.|\\B){1,2}){1,2}", "baax");
+  }
+
   @FuzzTest(maxDuration = "30s")
   void sequence(FuzzedDataProvider data) {
     String regex;
     int flags;
     String input;
-    switch (data.consumeInt(0, 2)) {
+    switch (data.consumeInt(0, 6)) {
       case 0 -> {
         regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
         flags = 0;
@@ -40,6 +51,33 @@ final class FindSequenceFuzzer {
         regex = data.consumeString(256);
         flags = FuzzSupport.consumeFlags(data);
         input = data.consumeString(2048);
+      }
+      case 3 -> {
+        regex = "$";
+        flags = 0;
+        String terminator =
+            switch (data.consumeInt(0, 2)) {
+              case 0 -> "\n";
+              case 1 -> "\r\n";
+              case 2 -> "\u2028";
+              default -> throw new AssertionError();
+            };
+        input = data.consumeString(64) + "a" + terminator;
+      }
+      case 4 -> {
+        regex = "(?:\\B{1}|a).a?";
+        flags = 0;
+        input = "ab".repeat(data.consumeInt(0, 700)) + data.consumeString(2);
+      }
+      case 5 -> {
+        regex = "(?:a+?|(?:[^x])*)$";
+        flags = 0;
+        input = "x".repeat(data.consumeInt(0, 700)) + data.consumeString(4);
+      }
+      case 6 -> {
+        regex = "(?:a{2,}|(?:.|\\B){1,2}){1,2}";
+        flags = 0;
+        input = data.consumeBoolean() ? "baax" : data.consumeString(16);
       }
       default -> throw new AssertionError();
     }
@@ -100,5 +138,17 @@ final class FindSequenceFuzzer {
 
   private static String nestedCapturingGroups(int depth) {
     return "(".repeat(depth) + "a" + ")".repeat(depth);
+  }
+
+  private static void assertFindSequence(String regex, String input) {
+    FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, 0);
+    pattern.matcher(input).find();
+    FuzzSupport.MatcherPair matcher = pattern.matcher(input);
+    int maxFinds = Math.min(input.length() + 2, 128);
+    for (int i = 0; i < maxFinds; i++) {
+      if (!matcher.find()) {
+        return;
+      }
+    }
   }
 }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -36,7 +36,11 @@ import java.util.TreeSet;
 final class Dfa {
 
   /** Result of a DFA search. */
-  record SearchResult(boolean matched, int pos) {}
+  record SearchResult(boolean matched, int pos, boolean ambiguous) {
+    SearchResult(boolean matched, int pos) {
+      this(matched, pos, false);
+    }
+  }
 
   /** Result of a multi-match DFA search. */
   // TODO(#98): Replace int[] with Guava ImmutableIntArray to get proper value semantics.
@@ -1285,6 +1289,7 @@ final class Dfa {
 
     boolean matched = false;
     int matchStart = -1;
+    boolean ambiguous = false;
 
     // Check if start state is already a match (e.g., empty pattern).
     if (s.isMatch()) {
@@ -1366,8 +1371,9 @@ final class Dfa {
             boolean alreadyMatched = matched;
             matched = true;
             matchStart = longest && alreadyMatched ? Math.min(matchStart, pos) : pos;
+            ambiguous |= (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0;
             if (!longest && !needEndMatch) {
-              return new SearchResult(true, matchStart);
+              return new SearchResult(true, matchStart, ambiguous);
             }
           }
         }
@@ -1378,8 +1384,9 @@ final class Dfa {
             boolean alreadyMatched = matched;
             matched = true;
             matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
+            ambiguous |= (s.flags & FLAG_MATCH_AFTER_DEFERRED) != 0;
             if (!longest && !needEndMatch) {
-              return new SearchResult(true, matchStart);
+              return new SearchResult(true, matchStart, ambiguous);
             }
           }
         }
@@ -1390,7 +1397,7 @@ final class Dfa {
       }
       pos = prevPos;
     }
-    return new SearchResult(matched, matchStart);
+    return new SearchResult(matched, matchStart, ambiguous);
   }
 
   // ---------------------------------------------------------------------------

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1364,11 +1364,15 @@ public final class Matcher implements MatchResult {
         Dfa.SearchResult revResult =
             revDfa.doSearchReverse(text, textLen, effectiveStart, true, true);
         int matchStart;
+        boolean matchStartAmbiguous;
         if (revResult == null) {
           budgetExceeded = true;
           matchStart = -1;
+          matchStartAmbiguous = false;
         } else {
-          matchStart = revResult.matched() ? revResult.pos() : -1;
+          matchStart =
+              revResult.matched() && revResult.pos() >= effectiveStart ? revResult.pos() : -1;
+          matchStartAmbiguous = matchStart >= 0 && revResult.ambiguous();
         }
 
         // For $ (dollarAnchorEnd), also try before trailing line terminator. The $ anchor
@@ -1393,8 +1397,11 @@ public final class Matcher implements MatchResult {
                   revDfa.doSearchReverse(text, textLen - 1, effectiveStart, true, true);
               if (altRev == null) {
                 budgetExceeded = true;
-              } else if (altRev.matched() && (matchStart < 0 || altRev.pos() < matchStart)) {
+              } else if (altRev.matched()
+                  && altRev.pos() >= effectiveStart
+                  && (matchStart < 0 || altRev.pos() < matchStart)) {
                 matchStart = altRev.pos();
+                matchStartAmbiguous = altRev.ambiguous();
               }
             }
             // For \r\n, try position before \r.
@@ -1403,8 +1410,11 @@ public final class Matcher implements MatchResult {
                   revDfa.doSearchReverse(text, textLen - 2, effectiveStart, true, true);
               if (altRev2 == null) {
                 budgetExceeded = true;
-              } else if (altRev2.matched() && (matchStart < 0 || altRev2.pos() < matchStart)) {
+              } else if (altRev2.matched()
+                  && altRev2.pos() >= effectiveStart
+                  && (matchStart < 0 || altRev2.pos() < matchStart)) {
                 matchStart = altRev2.pos();
+                matchStartAmbiguous = altRev2.ambiguous();
               }
             }
           }
@@ -1415,14 +1425,21 @@ public final class Matcher implements MatchResult {
             // No match possible at end of text — fail immediately without forward scan.
             return applyEngineResult(new NoMatchResult());
           }
-
-          // Reverse DFA found a match start. Run forward DFA from there (anchored, longest)
-          // to find the actual match end.
-          Dfa.SearchResult fwdAnchored = dfa(true).doSearch(text, matchStart, true, true);
-          if (fwdAnchored != null && fwdAnchored.matched()) {
-            int matchEnd = fwdAnchored.pos();
-            return applyEngineResult(
-                new DeferredMatchResult(matchStart, matchEnd, prog.numCaptures(), false));
+          if (matchStartAmbiguous) {
+            // The reverse DFA can prove that a suffix match exists, but not which accepted
+            // candidate supplies the leftmost start. Fall through to the normal engine path.
+          } else {
+            // Reverse DFA found a match start. It proposes the left edge only; resolve the public
+            // group(0) end with the exact engine anchored at that start so lazy alternatives and
+            // dollar-before-terminator semantics remain leftmost-first.
+            int[] exact =
+                searchWithBitStateOrNfa(
+                    prog, text, matchStart, matchStart, textLen, true, false, false, 1);
+            if (exact != null) {
+              int matchEnd = exact[1];
+              return applyEngineResult(
+                  new DeferredMatchResult(matchStart, matchEnd, prog.numCaptures(), false));
+            }
           }
         }
         // DFA budget exceeded or forward DFA disagreed — fall through to normal path.
@@ -1511,9 +1528,10 @@ public final class Matcher implements MatchResult {
           if (revResult != null && revResult.matched()) {
             int matchStart = revResult.pos();
             boolean authoritativeStart =
-                !options.semanticGuards()
-                    || matchStart == effectiveStart
-                    || parentPattern.dfaStartReliable();
+                !revResult.ambiguous()
+                    && (!options.semanticGuards()
+                        || matchStart == effectiveStart
+                        || parentPattern.dfaStartReliable());
 
             // For dollarAnchorEnd patterns, the forward DFA's earlyEnd is always textLen
             // (it can't return early). But the correct leftmost match may end before the
@@ -1540,9 +1558,10 @@ public final class Matcher implements MatchResult {
                       && altRevResult.pos() < matchStart) {
                     matchStart = altRevResult.pos();
                     authoritativeStart =
-                        !options.semanticGuards()
-                            || matchStart == effectiveStart
-                            || parentPattern.dfaStartReliable();
+                        !altRevResult.ambiguous()
+                            && (!options.semanticGuards()
+                                || matchStart == effectiveStart
+                                || parentPattern.dfaStartReliable());
                   }
                 }
                 // For \r\n, try position before \r.
@@ -1554,9 +1573,10 @@ public final class Matcher implements MatchResult {
                       && altRevResult2.pos() < matchStart) {
                     matchStart = altRevResult2.pos();
                     authoritativeStart =
-                        !options.semanticGuards()
-                            || matchStart == effectiveStart
-                            || parentPattern.dfaStartReliable();
+                        !altRevResult2.ambiguous()
+                            && (!options.semanticGuards()
+                                || matchStart == effectiveStart
+                                || parentPattern.dfaStartReliable());
                   }
                 }
               }

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -90,6 +90,55 @@ class EnginePathEquivalenceTest {
   }
 
   @Test
+  @DisplayName("DFA sandwich reports ambiguous reverse starts")
+  void dfaSandwichReportsAmbiguousReverseStarts() {
+    String regex = "(?:\\B{1}|a).";
+    String input = "ab";
+    Pattern canonical = Pattern.compile(regex);
+    Pattern unguarded =
+        Pattern.compile(
+            regex,
+            0,
+            EnginePathOptions.builder()
+                .semanticGuards(false)
+                .onePass(false)
+                .bitState(false)
+                .build());
+
+    assertThat(canonical.dfaStartReliable()).isFalse();
+    assertThat(findTrace(unguarded.matcher(input)))
+        .as("DFA sandwich should not publish ambiguous reverse-DFA starts")
+        .isEqualTo(findTrace(canonical.matcher(input)));
+  }
+
+  @Test
+  @DisplayName("unguarded DFA paths preserve repeated $ find trace")
+  void unguardedDfaPathsPreserveRepeatedDollarFindTrace() {
+    assertUnguardedDfaFindEquivalent("$", "x".repeat(2000) + "a\n");
+    assertUnguardedDfaFindEquivalent("$", "x".repeat(2000) + "a\r\n");
+    assertUnguardedDfaFindEquivalent("$", "x".repeat(2000) + "a\u2028");
+  }
+
+  @Test
+  @DisplayName("unguarded DFA paths fall back for ambiguous reverse starts")
+  void unguardedDfaPathsFallBackForAmbiguousReverseStarts() {
+    assertUnguardedDfaFindEquivalent("(?:\\B{1}|a).a?", "ab".repeat(600) + "c");
+    assertUnguardedDfaFindEquivalent("(?:\\B{1}|a).a?$", "x".repeat(1100) + "ab");
+  }
+
+  @Test
+  @DisplayName("unguarded DFA paths preserve end-anchored trailing terminator trace")
+  void unguardedDfaPathsPreserveEndAnchoredTrailingTerminatorTrace() {
+    assertUnguardedDfaFindEquivalent("(?:a+?|(?:[^x])*)$", "x".repeat(1100) + "a\n");
+  }
+
+  @Test
+  @DisplayName("unguarded DFA paths preserve boundary candidate priority")
+  void unguardedDfaPathsPreserveBoundaryCandidatePriority() {
+    assertUnguardedDfaFindEquivalent("(?:a{2,}|(?:.|\\B){1,2}){1,2}", "baax");
+  }
+
+  @Test
   @DisplayName("literal fast paths match the canonical engine trace")
   void literalFastPathsMatchCanonicalTrace() {
     assertEquivalent(
@@ -185,6 +234,34 @@ class EnginePathEquivalenceTest {
     assertThat(appendReplacementTrace(defaultPattern.matcher(input)))
         .as("appendReplacement trace for /%s/ on %s", regex, input)
         .isEqualTo(appendReplacementTrace(forcedPattern.matcher(input)));
+  }
+
+  private static void assertUnguardedDfaFindEquivalent(String regex, String input) {
+    Pattern canonical = Pattern.compile(regex);
+    Pattern unguarded =
+        Pattern.compile(
+            regex, 0, EnginePathOptions.builder().semanticGuards(false).onePass(false).build());
+
+    assertFindPrefixEquivalent(
+        unguarded.matcher(input), canonical.matcher(input), input.length() + 2, regex, input);
+  }
+
+  private static void assertFindPrefixEquivalent(
+      Matcher actual, Matcher expected, int maxSteps, String regex, String input) {
+    for (int step = 0; step < maxSteps; step++) {
+      boolean actualFound = actual.find();
+      boolean expectedFound = expected.find();
+      assertThat(actualFound)
+          .as("find step %s found state for /%s/ on %s", step, regex, input)
+          .isEqualTo(expectedFound);
+      if (!expectedFound) {
+        return;
+      }
+      assertThat(snapshot(actual, true))
+          .as("find step %s trace for /%s/ on %s", step, regex, input)
+          .isEqualTo(snapshot(expected, true));
+    }
+    throw new AssertionError("find trace exceeded " + maxSteps + " steps for /" + regex + "/");
   }
 
   @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -678,6 +678,31 @@ class MatcherTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"\n", "\r\n", "\u2028"})
+    @DisplayName("find() after $ before a trailing terminator advances to text end")
+    void findAfterDollarBeforeTrailingTerminatorAdvancesToTextEnd(String terminator) {
+      assertAllFindsMatchJdk("$", "x".repeat(2000) + "a" + terminator);
+    }
+
+    @Test
+    @DisplayName("find() falls back when reverse DFA start is ambiguous")
+    void findFallsBackWhenReverseDfaStartIsAmbiguous() {
+      assertAllFindsMatchJdk("(?:\\B{1}|a).a?", "ab".repeat(600) + "c");
+    }
+
+    @Test
+    @DisplayName("find() does not overconsume before trailing terminator for end anchor")
+    void findDoesNotOverconsumeBeforeTrailingTerminatorForEndAnchor() {
+      assertAllFindsMatchJdk("(?:a+?|(?:[^x])*)$", "x".repeat(1100) + "a\n");
+    }
+
+    @Test
+    @DisplayName("find() preserves boundary candidate priority in reverse DFA fallback")
+    void findPreservesBoundaryCandidatePriorityInReverseDfaFallback() {
+      assertAllFindsMatchJdk("(?:a{2,}|(?:.|\\B){1,2}){1,2}", "baax");
+    }
+
+    @ParameterizedTest
     @ValueSource(
         strings = {
           "(bcd|abcde)",


### PR DESCRIPTION
## Summary

Fixes #538.

This fixes the underlying DFA bound-semantics issue behind the start-reliability guards instead of adding more pattern guards. Reverse DFA search results now report when the selected start is ambiguous because before-consume and after-consume match candidates coexist. The matcher uses that result-level signal to fall through to the normal engine path instead of publishing an unsafe DFA start.

The change also tightens reverse-first end-anchor handling so candidates before the effective find start are discarded, and exact group(0) end resolution remains anchored to an authoritative DFA-proposed start.

## Impact

This should allow follow-up work such as #506 to replace broad AST-level start-reliability screening with precise DFA result ambiguity handling, preserving the DFA sandwich performance path where the reverse start is actually authoritative.

## Tests

Post-rebase checks run on the current PR head:

- `mvn -pl safere -Dtest=EnginePathEquivalenceTest test -q`
- `mvn -pl safere -Dtest=MatcherTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn -pl safere spotless:check -q`
- `git diff --check`

Not run on the rebased PR head:

- `mvn -pl safere test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests`
- `./run-java-benchmarks.sh '^org\\.safere\\.benchmark\\.Issue488ReplaceAllBenchmark\\.lazyAlt_safere$' -- -p textSize=100000`

## Review

- Ran `codex exec review --base main --json --output-last-message ... --ephemeral`
- Final reviewer pass reported no actionable correctness, performance, or maintainability issues.
