### PR TITLE
Improve the performance for the RE2 FFM wrapper.

### DIFF
--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -21,6 +21,15 @@
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <!-- Build native shim library via cmake -->
@@ -131,6 +140,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
+        <configuration>
+          <argLine>-Djava.library.path=${project.basedir}/build</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmMatcher.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmMatcher.java
@@ -9,6 +9,7 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 /**
  * A matcher for a {@link RE2FfmPattern} against an input string. This is a benchmark-oriented
@@ -24,8 +25,7 @@ public final class RE2FfmMatcher {
   private String inputString;
   private byte[] inputUtf8;
 
-  // Mapping from UTF-8 byte offset to Java char offset. Built lazily.
-  private int[] byteToCharMap;
+  private int[] charToByteMap;
 
   // Match state: byte offsets from RE2. Length = 2 * (numGroups + 1).
   // [start0, end0, start1, end1, ...]
@@ -49,7 +49,7 @@ public final class RE2FfmMatcher {
   public RE2FfmMatcher reset(String input) {
     this.inputString = input;
     this.inputUtf8 = input.getBytes(StandardCharsets.UTF_8);
-    this.byteToCharMap = null;
+    buildCharToByteMap(inputString, inputUtf8);
     this.matchByteOffsets = new int[2 * (pattern.numGroups() + 1)];
     this.matched = false;
     this.searchBytePos = 0;
@@ -334,52 +334,72 @@ public final class RE2FfmMatcher {
     }
   }
 
-  /** Lazily build the byte-to-char offset mapping. */
-  private int[] getByteToCharMap() {
-    if (byteToCharMap == null) {
-      // Build a mapping from byte offset -> char offset.
-      byteToCharMap = new int[inputUtf8.length + 1];
-      int charIdx = 0;
-      int byteIdx = 0;
-      while (byteIdx < inputUtf8.length) {
-        byteToCharMap[byteIdx] = charIdx;
-        // Determine UTF-8 byte length of this code point.
-        int b = inputUtf8[byteIdx] & 0xFF;
-        int seqLen;
-        if (b < 0x80) {
-          seqLen = 1;
-        } else if (b < 0xE0) {
-          seqLen = 2;
-        } else if (b < 0xF0) {
-          seqLen = 3;
-        } else {
-          seqLen = 4;
+  private void buildCharToByteMap(String s, byte[] bytes) {
+    if (bytes.length == s.length()) {
+      boolean ok = true;
+      for (int i = 0; i < bytes.length; i++) {
+        if (bytes[i] == '?' && s.charAt(i) != '?') {
+          ok = false;
+          break;
         }
-        // Fill intermediate byte offsets to point at the same char.
-        for (int j = 1; j < seqLen && byteIdx + j < inputUtf8.length; j++) {
-          byteToCharMap[byteIdx + j] = charIdx;
-        }
-        byteIdx += seqLen;
-        // Supplementary code points (4-byte UTF-8) use 2 chars in UTF-16.
-        charIdx += (seqLen == 4) ? 2 : 1;
       }
-      byteToCharMap[inputUtf8.length] = charIdx;
+      if (ok) {
+        charToByteMap = null;
+        return;
+      }
     }
-    return byteToCharMap;
+
+    charToByteMap = new int[s.length()];
+    for (int byteI = 0, charI = 0; byteI < bytes.length; ) {
+      byte b = bytes[byteI];
+      int len;
+      if (b >= 0) {
+        charToByteMap[charI++] = byteI;
+        len = 1;
+      } else {
+        len = Integer.numberOfLeadingZeros(~(b << 24));
+        if (charI < charToByteMap.length) {
+          charToByteMap[charI++] = byteI;
+        }
+        if (len == 4) {
+          if (charI < charToByteMap.length) {
+            charToByteMap[charI++] = byteI + 2;
+          }
+        }
+      }
+      byteI += len;
+    }
   }
 
-  private int byteOffsetToCharOffset(int byteOffset) {
-    return getByteToCharMap()[byteOffset];
+  int byteOffsetToCharOffset(int byteOffset) {
+    if (charToByteMap == null) {
+      return byteOffset;
+    }
+    if (byteOffset <= 0) {
+      return 0;
+    }
+    if (byteOffset >= inputUtf8.length) {
+      return inputString.length();
+    }
+
+    int i = Arrays.binarySearch(charToByteMap, byteOffset);
+    if (i < 0) {
+      i = -(i + 1); // insertion point (round up)
+    }
+    return i;
   }
 
   private int charOffsetToByteOffset(int charOffset) {
-    // Walk the byte-to-char map to find the byte offset.
-    int[] map = getByteToCharMap();
-    if (charOffset == 0) return 0;
-    for (int i = 0; i <= inputUtf8.length; i++) {
-      if (map[i] == charOffset) return i;
+    if (charToByteMap == null) {
+      return charOffset;
     }
-    return inputUtf8.length;
+    if (charOffset <= 0) {
+      return 0;
+    }
+    if (charOffset >= inputString.length()) {
+      return inputUtf8.length;
+    }
+    return charToByteMap[charOffset];
   }
 
   private void checkMatch() {

--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmPattern.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmPattern.java
@@ -108,20 +108,52 @@ public final class RE2FfmPattern {
    */
   public String[] split(CharSequence input, int limit) {
     String text = input.toString();
+    byte[] inputUtf8 = text.getBytes(StandardCharsets.UTF_8);
+
     RE2FfmMatcher matcher = matcher(text);
+
+    // Start with a buffer for the expected matches (or a default of 128).
+    // The buffer size is doubled dynamically inside the loop if the text contains more matches.
+    int maxMatches = (limit > 0) ? limit : 128;
+    int numMatches;
+    int[] byteOffsets;
+
+    while (true) {
+      try (Arena arena = Arena.ofConfined()) {
+        MemorySegment textSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, inputUtf8);
+        MemorySegment matchesSeg = arena.allocate(ValueLayout.JAVA_INT, 2L * maxMatches);
+
+        numMatches = Re2Shim.findAll(nativeHandle, textSeg, inputUtf8.length, matchesSeg, maxMatches);
+
+        if (numMatches < maxMatches || limit > 0) {
+          byteOffsets = new int[2 * numMatches];
+          MemorySegment.copy(matchesSeg, ValueLayout.JAVA_INT, 0, byteOffsets, 0, 2 * numMatches);
+          break;
+        }
+        maxMatches *= 2;
+      }
+    }
+
     List<String> parts = new ArrayList<>();
     int last = 0;
 
-    while (matcher.find()) {
+    for (int i = 0; i < numMatches; i++) {
       if (limit > 0 && parts.size() >= limit - 1) {
         break;
       }
-      if (last == 0 && matcher.start() == 0 && matcher.end() == 0) {
+      int startByte = byteOffsets[2 * i];
+      int endByte = byteOffsets[2 * i + 1];
+
+      int startChar = matcher.byteOffsetToCharOffset(startByte);
+      int endChar = matcher.byteOffsetToCharOffset(endByte);
+
+      if (last == 0 && startChar == 0 && endChar == 0) {
         continue;
       }
-      parts.add(text.substring(last, matcher.start()));
-      last = matcher.end();
+      parts.add(text.substring(last, startChar));
+      last = endChar;
     }
+
     if (last == 0) {
       return new String[] {text};
     }

--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmPattern.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/RE2FfmPattern.java
@@ -123,7 +123,8 @@ public final class RE2FfmPattern {
         MemorySegment textSeg = arena.allocateFrom(ValueLayout.JAVA_BYTE, inputUtf8);
         MemorySegment matchesSeg = arena.allocate(ValueLayout.JAVA_INT, 2L * maxMatches);
 
-        numMatches = Re2Shim.findAll(nativeHandle, textSeg, inputUtf8.length, matchesSeg, maxMatches);
+        numMatches =
+            Re2Shim.findAll(nativeHandle, textSeg, inputUtf8.length, matchesSeg, maxMatches);
 
         if (numMatches < maxMatches || limit > 0) {
           byteOffsets = new int[2 * numMatches];

--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/Re2Shim.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/Re2Shim.java
@@ -29,6 +29,7 @@ final class Re2Shim {
   private static final MethodHandle NUM_CAPTURING_GROUPS;
   private static final MethodHandle FULL_MATCH;
   private static final MethodHandle FIND;
+  private static final MethodHandle FIND_ALL;
   private static final MethodHandle REPLACE_ALL;
 
   static {
@@ -122,6 +123,19 @@ final class Re2Shim {
                 ValueLayout.ADDRESS,
                 ValueLayout.JAVA_INT,
                 ValueLayout.ADDRESS));
+
+    // int re2_find_all(const re2_pattern_t* p, const char* text, int text_len,
+    //                  int32_t* matches_out, int max_matches)
+    FIND_ALL =
+        linker.downcallHandle(
+            lookup.find("re2_find_all").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_INT,
+                ValueLayout.ADDRESS,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_INT,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_INT));
   }
 
   private Re2Shim() {}
@@ -192,6 +206,19 @@ final class Re2Shim {
       int nmatches) {
     try {
       return (boolean) FIND.invokeExact(handle, text, textLen, startpos, matchesOut, nmatches);
+    } catch (Throwable t) {
+      throw new AssertionError("FFM call failed", t);
+    }
+  }
+
+  static int findAll(
+      MemorySegment handle,
+      MemorySegment text,
+      int textLen,
+      MemorySegment matchesOut,
+      int maxMatches) {
+    try {
+      return (int) FIND_ALL.invokeExact(handle, text, textLen, matchesOut, maxMatches);
     } catch (Throwable t) {
       throw new AssertionError("FFM call failed", t);
     }

--- a/safere-ffm-re2/src/main/native/re2_shim.cpp
+++ b/safere-ffm-re2/src/main/native/re2_shim.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
 // See LICENSE file in the project root for details.
 
-#include "third_party/java/safere/safere-ffm-re2/src/main/native/re2_shim.h"
+#include "re2_shim.h"
 #include <cstring>
 #include <string>
 #include <vector>

--- a/safere-ffm-re2/src/main/native/re2_shim.cpp
+++ b/safere-ffm-re2/src/main/native/re2_shim.cpp
@@ -1,9 +1,7 @@
 // Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
 // See LICENSE file in the project root for details.
 
-#include "re2_shim.h"
-
-#include <algorithm>
+#include "third_party/java/safere/safere-ffm-re2/src/main/native/re2_shim.h"
 #include <cstring>
 #include <string>
 #include <vector>
@@ -91,6 +89,47 @@ bool re2_find(const re2_pattern_t* p, const char* text, int text_len,
     }
   }
   return true;
+}
+
+int re2_find_all(const re2_pattern_t* p, const char* text, int text_len,
+                 int32_t* matches_out, int max_matches) {
+  if (!p || !p->re2->ok()) return 0;
+
+  absl::string_view input(text, text_len);
+  int count = 0;
+  int start_pos = 0;
+  absl::string_view match;
+
+  while (count < max_matches) {
+    if (!p->re2->Match(input, start_pos, text_len, RE2::UNANCHORED, &match,
+                       1)) {
+      break;
+    }
+    int32_t start = static_cast<int32_t>(match.data() - text);
+    int32_t end = static_cast<int32_t>(match.data() - text + match.size());
+    matches_out[2 * count] = start;
+    matches_out[2 * count + 1] = end;
+    count++;
+
+    if (start == end) {
+      if (start_pos >= text_len) {
+        break;
+      }
+      unsigned char c = static_cast<unsigned char>(text[start_pos]);
+      if (c < 0x80) {
+        start_pos += 1;
+      } else if (c < 0xE0) {
+        start_pos += 2;
+      } else if (c < 0xF0) {
+        start_pos += 3;
+      } else {
+        start_pos += 4;
+      }
+    } else {
+      start_pos = end;
+    }
+  }
+  return count;
 }
 
 int re2_replace_all(const re2_pattern_t* p,

--- a/safere-ffm-re2/src/main/native/re2_shim.h
+++ b/safere-ffm-re2/src/main/native/re2_shim.h
@@ -50,6 +50,12 @@ bool re2_full_match(const re2_pattern_t* p, const char* text, int text_len);
 bool re2_find(const re2_pattern_t* p, const char* text, int text_len,
               int startpos, int32_t* matches_out, int nmatches);
 
+// Finds all matches in the text. Writes start/end offsets sequentially into
+// matches_out (length = 2 * max_matches).
+// Returns the total number of matches found.
+int re2_find_all(const re2_pattern_t* p, const char* text, int text_len,
+                 int32_t* matches_out, int max_matches);
+
 // Replace all occurrences of the pattern in text with rewrite.
 // Writes the result into out_buf (up to out_cap bytes) and sets *out_len
 // to the actual result length. Returns the number of replacements made,

--- a/safere-ffm-re2/src/test/java/org/safere/re2ffm/RE2FfmTest.java
+++ b/safere-ffm-re2/src/test/java/org/safere/re2ffm/RE2FfmTest.java
@@ -1,0 +1,61 @@
+package org.safere.re2ffm;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class RE2FfmTest {
+
+  public RE2FfmTest() {}
+
+  @Test
+  public void testSimpleSplit() {
+    RE2FfmPattern p = RE2FfmPattern.compile(",");
+    String[] parts = p.split("a,b,c");
+    assertArrayEquals(new String[] {"a", "b", "c"}, parts);
+  }
+
+  @Test
+  public void testSplitLimit() {
+    RE2FfmPattern p = RE2FfmPattern.compile(",");
+    String[] parts = p.split("a,b,c", 2);
+    assertArrayEquals(new String[] {"a", "b,c"}, parts);
+  }
+
+  @Test
+  public void testNonAsciiMapping() {
+    // "hello, \u4e16\u754c" ("hello, 世界")
+    // "世界" starts at char offset 7.
+    // "世" in UTF-8 is 3 bytes: \xE4\xB8\x96.
+    // "界" in UTF-8 is 3 bytes: \xE5\x85\x8C.
+    RE2FfmPattern p = RE2FfmPattern.compile("世界");
+    RE2FfmMatcher m = p.matcher("hello, 世界!");
+
+    assertTrue(m.find());
+    assertEquals(7, m.start());
+    assertEquals(9, m.end());
+    assertEquals("世界", m.group());
+  }
+
+  @Test
+  public void testSurrogatePairs() {
+    // \uD83D\uDE00 is the emoji grinning face 😀 (1 character point, 2 Java chars, 4 UTF-8 bytes)
+    String text = "hello \uD83D\uDE00 world";
+    RE2FfmPattern p = RE2FfmPattern.compile("\uD83D\uDE00");
+    RE2FfmMatcher m = p.matcher(text);
+
+    assertTrue(m.find());
+    assertEquals(6, m.start());
+    assertEquals(8, m.end());
+    assertEquals("\uD83D\uDE00", m.group());
+
+    // Split around surrogate
+    String[] parts = p.split(text);
+    assertArrayEquals(new String[] {"hello ", " world"}, parts);
+  }
+}


### PR DESCRIPTION
Improve the performance for the RE2 FFM wrapper.

* Replace flat byte-to-char mapping array (which required O(N) scans for reverse lookups) with mapping array that indexes from characters to bytes, and does binary search for byte-to-character lookups, eliminating a bottleneck on long strings.
* Add `re2_find_all()` to collect all non-overlapping match boundaries in a single linear pass, and use it to implement `split()`.

This is sort of related to #490, but unlike critical calls these optimizations don't come up any real tradeoffs, and make the comparison to RE2-FFM a bit closer to a production solution.

The following benchmark shows performance of `split()` on a long string, SafeRE is still coming out ahead here but this makes the RE2-FFM performance less pathological. (The SafeRE numbers here were also stacked on top of other changes including #549 to may not reproduce exactly against `main`.)

```
./run-java-benchmarks.sh --fastbuild '^org\.safere\.benchmark\.Issue481ScalingBenchmark\.split.*_(safere|re2ffm)$' -- -p textSize=102400,1048576
```

| Input Size | SafeRE (us/op) | Baseline FFM (us/op) | Optimized FFM (us/op) | FFM Optimization Speedup | Optimized FFM vs SafeRE |
| :--- | :---: | :---: | :---: | :---: | :---: |
| **100KB** (`102400`) | 1,928.49 | 42,887.64 | 4,679.21 | **9.17x** | 2.42x slower |
| **1MB** (`1048576`) | 19,019.42 | 5,186,341.35 | 43,453.90 | **119.35x** | 2.28x slower |

