### PR TITLE
Cache non-ASCII character class lookups

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -355,6 +355,19 @@
           "nonMatchRepeats": 5,
           "delimiterAlphabet": " "
         }
+      },
+      {
+        "name": "turnTitleWhitespaceCjk",
+        "pattern": "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+",
+        "op": "replaceAllEmpty",
+        "match": "いくつもの\u3000中国語と日本語の文字\u3000がここにあります\u3000そして\u3000いくつかのスペース\u3000があります",
+        "nonMatch": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
       }
     ]
   },

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -123,7 +123,8 @@ public class RealWorldRegexBenchmark {
     "fruitSearchQuery",
     "fruitMarkupTag",
     "charReplace",
-    "layoutBlock"
+    "layoutBlock",
+    "turnTitleWhitespaceCjk"
   })
   public String patternName;
 

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -180,6 +180,10 @@ final class Dfa {
    */
   private final int[] asciiClassMap;
 
+  /** Cache for mapping code points >= 128 to their equivalence class. */
+  private final int[] cacheCps = new int[256];
+  private final char[] cacheClasses = new char[256];
+
   /** State cache: maps instruction-set + flags to canonical State instance. */
   private final Map<StateKey, State> cache = new HashMap<>();
 
@@ -268,6 +272,7 @@ final class Dfa {
     this.boundaries = setup.boundaries;
     this.numClasses = setup.numClasses;
     this.asciiClassMap = setup.asciiClassMap;
+    Arrays.fill(this.cacheCps, -1);
     this.expandVisitedGen = new int[prog.size()];
     this.expandStack = new int[prog.size()];
     this.expandFrontier = new int[prog.size()];
@@ -391,11 +396,15 @@ final class Dfa {
     if (cp < 128) {
       return asciiClassMap[cp];
     }
-    int idx = Arrays.binarySearch(boundaries, cp);
-    if (idx >= 0) {
-      return idx;
+    int cacheIdx = cp & 255;
+    if (cacheCps[cacheIdx] == cp) {
+      return cacheClasses[cacheIdx];
     }
-    return (-idx - 1) - 1;
+    int idx = Arrays.binarySearch(boundaries, cp);
+    int cls = (idx >= 0) ? idx : (-idx - 1) - 1;
+    cacheCps[cacheIdx] = cp;
+    cacheClasses[cacheIdx] = (char) cls;
+    return cls;
   }
 
   // ---------------------------------------------------------------------------

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -182,6 +182,7 @@ final class Dfa {
 
   /** Cache for mapping code points >= 128 to their equivalence class. */
   private final int[] cacheCps = new int[256];
+
   private final char[] cacheClasses = new char[256];
 
   /** State cache: maps instruction-set + flags to canonical State instance. */


### PR DESCRIPTION
When the DFA loop looks up character classes, it looks up classes for ASCII in `asciiClassMap`, and does a binary search on the boundaries array.

For patterns with non-ASCII character classes on inputs with non-ASCII characters, the binary search becomes a bottleneck.

#519 was another attempt to optimize this with a 128 KB `char[] bmpClassMap` for non-ASCII lookups, but that requires allocating a lot of memory, and is bad for memory locality because the entire array won't be in cache.

Instead of a lookup table for all possible BMP characters, this change creates a small cache-friendly hash table for character class lookups to reduce the amount of binary searching.

Comparing against baseline and #519, this appears to perform better than #519, likely because the hash table has a good hit rate and it's possible to keep it in cache.

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark.runBenchmark -- \
    -p patternName=turnTitleWhitespaceCjk \
    -p engine=SafeRE \
    -p match=false \
    -p inputSize=1000
```

| Approach / Branch | JMH Score (ns/op) | Delta (ns) | Latency Reduction | Speedup | Memory Overhead |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **Baseline**  | 17,000.285 ± 396.919 | *reference* | *reference* | *1.00x* | **0 bytes** |
| #519 | 15,452.880 ± 727.221 | -1,547.41 | -9.1% | **1.10x** | **131,072 bytes** (131 KB) |
| cjk-cache | 14,255.068 ± 1113.077 | -2,745.22 | **-16.1%** | **1.19x** | **1,536 bytes** (1.5 KB) |