### PR TITLE
Preallocate the groups array in Matcher

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -355,6 +355,19 @@
           "nonMatchRepeats": 5,
           "delimiterAlphabet": " "
         }
+      },
+      {
+        "name": "turnTitleWhitespaceCjk",
+        "pattern": "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+",
+        "op": "replaceAllEmpty",
+        "match": "いくつもの\u3000中国語と日本語の文字\u3000がここにあります\u3000そして\u3000いくつかのスペース\u3000があります",
+        "nonMatch": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
       }
     ]
   },

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -123,7 +123,8 @@ public class RealWorldRegexBenchmark {
     "fruitSearchQuery",
     "fruitMarkupTag",
     "charReplace",
-    "layoutBlock"
+    "layoutBlock",
+    "turnTitleWhitespaceCjk"
   })
   public String patternName;
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1823,8 +1823,6 @@ public final class Matcher implements MatchResult {
         null);
   }
 
-
-
   @SuppressWarnings("ReferenceEquality")
   private int[] searchWithBitStateOrNfa(
       Prog prog,
@@ -1902,8 +1900,6 @@ public final class Matcher implements MatchResult {
         preserveOuterEmptyContext,
         reuseGroups);
   }
-
-
 
   private int[] searchNfa(
       Prog prog,

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -173,6 +173,7 @@ public final class Matcher implements MatchResult {
     this.inputSequence = input;
     this.text = charSequenceToString(input);
     this.regionEnd = text.length();
+    this.groups = new int[2 * pattern.prog().numCaptures()];
   }
 
   /**
@@ -207,7 +208,6 @@ public final class Matcher implements MatchResult {
   }
 
   private void applyFailedMatchResult() {
-    groups = null;
     hasMatch = false;
     resultStatus = ResultStatus.FAILED;
     clearDeferredCaptureState();
@@ -215,15 +215,16 @@ public final class Matcher implements MatchResult {
 
   private void applyFullMatchResult(int[] resultGroups) {
     findExhaustedAfterTerminalEmptyMatch = false;
-    groups = resultGroups;
     hasMatch = resultGroups != null;
+    if (hasMatch) {
+      System.arraycopy(resultGroups, 0, this.groups, 0, resultGroups.length);
+    }
     resultStatus = hasMatch ? ResultStatus.MATCHED : ResultStatus.FAILED;
     clearDeferredCaptureState();
   }
 
   private void applyDeferredMatchResult(DeferredMatchResult deferred) {
     findExhaustedAfterTerminalEmptyMatch = false;
-    groups = new int[2 * deferred.ncap()];
     Arrays.fill(groups, -1);
     groups[0] = deferred.start();
     groups[1] = deferred.end();
@@ -238,7 +239,6 @@ public final class Matcher implements MatchResult {
 
   private void clearCurrentResult() {
     findExhaustedAfterTerminalEmptyMatch = false;
-    groups = null;
     hasMatch = false;
     resultStatus = ResultStatus.RESET_NO_ATTEMPT;
     clearDeferredCaptureState();
@@ -690,7 +690,7 @@ public final class Matcher implements MatchResult {
     } finally {
       if (regionSubstituted) {
         text = savedText;
-        if (groups != null) {
+        if (hasMatch) {
           for (int i = 0; i < groups.length; i++) {
             if (groups[i] >= 0) {
               groups[i] += regionStart;
@@ -829,7 +829,7 @@ public final class Matcher implements MatchResult {
     } finally {
       if (regionSubstituted) {
         text = savedText;
-        if (groups != null) {
+        if (hasMatch) {
           for (int i = 0; i < groups.length; i++) {
             if (groups[i] >= 0) {
               groups[i] += regionStart;
@@ -1042,7 +1042,7 @@ public final class Matcher implements MatchResult {
       if (regionSubstituted) {
         text = savedText;
         searchFrom = savedSearchFrom;
-        if (groups != null) {
+        if (hasMatch) {
           for (int i = 0; i < groups.length; i++) {
             if (groups[i] >= 0) {
               groups[i] += regionStart;
@@ -2449,7 +2449,7 @@ public final class Matcher implements MatchResult {
   @Override
   public String toString() {
     String lastMatch = "";
-    if (hasMatch && groups != null && groups[0] >= 0 && groups[1] >= groups[0]) {
+    if (hasMatch && groups[0] >= 0 && groups[1] >= groups[0]) {
       lastMatch = text.substring(groups[0], groups[1]);
     }
     return "org.safere.Matcher[pattern="
@@ -2477,7 +2477,7 @@ public final class Matcher implements MatchResult {
       throw new IllegalArgumentException("Pattern cannot be null");
     }
     modCount++;
-    if (hasMatch && groups != null) {
+    if (hasMatch) {
       if (!groupZeroResolved) {
         resolveCaptures();
       }
@@ -2487,6 +2487,7 @@ public final class Matcher implements MatchResult {
       }
     }
     this.parentPattern = newPattern;
+    this.groups = new int[2 * newPattern.prog().numCaptures()];
     invalidatePatternCaches();
     clearCurrentResult();
     eagerFallbackCaptures = false;
@@ -2553,7 +2554,7 @@ public final class Matcher implements MatchResult {
       resolveCaptures();
     }
     return new SnapshotMatchResult(
-        groups != null ? groups.clone() : null,
+        hasMatch ? groups.clone() : null,
         text,
         groupCount(),
         parentPattern.namedGroups(),

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -44,28 +44,6 @@ import java.util.stream.StreamSupport;
  * </ul>
  */
 public final class Matcher implements MatchResult {
-  private sealed interface EngineResult
-      permits NoMatchResult, FullMatchResult, DeferredMatchResult {}
-
-  private record NoMatchResult() implements EngineResult {}
-
-  private static final NoMatchResult NO_MATCH = new NoMatchResult();
-
-  private static final class FullMatchResult implements EngineResult {
-    private final int[] groups;
-
-    private FullMatchResult(int[] groups) {
-      this.groups = groups;
-    }
-
-    private int[] groups() {
-      return groups;
-    }
-  }
-
-  private record DeferredMatchResult(
-      int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch)
-      implements EngineResult {}
 
   private enum ResultStatus {
     RESET_NO_ATTEMPT,
@@ -194,49 +172,38 @@ public final class Matcher implements MatchResult {
     return new String(chars);
   }
 
-  private boolean applyEngineResult(EngineResult result) {
-    switch (result) {
-      case NoMatchResult ignored -> {
-        applyFailedMatchResult();
-      }
-      case FullMatchResult full -> {
-        applyFullMatchResult(full.groups());
-      }
-      case DeferredMatchResult deferred -> {
-        applyDeferredMatchResult(deferred);
-      }
-    }
-    return hasMatch;
-  }
-
-  private void applyFailedMatchResult() {
+  private boolean applyFailedMatchResult() {
     hasMatch = false;
     resultStatus = ResultStatus.FAILED;
     clearDeferredCaptureState();
+    return false;
   }
 
-  private void applyFullMatchResult(int[] resultGroups) {
+  private boolean applyFullMatchResult(int[] resultGroups) {
     findExhaustedAfterTerminalEmptyMatch = false;
     hasMatch = resultGroups != null;
-    if (hasMatch) {
+    if (hasMatch && resultGroups != this.groups) {
       System.arraycopy(resultGroups, 0, this.groups, 0, resultGroups.length);
     }
     resultStatus = hasMatch ? ResultStatus.MATCHED : ResultStatus.FAILED;
     clearDeferredCaptureState();
+    return hasMatch;
   }
 
-  private void applyDeferredMatchResult(DeferredMatchResult deferred) {
+  private boolean applyDeferredMatchResult(
+      int start, int end, int ncap, boolean groupZeroResolved, boolean endMatch) {
     findExhaustedAfterTerminalEmptyMatch = false;
     Arrays.fill(groups, -1);
-    groups[0] = deferred.start();
-    groups[1] = deferred.end();
-    deferredMatchStart = deferred.start();
-    deferredMatchEnd = deferred.end();
-    deferredEndMatch = deferred.endMatch();
-    capturesResolved = deferred.ncap() <= 1;
-    groupZeroResolved = deferred.groupZeroResolved();
+    groups[0] = start;
+    groups[1] = end;
+    deferredMatchStart = start;
+    deferredMatchEnd = end;
+    deferredEndMatch = endMatch;
+    capturesResolved = ncap <= 1;
+    this.groupZeroResolved = groupZeroResolved;
     hasMatch = true;
     resultStatus = ResultStatus.MATCHED;
+    return true;
   }
 
   private void clearCurrentResult() {
@@ -370,9 +337,9 @@ public final class Matcher implements MatchResult {
     int len = text.length();
     if (len == 0) {
       if (allowEmpty) {
-        return applyEngineResult(new FullMatchResult(new int[] {0, 0}));
+        return applyFullMatchResult(new int[] {0, 0});
       }
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
 
     // Scan every code point.
@@ -384,21 +351,21 @@ public final class Matcher implements MatchResult {
       int cp = text.codePointAt(i);
       if (cp < 64) {
         if ((b0 & (1L << cp)) == 0) {
-          return applyEngineResult(NO_MATCH);
+          return applyFailedMatchResult();
         }
       } else if (cp < 128) {
         if ((b1 & (1L << (cp - 64))) == 0) {
-          return applyEngineResult(NO_MATCH);
+          return applyFailedMatchResult();
         }
       } else {
         if (!binarySearchRanges(ranges, cp)) {
-          return applyEngineResult(NO_MATCH);
+          return applyFailedMatchResult();
         }
       }
       i += Character.charCount(cp);
     }
 
-    return applyEngineResult(new FullMatchResult(new int[] {0, len}));
+    return applyFullMatchResult(new int[] {0, len});
   }
 
   /**
@@ -417,11 +384,11 @@ public final class Matcher implements MatchResult {
       }
       int cp = text.codePointAt(i);
       if (charClassContains(ranges, b0, b1, cp)) {
-        return applyEngineResult(new FullMatchResult(new int[] {i, i + Character.charCount(cp)}));
+        return applyFullMatchResult(new int[] {i, i + Character.charCount(cp)});
       }
       i += Character.charCount(cp);
     }
-    return applyEngineResult(NO_MATCH);
+    return applyFailedMatchResult();
   }
 
   private boolean containsRequiredMatchClass(int[] ranges) {
@@ -679,7 +646,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return matchesTransparentRegion();
@@ -725,10 +692,10 @@ public final class Matcher implements MatchResult {
         matched = text.equals(literal);
       }
       if (matched) {
-        applyEngineResult(new FullMatchResult(new int[] {0, text.length()}));
+        applyFullMatchResult(new int[] {0, text.length()});
       } else {
         if (isPartialLiteralMatch(literal, 0)) {}
-        applyEngineResult(NO_MATCH);
+        applyFailedMatchResult();
       }
       return hasMatch;
     }
@@ -743,7 +710,7 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().charClassMatchFastPaths()
         && requiredRanges != null
         && !containsRequiredMatchClass(requiredRanges)) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
 
     Prog prog = parentPattern.prog();
@@ -754,8 +721,8 @@ public final class Matcher implements MatchResult {
     if (onePass != null
         && !prog.hasGraphemeSemantics()
         && !parentPattern.hasNullableAlternation()) {
-      OnePass.SearchResult result = onePass.search(text, true, prog.numCaptures());
-      return applyEngineResult(new FullMatchResult(result.groups()));
+      OnePass.SearchResult result = onePass.search(text, true, prog.numCaptures(), this.groups);
+      return applyFullMatchResult(result.groups());
     }
 
     // Medium path: use DFA to check if a full match exists.
@@ -763,21 +730,31 @@ public final class Matcher implements MatchResult {
 
       Dfa.SearchResult dfaResult = dfa(true).doSearch(text, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       if (dfaResult != null && dfaResult.pos() != text.length()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       if (dfaResult != null && prog.numLoopRegs() == 0) {
-        return applyEngineResult(
-            new DeferredMatchResult(0, text.length(), prog.numCaptures(), true, true));
+        return applyDeferredMatchResult(0, text.length(), prog.numCaptures(), true, true);
       }
     }
 
     // Slow path: try BitState (faster than NFA for small texts), then NFA.
     int[] result =
         searchWithBitStateOrNfa(
-            prog, text, 0, text.length(), text.length(), true, false, true, prog.numCaptures());
+            prog,
+            text,
+            0,
+            text.length(),
+            text.length(),
+            text.length(),
+            true,
+            false,
+            true,
+            prog.numCaptures(),
+            false,
+            this.groups);
     // matches() requires the entire text to be consumed. With dollarAnchorEnd, the BitState
     // may accept a match ending before a trailing \n. In that case, fall back to the NFA
     // which uses longest-match mode for FULL_MATCH and finds the correct full-text match.
@@ -788,14 +765,15 @@ public final class Matcher implements MatchResult {
               0,
               text.length(),
               text.length(),
-              0,
+              text.length(),
               prog.numCaptures(),
               Nfa.Anchor.ANCHORED,
               Nfa.MatchKind.FULL_MATCH,
-              false);
+              false,
+              this.groups);
       result = nfaResult;
     }
-    return applyEngineResult(new FullMatchResult(result));
+    return applyFullMatchResult(result);
   }
 
   /**
@@ -818,7 +796,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return lookingAtTransparentRegion();
@@ -864,10 +842,10 @@ public final class Matcher implements MatchResult {
         matched = text.startsWith(literal);
       }
       if (matched) {
-        applyEngineResult(new FullMatchResult(new int[] {0, literal.length()}));
+        applyFullMatchResult(new int[] {0, literal.length()});
       } else {
         if (isPartialLiteralMatch(literal, 0)) {}
-        applyEngineResult(NO_MATCH);
+        applyFailedMatchResult();
       }
       return hasMatch;
     }
@@ -879,8 +857,8 @@ public final class Matcher implements MatchResult {
         && parentPattern.canOnePassPrimary()
         && !prog.hasGraphemeSemantics()) {
       OnePass onePass = parentPattern.onePass();
-      OnePass.SearchResult result = onePass.search(text, false, prog.numCaptures());
-      return applyEngineResult(new FullMatchResult(result.groups()));
+      OnePass.SearchResult result = onePass.search(text, false, prog.numCaptures(), this.groups);
+      return applyFullMatchResult(result.groups());
     }
 
     // Medium path: use DFA to check if an anchored match exists.
@@ -888,23 +866,26 @@ public final class Matcher implements MatchResult {
 
       Dfa.SearchResult dfaResult = dfa(false).doSearch(text, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
     }
 
     // Slow path: try BitState (faster than NFA for small texts), then NFA.
-    return applyEngineResult(
-        new FullMatchResult(
-            searchWithBitStateOrNfa(
-                prog,
-                text,
-                0,
-                text.length(),
-                text.length(),
-                true,
-                false,
-                false,
-                prog.numCaptures())));
+    int[] result =
+        searchWithBitStateOrNfa(
+            prog,
+            text,
+            0,
+            text.length(),
+            text.length(),
+            text.length(),
+            true,
+            false,
+            false,
+            prog.numCaptures(),
+            false,
+            this.groups);
+    return applyFullMatchResult(result);
   }
 
   /**
@@ -919,7 +900,7 @@ public final class Matcher implements MatchResult {
   public boolean find() {
     modCount++;
     if (findExhaustedAfterTerminalEmptyMatch) {
-      applyEngineResult(NO_MATCH);
+      applyFailedMatchResult();
       return false;
     }
     if (hasMatch) {
@@ -932,7 +913,7 @@ public final class Matcher implements MatchResult {
       searchFrom = groups[1];
       if (groups[0] == groups[1]) { // empty match
         if (searchFrom >= regionEnd) {
-          applyEngineResult(NO_MATCH);
+          applyFailedMatchResult();
           findExhaustedAfterTerminalEmptyMatch = true;
           searchFrom = regionEnd + 1;
           return false;
@@ -1029,7 +1010,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return doFindTransparentRegion();
@@ -1119,19 +1100,21 @@ public final class Matcher implements MatchResult {
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
-    return applyEngineResult(
-        new FullMatchResult(
-            searchWithBitStateOrNfa(
-                prog,
-                text,
-                regionStart,
-                regionStart,
-                regionEnd,
-                graphemeConsumeEndPos,
-                true,
-                false,
-                true,
-                prog.numCaptures())));
+    int[] result =
+        searchWithBitStateOrNfa(
+            prog,
+            text,
+            regionStart,
+            regionStart,
+            regionEnd,
+            graphemeConsumeEndPos,
+            true,
+            false,
+            true,
+            prog.numCaptures(),
+            false,
+            this.groups);
+    return applyFullMatchResult(result);
   }
 
   private boolean lookingAtTransparentRegion() {
@@ -1139,30 +1122,32 @@ public final class Matcher implements MatchResult {
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
-    return applyEngineResult(
-        new FullMatchResult(
-            searchWithBitStateOrNfa(
-                prog,
-                text,
-                regionStart,
-                regionStart,
-                regionEnd,
-                graphemeConsumeEndPos,
-                true,
-                false,
-                false,
-                prog.numCaptures())));
+    int[] result =
+        searchWithBitStateOrNfa(
+            prog,
+            text,
+            regionStart,
+            regionStart,
+            regionEnd,
+            graphemeConsumeEndPos,
+            true,
+            false,
+            false,
+            prog.numCaptures(),
+            false,
+            this.groups);
+    return applyFullMatchResult(result);
   }
 
   private boolean doFindTransparentRegion() {
     if (searchFrom > regionEnd) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
     capturesResolved = true;
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     if (prog.anchorStart() && searchFrom > regionStart) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
     int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
     int[] result =
@@ -1176,8 +1161,10 @@ public final class Matcher implements MatchResult {
             false,
             false,
             false,
-            prog.numCaptures());
-    return applyEngineResult(new FullMatchResult(result));
+            prog.numCaptures(),
+            false,
+            this.groups);
+    return applyFullMatchResult(result);
   }
 
   /**
@@ -1187,7 +1174,7 @@ public final class Matcher implements MatchResult {
    */
   private boolean doFindCore(boolean regionActive) {
     if (searchFrom > text.length()) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
 
     // Reset deferred-capture state; DFA sandwich path may set it to false.
@@ -1214,9 +1201,9 @@ public final class Matcher implements MatchResult {
         } else {
           if (isPartialLiteralMatch(literal, searchFrom)) {}
         }
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
-      return applyEngineResult(new FullMatchResult(new int[] {idx, idx + literal.length()}));
+      return applyFullMatchResult(new int[] {idx, idx + literal.length()});
     }
 
     int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
@@ -1234,7 +1221,7 @@ public final class Matcher implements MatchResult {
     // when a region is active). Return false immediately to avoid the DFA matching at every
     // position because the compiler strips the anchor into prog.anchorStart().
     if (prog.anchorStart() && searchFrom > 0) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
 
     int[] requiredRanges = parentPattern.requiredMatchClassRanges();
@@ -1249,7 +1236,7 @@ public final class Matcher implements MatchResult {
         && requiredRanges != null
         && !hasAcceleratedSearchPath
         && !containsRequiredMatchClass(requiredRanges, searchFrom)) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
 
     // Anchored OnePass fast path: for anchored OnePass-eligible patterns on small text, use
@@ -1273,8 +1260,8 @@ public final class Matcher implements MatchResult {
       OnePass.SearchResult result =
           parentPattern
               .onePass()
-              .search(text, searchFrom, text.length(), false, prog.numCaptures());
-      return applyEngineResult(new FullMatchResult(result.groups()));
+              .search(text, searchFrom, text.length(), false, prog.numCaptures(), this.groups);
+      return applyFullMatchResult(result.groups());
     }
 
     // Prefix acceleration: if the pattern starts with a literal prefix, skip ahead to where
@@ -1299,7 +1286,7 @@ public final class Matcher implements MatchResult {
           if (remainingLen < prefix.length()
               && literalRegionMatches(prefix, searchFrom, remainingLen)) {}
         }
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       effectiveStart = idx;
       literalPrefixCandidateStart = true;
@@ -1316,7 +1303,7 @@ public final class Matcher implements MatchResult {
         } else {
           if (searchFrom == text.length()) {}
         }
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       effectiveStart = idx;
     }
@@ -1329,7 +1316,7 @@ public final class Matcher implements MatchResult {
         } else {
           if (searchFrom == text.length()) {}
         }
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
       effectiveStart = idx;
     }
@@ -1426,7 +1413,7 @@ public final class Matcher implements MatchResult {
         if (!budgetExceeded) {
           if (matchStart < 0) {
             // No match possible at end of text — fail immediately without forward scan.
-            return applyEngineResult(NO_MATCH);
+            return applyFailedMatchResult();
           }
           if (matchStartAmbiguous) {
             // The reverse DFA can prove that a suffix match exists, but not which accepted
@@ -1440,8 +1427,8 @@ public final class Matcher implements MatchResult {
                     prog, text, matchStart, matchStart, textLen, true, false, false, 1);
             if (exact != null) {
               int matchEnd = exact[1];
-              return applyEngineResult(
-                  new DeferredMatchResult(matchStart, matchEnd, prog.numCaptures(), true, false));
+              return applyDeferredMatchResult(
+                  matchStart, matchEnd, prog.numCaptures(), true, false);
             }
           }
         }
@@ -1457,7 +1444,7 @@ public final class Matcher implements MatchResult {
     } else {
       fwdResult = dfa(false).doSearch(text, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
-        return applyEngineResult(NO_MATCH);
+        return applyFailedMatchResult();
       }
     }
 
@@ -1502,13 +1489,12 @@ public final class Matcher implements MatchResult {
         Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
         if (fwdFirst != null && fwdFirst.matched()) {
           int matchEnd = fwdFirst.pos();
-          return applyEngineResult(
-              new DeferredMatchResult(
-                  effectiveStart,
-                  matchEnd,
-                  prog.numCaptures(),
-                  parentPattern.dfaGroupZeroReliable(),
-                  false));
+          return applyDeferredMatchResult(
+              effectiveStart,
+              matchEnd,
+              prog.numCaptures(),
+              parentPattern.dfaGroupZeroReliable(),
+              false);
         }
       } else {
         if (literalPrefixCandidateStart) {
@@ -1519,13 +1505,12 @@ public final class Matcher implements MatchResult {
           Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
           if (fwdFirst != null && fwdFirst.matched()) {
             int matchEnd = fwdFirst.pos();
-            return applyEngineResult(
-                new DeferredMatchResult(
-                    effectiveStart,
-                    matchEnd,
-                    prog.numCaptures(),
-                    parentPattern.dfaGroupZeroReliable(),
-                    false));
+            return applyDeferredMatchResult(
+                effectiveStart,
+                matchEnd,
+                prog.numCaptures(),
+                parentPattern.dfaGroupZeroReliable(),
+                false);
           }
         }
         Dfa revDfa = reverseDfa();
@@ -1588,13 +1573,12 @@ public final class Matcher implements MatchResult {
               if (fwdFirst != null && fwdFirst.matched()) {
                 int matchEnd = fwdFirst.pos();
                 // Step 4: Store group(0) boundaries, defer inner captures until requested.
-                return applyEngineResult(
-                    new DeferredMatchResult(
-                        matchStart,
-                        matchEnd,
-                        prog.numCaptures(),
-                        parentPattern.dfaGroupZeroReliable(),
-                        false));
+                return applyDeferredMatchResult(
+                    matchStart,
+                    matchEnd,
+                    prog.numCaptures(),
+                    parentPattern.dfaGroupZeroReliable(),
+                    false);
               }
             }
             // If anchored forward DFA fails, fall through to full search.
@@ -1624,18 +1608,20 @@ public final class Matcher implements MatchResult {
             effectiveStart,
             text.length(),
             text.length(),
+            text.length(),
             false,
             false,
             false,
-            nsubmatch);
+            nsubmatch,
+            false,
+            this.groups);
     if (result == null) {
-      return applyEngineResult(NO_MATCH);
+      return applyFailedMatchResult();
     }
     if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
-      return applyEngineResult(new FullMatchResult(result));
+      return applyFullMatchResult(result);
     } else {
-      return applyEngineResult(
-          new DeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false));
+      return applyDeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false);
     }
   }
 
@@ -1663,14 +1649,14 @@ public final class Matcher implements MatchResult {
               keywordGroups[2 * group] = i;
               keywordGroups[2 * group + 1] = end;
             }
-            return applyEngineResult(new FullMatchResult(keywordGroups));
+            return applyFullMatchResult(keywordGroups);
           }
         }
       }
       int cp = text.codePointAt(i);
       i += Character.charCount(cp) - 1;
     }
-    return applyEngineResult(NO_MATCH);
+    return applyFailedMatchResult();
   }
 
   private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1822,7 +1822,18 @@ public final class Matcher implements MatchResult {
       boolean endMatch,
       int nsubmatch) {
     return searchWithBitStateOrNfa(
-        prog, text, startPos, searchLimit, endPos, endPos, anchored, longest, endMatch, nsubmatch);
+        prog,
+        text,
+        startPos,
+        searchLimit,
+        endPos,
+        endPos,
+        anchored,
+        longest,
+        endMatch,
+        nsubmatch,
+        false,
+        null);
   }
 
   private int[] searchWithBitStateOrNfa(
@@ -1847,9 +1858,11 @@ public final class Matcher implements MatchResult {
         longest,
         endMatch,
         nsubmatch,
-        false);
+        false,
+        null);
   }
 
+  @SuppressWarnings("ReferenceEquality")
   private int[] searchWithBitStateOrNfa(
       Prog prog,
       String text,
@@ -1861,7 +1874,8 @@ public final class Matcher implements MatchResult {
       boolean longest,
       boolean endMatch,
       int nsubmatch,
-      boolean preserveOuterEmptyContext) {
+      boolean preserveOuterEmptyContext,
+      int[] reuseGroups) {
     // Try BitState if the full text is small enough for the visited bitmap. BitState is an
     // optimization; if capture-priority backtracking exceeds its work budget, fall back to the
     // Pike NFA below.
@@ -1883,10 +1897,15 @@ public final class Matcher implements MatchResult {
       BitState bs =
           BitState.getOrCreate(
               cachedBitState, prog, text, endPos, ncap, longest, endMatchEffective);
-      if (bitStateResult == null || bitStateResult.length < ncap) {
-        bitStateResult = new int[ncap];
+      int[] destBuf =
+          reuseGroups != null && reuseGroups.length >= ncap ? reuseGroups : bitStateResult;
+      if (destBuf == null || destBuf.length < ncap) {
+        destBuf = new int[ncap];
       }
-      int[] result = bs.doSearch(startPos, searchLimit, anchoredEffective, bitStateResult);
+      if (destBuf != reuseGroups) {
+        bitStateResult = destBuf;
+      }
+      int[] result = bs.doSearch(startPos, searchLimit, anchoredEffective, destBuf);
       cachedBitState = bs;
       // Return to Pattern's cache for reuse by future Matchers.
       parentPattern.returnBitState(bs);
@@ -1917,7 +1936,8 @@ public final class Matcher implements MatchResult {
         nsubmatch,
         nfaAnchor,
         nfaKind,
-        preserveOuterEmptyContext);
+        preserveOuterEmptyContext,
+        reuseGroups);
   }
 
   private int[] searchNfa(
@@ -1930,6 +1950,30 @@ public final class Matcher implements MatchResult {
       Nfa.Anchor nfaAnchor,
       Nfa.MatchKind nfaKind,
       boolean preserveOuterEmptyContext) {
+    return searchNfa(
+        prog,
+        startPos,
+        searchLimit,
+        endPos,
+        graphemeConsumeEndPos,
+        nsubmatch,
+        nfaAnchor,
+        nfaKind,
+        preserveOuterEmptyContext,
+        null);
+  }
+
+  private int[] searchNfa(
+      Prog prog,
+      int startPos,
+      int searchLimit,
+      int endPos,
+      int graphemeConsumeEndPos,
+      int nsubmatch,
+      Nfa.Anchor nfaAnchor,
+      Nfa.MatchKind nfaKind,
+      boolean preserveOuterEmptyContext,
+      int[] reuseGroups) {
     if (prog.start() == 0) {
       return null;
     }
@@ -1986,7 +2030,7 @@ public final class Matcher implements MatchResult {
     }
 
     Nfa nfa = Nfa.getOrCreate(cachedNfa, prog, context, ncapture, longestMode, endmatch);
-    Nfa.SearchResult nfaResult = nfa.runSearch(anchored, nfaKind, nsubmatch, endPos);
+    Nfa.SearchResult nfaResult = nfa.runSearch(anchored, nfaKind, nsubmatch, endPos, reuseGroups);
     cachedNfa = nfa;
     parentPattern.returnNfa(nfa);
 
@@ -2576,6 +2620,7 @@ public final class Matcher implements MatchResult {
    * (fo|foo)} matching "fo" rather than "foo"). For {@code matches()}, the deferred search must
    * still cover the whole input.
    */
+  @SuppressWarnings("ReferenceEquality")
   private void resolveCaptures() {
     if (capturesResolved) {
       return;
@@ -2597,7 +2642,7 @@ public final class Matcher implements MatchResult {
       result =
           parentPattern
               .onePass()
-              .search(text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures())
+              .search(text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures(), groups)
               .groups();
     } else {
       result =
@@ -2612,9 +2657,10 @@ public final class Matcher implements MatchResult {
               false,
               deferredEndMatch,
               prog.numCaptures(),
-              true);
+              true,
+              groups);
     }
-    if (result != null) {
+    if (result != null && result != groups) {
       groups = result;
     }
     capturesResolved = true;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -179,6 +179,7 @@ public final class Matcher implements MatchResult {
     return false;
   }
 
+  @SuppressWarnings("ReferenceEquality")
   private boolean applyFullMatchResult(int[] resultGroups) {
     findExhaustedAfterTerminalEmptyMatch = false;
     hasMatch = resultGroups != null;
@@ -1822,31 +1823,7 @@ public final class Matcher implements MatchResult {
         null);
   }
 
-  private int[] searchWithBitStateOrNfa(
-      Prog prog,
-      String text,
-      int startPos,
-      int searchLimit,
-      int endPos,
-      int graphemeConsumeEndPos,
-      boolean anchored,
-      boolean longest,
-      boolean endMatch,
-      int nsubmatch) {
-    return searchWithBitStateOrNfa(
-        prog,
-        text,
-        startPos,
-        searchLimit,
-        endPos,
-        graphemeConsumeEndPos,
-        anchored,
-        longest,
-        endMatch,
-        nsubmatch,
-        false,
-        null);
-  }
+
 
   @SuppressWarnings("ReferenceEquality")
   private int[] searchWithBitStateOrNfa(
@@ -1926,28 +1903,7 @@ public final class Matcher implements MatchResult {
         reuseGroups);
   }
 
-  private int[] searchNfa(
-      Prog prog,
-      int startPos,
-      int searchLimit,
-      int endPos,
-      int graphemeConsumeEndPos,
-      int nsubmatch,
-      Nfa.Anchor nfaAnchor,
-      Nfa.MatchKind nfaKind,
-      boolean preserveOuterEmptyContext) {
-    return searchNfa(
-        prog,
-        startPos,
-        searchLimit,
-        endPos,
-        graphemeConsumeEndPos,
-        nsubmatch,
-        nfaAnchor,
-        nfaKind,
-        preserveOuterEmptyContext,
-        null);
-  }
+
 
   private int[] searchNfa(
       Prog prog,

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -49,6 +49,8 @@ public final class Matcher implements MatchResult {
 
   private record NoMatchResult() implements EngineResult {}
 
+  private static final NoMatchResult NO_MATCH = new NoMatchResult();
+
   private static final class FullMatchResult implements EngineResult {
     private final int[] groups;
 
@@ -370,7 +372,7 @@ public final class Matcher implements MatchResult {
       if (allowEmpty) {
         return applyEngineResult(new FullMatchResult(new int[] {0, 0}));
       }
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
 
     // Scan every code point.
@@ -382,15 +384,15 @@ public final class Matcher implements MatchResult {
       int cp = text.codePointAt(i);
       if (cp < 64) {
         if ((b0 & (1L << cp)) == 0) {
-          return applyEngineResult(new NoMatchResult());
+          return applyEngineResult(NO_MATCH);
         }
       } else if (cp < 128) {
         if ((b1 & (1L << (cp - 64))) == 0) {
-          return applyEngineResult(new NoMatchResult());
+          return applyEngineResult(NO_MATCH);
         }
       } else {
         if (!binarySearchRanges(ranges, cp)) {
-          return applyEngineResult(new NoMatchResult());
+          return applyEngineResult(NO_MATCH);
         }
       }
       i += Character.charCount(cp);
@@ -419,7 +421,7 @@ public final class Matcher implements MatchResult {
       }
       i += Character.charCount(cp);
     }
-    return applyEngineResult(new NoMatchResult());
+    return applyEngineResult(NO_MATCH);
   }
 
   private boolean containsRequiredMatchClass(int[] ranges) {
@@ -677,7 +679,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return matchesTransparentRegion();
@@ -726,7 +728,7 @@ public final class Matcher implements MatchResult {
         applyEngineResult(new FullMatchResult(new int[] {0, text.length()}));
       } else {
         if (isPartialLiteralMatch(literal, 0)) {}
-        applyEngineResult(new NoMatchResult());
+        applyEngineResult(NO_MATCH);
       }
       return hasMatch;
     }
@@ -741,7 +743,7 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().charClassMatchFastPaths()
         && requiredRanges != null
         && !containsRequiredMatchClass(requiredRanges)) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
 
     Prog prog = parentPattern.prog();
@@ -761,10 +763,10 @@ public final class Matcher implements MatchResult {
 
       Dfa.SearchResult dfaResult = dfa(true).doSearch(text, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       if (dfaResult != null && dfaResult.pos() != text.length()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       if (dfaResult != null && prog.numLoopRegs() == 0) {
         return applyEngineResult(
@@ -816,7 +818,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return lookingAtTransparentRegion();
@@ -865,7 +867,7 @@ public final class Matcher implements MatchResult {
         applyEngineResult(new FullMatchResult(new int[] {0, literal.length()}));
       } else {
         if (isPartialLiteralMatch(literal, 0)) {}
-        applyEngineResult(new NoMatchResult());
+        applyEngineResult(NO_MATCH);
       }
       return hasMatch;
     }
@@ -886,7 +888,7 @@ public final class Matcher implements MatchResult {
 
       Dfa.SearchResult dfaResult = dfa(false).doSearch(text, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
     }
 
@@ -917,7 +919,7 @@ public final class Matcher implements MatchResult {
   public boolean find() {
     modCount++;
     if (findExhaustedAfterTerminalEmptyMatch) {
-      applyEngineResult(new NoMatchResult());
+      applyEngineResult(NO_MATCH);
       return false;
     }
     if (hasMatch) {
@@ -930,7 +932,7 @@ public final class Matcher implements MatchResult {
       searchFrom = groups[1];
       if (groups[0] == groups[1]) { // empty match
         if (searchFrom >= regionEnd) {
-          applyEngineResult(new NoMatchResult());
+          applyEngineResult(NO_MATCH);
           findExhaustedAfterTerminalEmptyMatch = true;
           searchFrom = regionEnd + 1;
           return false;
@@ -1027,7 +1029,7 @@ public final class Matcher implements MatchResult {
 
     try {
       if (regionActive && !anchoringBounds && regionTextAnchorCannotMatch()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       if (needsFullTextRegionContext(regionActive, parentPattern.prog())) {
         return doFindTransparentRegion();
@@ -1154,13 +1156,13 @@ public final class Matcher implements MatchResult {
 
   private boolean doFindTransparentRegion() {
     if (searchFrom > regionEnd) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
     capturesResolved = true;
     fullTextRegionContext = true;
     Prog prog = parentPattern.prog();
     if (prog.anchorStart() && searchFrom > regionStart) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
     int graphemeConsumeEndPos = graphemeConsumeEndPos(prog, regionEnd);
     int[] result =
@@ -1185,7 +1187,7 @@ public final class Matcher implements MatchResult {
    */
   private boolean doFindCore(boolean regionActive) {
     if (searchFrom > text.length()) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
 
     // Reset deferred-capture state; DFA sandwich path may set it to false.
@@ -1212,7 +1214,7 @@ public final class Matcher implements MatchResult {
         } else {
           if (isPartialLiteralMatch(literal, searchFrom)) {}
         }
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       return applyEngineResult(new FullMatchResult(new int[] {idx, idx + literal.length()}));
     }
@@ -1232,7 +1234,7 @@ public final class Matcher implements MatchResult {
     // when a region is active). Return false immediately to avoid the DFA matching at every
     // position because the compiler strips the anchor into prog.anchorStart().
     if (prog.anchorStart() && searchFrom > 0) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
 
     int[] requiredRanges = parentPattern.requiredMatchClassRanges();
@@ -1247,7 +1249,7 @@ public final class Matcher implements MatchResult {
         && requiredRanges != null
         && !hasAcceleratedSearchPath
         && !containsRequiredMatchClass(requiredRanges, searchFrom)) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
 
     // Anchored OnePass fast path: for anchored OnePass-eligible patterns on small text, use
@@ -1297,7 +1299,7 @@ public final class Matcher implements MatchResult {
           if (remainingLen < prefix.length()
               && literalRegionMatches(prefix, searchFrom, remainingLen)) {}
         }
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       effectiveStart = idx;
       literalPrefixCandidateStart = true;
@@ -1314,7 +1316,7 @@ public final class Matcher implements MatchResult {
         } else {
           if (searchFrom == text.length()) {}
         }
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       effectiveStart = idx;
     }
@@ -1327,7 +1329,7 @@ public final class Matcher implements MatchResult {
         } else {
           if (searchFrom == text.length()) {}
         }
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
       effectiveStart = idx;
     }
@@ -1424,7 +1426,7 @@ public final class Matcher implements MatchResult {
         if (!budgetExceeded) {
           if (matchStart < 0) {
             // No match possible at end of text — fail immediately without forward scan.
-            return applyEngineResult(new NoMatchResult());
+            return applyEngineResult(NO_MATCH);
           }
           if (matchStartAmbiguous) {
             // The reverse DFA can prove that a suffix match exists, but not which accepted
@@ -1455,7 +1457,7 @@ public final class Matcher implements MatchResult {
     } else {
       fwdResult = dfa(false).doSearch(text, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
-        return applyEngineResult(new NoMatchResult());
+        return applyEngineResult(NO_MATCH);
       }
     }
 
@@ -1627,7 +1629,7 @@ public final class Matcher implements MatchResult {
             false,
             nsubmatch);
     if (result == null) {
-      return applyEngineResult(new NoMatchResult());
+      return applyEngineResult(NO_MATCH);
     }
     if (!lazyFallbackCaptures || prog.numCaptures() <= 1) {
       return applyEngineResult(new FullMatchResult(result));
@@ -1668,7 +1670,7 @@ public final class Matcher implements MatchResult {
       int cp = text.codePointAt(i);
       i += Character.charCount(cp) - 1;
     }
-    return applyEngineResult(new NoMatchResult());
+    return applyEngineResult(NO_MATCH);
   }
 
   private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -288,6 +288,11 @@ final class Nfa {
   }
 
   SearchResult runSearch(boolean anchored, MatchKind kind, int nsubmatch, int endPos) {
+    return runSearch(anchored, kind, nsubmatch, endPos, null);
+  }
+
+  SearchResult runSearch(
+      boolean anchored, MatchKind kind, int nsubmatch, int endPos, int[] reuseGroups) {
     if (prog.hasGraphemeSemantics()) {
       doSearchEveryCharPosition(anchored);
     } else {
@@ -301,7 +306,8 @@ final class Nfa {
       return new SearchResult(null);
     }
 
-    int[] result = new int[2 * nsubmatch];
+    int nlen = 2 * nsubmatch;
+    int[] result = reuseGroups != null && reuseGroups.length >= nlen ? reuseGroups : new int[nlen];
     int ncopy = Math.min(ncapture, result.length);
     System.arraycopy(bestMatch, 0, result, 0, ncopy);
     if (ncopy < result.length) {

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -482,9 +482,14 @@ final class OnePass {
    * @return submatch positions relative to {@code text}, or null if no match
    */
   SearchResult search(String text, int startPos, int endPos, boolean endMatch, int nsubmatch) {
+    return search(text, startPos, endPos, endMatch, nsubmatch, null);
+  }
+
+  SearchResult search(
+      String text, int startPos, int endPos, boolean endMatch, int nsubmatch, int[] reuseGroups) {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
-    return search(text, startPos, endPos, endMatch, nsubmatch, graphemeContext);
+    return search(text, startPos, endPos, endMatch, nsubmatch, reuseGroups, graphemeContext);
   }
 
   private SearchResult search(
@@ -493,6 +498,7 @@ final class OnePass {
       int endPos,
       boolean endMatch,
       int nsubmatch,
+      int[] reuseGroups,
       GraphemeSupport.Context graphemeContext) {
     int ncap = 2 * Math.max(nsubmatch, 1);
     int[] cap = new int[ncap];
@@ -501,7 +507,7 @@ final class OnePass {
 
     int state = 0;
     boolean matched = false;
-    int[] bestCap = new int[ncap];
+    int[] bestCap = reuseGroups != null && reuseGroups.length >= ncap ? reuseGroups : new int[ncap];
 
     int nc = numClasses;
     long[] fa = flatActions;
@@ -631,7 +637,7 @@ final class OnePass {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
     for (int start = startPos; start < limit; start++) {
-      SearchResult result = search(text, start, textLen, false, nsubmatch, graphemeContext);
+      SearchResult result = search(text, start, textLen, false, nsubmatch, null, graphemeContext);
       if (result.groups() != null) {
         return result.groups();
       }

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -465,6 +465,10 @@ final class OnePass {
     return search(text, 0, text.length(), endMatch, nsubmatch);
   }
 
+  SearchResult search(String text, boolean endMatch, int nsubmatch, int[] reuseGroups) {
+    return search(text, 0, text.length(), endMatch, nsubmatch, reuseGroups);
+  }
+
   /**
    * Searches for an anchored match in the text starting from {@code startPos}, scanning up to
    * {@code endPos}. This is equivalent to running OnePass on {@code text.substring(startPos,


### PR DESCRIPTION
Preallocating a `groups` array per `Matcher` instance and then copying it as needed saves a bit of memory and slightly improves latency compared to allocating a new one every time.

I don't have super strong evidence this is an important bottleneck for real world applications, but it's also a simple change and I think the fundamentals of it make sense.

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark.runBenchmark -- \
    -p patternName=turnTitleWhitespaceCjk \
    -p engine=SafeRE \
    -p match=false \
    -p inputSize=1000 \
    -prof gc
```

| Metric | Baseline (`cjk-baseline`) | Optimized (`preallocate-groups`) | Delta | Change (%) |
| :--- | :---: | :---: | :---: | :---: |
| **JMH Latency Score** | 17,656.795 ± 687.047 ns/op | 16,904.491 ± 316.517 ns/op | -752.30 ns | **-4.3%** (1.04x speedup) |
| **GC Alloc Rate (Norm)** | 7,512.248 B/op | 6,960.238 B/op | -552.01 B/op | **-7.3%** allocation reduction |
| **GC Alloc Rate (Total)** | 405.508 MB/sec | 392.251 MB/sec | -13.26 MB/sec | **-3.3%** allocation bandwidth |
| **GC Pause Count** | 10.000 counts | 10.000 counts | 0.00 | *flat* |
| **GC Pause Time** | 30.000 ms | 26.000 ms | -4.00 ms | **-13.3%** CPU GC time |
