### PR TITLE
Avoid temporary String allocations for group references in Matcher.appendReplacement

### DIFF
--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ReplaceBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ReplaceBenchmark.java
@@ -267,4 +267,39 @@ public class ReplaceBenchmark {
   public String emptyReplaceAll_re2ffm() {
     return re2ffmEmpty.matcher(emptyText).replaceAll(emptyReplacement);
   }
+
+  // ===== Manual appendReplacement loop (for group reference performance) =====
+
+  @Benchmark
+  public String manualReplaceAll_safere() {
+    org.safere.Matcher m = safePigLatin.matcher(pigLatinText);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, pigLatinReplacement);
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  @Benchmark
+  public String manualReplaceAll_jdk() {
+    java.util.regex.Matcher m = jdkPigLatin.matcher(pigLatinText);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, pigLatinReplacement);
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  @Benchmark
+  public String manualReplaceAll_re2j() {
+    com.google.re2j.Matcher m = re2jPigLatin.matcher(pigLatinText);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, pigLatinReplacement);
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2642,6 +2642,13 @@ public final class Matcher implements MatchResult {
    * $1}, {@code ${name}}, {@code \\} (literal backslash), and {@code \$} (literal dollar).
    */
   private void appendReplacementBody(StringBuilder sb, String replacement) {
+    if (isSimpleReplacement(replacement)) {
+      sb.append(replacement);
+      return;
+    }
+    if (!capturesResolved) {
+      resolveCaptures();
+    }
     int i = 0;
     while (i < replacement.length()) {
       char c = replacement.charAt(i);
@@ -2669,18 +2676,25 @@ public final class Matcher implements MatchResult {
           }
           String name = replacement.substring(nameStart, i);
           i++; // skip '}'
-          String g = group(name);
-          if (g != null) {
-            sb.append(g);
+          Integer idx = parentPattern.namedGroups().get(name);
+          if (idx == null) {
+            throw new IllegalArgumentException("No group with name <" + name + ">");
+          }
+          int g = idx;
+          int start = groups[2 * g];
+          int end = groups[2 * g + 1];
+          if (start >= 0 && end >= 0) {
+            sb.append(text, start, end);
           }
         } else if (Character.isDigit(replacement.charAt(i))) {
           // Numeric group reference: $0, $1, $12, etc.
           NumericGroupReference groupRef = parseNumericGroupReference(replacement, i, groupCount());
           int groupIdx = groupRef.groupNum();
           i = groupRef.end();
-          String g = group(groupIdx);
-          if (g != null) {
-            sb.append(g);
+          int start = groups[2 * groupIdx];
+          int end = groups[2 * groupIdx + 1];
+          if (start >= 0 && end >= 0) {
+            sb.append(text, start, end);
           }
         } else {
           throw new IllegalArgumentException("Invalid group reference in replacement string");

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2633,9 +2633,6 @@ public final class Matcher implements MatchResult {
       sb.append(replacement);
       return;
     }
-    if (!capturesResolved) {
-      resolveCaptures();
-    }
     int i = 0;
     while (i < replacement.length()) {
       char c = replacement.charAt(i);
@@ -2668,8 +2665,8 @@ public final class Matcher implements MatchResult {
             throw new IllegalArgumentException("No group with name <" + name + ">");
           }
           int g = idx;
-          int start = groups[2 * g];
-          int end = groups[2 * g + 1];
+          int start = start(g);
+          int end = end(g);
           if (start >= 0 && end >= 0) {
             sb.append(text, start, end);
           }
@@ -2677,10 +2674,9 @@ public final class Matcher implements MatchResult {
           // Numeric group reference: $0, $1, $12, etc.
           NumericGroupReference groupRef = parseNumericGroupReference(replacement, i, groupCount());
           int groupIdx = groupRef.groupNum();
-          checkGroup(groupIdx);
           i = groupRef.end();
-          int start = groups[2 * groupIdx];
-          int end = groups[2 * groupIdx + 1];
+          int start = start(groupIdx);
+          int end = end(groupIdx);
           if (start >= 0 && end >= 0) {
             sb.append(text, start, end);
           }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2690,6 +2690,7 @@ public final class Matcher implements MatchResult {
           // Numeric group reference: $0, $1, $12, etc.
           NumericGroupReference groupRef = parseNumericGroupReference(replacement, i, groupCount());
           int groupIdx = groupRef.groupNum();
+          checkGroup(groupIdx);
           i = groupRef.end();
           int start = groups[2 * groupIdx];
           int end = groups[2 * groupIdx + 1];


### PR DESCRIPTION
This avoids temporary `String` allocations for group references in `Matcher.appendReplacement`. Instead of creating a substring with `group(N)` and appending it via `StringBuilder#append(String)`, it retrieves the group bounds directly and uses `StringBuilder#append(CharSequence, int, int)` to write from the input string directly to the `StringBuilder`.

It also adds a fast-path for simple replacements (without `$` or `\`), bypassing the character-by-character parsing loop entirely.

This avoids some allocations, and also improves latency:

```
./run-java-benchmarks.sh --fastbuild 'ReplaceBenchmark\.manualReplaceAll_safere'
```

| Benchmark | Baseline  | `string-ops-optimization` | Latency Reduction | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| `ReplaceBenchmark.manualReplaceAll_safere` | `3911.197 ± 331.893` ns/op | `3481.292 ± 60.404` ns/op | **-11.0%** (save ~430 ns) | **1.12x** |