### PR TITLE
Eagerly perform analysis in Pattern.compile

### DIFF
--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -292,6 +292,11 @@ public final class Pattern implements Serializable {
     this.requiredMatchClassRanges = requiredMatchClassRanges;
     this.requiredMatchClassBitmap0 = requiredMatchClassBitmap0;
     this.requiredMatchClassBitmap1 = requiredMatchClassBitmap1;
+
+    // Eagerly compute analysis and setup to avoid latency spikes on first use.
+    onePassAnalysis();
+    forwardDfaSetup();
+    flatReverseDfaProg();
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -296,7 +296,9 @@ public final class Pattern implements Serializable {
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
     onePassAnalysis();
     forwardDfaSetup();
-    flatReverseDfaProg();
+    if (!prog.anchorStart()) {
+      flatReverseDfaProg();
+    }
   }
 
   /**


### PR DESCRIPTION
This change eagerly initializes the DFA, OnePass, and reverse DFA in `Pattern.compile`.

Currently this initialization happens lazily when the pattern is first used. We noticed this in part comparing latency for individual regex operations between SafeRE and other engines, this approach means the first usage of a pattern is expensive, which increases the tail latency.

I think doing this initialization eagerly in `Pattern.compile` is the right thing to do for typical applications, not just because it affects metrics. For typical patterns in `static final` constants, this pays the cost during class initialization, and improves tail latency for initial requests after the application has started up.