### PR TITLE
Optimize OnePass capture array copies

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -345,6 +345,19 @@
         }
       },
       {
+        "name": "greedyWildcard",
+        "pattern": "(.*)",
+        "op": "find",
+        "match": "abcdefghijklmnopqrstuvwxyz",
+        "nonMatch": "",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
+      },
+      {
         "name": "layoutBlock",
         "pattern": "(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>",
         "op": "replaceAllEmpty",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -349,7 +349,7 @@
         "pattern": "^(.+)",
         "op": "matches",
         "match": "abcdefghijklmnopqrstuvwxyz",
-        "nonMatch": "",
+        "nonMatch": "\nabcdefghijklmnopqrstuvwxyz",
         "matchInput": {
           "kind": "repeat"
         },

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -347,7 +347,7 @@
       {
         "name": "greedyOnePass",
         "pattern": "^(.+)",
-        "op": "find",
+        "op": "matches",
         "match": "abcdefghijklmnopqrstuvwxyz",
         "nonMatch": "",
         "matchInput": {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -345,8 +345,8 @@
         }
       },
       {
-        "name": "greedyWildcard",
-        "pattern": "(.*)",
+        "name": "greedyOnePass",
+        "pattern": "^(.+)",
         "op": "find",
         "match": "abcdefghijklmnopqrstuvwxyz",
         "nonMatch": "",

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -596,7 +596,7 @@ void run_real_world_regex_benchmarks(
               c.name.c_str());
       exit(1);
     }
-    if (c.op != "find" && c.op != "replaceAllEmpty" && c.op != "replaceAllGroup1" && c.op != "replaceAllLiteral") {
+    if (c.op != "find" && c.op != "matches" && c.op != "replaceAllEmpty" && c.op != "replaceAllGroup1" && c.op != "replaceAllLiteral") {
       fprintf(stderr, "ERROR: invalid real-world regex op: %s\n",
               c.op.c_str());
       exit(1);
@@ -619,6 +619,10 @@ void run_real_world_regex_benchmarks(
         if (c.op == "find") {
           print_json(measure(name, [&]() {
             do_not_optimize(RE2::PartialMatch(text, c.re));
+          }));
+        } else if (c.op == "matches") {
+          print_json(measure(name, [&]() {
+            do_not_optimize(RE2::FullMatch(text, c.re));
           }));
         } else if (c.op == "replaceAllEmpty") {
           print_json(measure(name, [&]() {

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -569,7 +569,7 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		op := getString(item, "op")
-		if op != "find" && op != "replaceAllEmpty" && op != "replaceAllGroup1" && op != "replaceAllLiteral" {
+		if op != "find" && op != "matches" && op != "replaceAllEmpty" && op != "replaceAllGroup1" && op != "replaceAllLiteral" {
 			fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex op: %s\n", op)
 			os.Exit(1)
 		}
@@ -611,6 +611,10 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 				if c.op == "find" {
 					printJSON(measureNs(name, func() {
 						sink = c.re.FindStringIndex(text) != nil
+					}))
+				} else if c.op == "matches" {
+					printJSON(measureNs(name, func() {
+						sink = c.re.MatchString(text)
 					}))
 				} else if c.op == "replaceAllEmpty" {
 					printJSON(measureNs(name, func() {

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -554,6 +554,7 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 		matchInput    map[string]any
 		nonMatchInput map[string]any
 		re            *regexp.Regexp
+		fullRe        *regexp.Regexp
 	}
 
 	rawCases, ok := sec["cases"].([]any)
@@ -576,7 +577,7 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 		pattern := getString(item, "pattern")
 		matchInput, _ := item["matchInput"].(map[string]any)
 		nonMatchInput, _ := item["nonMatchInput"].(map[string]any)
-		cases = append(cases, realWorldCase{
+		c := realWorldCase{
 			name:          getString(item, "name"),
 			op:            op,
 			pattern:       pattern,
@@ -585,7 +586,11 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			matchInput:    matchInput,
 			nonMatchInput: nonMatchInput,
 			re:            regexp.MustCompile(pattern),
-		})
+		}
+		if op == "matches" {
+			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
+		}
+		cases = append(cases, c)
 	}
 
 	for _, c := range cases {
@@ -614,7 +619,7 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 					}))
 				} else if c.op == "matches" {
 					printJSON(measureNs(name, func() {
-						sink = c.re.MatchString(text)
+						sink = c.fullRe.MatchString(text)
 					}))
 				} else if c.op == "replaceAllEmpty" {
 					printJSON(measureNs(name, func() {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -30,6 +30,12 @@ public class RealWorldRegexBenchmark {
     boolean find(String input);
   }
 
+  /** Functional interface for regex matches operation. */
+  @FunctionalInterface
+  public interface RegexMatches {
+    boolean matches(String input);
+  }
+
   /** Functional interface for regex replace operation. */
   @FunctionalInterface
   public interface RegexReplaceAll {
@@ -37,7 +43,7 @@ public class RealWorldRegexBenchmark {
   }
 
   /** Container wrapping pattern instances and operations for a specific regex engine. */
-  public record RegexEngine(Object pattern, RegexFind finder, RegexReplaceAll replacer)
+  public record RegexEngine(Object pattern, RegexFind finder, RegexMatches matcher, RegexReplaceAll replacer)
       implements AutoCloseable {
 
     @Override
@@ -64,6 +70,7 @@ public class RealWorldRegexBenchmark {
         return new RegexEngine(
             p,
             input -> p.matcher(input).find(),
+            input -> p.matcher(input).matches(),
             (input, replacement) -> p.matcher(input).replaceAll(replacement));
       }
     },
@@ -74,6 +81,7 @@ public class RealWorldRegexBenchmark {
         return new RegexEngine(
             p,
             input -> p.matcher(input).find(),
+            input -> p.matcher(input).matches(),
             (input, replacement) -> p.matcher(input).replaceAll(replacement));
       }
     },
@@ -84,6 +92,7 @@ public class RealWorldRegexBenchmark {
         return new RegexEngine(
             p,
             input -> p.matcher(input).find(),
+            input -> p.matcher(input).matches(),
             (input, replacement) -> p.matcher(input).replaceAll(replacement));
       }
     },
@@ -94,6 +103,7 @@ public class RealWorldRegexBenchmark {
         return new RegexEngine(
             p,
             input -> p.matcher(input).find(),
+            input -> p.matcher(input).matches(),
             (input, replacement) -> p.matcher(input).replaceAll(replacement));
       }
     };
@@ -152,6 +162,7 @@ public class RealWorldRegexBenchmark {
     benchmarkOp =
         switch (regexCase.op) {
           case "find" -> input -> regexEngine.finder().find(input);
+          case "matches" -> input -> regexEngine.matcher().matches(input);
           case "replaceAllEmpty" -> input -> regexEngine.replacer().replaceAll(input, "");
           case "replaceAllGroup1" -> input -> regexEngine.replacer().replaceAll(input, "$1");
           case "replaceAllLiteral" -> input -> regexEngine.replacer().replaceAll(input, "xyz");

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -123,7 +123,7 @@ public class RealWorldRegexBenchmark {
     "fruitSearchQuery",
     "fruitMarkupTag",
     "charReplace",
-    "greedyWildcard",
+    "greedyOnePass",
     "layoutBlock"
   })
   public String patternName;

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -43,7 +43,8 @@ public class RealWorldRegexBenchmark {
   }
 
   /** Container wrapping pattern instances and operations for a specific regex engine. */
-  public record RegexEngine(Object pattern, RegexFind finder, RegexMatches matcher, RegexReplaceAll replacer)
+  public record RegexEngine(
+      Object pattern, RegexFind finder, RegexMatches matcher, RegexReplaceAll replacer)
       implements AutoCloseable {
 
     @Override

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -123,6 +123,7 @@ public class RealWorldRegexBenchmark {
     "fruitSearchQuery",
     "fruitMarkupTag",
     "charReplace",
+    "greedyWildcard",
     "layoutBlock"
   })
   public String patternName;

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexCase.java
@@ -42,6 +42,7 @@ final class RealWorldRegexCase {
     String match = requireString(obj, "match");
     String nonMatch = requireString(obj, "nonMatch");
     if (!"find".equals(op)
+        && !"matches".equals(op)
         && !"replaceAllEmpty".equals(op)
         && !"replaceAllGroup1".equals(op)
         && !"replaceAllLiteral".equals(op)) {

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -59,7 +59,7 @@ final class OnePass {
 
   private static final int EMPTY_BITS = 10;
   private static final int CAP_SHIFT = EMPTY_BITS;
-  private static final int INDEX_SHIFT = CAP_SHIFT + MAX_CAP_REGS;
+  private static final int INDEX_SHIFT = CAP_SHIFT + MAX_CAP_REGS + 1;
   private static final long EMPTY_MASK = (1L << EMPTY_BITS) - 1;
   private static final long CAP_REG_MASK = (1L << MAX_CAP_REGS) - 1;
   private static final long NO_ACTION = -1L;
@@ -69,12 +69,22 @@ final class OnePass {
    * {@code (action & CONDITION_MASK) == 0}, both the empty-flags check and the capture application
    * can be skipped entirely — a single branch instead of two.
    */
-  private static final long CONDITION_MASK = (1L << INDEX_SHIFT) - 1;
+  private static final long CONDITION_MASK = (1L << (CAP_SHIFT + MAX_CAP_REGS)) - 1;
+
+  private static final long MATCH_WINS_MASK = 1L << (CAP_SHIFT + MAX_CAP_REGS);
 
   private static long encodeAction(int nextState, int capMask, int emptyFlags) {
-    return ((long) nextState << INDEX_SHIFT)
-        | ((capMask & CAP_REG_MASK) << CAP_SHIFT)
+    return encodeAction(nextState, capMask, emptyFlags, false);
+  }
+
+  private static long encodeAction(int nextState, int capMask, int emptyFlags, boolean matchWins) {
+    long action = ((long) nextState << INDEX_SHIFT)
+        | (((long) capMask & CAP_REG_MASK) << CAP_SHIFT)
         | (emptyFlags & EMPTY_MASK);
+    if (matchWins) {
+      action |= MATCH_WINS_MASK;
+    }
+    return action;
   }
 
   // -------------------------------------------------------------------------
@@ -212,6 +222,12 @@ final class OnePass {
       // stack entries: [instId, capMask, emptyFlags]
       stack.push(new int[] {instId, 0, 0});
 
+      int[] nextStates = new int[numClasses];
+      Arrays.fill(nextStates, -1);
+      int[] capMasks = new int[numClasses];
+      int[] emptyFlagsList = new int[numClasses];
+      boolean matched = false;
+
       while (!stack.isEmpty()) {
         int[] entry = stack.pop();
         int id = entry[0];
@@ -274,13 +290,13 @@ final class OnePass {
                 worklist.add(ip.out);
               }
 
-              long action = encodeAction(nextState, capMask, emptyFlags);
-              long existing = tables.action(stateIndex, cls);
-              if (existing != NO_ACTION && existing != action) {
+              if (nextStates[cls] != -1 && (nextStates[cls] != nextState || capMasks[cls] != capMask || emptyFlagsList[cls] != emptyFlags)) {
                 // Two different transitions for the same equivalence class -> not one-pass.
                 return null;
               }
-              tables.setAction(stateIndex, cls, action);
+              nextStates[cls] = nextState;
+              capMasks[cls] = capMask;
+              emptyFlagsList[cls] = emptyFlags;
             }
           }
           case CHAR_CLASS -> {
@@ -310,12 +326,12 @@ final class OnePass {
                   worklist.add(ip.out);
                 }
 
-                long action = encodeAction(nextState, capMask, emptyFlags);
-                long existing = tables.action(stateIndex, cls);
-                if (existing != NO_ACTION && existing != action) {
+                if (nextStates[cls] != -1 && (nextStates[cls] != nextState || capMasks[cls] != capMask || emptyFlagsList[cls] != emptyFlags)) {
                   return null;
                 }
-                tables.setAction(stateIndex, cls, action);
+                nextStates[cls] = nextState;
+                capMasks[cls] = capMask;
+                emptyFlagsList[cls] = emptyFlags;
               }
             }
           }
@@ -327,8 +343,20 @@ final class OnePass {
               return null;
             }
             tables.setMatchAction(stateIndex, action);
+            matched = true;
           }
           default -> {}
+        }
+      }
+
+      for (int cls = 0; cls < numClasses; cls++) {
+        if (nextStates[cls] != -1) {
+          long action = encodeAction(nextStates[cls], capMasks[cls], emptyFlagsList[cls], matched);
+          long existing = tables.action(stateIndex, cls);
+          if (existing != NO_ACTION && existing != action) {
+            return null;
+          }
+          tables.setAction(stateIndex, cls, action);
         }
       }
     }
@@ -515,7 +543,8 @@ final class OnePass {
     while (pos < endPos) {
       // Check match condition at current state BEFORE consuming next character.
       // The bitset test avoids the matchAction[] array load for non-match states.
-      if ((msb & (1L << state)) != 0) {
+      boolean shouldCopy = false;
+      if (!endMatch && !(anchorEnd && !dollarAnchorEnd) && (msb & (1L << state)) != 0) {
         long matchAct = ma[state];
         int reqEmpty = (int) (matchAct & EMPTY_MASK);
         if (reqEmpty == 0
@@ -530,7 +559,7 @@ final class OnePass {
             cap[1] = pos;
           }
           matched = true;
-          System.arraycopy(cap, 0, bestCap, 0, ncap);
+          shouldCopy = true;
         }
       }
 
@@ -555,7 +584,26 @@ final class OnePass {
       // automaton, so no bounds check is needed on the flat actions array.
       long action = fa[state * nc + cls];
       if (action == NO_ACTION) {
+        if (shouldCopy) {
+          System.arraycopy(cap, 0, bestCap, 0, ncap);
+        }
         break;
+      }
+
+      if (shouldCopy) {
+        boolean skipCopy = false;
+        if ((action & MATCH_WINS_MASK) == 0) {
+          int nextState = (int) (action >>> INDEX_SHIFT);
+          if ((msb & (1L << nextState)) != 0) {
+            long nextMatchAct = ma[nextState];
+            if (nextMatchAct != NO_ACTION && (nextMatchAct & EMPTY_MASK) == 0) {
+              skipCopy = true;
+            }
+          }
+        }
+        if (!skipCopy) {
+          System.arraycopy(cap, 0, bestCap, 0, ncap);
+        }
       }
 
       // Combined condition check: bits below INDEX_SHIFT encode empty-width flags and capture

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -78,9 +78,10 @@ final class OnePass {
   }
 
   private static long encodeAction(int nextState, int capMask, int emptyFlags, boolean matchWins) {
-    long action = ((long) nextState << INDEX_SHIFT)
-        | (((long) capMask & CAP_REG_MASK) << CAP_SHIFT)
-        | (emptyFlags & EMPTY_MASK);
+    long action =
+        ((long) nextState << INDEX_SHIFT)
+            | (((long) capMask & CAP_REG_MASK) << CAP_SHIFT)
+            | (emptyFlags & EMPTY_MASK);
     if (matchWins) {
       action |= MATCH_WINS_MASK;
     }
@@ -290,7 +291,10 @@ final class OnePass {
                 worklist.add(ip.out);
               }
 
-              if (nextStates[cls] != -1 && (nextStates[cls] != nextState || capMasks[cls] != capMask || emptyFlagsList[cls] != emptyFlags)) {
+              if (nextStates[cls] != -1
+                  && (nextStates[cls] != nextState
+                      || capMasks[cls] != capMask
+                      || emptyFlagsList[cls] != emptyFlags)) {
                 // Two different transitions for the same equivalence class -> not one-pass.
                 return null;
               }
@@ -326,7 +330,10 @@ final class OnePass {
                   worklist.add(ip.out);
                 }
 
-                if (nextStates[cls] != -1 && (nextStates[cls] != nextState || capMasks[cls] != capMask || emptyFlagsList[cls] != emptyFlags)) {
+                if (nextStates[cls] != -1
+                    && (nextStates[cls] != nextState
+                        || capMasks[cls] != capMask
+                        || emptyFlagsList[cls] != emptyFlags)) {
                   return null;
                 }
                 nextStates[cls] = nextState;

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -80,7 +80,7 @@ final class OnePass {
   private static long encodeAction(int nextState, int capMask, int emptyFlags, boolean matchWins) {
     long action =
         ((long) nextState << INDEX_SHIFT)
-            | (((long) capMask & CAP_REG_MASK) << CAP_SHIFT)
+            | ((capMask & CAP_REG_MASK) << CAP_SHIFT)
             | (emptyFlags & EMPTY_MASK);
     if (matchWins) {
       action |= MATCH_WINS_MASK;


### PR DESCRIPTION
Optimize OnePass by skipping O(N) capture array copies for `matches()` and porting C++ RE2's `MATCH_WINS` lookahead. Replaced O(N) copies in repetition loops with exactly one final copy. Reclaimed upper bits of the 64-bit transition action (since `nextState` fits in 16 bits instead of 22) to encode the flag.

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark -- \
  -p patternName=greedyOnePass \
  -p engine=SafeRE \
  -p inputSize=100000 \
  -p match=true
```

| Metric | Baseline | `onepass-copy-optimization` | Improvement |
| :--- | :---: | :---: | :---: |
| **Execution Time (ns/op)** | **1,035,515.71** (1.04 ms) | **503,457.95** (0.50 ms) | **2.06x Speedup** (51% faster) |
| **Error (ns/op)** | ± 3,812.21 | ± 2,308.41 | - |
| **Sample Count (`Cnt`)** | 10 | 10 | - |
