### PR TITLE
Presize StringBuilders in Matcher replacement methods

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -330,6 +330,19 @@
           "kind": "surroundWithSpaces",
           "body": "<Orange>"
         }
+      },
+      {
+        "name": "charReplace",
+        "pattern": "a",
+        "op": "replaceAllLiteral",
+        "match": "a",
+        "nonMatch": "b",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
       }
     ]
   },

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -596,7 +596,7 @@ void run_real_world_regex_benchmarks(
               c.name.c_str());
       exit(1);
     }
-    if (c.op != "find" && c.op != "replaceAllEmpty" && c.op != "replaceAllGroup1") {
+    if (c.op != "find" && c.op != "replaceAllEmpty" && c.op != "replaceAllGroup1" && c.op != "replaceAllLiteral") {
       fprintf(stderr, "ERROR: invalid real-world regex op: %s\n",
               c.op.c_str());
       exit(1);
@@ -630,6 +630,12 @@ void run_real_world_regex_benchmarks(
           print_json(measure(name, [&]() {
             std::string replaced = text;
             RE2::GlobalReplace(&replaced, c.re, "\\1");
+            do_not_optimize(replaced);
+          }));
+        } else if (c.op == "replaceAllLiteral") {
+          print_json(measure(name, [&]() {
+            std::string replaced = text;
+            RE2::GlobalReplace(&replaced, c.re, "xyz");
             do_not_optimize(replaced);
           }));
         }

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -569,7 +569,7 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		op := getString(item, "op")
-		if op != "find" && op != "replaceAllEmpty" && op != "replaceAllGroup1" {
+		if op != "find" && op != "replaceAllEmpty" && op != "replaceAllGroup1" && op != "replaceAllLiteral" {
 			fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex op: %s\n", op)
 			os.Exit(1)
 		}
@@ -619,6 +619,10 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 				} else if c.op == "replaceAllGroup1" {
 					printJSON(measureNs(name, func() {
 						sink = c.re.ReplaceAllString(text, "$1")
+					}))
+				} else if c.op == "replaceAllLiteral" {
+					printJSON(measureNs(name, func() {
+						sink = c.re.ReplaceAllString(text, "xyz")
 					}))
 				}
 			}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -121,11 +121,12 @@ public class RealWorldRegexBenchmark {
     "sparseUrl",
     "unprefixedWordBoundary",
     "fruitSearchQuery",
-    "fruitMarkupTag"
+    "fruitMarkupTag",
+    "charReplace"
   })
   public String patternName;
 
-  @Param({"1000", "10000"})
+  @Param({"1000", "10000", "100000"})
   public int inputSize;
 
   @Param({"true", "false"})
@@ -151,6 +152,7 @@ public class RealWorldRegexBenchmark {
           case "find" -> input -> regexEngine.finder().find(input);
           case "replaceAllEmpty" -> input -> regexEngine.replacer().replaceAll(input, "");
           case "replaceAllGroup1" -> input -> regexEngine.replacer().replaceAll(input, "$1");
+          case "replaceAllLiteral" -> input -> regexEngine.replacer().replaceAll(input, "xyz");
           default ->
               throw new IllegalArgumentException(
                   "Unknown real-world regex benchmark op: " + regexCase.op);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
@@ -41,7 +41,10 @@ final class RealWorldRegexCase {
     String pattern = requireString(obj, "pattern");
     String match = requireString(obj, "match");
     String nonMatch = requireString(obj, "nonMatch");
-    if (!"find".equals(op) && !"replaceAllEmpty".equals(op) && !"replaceAllGroup1".equals(op)) {
+    if (!"find".equals(op)
+        && !"replaceAllEmpty".equals(op)
+        && !"replaceAllGroup1".equals(op)
+        && !"replaceAllLiteral".equals(op)) {
       throw new IllegalArgumentException("Unknown real-world regex benchmark op: " + op);
     }
     InputSpec matchInput = InputSpec.fromJson(obj, "matchInput");

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2194,7 +2194,7 @@ public final class Matcher implements MatchResult {
     if (!find()) {
       return text;
     }
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(text.length());
     appendReplacement(sb, replacement);
     appendTail(sb);
     return sb.toString();
@@ -2215,7 +2215,7 @@ public final class Matcher implements MatchResult {
     if (!find()) {
       return text;
     }
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(text.length());
     int expectedModCount = modCount;
     String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
     checkConcurrentModification(expectedModCount);
@@ -2238,7 +2238,7 @@ public final class Matcher implements MatchResult {
     }
     // Pre-compile the replacement template once, avoiding per-match parseInt/substring overhead.
     ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(text.length());
     boolean needsCaptures = templateNeedsCaptures(template);
     do {
       if (needsCaptures || !groupZeroResolved) {
@@ -2267,7 +2267,7 @@ public final class Matcher implements MatchResult {
     if (!find()) {
       return text;
     }
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(text.length());
     do {
       int expectedModCount = modCount;
       String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));


### PR DESCRIPTION
This updates `Matcher#replaceAll` and `replaceFirst` to presize the `StringBuilder` to match the input length.

This reduces the number of times the stringbuilder has to be resized for long inputs with many replacements. The replacements could make the output longer or shorter than the input, but starting with the input length seems like a reasonable guess.

For the included benchmark this seems to be a ~2% latency improvement but also significantly reduces allocations:

| Input Size | Matches | Baseline Alloc (B/op) | Optimized Alloc (B/op) | Memory Saved (B/op) | Allocation Reduction |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **1,000** | 500 | 18,944.255 | 17,264.251 | **1,680 B** | **8.9%** |
| **10,000** | 5,000 | 214,130.589 | 170,266.542 | **43,864 B** (~44 KB) | **20.5%** |
| **100,000** | 50,000 | 1,990,299.004 | 1,700,288.881 | **290,010 B** (~290 KB) | **14.6%** |

