### PR TITLE
Optimize replacement operations with DFA fast path

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2210,7 +2210,8 @@ public final class Matcher implements MatchResult {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     if (!canUseForwardDfa()
         || !parentPattern.dfaGroupZeroReliable()
-        || parentPattern.prog().dollarAnchorEnd()
+        // dollarAnchorEnd is safe if start-anchored because we skip the reverse DFA scan.
+        || (parentPattern.prog().dollarAnchorEnd() && !parentPattern.prog().anchorStart())
         || parentPattern.literalMatch() != null
         || regionActive) {
       return null;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2205,13 +2205,13 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
+  @SuppressWarnings("ReferenceEquality")
   private String replaceDfaOptimized(LazyTemplate template, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     if (!canUseForwardDfa()
         || !parentPattern.dfaGroupZeroReliable()
         || parentPattern.prog().dollarAnchorEnd()
         || parentPattern.literalMatch() != null
-        || template.needsCaptures() // Route to fallback if it needs captures
         || regionActive) {
       return null;
     }
@@ -2248,6 +2248,18 @@ public final class Matcher implements MatchResult {
 
     ReplacementSegment[] compiledTemplate = template.get();
 
+    Prog prog = parentPattern.prog();
+    int numCaptures = prog.numCaptures();
+    if (groups == null || groups.length < 2 * numCaptures) {
+      groups = new int[2 * numCaptures];
+    }
+    boolean needsCaptures = template.needsCaptures();
+    boolean useOnePass =
+        needsCaptures
+            && enginePathOptions().onePass()
+            && parentPattern.canOnePassSubmatch()
+            && !parentPattern.hasNullableAlternation();
+
     int textLen = text.length();
     int replacementLen = 0;
     for (ReplacementSegment seg : compiledTemplate) {
@@ -2271,6 +2283,37 @@ public final class Matcher implements MatchResult {
 
       groups[0] = matchStart;
       groups[1] = matchEnd;
+      if (needsCaptures) {
+        Arrays.fill(groups, 2, groups.length, -1);
+        int[] resultGroups;
+        if (useOnePass) {
+          resultGroups =
+              parentPattern
+                  .onePass()
+                  .search(text, matchStart, matchEnd, false, numCaptures, groups);
+        } else {
+          resultGroups =
+              searchWithBitStateOrNfa(
+                  prog,
+                  text,
+                  matchStart,
+                  matchEnd,
+                  matchEnd,
+                  matchEnd,
+                  true,
+                  false,
+                  false,
+                  numCaptures,
+                  true,
+                  groups);
+        }
+        if (resultGroups != null && resultGroups != groups) {
+          System.arraycopy(resultGroups, 0, groups, 0, groups.length);
+        }
+        capturesResolved = true;
+        groupZeroResolved = true;
+      }
+
       sb.append(text, builderAppendPos, matchStart);
       applyReplacementTemplate(sb, compiledTemplate);
       builderAppendPos = matchEnd;
@@ -2279,10 +2322,6 @@ public final class Matcher implements MatchResult {
 
     int firstMatchStart = matchOffsets[0];
     int firstMatchEnd = matchOffsets[1];
-
-    if (groups == null) {
-      groups = new int[2 * parentPattern.prog().numCaptures()];
-    }
 
     if (limit == 1) {
       applyDeferredMatchResult(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1491,14 +1491,18 @@ public final class Matcher implements MatchResult {
       int earlyEnd = fwdResult.pos();
 
       if (prog.anchorStart()) {
-        // Anchored: match start is effectiveStart. Since it is start-anchored, the match end
-        // is guaranteed to be earlyEnd. Avoid redundant third DFA search.
-        return applyDeferredMatchResult(
-            effectiveStart,
-            earlyEnd,
-            prog.numCaptures(),
-            parentPattern.dfaGroupZeroReliable(),
-            false);
+        // Anchored: match start is effectiveStart. Run forward DFA (anchored, first-match) to find
+        // actual end, then defer inner captures until requested.
+        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+        if (fwdFirst != null && fwdFirst.matched()) {
+          int matchEnd = fwdFirst.pos();
+          return applyDeferredMatchResult(
+              effectiveStart,
+              matchEnd,
+              prog.numCaptures(),
+              parentPattern.dfaGroupZeroReliable(),
+              false);
+        }
       } else {
         if (literalPrefixCandidateStart) {
           // A literal prefix occurrence is a candidate match start, even when the prefix is

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2184,8 +2184,8 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
-    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     reset();
+    LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String fastResult = charClassReplaceFastPath(template, 1);
     if (fastResult != null) {
       return fastResult;
@@ -2205,13 +2205,13 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private String replaceDfaOptimized(ReplacementSegment[] compiledTemplate, int limit) {
+  private String replaceDfaOptimized(LazyTemplate template, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     if (!canUseForwardDfa()
         || !parentPattern.dfaGroupZeroReliable()
         || parentPattern.prog().dollarAnchorEnd()
         || parentPattern.literalMatch() != null
-        || templateNeedsCaptures(compiledTemplate)
+        || template.needsCaptures() // Route to fallback if it needs captures
         || regionActive) {
       return null;
     }
@@ -2245,6 +2245,8 @@ public final class Matcher implements MatchResult {
     if (matchesFound == 0) {
       return text;
     }
+
+    ReplacementSegment[] compiledTemplate = template.get();
 
     int textLen = text.length();
     StringBuilder sb = new StringBuilder(textLen);
@@ -2398,8 +2400,8 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
-    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     reset();
+    LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String fastResult = charClassReplaceFastPath(template, Integer.MAX_VALUE);
     if (fastResult != null) {
       return fastResult;
@@ -2414,13 +2416,14 @@ public final class Matcher implements MatchResult {
       return text;
     }
     StringBuilder sb = new StringBuilder(text.length());
-    boolean needsCaptures = templateNeedsCaptures(template);
+    ReplacementSegment[] compiledTemplate = template.get();
+    boolean needsCaptures = templateNeedsCaptures(compiledTemplate);
     do {
       if (needsCaptures || !groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
-      applyReplacementTemplate(sb, template);
+      applyReplacementTemplate(sb, compiledTemplate);
       appendPos = groups[1];
     } while (find());
     appendTail(sb);
@@ -2453,14 +2456,16 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private String charClassReplaceFastPath(ReplacementSegment[] template, int limit) {
+  private String charClassReplaceFastPath(LazyTemplate template, int limit) {
     if (!enginePathOptions().charClassReplacementFastPath()
         || parentPattern.charClassMatchRanges() == null
         || parentPattern.charClassMatchAllowEmpty()
         || parentPattern.hasLazyQuantifiers()) {
       return null;
     }
-    if (template.length != 1 || !(template[0] instanceof ReplacementSegment.Literal literalSeg)) {
+    ReplacementSegment[] compiledTemplate = template.get();
+    if (compiledTemplate.length != 1
+        || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
       return null;
     }
     String repText = literalSeg.text();
@@ -3068,6 +3073,51 @@ public final class Matcher implements MatchResult {
       if (!hasMatch) {
         throw new IllegalStateException("No match found");
       }
+    }
+  }
+
+  private static final class LazyTemplate {
+    private final String replacement;
+    private final int maxGroup;
+    private ReplacementSegment[] value;
+    private Boolean needsCaptures;
+
+    LazyTemplate(String replacement, int maxGroup) {
+      this.replacement = replacement;
+      this.maxGroup = maxGroup;
+    }
+
+    boolean needsCaptures() {
+      if (needsCaptures == null) {
+        needsCaptures = computeNeedsCaptures();
+      }
+      return needsCaptures;
+    }
+
+    private boolean computeNeedsCaptures() {
+      if (replacement == null) {
+        return false;
+      }
+      int len = replacement.length();
+      int i = 0;
+      while (i < len) {
+        char c = replacement.charAt(i);
+        if (c == '\\') {
+          i += 2;
+        } else if (c == '$') {
+          return true;
+        } else {
+          i++;
+        }
+      }
+      return false;
+    }
+
+    ReplacementSegment[] get() {
+      if (value == null) {
+        value = compileReplacementTemplate(replacement, maxGroup);
+      }
+      return value;
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1490,18 +1490,14 @@ public final class Matcher implements MatchResult {
       int earlyEnd = fwdResult.pos();
 
       if (prog.anchorStart()) {
-        // Anchored: match start is effectiveStart. Run forward DFA (anchored, first-match) to find
-        // actual end, then defer inner captures until requested.
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
-        if (fwdFirst != null && fwdFirst.matched()) {
-          int matchEnd = fwdFirst.pos();
-          return applyDeferredMatchResult(
-              effectiveStart,
-              matchEnd,
-              prog.numCaptures(),
-              parentPattern.dfaGroupZeroReliable(),
-              false);
-        }
+        // Anchored: match start is effectiveStart. Since it is start-anchored, the match end
+        // is guaranteed to be earlyEnd. Avoid redundant third DFA search.
+        return applyDeferredMatchResult(
+            effectiveStart,
+            earlyEnd,
+            prog.numCaptures(),
+            parentPattern.dfaGroupZeroReliable(),
+            false);
       } else {
         if (literalPrefixCandidateStart) {
           // A literal prefix occurrence is a candidate match start, even when the prefix is
@@ -2256,20 +2252,22 @@ public final class Matcher implements MatchResult {
       }
 
       int matchStart;
+      int matchEnd;
       if (isStartAnchored) {
         matchStart = pos;
+        matchEnd = earlyEnd;
       } else {
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched()) {
           return null;
         }
         matchStart = revResult.pos();
+        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+        if (fwdFirst == null || !fwdFirst.matched()) {
+          return null;
+        }
+        matchEnd = fwdFirst.pos();
       }
-      Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
-      if (fwdFirst == null || !fwdFirst.matched()) {
-        return null;
-      }
-      int matchEnd = fwdFirst.pos();
 
       if (compiledTemplate == null) {
         compiledTemplate = template.get();

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -962,8 +962,7 @@ public final class Matcher implements MatchResult {
     return enginePathOptions().dfa()
         && enginePathOptions().reverseDfa()
         && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
-        && !parentPattern.prog().anchorStart()
-        && reverseDfa() != null;
+        && !parentPattern.prog().anchorStart();
   }
 
   /**
@@ -2405,6 +2404,9 @@ public final class Matcher implements MatchResult {
               return -1;
             }
             revDfa = reverseDfa();
+            if (revDfa == null) {
+              return -1;
+            }
           }
           Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
           if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
@@ -2423,6 +2425,9 @@ public final class Matcher implements MatchResult {
             return -1;
           }
           revDfa = reverseDfa();
+          if (revDfa == null) {
+            return -1;
+          }
         }
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched() || revResult.ambiguous()) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2316,6 +2316,7 @@ public final class Matcher implements MatchResult {
       }
 
       sb.append(text, builderAppendPos, matchStart);
+      this.resultStatus = ResultStatus.MATCHED;
       applyReplacementTemplate(sb, compiledTemplate);
       builderAppendPos = matchEnd;
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -78,6 +78,7 @@ public final class Matcher implements MatchResult {
   private CharSequence inputSequence;
   private String text;
   private int[] groups;
+  private int[] matchOffsets;
   private boolean hasMatch;
   private ResultStatus resultStatus = ResultStatus.RESET_NO_ATTEMPT;
   private int searchFrom;
@@ -2183,9 +2184,9 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
-    LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     reset();
-    String fastResult = charClassReplaceFastPath(replacement, 1);
+    String fastResult = charClassReplaceFastPath(template, 1);
     if (fastResult != null) {
       return fastResult;
     }
@@ -2204,18 +2205,16 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private String replaceDfaOptimized(LazyTemplate template, int limit) {
+  private String replaceDfaOptimized(ReplacementSegment[] compiledTemplate, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     if (!canUseForwardDfa()
         || !parentPattern.dfaGroupZeroReliable()
         || parentPattern.prog().dollarAnchorEnd()
+        || parentPattern.literalMatch() != null
+        || templateNeedsCaptures(compiledTemplate)
         || regionActive) {
       return null;
     }
-
-    ReplacementSegment[] compiledTemplate = null;
-    int textLen = text.length();
-    int pos = searchFrom;
 
     Dfa fwdDfa = dfa(false);
     if (fwdDfa == null) {
@@ -2234,11 +2233,69 @@ public final class Matcher implements MatchResult {
     String prefix = parentPattern.prefix();
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
-    int matchesFound = 0;
-    int firstMatchStart = -1;
-    int firstMatchEnd = -1;
+
+    int matchesFound =
+        findDfaMatches(
+            fwdDfa, revDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, limit);
+
+    if (matchesFound < 0) {
+      return null;
+    }
+
+    if (matchesFound == 0) {
+      return text;
+    }
+
+    int textLen = text.length();
+    StringBuilder sb = new StringBuilder(textLen);
     int builderAppendPos = searchFrom;
-    StringBuilder sb = null;
+
+    for (int i = 0; i < matchesFound; i++) {
+      int matchStart = matchOffsets[2 * i];
+      int matchEnd = matchOffsets[2 * i + 1];
+
+      groups[0] = matchStart;
+      groups[1] = matchEnd;
+      sb.append(text, builderAppendPos, matchStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      builderAppendPos = matchEnd;
+    }
+    sb.append(text, builderAppendPos, textLen);
+
+    int firstMatchStart = matchOffsets[0];
+    int firstMatchEnd = matchOffsets[1];
+
+    if (groups == null) {
+      groups = new int[2 * parentPattern.prog().numCaptures()];
+    }
+
+    if (limit == 1) {
+      applyDeferredMatchResult(
+          firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
+      this.appendPos = firstMatchEnd;
+    } else {
+      applyFailedMatchResult();
+      this.appendPos = textLen;
+      this.searchFrom = textLen;
+    }
+    return sb.toString();
+  }
+
+  private int findDfaMatches(
+      Dfa fwdDfa,
+      Dfa revDfa,
+      boolean isStartAnchored,
+      String prefix,
+      boolean foldCase,
+      boolean hasStartAcceleration,
+      int limit) {
+    int textLen = text.length();
+    int pos = searchFrom;
+    int matchesFound = 0;
+
+    if (matchOffsets == null) {
+      matchOffsets = new int[16];
+    }
 
     while (pos <= textLen && matchesFound < limit) {
       if (parentPattern.prog().anchorStart() && pos > 0) {
@@ -2259,7 +2316,7 @@ public final class Matcher implements MatchResult {
 
       int earlyEnd = fwdResult.pos();
       if (earlyEnd <= pos) {
-        return null; // Fallback for empty match
+        return -1;
       }
 
       int matchStart;
@@ -2267,61 +2324,46 @@ public final class Matcher implements MatchResult {
       if (isStartAnchored) {
         matchStart = pos;
         matchEnd = earlyEnd;
+      } else if (hasStartAcceleration) {
+        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, pos, true, false);
+        if (fwdFirst != null && fwdFirst.matched()) {
+          matchStart = pos;
+          matchEnd = fwdFirst.pos();
+        } else {
+          Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+          if (revResult == null || !revResult.matched()) {
+            return -1;
+          }
+          matchStart = revResult.pos();
+          Dfa.SearchResult fwdFirst2 = fwdDfa.doSearch(text, matchStart, true, false);
+          if (fwdFirst2 == null || !fwdFirst2.matched()) {
+            return -1;
+          }
+          matchEnd = fwdFirst2.pos();
+        }
       } else {
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched()) {
-          return null;
+          return -1;
         }
         matchStart = revResult.pos();
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, matchStart, true, false);
         if (fwdFirst == null || !fwdFirst.matched()) {
-          return null;
+          return -1;
         }
         matchEnd = fwdFirst.pos();
       }
 
-      if (compiledTemplate == null) {
-        compiledTemplate = template.get();
-        if (templateNeedsCaptures(compiledTemplate)) {
-          return null;
-        }
-        sb = new StringBuilder(textLen);
+      if (2 * matchesFound >= matchOffsets.length) {
+        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
       }
-
-      groups[0] = matchStart;
-      groups[1] = matchEnd;
-      sb.append(text, builderAppendPos, matchStart);
-      applyReplacementTemplate(sb, compiledTemplate);
-      builderAppendPos = matchEnd;
-
-      if (matchesFound == 0) {
-        firstMatchStart = matchStart;
-        firstMatchEnd = matchEnd;
-      }
+      matchOffsets[2 * matchesFound] = matchStart;
+      matchOffsets[2 * matchesFound + 1] = matchEnd;
 
       pos = matchEnd;
       matchesFound++;
     }
-
-    if (matchesFound == 0) {
-      return text;
-    }
-
-    if (groups == null) {
-      groups = new int[2 * parentPattern.prog().numCaptures()];
-    }
-    sb.append(text, builderAppendPos, textLen);
-
-    if (limit == 1) {
-      applyDeferredMatchResult(
-          firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
-      this.appendPos = firstMatchEnd;
-    } else {
-      applyFailedMatchResult();
-      this.appendPos = textLen;
-      this.searchFrom = textLen;
-    }
-    return sb.toString();
+    return matchesFound;
   }
 
   /**
@@ -2356,9 +2398,9 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
-    LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     reset();
-    String fastResult = charClassReplaceFastPath(replacement, Integer.MAX_VALUE);
+    String fastResult = charClassReplaceFastPath(template, Integer.MAX_VALUE);
     if (fastResult != null) {
       return fastResult;
     }
@@ -2372,13 +2414,13 @@ public final class Matcher implements MatchResult {
       return text;
     }
     StringBuilder sb = new StringBuilder(text.length());
-    boolean needsCaptures = templateNeedsCaptures(template.get());
+    boolean needsCaptures = templateNeedsCaptures(template);
     do {
       if (needsCaptures || !groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
-      applyReplacementTemplate(sb, template.get());
+      applyReplacementTemplate(sb, template);
       appendPos = groups[1];
     } while (find());
     appendTail(sb);
@@ -2411,17 +2453,11 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private String charClassReplaceFastPath(String replacement, int limit) {
+  private String charClassReplaceFastPath(ReplacementSegment[] template, int limit) {
     if (!enginePathOptions().charClassReplacementFastPath()
         || parentPattern.charClassMatchRanges() == null
         || parentPattern.charClassMatchAllowEmpty()
         || parentPattern.hasLazyQuantifiers()) {
-      return null;
-    }
-    ReplacementSegment[] template;
-    try {
-      template = compileReplacementTemplate(replacement, 0);
-    } catch (IllegalArgumentException e) {
       return null;
     }
     if (template.length != 1 || !(template[0] instanceof ReplacementSegment.Literal literalSeg)) {
@@ -3032,24 +3068,6 @@ public final class Matcher implements MatchResult {
       if (!hasMatch) {
         throw new IllegalStateException("No match found");
       }
-    }
-  }
-
-  private static final class LazyTemplate {
-    private final String replacement;
-    private final int maxGroup;
-    private ReplacementSegment[] value;
-
-    LazyTemplate(String replacement, int maxGroup) {
-      this.replacement = replacement;
-      this.maxGroup = maxGroup;
-    }
-
-    ReplacementSegment[] get() {
-      if (value == null) {
-        value = compileReplacementTemplate(replacement, maxGroup);
-      }
-      return value;
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -961,7 +961,8 @@ public final class Matcher implements MatchResult {
     return enginePathOptions().dfa()
         && enginePathOptions().reverseDfa()
         && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
-        && !parentPattern.prog().anchorStart();
+        && !parentPattern.prog().anchorStart()
+        && reverseDfa() != null;
   }
 
   /**
@@ -2186,13 +2187,151 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
+    LazyTemplate template = new LazyTemplate(replacement, groupCount());
     reset();
+    String result = replaceDfaOptimized(template, 1);
+    if (result != null) {
+      return result;
+    }
+
     if (!find()) {
       return text;
     }
     StringBuilder sb = new StringBuilder(text.length());
     appendReplacement(sb, replacement);
     appendTail(sb);
+    return sb.toString();
+  }
+
+  private String replaceDfaOptimized(LazyTemplate template, int limit) {
+    boolean regionActive = (regionStart != 0 || regionEnd != text.length());
+    if (!canUseForwardDfa() || !parentPattern.dfaGroupZeroReliable() || regionActive) {
+      return null;
+    }
+
+    ReplacementSegment[] compiledTemplate = null;
+    int textLen = text.length();
+    int pos = searchFrom;
+
+    Dfa fwdDfa = dfa(false);
+    if (fwdDfa == null) {
+      return null;
+    }
+
+    Dfa revDfa = null;
+    boolean isStartAnchored = parentPattern.prog().anchorStart();
+    if (!isStartAnchored) {
+      if (!canUseReverseDfa()) {
+        return null;
+      }
+      revDfa = reverseDfa();
+    }
+
+    String prefix = parentPattern.prefix();
+    boolean foldCase = parentPattern.prefixFoldCase();
+    boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
+    int matchesFound = 0;
+    int[] matchOffsets = null;
+
+    while (pos <= textLen && matchesFound < limit) {
+      if (parentPattern.prog().anchorStart() && pos > 0) {
+        break;
+      }
+      if (hasStartAcceleration && pos < textLen) {
+        int idx = foldCase ? indexOfIgnoreCase(text, prefix, pos) : text.indexOf(prefix, pos);
+        if (idx < 0) {
+          break;
+        }
+        pos = idx;
+      }
+
+      Dfa.SearchResult fwdResult = fwdDfa.doSearch(text, pos, false, false);
+      if (fwdResult == null || !fwdResult.matched()) {
+        break;
+      }
+
+      int earlyEnd = fwdResult.pos();
+      if (earlyEnd <= pos) {
+        return null; // Fallback for empty match
+      }
+
+      int matchStart;
+      if (isStartAnchored) {
+        matchStart = pos;
+      } else {
+        Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+        if (revResult == null || !revResult.matched()) {
+          return null;
+        }
+        matchStart = revResult.pos();
+      }
+      Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+      if (fwdFirst == null || !fwdFirst.matched()) {
+        return null;
+      }
+      int matchEnd = fwdFirst.pos();
+
+      if (compiledTemplate == null) {
+        compiledTemplate = template.get();
+        if (templateNeedsCaptures(compiledTemplate)) {
+          return null;
+        }
+        matchOffsets = new int[16];
+      }
+
+      if (2 * matchesFound >= matchOffsets.length) {
+        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
+      }
+
+      matchOffsets[2 * matchesFound] = matchStart;
+      matchOffsets[2 * matchesFound + 1] = matchEnd;
+
+      pos = matchEnd;
+      matchesFound++;
+    }
+
+    if (matchesFound == 0) {
+      return text;
+    }
+
+    if (groups == null) {
+      groups = new int[2 * parentPattern.prog().numCaptures()];
+    }
+    groups[0] = matchOffsets[0];
+    groups[1] = matchOffsets[1];
+
+    int totalMatchLength = 0;
+    for (int i = 0; i < matchesFound; i++) {
+      totalMatchLength += (matchOffsets[2 * i + 1] - matchOffsets[2 * i]);
+    }
+    int replacementLen = 0;
+    for (ReplacementSegment seg : compiledTemplate) {
+      if (seg instanceof ReplacementSegment.Literal literal) {
+        replacementLen += literal.text().length();
+      }
+    }
+    int finalCapacity = textLen - totalMatchLength + (matchesFound * replacementLen);
+
+    StringBuilder sb = new StringBuilder(finalCapacity);
+    int appendPos = searchFrom;
+    for (int i = 0; i < matchesFound; i++) {
+      int mStart = matchOffsets[2 * i];
+      int mEnd = matchOffsets[2 * i + 1];
+      groups[0] = mStart;
+      groups[1] = mEnd;
+      sb.append(text, appendPos, mStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      appendPos = mEnd;
+    }
+    sb.append(text, appendPos, textLen);
+
+    if (limit == 1) {
+      deferredMatchStart = groups[0];
+      deferredMatchEnd = groups[1];
+      capturesResolved = parentPattern.prog().numCaptures() <= 1;
+      groupZeroResolved = true;
+    }
+    resultStatus = (limit == 1) ? ResultStatus.MATCHED : ResultStatus.FAILED;
     return sb.toString();
   }
 
@@ -2228,20 +2367,24 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
+    LazyTemplate template = new LazyTemplate(replacement, groupCount());
     reset();
+    String result = replaceDfaOptimized(template, Integer.MAX_VALUE);
+    if (result != null) {
+      return result;
+    }
+
     if (!find()) {
       return text;
     }
-    // Pre-compile the replacement template once, avoiding per-match parseInt/substring overhead.
-    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     StringBuilder sb = new StringBuilder(text.length());
-    boolean needsCaptures = templateNeedsCaptures(template);
+    boolean needsCaptures = templateNeedsCaptures(template.get());
     do {
       if (needsCaptures || !groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
-      applyReplacementTemplate(sb, template);
+      applyReplacementTemplate(sb, template.get());
       appendPos = groups[1];
     } while (find());
     appendTail(sb);
@@ -2796,6 +2939,24 @@ public final class Matcher implements MatchResult {
       if (!hasMatch) {
         throw new IllegalStateException("No match found");
       }
+    }
+  }
+
+  private static final class LazyTemplate {
+    private final String replacement;
+    private final int maxGroup;
+    private ReplacementSegment[] value;
+
+    LazyTemplate(String replacement, int maxGroup) {
+      this.replacement = replacement;
+      this.maxGroup = maxGroup;
+    }
+
+    ReplacementSegment[] get() {
+      if (value == null) {
+        value = compileReplacementTemplate(replacement, maxGroup);
+      }
+      return value;
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2249,7 +2249,20 @@ public final class Matcher implements MatchResult {
     ReplacementSegment[] compiledTemplate = template.get();
 
     int textLen = text.length();
-    StringBuilder sb = new StringBuilder(textLen);
+    int replacementLen = 0;
+    for (ReplacementSegment seg : compiledTemplate) {
+      if (seg instanceof ReplacementSegment.Literal lit) {
+        replacementLen += lit.text().length();
+      }
+    }
+
+    int totalMatchLen = 0;
+    for (int i = 0; i < matchesFound; i++) {
+      totalMatchLen += (matchOffsets[2 * i + 1] - matchOffsets[2 * i]);
+    }
+    int finalLen = textLen - totalMatchLen + (matchesFound * replacementLen);
+
+    StringBuilder sb = new StringBuilder(finalLen);
     int builderAppendPos = searchFrom;
 
     for (int i = 0; i < matchesFound; i++) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2216,7 +2216,6 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  @SuppressWarnings("ReferenceEquality")
   private String replaceDfaOptimized(LazyTemplate template, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     if (!canUseForwardDfa()
@@ -2224,12 +2223,9 @@ public final class Matcher implements MatchResult {
         // dollarAnchorEnd is safe if start-anchored because we skip the reverse DFA scan.
         || (parentPattern.prog().dollarAnchorEnd() && !parentPattern.prog().anchorStart())
         || parentPattern.literalMatch() != null
+        || parentPattern.canMatchEmpty()
+        || parentPattern.hasNullableAlternation()
         || regionActive) {
-      return null;
-    }
-
-    Dfa fwdDfa = dfa(false);
-    if (fwdDfa == null) {
       return null;
     }
 
@@ -2237,7 +2233,6 @@ public final class Matcher implements MatchResult {
     String prefix = parentPattern.prefix();
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
-
     int startPos = searchFrom;
     if (hasStartAcceleration) {
       int firstIdx =
@@ -2248,32 +2243,31 @@ public final class Matcher implements MatchResult {
       startPos = firstIdx;
     }
 
-    int matchesFound =
-        findDfaMatches(
-            fwdDfa,
-            isStartAnchored,
-            prefix,
-            foldCase,
-            hasStartAcceleration,
-            startPos,
-            limit,
-            limit == 1);
-
-    if (matchesFound < 0) {
+    Dfa fwdDfa = dfa(false);
+    if (fwdDfa == null) {
       return null;
     }
 
-    if (matchesFound == 0) {
+    DfaMatchCursor cursor = new DfaMatchCursor(startPos);
+    int matchResult =
+        findNextDfaMatch(fwdDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, cursor);
+
+    if (matchResult < 0) {
+      return null;
+    }
+    if (matchResult == 0) {
       return text;
     }
-
-    ReplacementSegment[] compiledTemplate = template.get();
 
     Prog prog = parentPattern.prog();
     int numCaptures = prog.numCaptures();
     if (groups == null || groups.length < 2 * numCaptures) {
       groups = new int[2 * numCaptures];
     }
+    applyDeferredMatchResult(matchOffsets[0], matchOffsets[1], numCaptures, true, false);
+
+    ReplacementSegment[] compiledTemplate = template.get();
+
     boolean needsCaptures = template.needsCaptures();
     boolean useOnePass =
         needsCaptures
@@ -2282,40 +2276,16 @@ public final class Matcher implements MatchResult {
             && !parentPattern.hasNullableAlternation();
 
     int textLen = text.length();
-    int replacementLen = 0;
-    for (ReplacementSegment seg : compiledTemplate) {
-      if (seg instanceof ReplacementSegment.Literal lit) {
-        replacementLen += lit.text().length();
-      }
-    }
-
-    int finalLen = textLen + (matchesFound * replacementLen);
-
-    StringBuilder sb = new StringBuilder(finalLen);
+    StringBuilder sb = new StringBuilder(textLen);
     int builderAppendPos = searchFrom;
     int firstMatchStart = -1;
     int firstMatchEnd = -1;
+    int matchesFound = 0;
 
-    for (int i = 0; i < matchesFound; i++) {
-      if (limit != 1) {
-        int nextMatch =
-            findDfaMatches(
-                fwdDfa,
-                isStartAnchored,
-                prefix,
-                foldCase,
-                hasStartAcceleration,
-                builderAppendPos,
-                1,
-                true);
-        if (nextMatch != 1) {
-          return null;
-        }
-      }
-      int offsetIndex = limit == 1 ? 2 * i : 0;
-      int matchStart = matchOffsets[offsetIndex];
-      int matchEnd = matchOffsets[offsetIndex + 1];
-      if (i == 0) {
+    while (matchResult == 1 && matchesFound < limit) {
+      int matchStart = matchOffsets[0];
+      int matchEnd = matchOffsets[1];
+      if (matchesFound == 0) {
         firstMatchStart = matchStart;
         firstMatchEnd = matchEnd;
       }
@@ -2346,7 +2316,7 @@ public final class Matcher implements MatchResult {
                   true,
                   groups);
         }
-        if (resultGroups != null && resultGroups != groups) {
+        if (resultGroups != null) {
           System.arraycopy(resultGroups, 0, groups, 0, groups.length);
         }
         capturesResolved = true;
@@ -2357,6 +2327,17 @@ public final class Matcher implements MatchResult {
       this.resultStatus = ResultStatus.MATCHED;
       applyReplacementTemplate(sb, compiledTemplate);
       builderAppendPos = matchEnd;
+
+      cursor.pos = matchEnd;
+      matchesFound++;
+      if (matchesFound < limit) {
+        matchResult =
+            findNextDfaMatch(
+                fwdDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, cursor);
+        if (matchResult < 0) {
+          return null;
+        }
+      }
     }
     sb.append(text, builderAppendPos, textLen);
 
@@ -2372,25 +2353,21 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private int findDfaMatches(
+  private int findNextDfaMatch(
       Dfa fwdDfa,
       boolean isStartAnchored,
       String prefix,
       boolean foldCase,
       boolean hasStartAcceleration,
-      int startPos,
-      int limit,
-      boolean storeOffsets) {
+      DfaMatchCursor cursor) {
     int textLen = text.length();
-    int pos = startPos;
-    int matchesFound = 0;
-    Dfa revDfa = null;
+    int pos = cursor.pos;
 
-    if (storeOffsets && matchOffsets == null) {
-      matchOffsets = new int[16];
+    if (matchOffsets == null) {
+      matchOffsets = new int[2];
     }
 
-    while (pos <= textLen && matchesFound < limit) {
+    while (pos <= textLen) {
       if (parentPattern.prog().anchorStart() && pos > 0) {
         break;
       }
@@ -2423,16 +2400,17 @@ public final class Matcher implements MatchResult {
           matchStart = pos;
           matchEnd = fwdFirst.pos();
         } else {
-          if (revDfa == null) {
+          if (cursor.revDfa == null) {
             if (!canUseReverseDfa()) {
               return -1;
             }
-            revDfa = reverseDfa();
-            if (revDfa == null) {
+            cursor.revDfa = reverseDfa();
+            if (cursor.revDfa == null) {
               return -1;
             }
           }
-          Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+          Dfa.SearchResult revResult =
+              cursor.revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
           if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
             return -1;
           }
@@ -2444,16 +2422,16 @@ public final class Matcher implements MatchResult {
           matchEnd = fwdFirst2.pos();
         }
       } else {
-        if (revDfa == null) {
+        if (cursor.revDfa == null) {
           if (!canUseReverseDfa()) {
             return -1;
           }
-          revDfa = reverseDfa();
-          if (revDfa == null) {
+          cursor.revDfa = reverseDfa();
+          if (cursor.revDfa == null) {
             return -1;
           }
         }
-        Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+        Dfa.SearchResult revResult = cursor.revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
           return -1;
         }
@@ -2465,18 +2443,11 @@ public final class Matcher implements MatchResult {
         matchEnd = fwdFirst.pos();
       }
 
-      if (storeOffsets) {
-        if (2 * matchesFound >= matchOffsets.length) {
-          matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
-        }
-        matchOffsets[2 * matchesFound] = matchStart;
-        matchOffsets[2 * matchesFound + 1] = matchEnd;
-      }
-
-      pos = matchEnd;
-      matchesFound++;
+      matchOffsets[0] = matchStart;
+      matchOffsets[1] = matchEnd;
+      return 1;
     }
-    return matchesFound;
+    return 0;
   }
 
   /**
@@ -2615,14 +2586,21 @@ public final class Matcher implements MatchResult {
       int matchEnd = pos;
 
       if (matchesFound == 0) {
-        ReplacementSegment[] compiledTemplate = template.get();
+        firstMatchStart = matchStart;
+        firstMatchEnd = matchEnd;
+        ReplacementSegment[] compiledTemplate;
+        try {
+          compiledTemplate = template.get();
+        } catch (IllegalArgumentException e) {
+          applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
+          throw e;
+        }
         if (compiledTemplate.length != 1
             || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
           return null;
         }
+        applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
         repText = literalSeg.text();
-        firstMatchStart = matchStart;
-        firstMatchEnd = matchEnd;
       }
 
       if (sb == null) {
@@ -3230,6 +3208,15 @@ public final class Matcher implements MatchResult {
         value = compileReplacementTemplate(replacement, maxGroup);
       }
       return value;
+    }
+  }
+
+  private static final class DfaMatchCursor {
+    private int pos;
+    private Dfa revDfa;
+
+    DfaMatchCursor(int pos) {
+      this.pos = pos;
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2238,9 +2238,19 @@ public final class Matcher implements MatchResult {
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
 
+    int startPos = searchFrom;
+    if (hasStartAcceleration) {
+      int firstIdx =
+          foldCase ? indexOfIgnoreCase(text, prefix, searchFrom) : text.indexOf(prefix, searchFrom);
+      if (firstIdx < 0) {
+        return text;
+      }
+      startPos = firstIdx;
+    }
+
     int matchesFound =
         findDfaMatches(
-            fwdDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, limit);
+            fwdDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, startPos, limit);
 
     if (matchesFound < 0) {
       return null;
@@ -2346,9 +2356,10 @@ public final class Matcher implements MatchResult {
       String prefix,
       boolean foldCase,
       boolean hasStartAcceleration,
+      int startPos,
       int limit) {
     int textLen = text.length();
-    int pos = searchFrom;
+    int pos = startPos;
     int matchesFound = 0;
     Dfa revDfa = null;
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2194,6 +2194,7 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
+    Objects.requireNonNull(replacement, "replacement");
     reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String fastResult = charClassReplaceFastPath(template, 1);
@@ -2249,7 +2250,14 @@ public final class Matcher implements MatchResult {
 
     int matchesFound =
         findDfaMatches(
-            fwdDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, startPos, limit);
+            fwdDfa,
+            isStartAnchored,
+            prefix,
+            foldCase,
+            hasStartAcceleration,
+            startPos,
+            limit,
+            limit == 1);
 
     if (matchesFound < 0) {
       return null;
@@ -2281,18 +2289,36 @@ public final class Matcher implements MatchResult {
       }
     }
 
-    int totalMatchLen = 0;
-    for (int i = 0; i < matchesFound; i++) {
-      totalMatchLen += (matchOffsets[2 * i + 1] - matchOffsets[2 * i]);
-    }
-    int finalLen = textLen - totalMatchLen + (matchesFound * replacementLen);
+    int finalLen = textLen + (matchesFound * replacementLen);
 
     StringBuilder sb = new StringBuilder(finalLen);
     int builderAppendPos = searchFrom;
+    int firstMatchStart = -1;
+    int firstMatchEnd = -1;
 
     for (int i = 0; i < matchesFound; i++) {
-      int matchStart = matchOffsets[2 * i];
-      int matchEnd = matchOffsets[2 * i + 1];
+      if (limit != 1) {
+        int nextMatch =
+            findDfaMatches(
+                fwdDfa,
+                isStartAnchored,
+                prefix,
+                foldCase,
+                hasStartAcceleration,
+                builderAppendPos,
+                1,
+                true);
+        if (nextMatch != 1) {
+          return null;
+        }
+      }
+      int offsetIndex = limit == 1 ? 2 * i : 0;
+      int matchStart = matchOffsets[offsetIndex];
+      int matchEnd = matchOffsets[offsetIndex + 1];
+      if (i == 0) {
+        firstMatchStart = matchStart;
+        firstMatchEnd = matchEnd;
+      }
 
       groups[0] = matchStart;
       groups[1] = matchEnd;
@@ -2334,9 +2360,6 @@ public final class Matcher implements MatchResult {
     }
     sb.append(text, builderAppendPos, textLen);
 
-    int firstMatchStart = matchOffsets[0];
-    int firstMatchEnd = matchOffsets[1];
-
     if (limit == 1) {
       applyDeferredMatchResult(
           firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
@@ -2356,13 +2379,14 @@ public final class Matcher implements MatchResult {
       boolean foldCase,
       boolean hasStartAcceleration,
       int startPos,
-      int limit) {
+      int limit,
+      boolean storeOffsets) {
     int textLen = text.length();
     int pos = startPos;
     int matchesFound = 0;
     Dfa revDfa = null;
 
-    if (matchOffsets == null) {
+    if (storeOffsets && matchOffsets == null) {
       matchOffsets = new int[16];
     }
 
@@ -2441,11 +2465,13 @@ public final class Matcher implements MatchResult {
         matchEnd = fwdFirst.pos();
       }
 
-      if (2 * matchesFound >= matchOffsets.length) {
-        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
+      if (storeOffsets) {
+        if (2 * matchesFound >= matchOffsets.length) {
+          matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
+        }
+        matchOffsets[2 * matchesFound] = matchStart;
+        matchOffsets[2 * matchesFound + 1] = matchEnd;
       }
-      matchOffsets[2 * matchesFound] = matchStart;
-      matchOffsets[2 * matchesFound + 1] = matchEnd;
 
       pos = matchEnd;
       matchesFound++;
@@ -2548,12 +2574,7 @@ public final class Matcher implements MatchResult {
         || parentPattern.hasLazyQuantifiers()) {
       return null;
     }
-    ReplacementSegment[] compiledTemplate = template.get();
-    if (compiledTemplate.length != 1
-        || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
-      return null;
-    }
-    String repText = literalSeg.text();
+    String repText = null;
 
     int textLen = text.length();
     int pos = searchFrom;
@@ -2594,6 +2615,12 @@ public final class Matcher implements MatchResult {
       int matchEnd = pos;
 
       if (matchesFound == 0) {
+        ReplacementSegment[] compiledTemplate = template.get();
+        if (compiledTemplate.length != 1
+            || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
+          return null;
+        }
+        repText = literalSeg.text();
         firstMatchStart = matchStart;
         firstMatchEnd = matchEnd;
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2233,22 +2233,14 @@ public final class Matcher implements MatchResult {
       return null;
     }
 
-    Dfa revDfa = null;
     boolean isStartAnchored = parentPattern.prog().anchorStart();
-    if (!isStartAnchored) {
-      if (!canUseReverseDfa()) {
-        return null;
-      }
-      revDfa = reverseDfa();
-    }
-
     String prefix = parentPattern.prefix();
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
 
     int matchesFound =
         findDfaMatches(
-            fwdDfa, revDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, limit);
+            fwdDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, limit);
 
     if (matchesFound < 0) {
       return null;
@@ -2350,7 +2342,6 @@ public final class Matcher implements MatchResult {
 
   private int findDfaMatches(
       Dfa fwdDfa,
-      Dfa revDfa,
       boolean isStartAnchored,
       String prefix,
       boolean foldCase,
@@ -2359,6 +2350,7 @@ public final class Matcher implements MatchResult {
     int textLen = text.length();
     int pos = searchFrom;
     int matchesFound = 0;
+    Dfa revDfa = null;
 
     if (matchOffsets == null) {
       matchOffsets = new int[16];
@@ -2397,6 +2389,12 @@ public final class Matcher implements MatchResult {
           matchStart = pos;
           matchEnd = fwdFirst.pos();
         } else {
+          if (revDfa == null) {
+            if (!canUseReverseDfa()) {
+              return -1;
+            }
+            revDfa = reverseDfa();
+          }
           Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
           if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
             return -1;
@@ -2409,6 +2407,12 @@ public final class Matcher implements MatchResult {
           matchEnd = fwdFirst2.pos();
         }
       } else {
+        if (revDfa == null) {
+          if (!canUseReverseDfa()) {
+            return -1;
+          }
+          revDfa = reverseDfa();
+        }
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
           return -1;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2201,7 +2201,10 @@ public final class Matcher implements MatchResult {
 
   private String replaceDfaOptimized(LazyTemplate template, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
-    if (!canUseForwardDfa() || !parentPattern.dfaGroupZeroReliable() || regionActive) {
+    if (!canUseForwardDfa()
+        || !parentPattern.dfaGroupZeroReliable()
+        || parentPattern.prog().dollarAnchorEnd()
+        || regionActive) {
       return null;
     }
 
@@ -2227,7 +2230,10 @@ public final class Matcher implements MatchResult {
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
     int matchesFound = 0;
-    int[] matchOffsets = null;
+    int firstMatchStart = -1;
+    int firstMatchEnd = -1;
+    int builderAppendPos = searchFrom;
+    StringBuilder sb = null;
 
     while (pos <= textLen && matchesFound < limit) {
       if (parentPattern.prog().anchorStart() && pos > 0) {
@@ -2274,15 +2280,19 @@ public final class Matcher implements MatchResult {
         if (templateNeedsCaptures(compiledTemplate)) {
           return null;
         }
-        matchOffsets = new int[16];
+        sb = new StringBuilder(textLen);
       }
 
-      if (2 * matchesFound >= matchOffsets.length) {
-        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
-      }
+      groups[0] = matchStart;
+      groups[1] = matchEnd;
+      sb.append(text, builderAppendPos, matchStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      builderAppendPos = matchEnd;
 
-      matchOffsets[2 * matchesFound] = matchStart;
-      matchOffsets[2 * matchesFound + 1] = matchEnd;
+      if (matchesFound == 0) {
+        firstMatchStart = matchStart;
+        firstMatchEnd = matchEnd;
+      }
 
       pos = matchEnd;
       matchesFound++;
@@ -2295,41 +2305,17 @@ public final class Matcher implements MatchResult {
     if (groups == null) {
       groups = new int[2 * parentPattern.prog().numCaptures()];
     }
-    groups[0] = matchOffsets[0];
-    groups[1] = matchOffsets[1];
-
-    int totalMatchLength = 0;
-    for (int i = 0; i < matchesFound; i++) {
-      totalMatchLength += (matchOffsets[2 * i + 1] - matchOffsets[2 * i]);
-    }
-    int replacementLen = 0;
-    for (ReplacementSegment seg : compiledTemplate) {
-      if (seg instanceof ReplacementSegment.Literal literal) {
-        replacementLen += literal.text().length();
-      }
-    }
-    int finalCapacity = textLen - totalMatchLength + (matchesFound * replacementLen);
-
-    StringBuilder sb = new StringBuilder(finalCapacity);
-    int appendPos = searchFrom;
-    for (int i = 0; i < matchesFound; i++) {
-      int mStart = matchOffsets[2 * i];
-      int mEnd = matchOffsets[2 * i + 1];
-      groups[0] = mStart;
-      groups[1] = mEnd;
-      sb.append(text, appendPos, mStart);
-      applyReplacementTemplate(sb, compiledTemplate);
-      appendPos = mEnd;
-    }
-    sb.append(text, appendPos, textLen);
+    sb.append(text, builderAppendPos, textLen);
 
     if (limit == 1) {
-      deferredMatchStart = groups[0];
-      deferredMatchEnd = groups[1];
-      capturesResolved = parentPattern.prog().numCaptures() <= 1;
-      groupZeroResolved = true;
+      applyDeferredMatchResult(
+          firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
+      this.appendPos = firstMatchEnd;
+    } else {
+      applyFailedMatchResult();
+      this.appendPos = textLen;
+      this.searchFrom = textLen;
     }
-    resultStatus = (limit == 1) ? ResultStatus.MATCHED : ResultStatus.FAILED;
     return sb.toString();
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2394,7 +2394,7 @@ public final class Matcher implements MatchResult {
           matchEnd = fwdFirst.pos();
         } else {
           Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
-          if (revResult == null || !revResult.matched()) {
+          if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
             return -1;
           }
           matchStart = revResult.pos();
@@ -2406,7 +2406,7 @@ public final class Matcher implements MatchResult {
         }
       } else {
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
-        if (revResult == null || !revResult.matched()) {
+        if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
           return -1;
         }
         matchStart = revResult.pos();

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -107,6 +107,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasLazy;
   private final transient boolean hasAlternation;
   private final transient boolean hasNullableAlternation;
+  private final transient boolean canMatchEmpty;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
   private final transient CharClassScanInfo charClassPrefix;
@@ -227,6 +228,7 @@ public final class Pattern implements Serializable {
       boolean hasLazy,
       boolean hasAlternation,
       boolean hasNullableAlternation,
+      boolean canMatchEmpty,
       boolean startsWithGraphemeClusterBoundary,
       boolean hasInternalGraphemeClusterBoundary,
       CharClassScanInfo charClassPrefix,
@@ -275,6 +277,7 @@ public final class Pattern implements Serializable {
     this.hasLazy = hasLazy;
     this.hasAlternation = hasAlternation;
     this.hasNullableAlternation = hasNullableAlternation;
+    this.canMatchEmpty = canMatchEmpty;
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
     this.charClassPrefix = charClassPrefix;
@@ -351,6 +354,7 @@ public final class Pattern implements Serializable {
     String literalMatch = extractLiteralMatch(metadataAst);
     boolean hasLazy = hasLazyQuantifiers(re);
     boolean hasAlt = hasAlternation(re);
+    boolean canMatchEmpty = canMatchEmpty(re);
     boolean hasNullableAlt = hasAlt && hasNullableAlternation(re);
     boolean startsWithGcb = startsWithGraphemeClusterBoundary(metadataAst);
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
@@ -377,6 +381,7 @@ public final class Pattern implements Serializable {
         hasLazy,
         hasAlt,
         hasNullableAlt,
+        canMatchEmpty,
         startsWithGcb,
         hasInternalGcb,
         charClassPrefix,
@@ -847,6 +852,11 @@ public final class Pattern implements Serializable {
    */
   boolean hasNullableAlternation() {
     return hasNullableAlternation;
+  }
+
+  /** Returns {@code true} if this pattern can match zero characters. */
+  boolean canMatchEmpty() {
+    return canMatchEmpty;
   }
 
   /** Returns whether this pattern contains any lazy quantifiers. */

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1266,6 +1266,8 @@ class MatcherTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"$", "\\"})
+    @DisabledForCrosscheck(
+        "generated wrapper cannot advance both delegates after the first delegate throws")
     @DisplayName("replaceAll() with malformed replacement records first match before throwing")
     void replaceAllMalformedReplacementRecordsFirstMatch(String replacement) {
       Pattern p = Pattern.compile("a.");
@@ -1280,6 +1282,8 @@ class MatcherTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"$", "\\"})
+    @DisabledForCrosscheck(
+        "generated wrapper cannot advance both delegates after the first delegate throws")
     @DisplayName("replaceFirst() with malformed replacement records first match before throwing")
     void replaceFirstMalformedReplacementRecordsFirstMatch(String replacement) {
       Pattern p = Pattern.compile("a.");
@@ -1294,6 +1298,8 @@ class MatcherTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"$", "\\"})
+    @DisabledForCrosscheck(
+        "generated wrapper cannot advance both delegates after the first delegate throws")
     @DisplayName("replaceAll() char-class fast path records first match before throwing")
     void replaceAllCharClassMalformedReplacementRecordsFirstMatch(String replacement) {
       Pattern p = Pattern.compile("\\d+");
@@ -1308,6 +1314,8 @@ class MatcherTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"$", "\\"})
+    @DisabledForCrosscheck(
+        "generated wrapper cannot advance both delegates after the first delegate throws")
     @DisplayName("replaceFirst() char-class fast path records first match before throwing")
     void replaceFirstCharClassMalformedReplacementRecordsFirstMatch(String replacement) {
       Pattern p = Pattern.compile("\\d+");

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1214,6 +1214,36 @@ class MatcherTest {
       assertThat(m.replaceAll("X")).isEqualTo("abc");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisplayName("replaceAll() with no match does not validate malformed replacement")
+    void replaceAllNoMatchDoesNotValidateMalformedReplacement(String replacement) {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("abc");
+
+      assertThat(m.replaceAll(replacement)).isEqualTo("abc");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisplayName("replaceFirst() with no match does not validate malformed replacement")
+    void replaceFirstNoMatchDoesNotValidateMalformedReplacement(String replacement) {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("abc");
+
+      assertThat(m.replaceFirst(replacement)).isEqualTo("abc");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() with no match rejects null replacement")
+    void replaceFirstNoMatchRejectsNullReplacement() {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("abc");
+
+      assertThatThrownBy(() -> m.replaceFirst((String) null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
     @Test
     @DisplayName("replaceFirst() with start-anchored pattern replaces correct match")
     void replaceFirstStartAnchored() {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1156,11 +1156,57 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceFirst() leaves matcher state at the replaced occurrence")
+    void replaceFirstLeavesMatcherAtReplacedOccurrence() {
+      Matcher m = Pattern.compile("a").matcher("aba");
+
+      assertThat(m.replaceFirst("X")).isEqualTo("Xba");
+
+      assertThat(m.toMatchResult().start()).isEqualTo(0);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("replaceFirst() leaves append position after the replaced occurrence")
+    void replaceFirstLeavesAppendPositionAfterReplacedOccurrence() {
+      Matcher m = Pattern.compile("a").matcher("aba");
+
+      assertThat(m.replaceFirst("X")).isEqualTo("Xba");
+      StringBuilder sb = new StringBuilder();
+      m.appendTail(sb);
+
+      assertThat(sb).hasToString("ba");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() preserves dollar-anchor match before trailing line terminator")
+    void replaceFirstPreservesDollarAnchorBeforeTrailingLineTerminator() {
+      Matcher m = Pattern.compile("([^a](\\s\\s)+)*$").matcher("a\n");
+
+      assertThat(m.replaceFirst("X")).isEqualTo("aX\n");
+    }
+
+    @Test
     @DisplayName("replaceAll() with start-anchored pattern replaces correct match")
     void replaceAllStartAnchored() {
       Pattern p = Pattern.compile("^\\d+");
       Matcher m = p.matcher("123abc456");
       assertThat(m.replaceAll("X")).isEqualTo("Xabc456");
+    }
+
+    @Test
+    @DisplayName("replaceAll() leaves matcher exhausted after the final replacement")
+    void replaceAllLeavesMatcherExhaustedAfterFinalReplacement() {
+      Matcher m = Pattern.compile("a").matcher("aba");
+
+      assertThat(m.replaceAll("X")).isEqualTo("XbX");
+
+      StringBuilder sb = new StringBuilder();
+      m.appendTail(sb);
+      assertThat(sb).hasToString("");
+      assertThat(m.find()).isFalse();
+      assertThatThrownBy(() -> m.toMatchResult().start()).isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1198,6 +1198,36 @@ class MatcherTest {
       assertThat(m.replaceFirst("X")).isEqualTo("Xbc");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"a?", "a*", ".*", ".?"})
+    @DisplayName("replaceAll() with nullable pattern matches JDK replacement sequence")
+    void replaceAllNullablePatternMatchesJdkReplacementSequence(String regex) {
+      String input = "a";
+
+      assertThat(Pattern.compile(regex).matcher(input).replaceAll("X"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceAll("X"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a?", "a*", ".*", ".?"})
+    @DisplayName("replaceFirst() with nullable pattern matches JDK replacement sequence")
+    void replaceFirstNullablePatternMatchesJdkReplacementSequence(String regex) {
+      String input = "a";
+
+      assertThat(Pattern.compile(regex).matcher(input).replaceFirst("X"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceFirst("X"));
+    }
+
+    @Test
+    @DisplayName("replaceAll() with nullable alternation matches JDK replacement sequence")
+    void replaceAllNullableAlternationMatchesJdkReplacementSequence() {
+      String regex = "(?:\\B|a).a?";
+      String input = "bbaaa";
+
+      assertThat(Pattern.compile(regex).matcher(input).replaceAll("X"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceAll("X"));
+    }
+
     @Test
     @DisplayName("replaceFirst() with no match returns original text")
     void replaceFirstNoMatch() {
@@ -1232,6 +1262,62 @@ class MatcherTest {
       Matcher m = p.matcher("abc");
 
       assertThat(m.replaceFirst(replacement)).isEqualTo("abc");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisplayName("replaceAll() with malformed replacement records first match before throwing")
+    void replaceAllMalformedReplacementRecordsFirstMatch(String replacement) {
+      Pattern p = Pattern.compile("a.");
+      Matcher m = p.matcher("abc");
+
+      assertThatThrownBy(() -> m.replaceAll(replacement))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.end()).isEqualTo(2);
+      assertThat(m.group()).isEqualTo("ab");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisplayName("replaceFirst() with malformed replacement records first match before throwing")
+    void replaceFirstMalformedReplacementRecordsFirstMatch(String replacement) {
+      Pattern p = Pattern.compile("a.");
+      Matcher m = p.matcher("abc");
+
+      assertThatThrownBy(() -> m.replaceFirst(replacement))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.end()).isEqualTo(2);
+      assertThat(m.group()).isEqualTo("ab");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisplayName("replaceAll() char-class fast path records first match before throwing")
+    void replaceAllCharClassMalformedReplacementRecordsFirstMatch(String replacement) {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("123 abc");
+
+      assertThatThrownBy(() -> m.replaceAll(replacement))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.end()).isEqualTo(3);
+      assertThat(m.group()).isEqualTo("123");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisplayName("replaceFirst() char-class fast path records first match before throwing")
+    void replaceFirstCharClassMalformedReplacementRecordsFirstMatch(String replacement) {
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher("123 abc");
+
+      assertThatThrownBy(() -> m.replaceFirst(replacement))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThat(m.start()).isEqualTo(0);
+      assertThat(m.end()).isEqualTo(3);
+      assertThat(m.group()).isEqualTo("123");
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1113,6 +1113,17 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceFirst() retains capture group state of the matched occurrence")
+    void replaceFirstRetainsCaptureGroups() {
+      Pattern p = Pattern.compile("testingRecord\\[(.+?)\\]");
+      Matcher m = p.matcher("object.testingDetails.testingRecord[0].result");
+      if (m.find()) {
+        m.replaceFirst("testingRecord");
+        assertThat(m.group(1)).isEqualTo("0");
+      }
+    }
+
+    @Test
     @DisplayName("replaceAll() replaces all matches")
     void replaceAll() {
       Pattern p = Pattern.compile("\\d+");
@@ -1134,6 +1145,22 @@ class MatcherTest {
       Pattern p = Pattern.compile("\\d+");
       Matcher m = p.matcher("abc");
       assertThat(m.replaceAll("X")).isEqualTo("abc");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() with start-anchored pattern replaces correct match")
+    void replaceFirstStartAnchored() {
+      Pattern p = Pattern.compile("^\\d+");
+      Matcher m = p.matcher("123abc456");
+      assertThat(m.replaceFirst("X")).isEqualTo("Xabc456");
+    }
+
+    @Test
+    @DisplayName("replaceAll() with start-anchored pattern replaces correct match")
+    void replaceAllStartAnchored() {
+      Pattern p = Pattern.compile("^\\d+");
+      Matcher m = p.matcher("123abc456");
+      assertThat(m.replaceAll("X")).isEqualTo("Xabc456");
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1285,6 +1285,24 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceAll() with ambiguous reverse DFA match start handles correctness")
+    void replaceAllWithAmbiguousReverseDfaMatchStart() {
+      Pattern p = Pattern.compile("(b|ab)c");
+      Matcher m = p.matcher("abc");
+      assertThat(m.replaceAll("X")).isEqualTo("X");
+    }
+
+    @Test
+    @DisplayName("find() with alternation prefers leftmost match over earliest DFA end")
+    void testAlternationDfaSandwichCorrectness() {
+      Pattern p = Pattern.compile("b|a.c");
+      Matcher m = p.matcher("abc");
+      boolean found = m.find();
+      assertThat(found).isTrue();
+      assertThat(m.group()).isEqualTo("abc");
+    }
+
+    @Test
     @DisplayName("replaceAll with group references preserves start-anchor find semantics")
     void replaceAllWithGroupReferencesPreservesStartAnchorFindSemantics() {
       String[][] cases = {
@@ -1509,6 +1527,40 @@ class MatcherTest {
       Matcher m = p.matcher("b");
       // $1 didn't participate (null), should be replaced with empty string
       assertThat(m.replaceFirst("[$1][$2]")).isEqualTo("[][b]");
+    }
+
+    @Test
+    @DisplayName("replaceAll() with dollar anchor and alternation matches JDK")
+    void testReplaceAllDollarAnchorAlternation() {
+      String regex = "(?:a+?|(?:[^x])*)$";
+      String input = "x".repeat(1100) + "a\n";
+      Pattern p = Pattern.compile(regex);
+      Matcher m = p.matcher(input);
+      String result = m.replaceAll("X");
+
+      java.util.regex.Pattern jdkP = java.util.regex.Pattern.compile(regex);
+      java.util.regex.Matcher jdkM = jdkP.matcher(input);
+      String jdkResult = jdkM.replaceAll("X");
+
+      assertThat(result).isEqualTo(jdkResult);
+    }
+
+    @Test
+    @DisplayName("find() with ambiguous reverse DFA start matches JDK")
+    void testFindAmbiguousReverseDfa() {
+      String regex = "(?:\\B|a).a?";
+      String input = "ab".repeat(600) + "c";
+      Pattern p = Pattern.compile(regex);
+      Matcher m = p.matcher(input);
+      java.util.regex.Pattern jdkP = java.util.regex.Pattern.compile(regex);
+      java.util.regex.Matcher jdkM = jdkP.matcher(input);
+
+      while (jdkM.find()) {
+        assertThat(m.find()).isTrue();
+        assertThat(m.start()).isEqualTo(jdkM.start());
+        assertThat(m.end()).isEqualTo(jdkM.end());
+      }
+      assertThat(m.find()).isFalse();
     }
   }
 


### PR DESCRIPTION
This adds a fast path implementation of `replaceAll` and `replaceFirst` for DFA-eligible patterns, which makes a single loop over the input bypassing `find()`.

This also updates `doFindCore` to avoid an unnecessary second DFA pass for start-anchored patterns, which was noticed because the new replace loop uses the same approach.

This reduces allocations for replacement operations and bypasses some checks that are done on every `find()` call and instead does them once up-front.

This is a ~20% win for the example below. It does add some more code for the fast path and there's a complexity/performance tradeoff, but I think it's worth it in this case. We can rely on exhaustive crosscheck coverage to ensure replacement behavior doesn't diverge.

(One option to have even more test coverage would be to have a way to choose between this path and using `find()` for `replaceAll` in `EnginePathOptions`, and then have the tests compare the two implementations. But I'm not sure that's necessary.)

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark.runBenchmark -- \
    -p patternName=turnTitleWhitespace,turnTitleWhitespaceCjk \
    -p engine=SafeRE \
    -p match=false \
    -p inputSize=1000
```

| Approach / Branch | JMH Score (ns/op) | Delta (ns) | Latency Reduction | Speedup |
| :--- | :---: | :---: | :---: | :---: |
| **Baseline** | 16,966.642 ± 308.114 | *reference* | *reference* | *1.00x* |
| `replace-dfa-optimized` | 13,288.455 ± 521.461 | -3,678.19 | **-21.7%** | **1.28x** |