### PR TITLE
Optimize split

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/SplitFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/SplitFuzzer.java
@@ -7,8 +7,16 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.List;
 
 final class SplitFuzzer {
+  private static final List<String> GRAPHEME_CRLF_DELIMITERS =
+      List.of("\\r\\b{g}\\n", "(?:\\r)\\b{g}\\n", "\\r(?:\\b{g})\\n");
+  private static final List<String> ADJACENT_CRLF_INPUTS =
+      List.of("#\r\n\r\n$", "\r\n\r\n", "a\r\n\r\nb");
+  private static final List<Integer> SPLIT_LIMITS = List.of(-1, 0, 2);
+  private static final List<Integer> LARGE_POSITIVE_LIMITS =
+      List.of(Integer.MAX_VALUE, Integer.MAX_VALUE / 2 + 1);
 
   @FuzzTest(maxDuration = "30s")
   void split(FuzzedDataProvider data) {
@@ -25,5 +33,24 @@ final class SplitFuzzer {
     pattern.split(input, limit);
     pattern.splitWithDelimiters(input);
     pattern.splitWithDelimiters(input, limit);
+    for (int largeLimit : LARGE_POSITIVE_LIMITS) {
+      pattern.split(input, largeLimit);
+      pattern.splitWithDelimiters(input, largeLimit);
+    }
+
+    for (String delimiter : GRAPHEME_CRLF_DELIMITERS) {
+      FuzzSupport.CompiledPattern graphemePattern = FuzzSupport.compileOrSkip(delimiter, 0);
+      if (graphemePattern == null) {
+        continue;
+      }
+      for (String adjacentCrLfInput : ADJACENT_CRLF_INPUTS) {
+        graphemePattern.split(adjacentCrLfInput);
+        graphemePattern.splitWithDelimiters(adjacentCrLfInput);
+        for (int splitLimit : SPLIT_LIMITS) {
+          graphemePattern.split(adjacentCrLfInput, splitLimit);
+          graphemePattern.splitWithDelimiters(adjacentCrLfInput, splitLimit);
+        }
+      }
+    }
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -969,6 +969,18 @@ public final class Matcher implements MatchResult {
     return prog != null && !prog.hasGraphemeSemantics() && prog.numLoopRegs() == 0;
   }
 
+  private boolean canUseForwardDfa() {
+    return enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg());
+  }
+
+  private boolean canUseReverseDfa() {
+    return enginePathOptions().dfa()
+        && enginePathOptions().reverseDfa()
+        && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
+        && !parentPattern.prog().anchorStart()
+        && reverseDfa() != null;
+  }
+
   /**
    * Resets this matcher and then attempts to find the next subsequence of the input that matches
    * the pattern, starting at the specified index.
@@ -1238,11 +1250,7 @@ public final class Matcher implements MatchResult {
     int[] requiredRanges = parentPattern.requiredMatchClassRanges();
     boolean hasAcceleratedSearchPath =
         (parentPattern.prefix() != null)
-            || (options.reverseDfa()
-                && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
-                && prog.anchorEnd()
-                && !prog.anchorStart()
-                && text.length() >= MIN_REVERSE_FIRST_LEN);
+            || (canUseReverseDfa() && prog.anchorEnd() && text.length() >= MIN_REVERSE_FIRST_LEN);
     if (options.charClassMatchFastPaths()
         && requiredRanges != null
         && !hasAcceleratedSearchPath
@@ -1349,12 +1357,9 @@ public final class Matcher implements MatchResult {
     //
     // A null result from the reverse DFA means the DFA budget was exceeded — in that case we
     // must fall through to the normal forward DFA path rather than returning false.
-    if (options.dfa()
-        && options.reverseDfa()
-        && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
+    if (canUseReverseDfa()
         && !regionActive
         && prog.anchorEnd()
-        && !prog.anchorStart()
         && text.length() >= MIN_REVERSE_FIRST_LEN) {
       Dfa revDfa = reverseDfa();
       if (revDfa != null) {
@@ -1526,8 +1531,8 @@ public final class Matcher implements MatchResult {
                     false));
           }
         }
-        Dfa revDfa = reverseDfa();
-        if (revDfa != null) {
+        if (canUseReverseDfa()) {
+          Dfa revDfa = reverseDfa();
           // Step 2: Reverse DFA backward from earliest match end to find match start.
           Dfa.SearchResult revResult =
               revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
@@ -2921,7 +2926,7 @@ public final class Matcher implements MatchResult {
     }
 
     Dfa.SearchResult fwdResult = null;
-    if (options.dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
+    if (canUseForwardDfa()) {
       fwdResult = dfa(false).doSearch(text, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
         return -1L;
@@ -2939,17 +2944,15 @@ public final class Matcher implements MatchResult {
         if (fwdFirst != null && fwdFirst.matched()) {
           return ((long) effectiveStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
         }
-      } else {
+      } else if (canUseReverseDfa()) {
         Dfa revDfa = reverseDfa();
-        if (revDfa != null) {
-          Dfa.SearchResult revResult =
-              revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
-          if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
-            int matchStart = revResult.pos();
-            Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
-            if (fwdFirst != null && fwdFirst.matched()) {
-              return ((long) matchStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
-            }
+        Dfa.SearchResult revResult =
+            revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
+        if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
+          int matchStart = revResult.pos();
+          Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+          if (fwdFirst != null && fwdFirst.matched()) {
+            return ((long) matchStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
           }
         }
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2801,4 +2801,173 @@ public final class Matcher implements MatchResult {
       }
     }
   }
+
+  static final class SplitBuffer {
+    int[] array = new int[32];
+    int size = 0;
+
+    void add(int start, int end) {
+      if (size + 2 > array.length) {
+        int[] newArray = new int[array.length * 2];
+        System.arraycopy(array, 0, newArray, 0, size);
+        array = newArray;
+      }
+      array[size++] = start;
+      array[size++] = end;
+    }
+  }
+
+  int findSplitPositions(int limit, SplitBuffer buffer) {
+    int last = 0;
+    int searchFrom = 0;
+    int textLen = text.length();
+
+    while (searchFrom <= textLen) {
+      long packed = findNextMatchPacked(searchFrom);
+      if (packed == -1L) {
+        break;
+      }
+      int start = (int) (packed >>> 32);
+      int end = (int) packed;
+
+      if (limit > 0 && (buffer.size / 2) >= limit - 1) {
+        break;
+      }
+
+      if (last == 0 && start == 0 && end == 0) {
+        searchFrom = 1;
+        continue;
+      }
+
+      buffer.add(start, end);
+      last = end;
+      searchFrom = (start == end) ? end + 1 : end;
+    }
+    return buffer.size / 2;
+  }
+
+  private long findNextMatchPacked(int fromIndex) {
+    if (fromIndex > text.length()) {
+      return -1L;
+    }
+    Prog prog = parentPattern.prog();
+    if (prog.anchorStart() && fromIndex > 0) {
+      return -1L;
+    }
+    EnginePathOptions options = enginePathOptions();
+
+    // Literal fast path
+    String literal = parentPattern.literalMatch();
+    if (options.literalFastPaths() && literal != null && parentPattern.numGroups() == 0) {
+      int idx = parentPattern.prefixFoldCase()
+          ? indexOfIgnoreCase(text, literal, fromIndex)
+          : text.indexOf(literal, fromIndex);
+      if (idx < 0) {
+        return -1L;
+      }
+      return ((long) idx << 32) | ((idx + literal.length()) & 0xFFFFFFFFL);
+    }
+
+    // Char class fast path
+    int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
+    if (options.charClassMatchFastPaths() && singleCharClassRanges != null) {
+      long b0 = parentPattern.singleCharClassBitmap0();
+      long b1 = parentPattern.singleCharClassBitmap1();
+      int i = fromIndex;
+      int len = text.length();
+      while (i < len) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
+        int cp = text.codePointAt(i);
+        if (charClassContains(singleCharClassRanges, b0, b1, cp)) {
+          return ((long) i << 32) | ((i + Character.charCount(cp)) & 0xFFFFFFFFL);
+        }
+        i += Character.charCount(cp);
+      }
+      return -1L;
+    }
+
+    int effectiveStart = fromIndex;
+    String prefix = parentPattern.prefix();
+    if (options.startAcceleration() && prefix != null) {
+      int idx = parentPattern.prefixFoldCase()
+          ? indexOfIgnoreCase(text, prefix, fromIndex)
+          : text.indexOf(prefix, fromIndex);
+      if (idx < 0) {
+        return -1L;
+      }
+      effectiveStart = idx;
+    }
+
+    boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
+    if (options.startAcceleration() && !prog.hasWordBoundary() && ccPrefixAscii != null) {
+      int idx = indexOfCharClass(text, ccPrefixAscii, fromIndex);
+      if (idx < 0) {
+        return -1L;
+      }
+      effectiveStart = idx;
+    }
+
+    Pattern.StartAcceleration startAcceleration = parentPattern.startAcceleration();
+    if (options.startAcceleration() && !prog.hasWordBoundary() && startAcceleration != null) {
+      int idx = nextAcceleratedStart(text, startAcceleration, effectiveStart, prog.unixLines());
+      if (idx < 0) {
+        return -1L;
+      }
+      effectiveStart = idx;
+    }
+
+    Dfa.SearchResult fwdResult = null;
+    if (options.dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
+      fwdResult = dfa(false).doSearch(text, effectiveStart, false, false);
+      if (fwdResult != null && !fwdResult.matched()) {
+        return -1L;
+      }
+    }
+
+    if (options.dfa()
+        && parentPattern.dfaGroupZeroReliable()
+        && fwdResult != null
+        && fwdResult.pos() > effectiveStart) {
+      int earlyEnd = fwdResult.pos();
+
+      if (prog.anchorStart()) {
+        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+        if (fwdFirst != null && fwdFirst.matched()) {
+          return ((long) effectiveStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
+        }
+      } else {
+        Dfa revDfa = reverseDfa();
+        if (revDfa != null) {
+          Dfa.SearchResult revResult =
+              revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
+          if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
+            int matchStart = revResult.pos();
+            Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+            if (fwdFirst != null && fwdFirst.matched()) {
+              return ((long) matchStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
+            }
+          }
+        }
+      }
+    }
+
+    int nsubmatch = 1;
+    int[] result =
+        searchWithBitStateOrNfa(
+            prog,
+            text,
+            effectiveStart,
+            text.length(),
+            text.length(),
+            false,
+            false,
+            false,
+            nsubmatch);
+    if (result == null) {
+      return -1L;
+    }
+    return ((long) result[0] << 32) | (result[1] & 0xFFFFFFFFL);
+  }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2859,9 +2859,10 @@ public final class Matcher implements MatchResult {
     // Literal fast path
     String literal = parentPattern.literalMatch();
     if (options.literalFastPaths() && literal != null && parentPattern.numGroups() == 0) {
-      int idx = parentPattern.prefixFoldCase()
-          ? indexOfIgnoreCase(text, literal, fromIndex)
-          : text.indexOf(literal, fromIndex);
+      int idx =
+          parentPattern.prefixFoldCase()
+              ? indexOfIgnoreCase(text, literal, fromIndex)
+              : text.indexOf(literal, fromIndex);
       if (idx < 0) {
         return -1L;
       }
@@ -2891,9 +2892,10 @@ public final class Matcher implements MatchResult {
     int effectiveStart = fromIndex;
     String prefix = parentPattern.prefix();
     if (options.startAcceleration() && prefix != null) {
-      int idx = parentPattern.prefixFoldCase()
-          ? indexOfIgnoreCase(text, prefix, fromIndex)
-          : text.indexOf(prefix, fromIndex);
+      int idx =
+          parentPattern.prefixFoldCase()
+              ? indexOfIgnoreCase(text, prefix, fromIndex)
+              : text.indexOf(prefix, fromIndex);
       if (idx < 0) {
         return -1L;
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -961,8 +961,7 @@ public final class Matcher implements MatchResult {
     return enginePathOptions().dfa()
         && enginePathOptions().reverseDfa()
         && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
-        && !parentPattern.prog().anchorStart()
-        && reverseDfa() != null;
+        && !parentPattern.prog().anchorStart();
   }
 
   /**
@@ -1240,7 +1239,7 @@ public final class Matcher implements MatchResult {
     int[] requiredRanges = parentPattern.requiredMatchClassRanges();
     boolean hasAcceleratedSearchPath =
         (parentPattern.prefix() != null)
-            || (canUseReverseDfa() && prog.anchorEnd() && text.length() >= MIN_REVERSE_FIRST_LEN);
+            || (prog.anchorEnd() && text.length() >= MIN_REVERSE_FIRST_LEN && canUseReverseDfa());
     if (options.charClassMatchFastPaths()
         && requiredRanges != null
         && !hasAcceleratedSearchPath
@@ -1347,10 +1346,10 @@ public final class Matcher implements MatchResult {
     //
     // A null result from the reverse DFA means the DFA budget was exceeded — in that case we
     // must fall through to the normal forward DFA path rather than returning false.
-    if (canUseReverseDfa()
-        && !regionActive
+    if (!regionActive
         && prog.anchorEnd()
-        && text.length() >= MIN_REVERSE_FIRST_LEN) {
+        && text.length() >= MIN_REVERSE_FIRST_LEN
+        && canUseReverseDfa()) {
       Dfa revDfa = reverseDfa();
       if (revDfa != null) {
         int textLen = text.length();
@@ -1521,75 +1520,80 @@ public final class Matcher implements MatchResult {
         }
         if (canUseReverseDfa()) {
           Dfa revDfa = reverseDfa();
-          // Step 2: Reverse DFA backward from earliest match end to find match start.
-          Dfa.SearchResult revResult =
-              revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
-          if (revResult != null && revResult.matched()) {
-            int matchStart = revResult.pos();
-            boolean reliableStart = !revResult.ambiguous();
+          if (revDfa != null) {
+            // Step 2: Reverse DFA backward from earliest match end to find match start.
+            Dfa.SearchResult revResult =
+                revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
+            if (revResult != null && revResult.matched()) {
+              int matchStart = revResult.pos();
+              boolean reliableStart = !revResult.ambiguous();
 
-            // For dollarAnchorEnd patterns, the forward DFA's earlyEnd is always textLen
-            // (it can't return early). But the correct leftmost match may end before the
-            // trailing line terminator. The reverse DFA from textLen only finds starts for
-            // matches ending AT textLen, potentially missing an earlier-starting match that
-            // ends before the trailing line terminator. Check all dollar positions.
-            if (prog.dollarAnchorEnd() && earlyEnd == text.length()) {
-              int len = text.length();
-              boolean ul = prog.unixLines();
-              // Try position before trailing line terminator.
-              if (len > 0
-                  && (ul
-                      ? text.charAt(len - 1) == '\n'
-                      : Nfa.isLineTerminator(text.charAt(len - 1)))) {
-                // For \r\n, the trailing terminator starts at len-2 (before \r), not
-                // len-1 (between \r and \n). Skip the earlyEnd-1 check for \r\n.
-                boolean isAtomicCrLf =
-                    !ul && len >= 2 && text.charAt(len - 2) == '\r' && text.charAt(len - 1) == '\n';
-                if (!isAtomicCrLf) {
-                  Dfa.SearchResult altRevResult =
-                      revDfa.doSearchReverse(text, earlyEnd - 1, effectiveStart, true, true);
-                  if (altRevResult != null
-                      && altRevResult.matched()
-                      && altRevResult.pos() < matchStart) {
-                    matchStart = altRevResult.pos();
-                    reliableStart = !altRevResult.ambiguous();
+              // For dollarAnchorEnd patterns, the forward DFA's earlyEnd is always textLen
+              // (it can't return early). But the correct leftmost match may end before the
+              // trailing line terminator. The reverse DFA from textLen only finds starts for
+              // matches ending AT textLen, potentially missing an earlier-starting match that
+              // ends before the trailing line terminator. Check all dollar positions.
+              if (prog.dollarAnchorEnd() && earlyEnd == text.length()) {
+                int len = text.length();
+                boolean ul = prog.unixLines();
+                // Try position before trailing line terminator.
+                if (len > 0
+                    && (ul
+                        ? text.charAt(len - 1) == '\n'
+                        : Nfa.isLineTerminator(text.charAt(len - 1)))) {
+                  // For \r\n, the trailing terminator starts at len-2 (before \r), not
+                  // len-1 (between \r and \n). Skip the earlyEnd-1 check for \r\n.
+                  boolean isAtomicCrLf =
+                      !ul
+                          && len >= 2
+                          && text.charAt(len - 2) == '\r'
+                          && text.charAt(len - 1) == '\n';
+                  if (!isAtomicCrLf) {
+                    Dfa.SearchResult altRevResult =
+                        revDfa.doSearchReverse(text, earlyEnd - 1, effectiveStart, true, true);
+                    if (altRevResult != null
+                        && altRevResult.matched()
+                        && altRevResult.pos() < matchStart) {
+                      matchStart = altRevResult.pos();
+                      reliableStart = !altRevResult.ambiguous();
+                    }
                   }
-                }
-                // For \r\n, try position before \r.
-                if (isAtomicCrLf && earlyEnd - 2 >= effectiveStart) {
-                  Dfa.SearchResult altRevResult2 =
-                      revDfa.doSearchReverse(text, earlyEnd - 2, effectiveStart, true, true);
-                  if (altRevResult2 != null
-                      && altRevResult2.matched()
-                      && altRevResult2.pos() < matchStart) {
-                    matchStart = altRevResult2.pos();
-                    reliableStart = !altRevResult2.ambiguous();
+                  // For \r\n, try position before \r.
+                  if (isAtomicCrLf && earlyEnd - 2 >= effectiveStart) {
+                    Dfa.SearchResult altRevResult2 =
+                        revDfa.doSearchReverse(text, earlyEnd - 2, effectiveStart, true, true);
+                    if (altRevResult2 != null
+                        && altRevResult2.matched()
+                        && altRevResult2.pos() < matchStart) {
+                      matchStart = altRevResult2.pos();
+                      reliableStart = !altRevResult2.ambiguous();
+                    }
                   }
                 }
               }
-            }
 
-            if (!reliableStart) {
-              matchStart = -1;
-            }
-
-            // Step 3: Forward DFA anchored at matchStart with longest=false to find actual end.
-            if (matchStart >= 0) {
-              Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
-              if (fwdFirst != null && fwdFirst.matched()) {
-                int matchEnd = fwdFirst.pos();
-                // Step 4: Store group(0) boundaries, defer inner captures until requested.
-                return applyDeferredMatchResult(
-                    matchStart,
-                    matchEnd,
-                    prog.numCaptures(),
-                    parentPattern.dfaGroupZeroReliable(),
-                    false);
+              if (!reliableStart) {
+                matchStart = -1;
               }
+
+              // Step 3: Forward DFA anchored at matchStart with longest=false to find actual end.
+              if (matchStart >= 0) {
+                Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+                if (fwdFirst != null && fwdFirst.matched()) {
+                  int matchEnd = fwdFirst.pos();
+                  // Step 4: Store group(0) boundaries, defer inner captures until requested.
+                  return applyDeferredMatchResult(
+                      matchStart,
+                      matchEnd,
+                      prog.numCaptures(),
+                      parentPattern.dfaGroupZeroReliable(),
+                      false);
+                }
+              }
+              // If anchored forward DFA fails, fall through to full search.
             }
-            // If anchored forward DFA fails, fall through to full search.
+            // If reverse DFA bails out, fall through to full search.
           }
-          // If reverse DFA bails out, fall through to full search.
         }
       }
     }
@@ -2833,7 +2837,15 @@ public final class Matcher implements MatchResult {
 
       buffer.add(start, end);
       last = end;
-      searchFrom = (start == end) ? end + 1 : end;
+      if (start == end) {
+        searchFrom = end + 1;
+      } else if (parentPattern.hasInternalGraphemeClusterBoundary()
+          && end < textLen
+          && endedAfterCrLf(end)) {
+        searchFrom = end + 1;
+      } else {
+        searchFrom = end;
+      }
     }
     return buffer.size / 2;
   }
@@ -2933,13 +2945,15 @@ public final class Matcher implements MatchResult {
         }
       } else if (canUseReverseDfa()) {
         Dfa revDfa = reverseDfa();
-        Dfa.SearchResult revResult =
-            revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
-        if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
-          int matchStart = revResult.pos();
-          Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
-          if (fwdFirst != null && fwdFirst.matched()) {
-            return packPositions(matchStart, fwdFirst.pos());
+        if (revDfa != null) {
+          Dfa.SearchResult revResult =
+              revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
+          if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
+            int matchStart = revResult.pos();
+            Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+            if (fwdFirst != null && fwdFirst.matched()) {
+              return packPositions(matchStart, fwdFirst.pos());
+            }
           }
         }
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2808,14 +2808,14 @@ public final class Matcher implements MatchResult {
   }
 
   static final class SplitBuffer {
+    /** Alternating (start, end) match positions. */
     int[] array = new int[32];
+
     int size = 0;
 
     void add(int start, int end) {
       if (size + 2 > array.length) {
-        int[] newArray = new int[array.length * 2];
-        System.arraycopy(array, 0, newArray, 0, size);
-        array = newArray;
+        array = Arrays.copyOf(array, array.length * 2);
       }
       array[size++] = start;
       array[size++] = end;
@@ -2832,8 +2832,8 @@ public final class Matcher implements MatchResult {
       if (packed == -1L) {
         break;
       }
-      int start = (int) (packed >>> 32);
-      int end = (int) packed;
+      int start = unpackStart(packed);
+      int end = unpackEnd(packed);
 
       if (limit > 0 && (buffer.size / 2) >= limit - 1) {
         break;
@@ -2871,7 +2871,7 @@ public final class Matcher implements MatchResult {
       if (idx < 0) {
         return -1L;
       }
-      return ((long) idx << 32) | ((idx + literal.length()) & 0xFFFFFFFFL);
+      return packPositions(idx, idx + literal.length());
     }
 
     // Char class fast path
@@ -2887,7 +2887,7 @@ public final class Matcher implements MatchResult {
         }
         int cp = text.codePointAt(i);
         if (charClassContains(singleCharClassRanges, b0, b1, cp)) {
-          return ((long) i << 32) | ((i + Character.charCount(cp)) & 0xFFFFFFFFL);
+          return packPositions(i, i + Character.charCount(cp));
         }
         i += Character.charCount(cp);
       }
@@ -2942,7 +2942,7 @@ public final class Matcher implements MatchResult {
       if (prog.anchorStart()) {
         Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
         if (fwdFirst != null && fwdFirst.matched()) {
-          return ((long) effectiveStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
+          return packPositions(effectiveStart, fwdFirst.pos());
         }
       } else if (canUseReverseDfa()) {
         Dfa revDfa = reverseDfa();
@@ -2952,7 +2952,7 @@ public final class Matcher implements MatchResult {
           int matchStart = revResult.pos();
           Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
           if (fwdFirst != null && fwdFirst.matched()) {
-            return ((long) matchStart << 32) | (fwdFirst.pos() & 0xFFFFFFFFL);
+            return packPositions(matchStart, fwdFirst.pos());
           }
         }
       }
@@ -2973,6 +2973,18 @@ public final class Matcher implements MatchResult {
     if (result == null) {
       return -1L;
     }
-    return ((long) result[0] << 32) | (result[1] & 0xFFFFFFFFL);
+    return packPositions(result[0], result[1]);
+  }
+
+  private static long packPositions(int start, int end) {
+    return ((long) start << 32) | (end & 0xFFFFFFFFL);
+  }
+
+  private static int unpackStart(long packed) {
+    return (int) (packed >>> 32);
+  }
+
+  private static int unpackEnd(long packed) {
+    return (int) packed;
   }
 }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -509,40 +509,34 @@ public final class Pattern implements Serializable {
   public String[] split(CharSequence input, int limit) {
     String text = charSequenceToString(input);
     Matcher m = matcher(text);
-    List<String> parts = new ArrayList<>();
-    int last = 0;
-
-    while (m.find()) {
-      if (limit > 0 && parts.size() >= limit - 1) {
-        break;
-      }
-      // JDK 8+: a zero-width match at the beginning of the input never produces
-      // a leading empty substring.
-      if (last == 0 && m.start() == 0 && m.end() == 0) {
-        continue;
-      }
-      parts.add(text.substring(last, m.start()));
-      last = m.end();
-    }
-    // If no match advanced the position, return the entire input as a single element.
-    // This matches JDK behavior: an input that was never actually split is returned as-is,
-    // bypassing trailing-empty-string removal.
-    if (last == 0) {
+    Matcher.SplitBuffer buffer = new Matcher.SplitBuffer();
+    int matchesCount = m.findSplitPositions(limit, buffer);
+    if (matchesCount == 0) {
       return new String[] {text};
     }
+    int partsCount = (limit > 0) ? Math.min(limit, matchesCount + 1) : matchesCount + 1;
+    String[] parts = new String[partsCount];
+    int last = 0;
+    int i = 0;
+    while (i < partsCount - 1) {
+      int start = buffer.array[2 * i];
+      int end = buffer.array[2 * i + 1];
+      parts[i] = text.substring(last, start);
+      last = end;
+      i++;
+    }
+    parts[i] = text.substring(last);
 
-    parts.add(text.substring(last));
-
-    // limit == 0: remove trailing empty strings.
     if (limit == 0) {
-      int end = parts.size();
-      while (end > 0 && parts.get(end - 1).isEmpty()) {
+      int end = partsCount;
+      while (end > 0 && parts[end - 1].isEmpty()) {
         end--;
       }
-      parts = parts.subList(0, end);
+      if (end < partsCount) {
+        parts = Arrays.copyOf(parts, end);
+      }
     }
-
-    return parts.toArray(new String[0]);
+    return parts;
   }
 
   /**
@@ -586,39 +580,36 @@ public final class Pattern implements Serializable {
   public String[] splitWithDelimiters(CharSequence input, int limit) {
     String text = charSequenceToString(input);
     Matcher m = matcher(text);
-    List<String> parts = new ArrayList<>();
-    int last = 0;
-
-    while (m.find()) {
-      if (limit > 0 && parts.size() >= 2 * limit - 2) {
-        break;
-      }
-      // JDK 8+: a zero-width match at the beginning of the input never produces
-      // a leading empty substring or empty delimiter.
-      if (last == 0 && m.start() == 0 && m.end() == 0) {
-        continue;
-      }
-      parts.add(text.substring(last, m.start()));
-      parts.add(text.substring(m.start(), m.end()));
-      last = m.end();
-    }
-    // If no match advanced the position, return the entire input as a single element.
-    if (last == 0) {
+    Matcher.SplitBuffer buffer = new Matcher.SplitBuffer();
+    int matchesCount = m.findSplitPositions(limit, buffer);
+    if (matchesCount == 0) {
       return new String[] {text};
     }
+    int partsCount = (limit > 0) ? Math.min(2 * limit - 1, 2 * matchesCount + 1) : 2 * matchesCount + 1;
+    String[] parts = new String[partsCount];
+    int last = 0;
+    int i = 0;
+    int matchIdx = 0;
+    while (i < partsCount - 1) {
+      int start = buffer.array[2 * matchIdx];
+      int end = buffer.array[2 * matchIdx + 1];
+      parts[i++] = text.substring(last, start);
+      parts[i++] = text.substring(start, end);
+      last = end;
+      matchIdx++;
+    }
+    parts[i] = text.substring(last);
 
-    parts.add(text.substring(last));
-
-    // limit == 0: remove trailing empty strings.
     if (limit == 0) {
-      int end = parts.size();
-      while (end > 0 && parts.get(end - 1).isEmpty()) {
+      int end = partsCount;
+      while (end > 0 && parts[end - 1].isEmpty()) {
         end--;
       }
-      parts = parts.subList(0, end);
+      if (end < partsCount) {
+        parts = Arrays.copyOf(parts, end);
+      }
     }
-
-    return parts.toArray(new String[0]);
+    return parts;
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -9,7 +9,6 @@ package org.safere;
 
 import java.io.Serializable;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
@@ -585,7 +584,8 @@ public final class Pattern implements Serializable {
     if (matchesCount == 0) {
       return new String[] {text};
     }
-    int partsCount = (limit > 0) ? Math.min(2 * limit - 1, 2 * matchesCount + 1) : 2 * matchesCount + 1;
+    int partsCount =
+        (limit > 0) ? Math.min(2 * limit - 1, 2 * matchesCount + 1) : 2 * matchesCount + 1;
     String[] parts = new String[partsCount];
     int last = 0;
     int i = 0;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -584,8 +584,10 @@ public final class Pattern implements Serializable {
     if (matchesCount == 0) {
       return new String[] {text};
     }
-    int partsCount =
-        (limit > 0) ? Math.min(2 * limit - 1, 2 * matchesCount + 1) : 2 * matchesCount + 1;
+    int partsCount = 2 * matchesCount + 1;
+    if (limit > 0) {
+      partsCount = (int) Math.min(2L * limit - 1, partsCount);
+    }
     String[] parts = new String[partsCount];
     int last = 0;
     int i = 0;

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -398,6 +398,14 @@ class PatternTest {
       String[] parts = p.split(new LiteralCharSequence("a,b,c"));
       assertThat(parts).containsExactly("a", "b", "c");
     }
+
+    @Test
+    @DisplayName("split advances after internal grapheme boundary CRLF matches")
+    void splitAdvancesAfterInternalGraphemeBoundaryCrLfMatches() {
+      Pattern p = Pattern.compile("\\r\\b{g}\\n");
+      String[] parts = p.split("#\r\n\r\n$", -1);
+      assertThat(parts).containsExactly("#", "\r\n$");
+    }
   }
 
   @Nested
@@ -429,6 +437,13 @@ class PatternTest {
       Pattern p = Pattern.compile(":+");
       String[] parts = p.splitWithDelimiters("boo:::and::foo", 5);
       assertThat(parts).containsExactly("boo", ":::", "and", "::", "foo");
+    }
+
+    @Test
+    void splitWithDelimitersLargePositiveLimit() {
+      Pattern p = Pattern.compile(",");
+      String[] parts = p.splitWithDelimiters("a,b", Integer.MAX_VALUE);
+      assertThat(parts).containsExactly("a", ",", "b");
     }
 
     @Test
@@ -481,6 +496,14 @@ class PatternTest {
       Pattern p = Pattern.compile(",");
       String[] parts = p.splitWithDelimiters(new LiteralCharSequence("a,b"));
       assertThat(parts).containsExactly("a", ",", "b");
+    }
+
+    @Test
+    @DisplayName("splitWithDelimiters advances after internal grapheme boundary CRLF matches")
+    void splitWithDelimitersAdvancesAfterInternalGraphemeBoundaryCrLfMatches() {
+      Pattern p = Pattern.compile("\\r\\b{g}\\n");
+      String[] parts = p.splitWithDelimiters("#\r\n\r\n$", -1);
+      assertThat(parts).containsExactly("#", "\r\n", "\r\n$");
     }
   }
 


### PR DESCRIPTION
This is in the same vein as #547. It adds a separate loop to implement `split` that avoids calling `find()`, to minimize repeated work in `find()` that can be done once in the new loop, and also optimizes allocations.

This is a 20% latency win for `split` on the long inputs in the benchmark below.

```
./run-java-benchmarks.sh --fastbuild Issue481ScalingBenchmark.splitWords_safere
```

| Input Text Size (chars) | Baseline Latency (us/op) | Optimized Latency (us/op) | Delta (us) | Latency Reduction | Speedup |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **128** | 2.996 ± 0.117 | 2.530 ± 0.075 | -0.466 | **-15.6%** | **1.18x** |
| **1,024** | 22.730 ± 1.743 | 20.754 ± 0.773 | -1.976 | **-8.7%** | **1.10x** |
| **10,240** | 231.492 ± 13.021 | 226.054 ± 14.337 | -5.438 | **-2.3%** | **1.02x** |
| **102,400** | 2,480.095 ± 95.703 | 1,927.739 ± 45.506 | -552.356 | **-22.3%** | **1.29x** |
| **1,048,576** (1 MB) | 23,969.911 ± 834.730 | 19,770.121 ± 480.684 | -4,199.790 | **-17.5%** | **1.21x** |



