### PR TITLE
Fix OnePass eligibility check

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2580,7 +2580,8 @@ public final class Matcher implements MatchResult {
       result =
           parentPattern
               .onePass()
-              .search(text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures(), groups);
+              .search(
+                  text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures(), groups);
     } else {
       result =
           searchWithBitStateOrNfa(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -752,8 +752,8 @@ public final class Matcher implements MatchResult {
     if (onePass != null
         && !prog.hasGraphemeSemantics()
         && !parentPattern.hasNullableAlternation()) {
-      OnePass.SearchResult result = onePass.search(text, true, prog.numCaptures());
-      return applyEngineResult(new FullMatchResult(result.groups()));
+      int[] result = onePass.search(text, true, prog.numCaptures());
+      return applyEngineResult(new FullMatchResult(result));
     }
 
     // Medium path: use DFA to check if a full match exists.
@@ -877,8 +877,8 @@ public final class Matcher implements MatchResult {
         && parentPattern.canOnePassPrimary()
         && !prog.hasGraphemeSemantics()) {
       OnePass onePass = parentPattern.onePass();
-      OnePass.SearchResult result = onePass.search(text, false, prog.numCaptures());
-      return applyEngineResult(new FullMatchResult(result.groups()));
+      int[] result = onePass.search(text, false, prog.numCaptures());
+      return applyEngineResult(new FullMatchResult(result));
     }
 
     // Medium path: use DFA to check if an anchored match exists.
@@ -1268,11 +1268,11 @@ public final class Matcher implements MatchResult {
     if (options.onePass()
         && parentPattern.canOnePassFind()
         && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT) {
-      OnePass.SearchResult result =
+      int[] result =
           parentPattern
               .onePass()
               .search(text, searchFrom, text.length(), false, prog.numCaptures());
-      return applyEngineResult(new FullMatchResult(result.groups()));
+      return applyEngineResult(new FullMatchResult(result));
     }
 
     // Prefix acceleration: if the pattern starts with a literal prefix, skip ahead to where
@@ -1984,11 +1984,11 @@ public final class Matcher implements MatchResult {
     }
 
     Nfa nfa = Nfa.getOrCreate(cachedNfa, prog, context, ncapture, longestMode, endmatch);
-    Nfa.SearchResult nfaResult = nfa.runSearch(anchored, nfaKind, nsubmatch, endPos);
+    int[] result = nfa.runSearch(anchored, nfaKind, nsubmatch, endPos);
     cachedNfa = nfa;
     parentPattern.returnNfa(nfa);
 
-    return nfaResult.groups();
+    return result;
   }
 
   // ---------------------------------------------------------------------------
@@ -2594,8 +2594,7 @@ public final class Matcher implements MatchResult {
       result =
           parentPattern
               .onePass()
-              .search(text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures())
-              .groups();
+              .search(text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures());
     } else {
       result =
           searchWithBitStateOrNfa(

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -163,8 +163,6 @@ final class Nfa {
     }
   }
 
-
-
   private Prog prog;
   private int ncapture;
 

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -288,8 +288,7 @@ final class Nfa {
     return runSearch(anchored, kind, nsubmatch, endPos, null);
   }
 
-  int[] runSearch(
-      boolean anchored, MatchKind kind, int nsubmatch, int endPos, int[] reuseGroups) {
+  int[] runSearch(boolean anchored, MatchKind kind, int nsubmatch, int endPos, int[] reuseGroups) {
     if (prog.hasGraphemeSemantics()) {
       doSearchEveryCharPosition(anchored);
     } else {

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -163,8 +163,7 @@ final class Nfa {
     }
   }
 
-  @SuppressWarnings("ArrayRecordComponent")
-  record SearchResult(int[] groups) {}
+
 
   private Prog prog;
   private int ncapture;
@@ -287,7 +286,7 @@ final class Nfa {
     context = null;
   }
 
-  SearchResult runSearch(boolean anchored, MatchKind kind, int nsubmatch, int endPos) {
+  int[] runSearch(boolean anchored, MatchKind kind, int nsubmatch, int endPos) {
     if (prog.hasGraphemeSemantics()) {
       doSearchEveryCharPosition(anchored);
     } else {
@@ -295,10 +294,10 @@ final class Nfa {
     }
 
     if (!matched) {
-      return new SearchResult(null);
+      return null;
     }
     if (kind == MatchKind.FULL_MATCH && bestMatch[1] != endPos) {
-      return new SearchResult(null);
+      return null;
     }
 
     int[] result = new int[2 * nsubmatch];
@@ -307,7 +306,7 @@ final class Nfa {
     if (ncopy < result.length) {
       Arrays.fill(result, ncopy, result.length, -1);
     }
-    return new SearchResult(result);
+    return result;
   }
 
   /**
@@ -322,7 +321,7 @@ final class Nfa {
    *     indices into the text. {@code result[2*i]} is the start of group i, {@code result[2*i+1]}
    *     is the end. -1 means the group did not participate.
    */
-  static SearchResult search(Prog prog, String text, Anchor anchor, MatchKind kind, int nsubmatch) {
+  static int[] search(Prog prog, String text, Anchor anchor, MatchKind kind, int nsubmatch) {
     return search(prog, text, 0, text.length(), text.length(), anchor, kind, nsubmatch);
   }
 
@@ -338,7 +337,7 @@ final class Nfa {
    * @return submatch positions as {@code int[2*nsubmatch]}, or null if no match. Positions are char
    *     indices into the full text.
    */
-  static SearchResult search(
+  static int[] search(
       Prog prog, String text, int startPos, Anchor anchor, MatchKind kind, int nsubmatch) {
     return search(prog, text, startPos, text.length(), text.length(), anchor, kind, nsubmatch);
   }
@@ -358,7 +357,7 @@ final class Nfa {
    * @return submatch positions as {@code int[2*nsubmatch]}, or null if no match. Positions are char
    *     indices into the full text.
    */
-  static SearchResult search(
+  static int[] search(
       Prog prog,
       String text,
       int startPos,
@@ -369,7 +368,7 @@ final class Nfa {
     return search(prog, text, startPos, searchLimit, text.length(), anchor, kind, nsubmatch);
   }
 
-  static SearchResult search(
+  static int[] search(
       Prog prog,
       String text,
       int startPos,
@@ -381,7 +380,7 @@ final class Nfa {
     return search(prog, text, startPos, searchLimit, endPos, 0, anchor, kind, nsubmatch);
   }
 
-  static SearchResult search(
+  static int[] search(
       Prog prog,
       String text,
       int startPos,
@@ -395,7 +394,7 @@ final class Nfa {
         prog, text, startPos, searchLimit, endPos, regionStart, anchor, kind, nsubmatch, null);
   }
 
-  static SearchResult search(
+  static int[] search(
       Prog prog,
       String text,
       int startPos,
@@ -425,7 +424,7 @@ final class Nfa {
         graphemeContext);
   }
 
-  static SearchResult search(
+  static int[] search(
       Prog prog,
       String text,
       int startPos,
@@ -457,7 +456,7 @@ final class Nfa {
         graphemeContext);
   }
 
-  static SearchResult search(
+  static int[] search(
       Prog prog,
       String text,
       int startPos,
@@ -475,7 +474,7 @@ final class Nfa {
       int nsubmatch,
       GraphemeSupport.Context graphemeContext) {
     if (prog.start() == 0) {
-      return new SearchResult(null);
+      return null;
     }
 
     boolean anchored = (anchor == Anchor.ANCHORED) || prog.anchorStart();

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -449,9 +449,6 @@ final class OnePass {
   // Search
   // -------------------------------------------------------------------------
 
-  @SuppressWarnings("ArrayRecordComponent")
-  record SearchResult(int[] groups) {}
-
   /**
    * Searches for a match in the given text starting at position 0. Convenience overload that
    * delegates to {@link #search(String, int, int, boolean, int)}.
@@ -461,7 +458,7 @@ final class OnePass {
    * @param nsubmatch number of submatch groups to track (including group 0)
    * @return submatch positions as {@code int[2*nsubmatch]}, or null if no match
    */
-  SearchResult search(String text, boolean endMatch, int nsubmatch) {
+  int[] search(String text, boolean endMatch, int nsubmatch) {
     return search(text, 0, text.length(), endMatch, nsubmatch);
   }
 
@@ -481,13 +478,13 @@ final class OnePass {
    * @param nsubmatch number of submatch groups to track (including group 0)
    * @return submatch positions relative to {@code text}, or null if no match
    */
-  SearchResult search(String text, int startPos, int endPos, boolean endMatch, int nsubmatch) {
+  int[] search(String text, int startPos, int endPos, boolean endMatch, int nsubmatch) {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
     return search(text, startPos, endPos, endMatch, nsubmatch, graphemeContext);
   }
 
-  private SearchResult search(
+  private int[] search(
       String text,
       int startPos,
       int endPos,
@@ -600,18 +597,18 @@ final class OnePass {
     }
 
     if (!matched) {
-      return new SearchResult(null);
+      return null;
     }
     if (endMatch && bestCap[1] != endPos) {
-      return new SearchResult(null);
+      return null;
     }
     if (anchorEnd && bestCap[1] != endPos) {
       // $ (dollarAnchorEnd) allows the match to end before a trailing line terminator.
       if (!dollarAnchorEnd || !Nfa.isAtTrailingLineTerminator(text, bestCap[1], unixLines)) {
-        return new SearchResult(null);
+        return null;
       }
     }
-    return new SearchResult(bestCap);
+    return bestCap;
   }
 
   /**
@@ -631,9 +628,9 @@ final class OnePass {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
     for (int start = startPos; start < limit; start++) {
-      SearchResult result = search(text, start, textLen, false, nsubmatch, graphemeContext);
-      if (result.groups() != null) {
-        return result.groups();
+      int[] result = search(text, start, textLen, false, nsubmatch, graphemeContext);
+      if (result != null) {
+        return result;
       }
       // Advance to next code point boundary.
       if (start < textLen) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -761,7 +761,11 @@ public final class Pattern implements Serializable {
       // must be excluded because OnePass returns leftmost-longest semantics, which disagrees
       // with JDK's leftmost-first (biased) semantics for nullable alternations.
       boolean canPrimary =
-          op != null && op.search("", false, 0) == null && !hasLazy && !hasNullableAlternation;
+          op != null
+              && op.search("", false, 0) == null
+              && !hasLazy
+              && !hasNullableAlternation
+              && !prog.hasGraphemeSemantics();
       // canFind is canPrimary restricted to anchored patterns (legacy flag).
       boolean canFind = canPrimary && prog.anchorStart();
       // OnePass can be used for the sandwich submatch extraction step (anchored, endMatch=true)

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -761,7 +761,11 @@ public final class Pattern implements Serializable {
       // must be excluded because OnePass returns leftmost-longest semantics, which disagrees
       // with JDK's leftmost-first (biased) semantics for nullable alternations.
       boolean canPrimary =
-          op != null && op.search("", false, 0) == null && !hasLazy && !hasNullableAlternation;
+          op != null
+              && op.search("", false, 0).groups() == null
+              && !hasLazy
+              && !hasNullableAlternation
+              && !prog.hasGraphemeSemantics();
       // canFind is canPrimary restricted to anchored patterns (legacy flag).
       boolean canFind = canPrimary && prog.anchorStart();
       // OnePass can be used for the sandwich submatch extraction step (anchored, endMatch=true)

--- a/safere/src/main/java/org/safere/SafeReDiagnostics.java
+++ b/safere/src/main/java/org/safere/SafeReDiagnostics.java
@@ -195,7 +195,7 @@ public final class SafeReDiagnostics {
 
   private static void appendResult(
       StringBuilder json, Prog prog, String input, Nfa.MatchKind matchKind) {
-    Nfa.SearchResult searchResult =
+    int[] groups =
         Nfa.search(
             prog,
             input,
@@ -207,7 +207,6 @@ public final class SafeReDiagnostics {
             matchKind,
             prog.numCaptures(),
             null);
-    int[] groups = searchResult.groups();
     json.append("\"result\":{");
     appendBooleanField(json, "matched", groups != null);
     json.append(',');

--- a/safere/src/test/java/org/safere/BitStateTest.java
+++ b/safere/src/test/java/org/safere/BitStateTest.java
@@ -40,8 +40,7 @@ class BitStateTest {
         endMatch
             ? Nfa.MatchKind.FULL_MATCH
             : (longest ? Nfa.MatchKind.LONGEST_MATCH : Nfa.MatchKind.FIRST_MATCH);
-    Nfa.SearchResult nfaSearchResult = Nfa.search(prog, text, Nfa.Anchor.ANCHORED, kind, nsubmatch);
-    int[] nfaResult = nfaSearchResult.groups();
+    int[] nfaResult = Nfa.search(prog, text, Nfa.Anchor.ANCHORED, kind, nsubmatch);
 
     assertCapturesEqual(pattern, text, bsResult, nfaResult);
   }
@@ -53,9 +52,8 @@ class BitStateTest {
     int nsubmatch = prog.numCaptures();
 
     int[] bsResult = BitState.search(prog, text, false, false, false, nsubmatch);
-    Nfa.SearchResult nfaSearchResult =
+    int[] nfaResult =
         Nfa.search(prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FIRST_MATCH, nsubmatch);
-    int[] nfaResult = nfaSearchResult.groups();
 
     assertCapturesEqual(pattern, text, bsResult, nfaResult);
   }
@@ -106,8 +104,7 @@ class BitStateTest {
         tc.endMatch()
             ? Nfa.MatchKind.FULL_MATCH
             : (tc.longest() ? Nfa.MatchKind.LONGEST_MATCH : Nfa.MatchKind.FIRST_MATCH);
-    Nfa.SearchResult nfaSearchResult = Nfa.search(prog, tc.input(), anchor, kind, nsubmatch);
-    int[] nfaResult = nfaSearchResult.groups();
+    int[] nfaResult = Nfa.search(prog, tc.input(), anchor, kind, nsubmatch);
 
     assertThat(bsResult)
         .as("BitState should return the reusable result buffer for %s", tc)

--- a/safere/src/test/java/org/safere/CompilerTest.java
+++ b/safere/src/test/java/org/safere/CompilerTest.java
@@ -28,9 +28,9 @@ class CompilerTest {
   }
 
   private static boolean fullMatch(Prog prog, String text) {
-    Nfa.SearchResult result =
+    int[] result =
         Nfa.search(prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FULL_MATCH, prog.numCaptures());
-    return result.groups() != null;
+    return result != null;
   }
 
   // ---------------------------------------------------------------------------

--- a/safere/src/test/java/org/safere/DfaNfaTest.java
+++ b/safere/src/test/java/org/safere/DfaNfaTest.java
@@ -324,14 +324,14 @@ class DfaNfaTest {
     // Run NFA with matching settings.
     Nfa.Anchor nfaAnchor = anchored ? Nfa.Anchor.ANCHORED : Nfa.Anchor.UNANCHORED;
     Nfa.MatchKind nfaKind = longest ? Nfa.MatchKind.LONGEST_MATCH : Nfa.MatchKind.FIRST_MATCH;
-    Nfa.SearchResult nfaResult = Nfa.search(prog, tc.input(), nfaAnchor, nfaKind, 1);
+    int[] nfaResult = Nfa.search(prog, tc.input(), nfaAnchor, nfaKind, 1);
 
     if (dfaResult == null) {
       // DFA bailed out due to budget -- skip consistency check.
       return;
     }
 
-    boolean nfaMatched = (nfaResult.groups() != null);
+    boolean nfaMatched = (nfaResult != null);
     String mode = (anchored ? "anchored" : "unanchored") + " " + (longest ? "longest" : "first");
 
     assertThat(dfaResult.matched())
@@ -351,8 +351,7 @@ class DfaNfaTest {
 
     Nfa.Anchor nfaAnchor = anchored ? Nfa.Anchor.ANCHORED : Nfa.Anchor.UNANCHORED;
     Nfa.MatchKind nfaKind = longest ? Nfa.MatchKind.LONGEST_MATCH : Nfa.MatchKind.FIRST_MATCH;
-    Nfa.SearchResult nfaSearchResult = Nfa.search(prog, tc.input(), nfaAnchor, nfaKind, 1);
-    int[] nfaResult = nfaSearchResult.groups();
+    int[] nfaResult = Nfa.search(prog, tc.input(), nfaAnchor, nfaKind, 1);
 
     if (dfaResult == null) {
       return;

--- a/safere/src/test/java/org/safere/NfaTest.java
+++ b/safere/src/test/java/org/safere/NfaTest.java
@@ -26,8 +26,7 @@ class NfaTest {
     Regexp re = Parser.parse(pattern, FLAGS);
     Prog prog = Compiler.compile(re);
     return Nfa.search(
-            prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FIRST_MATCH, prog.numCaptures())
-        .groups();
+        prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FIRST_MATCH, prog.numCaptures());
   }
 
   /** Search with full-match semantics. */
@@ -35,8 +34,7 @@ class NfaTest {
     Regexp re = Parser.parse(pattern, FLAGS);
     Prog prog = Compiler.compile(re);
     return Nfa.search(
-            prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FULL_MATCH, prog.numCaptures())
-        .groups();
+        prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FULL_MATCH, prog.numCaptures());
   }
 
   /** Search with longest-match semantics. */
@@ -44,8 +42,7 @@ class NfaTest {
     Regexp re = Parser.parse(pattern, FLAGS);
     Prog prog = Compiler.compile(re);
     return Nfa.search(
-            prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.LONGEST_MATCH, prog.numCaptures())
-        .groups();
+        prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.LONGEST_MATCH, prog.numCaptures());
   }
 
   /** Search with anchored semantics. */
@@ -53,8 +50,7 @@ class NfaTest {
     Regexp re = Parser.parse(pattern, FLAGS);
     Prog prog = Compiler.compile(re);
     return Nfa.search(
-            prog, text, Nfa.Anchor.ANCHORED, Nfa.MatchKind.FIRST_MATCH, prog.numCaptures())
-        .groups();
+        prog, text, Nfa.Anchor.ANCHORED, Nfa.MatchKind.FIRST_MATCH, prog.numCaptures());
   }
 
   @Nested

--- a/safere/src/test/java/org/safere/OnePassTest.java
+++ b/safere/src/test/java/org/safere/OnePassTest.java
@@ -44,7 +44,7 @@ class OnePassTest {
     Prog prog = Compiler.compile(re);
     OnePass op = OnePass.build(prog);
     assertThat(op).as("Pattern '%s' should be one-pass", pattern).isNotNull();
-    return op.search(text, false, prog.numCaptures()).groups();
+    return op.search(text, false, prog.numCaptures());
   }
 
   /** Helper: run one-pass search (anchored, endMatch=true, full match). */
@@ -53,7 +53,7 @@ class OnePassTest {
     Prog prog = Compiler.compile(re);
     OnePass op = OnePass.build(prog);
     assertThat(op).as("Pattern '%s' should be one-pass", pattern).isNotNull();
-    return op.search(text, true, prog.numCaptures()).groups();
+    return op.search(text, true, prog.numCaptures());
   }
 
   /** Asserts that OnePass and NFA agree on an anchored search. */
@@ -64,11 +64,10 @@ class OnePassTest {
     if (op == null) {
       return; // not one-pass; skip
     }
-    int[] opResult = op.search(text, endMatch, prog.numCaptures()).groups();
+    int[] opResult = op.search(text, endMatch, prog.numCaptures());
     Nfa.MatchKind kind = endMatch ? Nfa.MatchKind.FULL_MATCH : Nfa.MatchKind.FIRST_MATCH;
-    Nfa.SearchResult nfaSearchResult =
+    int[] nfaResult =
         Nfa.search(prog, text, Nfa.Anchor.ANCHORED, kind, prog.numCaptures());
-    int[] nfaResult = nfaSearchResult.groups();
 
     if (nfaResult == null) {
       assertThat(opResult)

--- a/safere/src/test/java/org/safere/OnePassTest.java
+++ b/safere/src/test/java/org/safere/OnePassTest.java
@@ -66,8 +66,7 @@ class OnePassTest {
     }
     int[] opResult = op.search(text, endMatch, prog.numCaptures());
     Nfa.MatchKind kind = endMatch ? Nfa.MatchKind.FULL_MATCH : Nfa.MatchKind.FIRST_MATCH;
-    int[] nfaResult =
-        Nfa.search(prog, text, Nfa.Anchor.ANCHORED, kind, prog.numCaptures());
+    int[] nfaResult = Nfa.search(prog, text, Nfa.Anchor.ANCHORED, kind, prog.numCaptures());
 
     if (nfaResult == null) {
       assertThat(opResult)

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -52,9 +52,9 @@ class ParserTest {
   private static boolean fullMatch(String pattern, String text, int flags) {
     Regexp re = Parser.parse(pattern, flags);
     Prog prog = Compiler.compile(re);
-    Nfa.SearchResult result =
+    int[] result =
         Nfa.search(prog, text, Nfa.Anchor.UNANCHORED, Nfa.MatchKind.FULL_MATCH, prog.numCaptures());
-    return result.groups() != null;
+    return result != null;
   }
 
   private static long bestParseTimeNanos(String pattern) {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -18,6 +18,21 @@ import org.junit.jupiter.params.provider.CsvSource;
 class PatternInternalTest {
 
   @Test
+  void testOnePassEligibility() {
+    Pattern p1 =
+        Pattern.compile(
+            "\\s*[\\[\\x{FF3B}]\\s*((?:[0-9]+\\.?){3,4}(?:\\s*[,\\x{3001}]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\\x{FF3D}]");
+    assertThat(p1.onePass()).isNull();
+    assertThat(p1.canOnePassPrimary()).isFalse();
+
+    Pattern p2 = Pattern.compile("\\b[Ff]ormer [Cc][Ee][Oo] ([Aa]lice\\b|\\*\\*[Aa]lice\\*\\*)");
+    assertThat(p2.onePass()).isNotNull();
+    assertThat(p2.canOnePassPrimary()).isTrue();
+    assertThat(p2.canOnePassFind()).isFalse();
+    assertThat(p2.canOnePassSubmatch()).isTrue();
+  }
+
+  @Test
   void numGroupsCounting() {
     Pattern p = Pattern.compile("(a)(b)(c)");
     assertThat(p.numGroups()).isEqualTo(3);

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -25,6 +25,20 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link Pattern}. */
 class PatternTest {
+  @Test
+  void testOnePassEligibility() {
+    Pattern p1 = Pattern.compile(
+        "\\s*[\\[\\x{FF3B}]\\s*((?:[0-9]+\\.?){3,4}(?:\\s*[,\\x{3001}]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\\x{FF3D}]");
+    assertThat(p1.onePass()).isNull();
+    assertThat(p1.canOnePassPrimary()).isFalse();
+
+    Pattern p2 = Pattern.compile("\\b[Ff]ormer [Cc][Ee][Oo] ([Aa]lice\\b|\\*\\*[Aa]lice\\*\\*)");
+    assertThat(p2.onePass()).isNotNull();
+    assertThat(p2.canOnePassPrimary()).isTrue();
+    assertThat(p2.canOnePassFind()).isFalse();
+    assertThat(p2.canOnePassSubmatch()).isTrue();
+  }
+
   private static final class LiteralCharSequence implements CharSequence {
     private final String value;
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -27,8 +27,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PatternTest {
   @Test
   void testOnePassEligibility() {
-    Pattern p1 = Pattern.compile(
-        "\\s*[\\[\\x{FF3B}]\\s*((?:[0-9]+\\.?){3,4}(?:\\s*[,\\x{3001}]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\\x{FF3D}]");
+    Pattern p1 =
+        Pattern.compile(
+            "\\s*[\\[\\x{FF3B}]\\s*((?:[0-9]+\\.?){3,4}(?:\\s*[,\\x{3001}]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\\x{FF3D}]");
     assertThat(p1.onePass()).isNull();
     assertThat(p1.canOnePassPrimary()).isFalse();
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -25,20 +25,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link Pattern}. */
 class PatternTest {
-  @Test
-  void testOnePassEligibility() {
-    Pattern p1 =
-        Pattern.compile(
-            "\\s*[\\[\\x{FF3B}]\\s*((?:[0-9]+\\.?){3,4}(?:\\s*[,\\x{3001}]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\\x{FF3D}]");
-    assertThat(p1.onePass()).isNull();
-    assertThat(p1.canOnePassPrimary()).isFalse();
-
-    Pattern p2 = Pattern.compile("\\b[Ff]ormer [Cc][Ee][Oo] ([Aa]lice\\b|\\*\\*[Aa]lice\\*\\*)");
-    assertThat(p2.onePass()).isNotNull();
-    assertThat(p2.canOnePassPrimary()).isTrue();
-    assertThat(p2.canOnePassFind()).isFalse();
-    assertThat(p2.canOnePassSubmatch()).isTrue();
-  }
 
   private static final class LiteralCharSequence implements CharSequence {
     private final String value;


### PR DESCRIPTION
This change fixes a regression that disabled the `OnePass` primary matching engine path in `Matcher.lookingAt()` and `Matcher.doFindCore()`.


In 25bf83b2037f715fc3ae474eeedcb7a80aa391c2 (Fix `hitEnd()` behavior) search engines were refactored to support the `hitEnd()` API. `OnePass.search()` was updated to return a `SearchResult` wrapper record instead of a raw `int[]` array (returning `new SearchResult(null)` on search failure). However, the OnePass eligibility check in `Pattern.java` was not updated and remained `op.search("", false, 0) == null`.

Since then `hitEnd()` / `requireEnd()` support was removed in bddf314.

This change reverts the unnecessary `SearchResult` wrapper and fixes the `OnePass` eligibility check, and adds test coverage.

```
./run-java-benchmarks.sh --fastbuild HttpBenchmark -p engine=SafeRE
```

| Benchmark | Baseline | `fix-onepass-primary-bug` | Speedup |
| :--- | :---: | :---: | :---: |
| **`HttpBenchmark.httpExtract_safere`** | 1,168.30 | 429.96 | **2.72x** |
| **`HttpBenchmark.httpFull_safere`** | 1,152.78 | 422.60 | **2.73x** |
| **`HttpBenchmark.httpSmall_safere`** | 239.62 | 104.77 | **2.29x** |
