### PR TITLE
Fix literal prefix acceleration fallback logic in Matcher

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -330,6 +330,18 @@
           "kind": "surroundWithSpaces",
           "body": "<Orange>"
         }
+      },
+      {
+        "name": "layoutBlock",
+        "pattern": "(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>",
+        "op": "replaceAllEmpty",
+        "match": "<block>\n  # category_defined: alpha, beta\n  entry: apple\n  entry: banana\n</block>\n",
+        "nonMatch": "<block>\n  # comment but not defined tag\n  entry: orange\n</block>\n",
+        "matchInput": {
+          "kind": "sparseMatch",
+          "nonMatchRepeats": 5,
+          "delimiterAlphabet": " "
+        }
       }
     ]
   },

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -121,7 +121,8 @@ public class RealWorldRegexBenchmark {
     "sparseUrl",
     "unprefixedWordBoundary",
     "fruitSearchQuery",
-    "fruitMarkupTag"
+    "fruitMarkupTag",
+    "layoutBlock"
   })
   public String patternName;
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1508,22 +1508,24 @@ public final class Matcher implements MatchResult {
                   parentPattern.dfaGroupZeroReliable(),
                   false));
         }
-      } else if (literalPrefixCandidateStart) {
-        // A literal prefix occurrence is a candidate match start, even when the prefix is preceded
-        // by zero-width assertions. Verify that candidate directly; if it fails, the exact fallback
-        // below can still search for later prefix occurrences.
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
-        if (fwdFirst != null && fwdFirst.matched()) {
-          int matchEnd = fwdFirst.pos();
-          return applyEngineResult(
-              new DeferredMatchResult(
-                  effectiveStart,
-                  matchEnd,
-                  prog.numCaptures(),
-                  parentPattern.dfaGroupZeroReliable(),
-                  false));
-        }
       } else {
+        if (literalPrefixCandidateStart) {
+          // A literal prefix occurrence is a candidate match start, even when the prefix is
+          // preceded by zero-width assertions. Verify that candidate directly; if it matches,
+          // return it. Otherwise, fall through to the reverse DFA search below to find the correct
+          // start.
+          Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+          if (fwdFirst != null && fwdFirst.matched()) {
+            int matchEnd = fwdFirst.pos();
+            return applyEngineResult(
+                new DeferredMatchResult(
+                    effectiveStart,
+                    matchEnd,
+                    prog.numCaptures(),
+                    parentPattern.dfaGroupZeroReliable(),
+                    false));
+          }
+        }
         Dfa revDfa = reverseDfa();
         if (revDfa != null) {
           // Step 2: Reverse DFA backward from earliest match end to find match start.


### PR DESCRIPTION
When literal prefix acceleration is active (`literalPrefixCandidateStart = true`), `Matcher` performs a fast anchored forward DFA search at the candidate start position to verify it.

Previously, if this anchored check failed, the Matcher fell out of the DFA sandwich block completely and fell back to the backtracking `searchWithBitStateOrNfa()` engine.

This change fixes the fallback path by falling through to the reverse DFA search instead of the backtracking engine if the initial candidate verification fails.

This depends on #506 because the semantic guards removed in #506 would otherwise discard the reverse DFA start position on the motivating pattern, forcing a backtracking fallback anyway.

This new diff here compared to #506 is the handling of `literalPrefixCandidateStart` in `Matcher.java`, and the new `layoutBlock` benchmark.

```
./run-java-benchmarks.sh RealWorldRegexBenchmark.runBenchmark -- -p patternName=layoutBlock -p engine=SafeRE
```

| Input Size (Chars) | Matches Exist (`match`) | Before Score (ns/op) | After Score (ns/op) | Speedup Ratio | Status / Outcome |
| :---: | :---: | :---: | :---: | :---: | :--- |
| **1,000** | `false` (Non-matching) | 7,249 ± 66 | 7,039 ± 847 | **1.03x** | Comparable (Early DFA fail) |
| **1,000** | `true` (Sparse Match) | 19,704 ± 193 | 14,276 ± 378 | **1.38x** | **Improved** |
| **10,000** | `false` (Non-matching) | 71,482 ± 755 | 71,560 ± 799 | **1.00x** | Comparable (Early DFA fail) |
| **10,000** | `true` (Sparse Match) | 793,214 ± 43,234 | 111,828 ± 7,832 | **7.09x** | **7.1x Speedup** (DFA sandwich fallback avoided) |