### PR TITLE
Fix literal prefix extraction from nested capturing groups

### DIFF
--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1538,11 +1538,10 @@ public final class Pattern implements Serializable {
     }
     if (node.op == RegexpOp.CONCAT) {
       for (Regexp child : node.subs) {
-        Regexp candidate = unwrapCaptures(child);
-        if (candidate == null || isLeadingZeroWidth(candidate)) {
-          continue;
+        Regexp candidate = firstPrefixCandidate(child);
+        if (candidate != null) {
+          return candidate;
         }
-        return candidate;
       }
       return null;
     }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1532,20 +1532,22 @@ public final class Pattern implements Serializable {
   }
 
   private static Regexp firstPrefixCandidate(Regexp re) {
-    Regexp node = unwrapCaptures(re);
-    if (node == null) {
-      return null;
-    }
-    if (node.op == RegexpOp.CONCAT) {
-      for (Regexp child : node.subs) {
-        Regexp candidate = firstPrefixCandidate(child);
-        if (candidate != null) {
-          return candidate;
-        }
+    Deque<Regexp> stack = new ArrayDeque<>();
+    stack.push(re);
+    while (!stack.isEmpty()) {
+      Regexp node = unwrapCaptures(stack.pop());
+      if (node == null || isLeadingZeroWidth(node)) {
+        continue;
       }
-      return null;
+      if (node.op == RegexpOp.CONCAT) {
+        for (int i = node.subs.size() - 1; i >= 0; i--) {
+          stack.push(node.subs.get(i));
+        }
+      } else {
+        return node;
+      }
     }
-    return isLeadingZeroWidth(node) ? null : node;
+    return null;
   }
 
   private static boolean isLeadingZeroWidth(Regexp re) {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -203,4 +203,17 @@ class PatternInternalTest {
     }
     return regex.toString();
   }
+
+  @Test
+  void prefixExtractionFromNestedCaptureInConcat() {
+    Pattern p1 = Pattern.compile("(foo bar)baz");
+    assertThat(p1.prefix()).isEqualTo("foo bar");
+
+    Pattern p2 = Pattern.compile("(<template name>.*)");
+    assertThat(p2.prefix()).isEqualTo("<template name>");
+
+    // reproducing the actual templateTagMatch pattern structure
+    Pattern p3 = Pattern.compile("(<template name>.*)([^>])");
+    assertThat(p3.prefix()).isEqualTo("<template name>");
+  }
 }

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -134,6 +134,13 @@ class PatternInternalTest {
   }
 
   @Test
+  void deeplyNestedConcatPrefixExtractionIsStackSafe() {
+    Pattern p = Pattern.compile(nestedPrefixConcatPattern(1_000));
+
+    assertThat(p.prefix()).isEqualTo("foo");
+  }
+
+  @Test
   void caseInsensitiveAsciiLiteralUsesLiteralMatchMetadata() {
     Pattern p = Pattern.compile("(?i)i");
 
@@ -200,6 +207,18 @@ class PatternInternalTest {
     regex.append('a');
     for (int i = 0; i < depth; i++) {
       regex.append("|b)");
+    }
+    return regex.toString();
+  }
+
+  private static String nestedPrefixConcatPattern(int depth) {
+    StringBuilder regex = new StringBuilder(depth * 3 + 3);
+    for (int i = 0; i < depth; i++) {
+      regex.append('(');
+    }
+    regex.append("foo");
+    for (int i = 0; i < depth; i++) {
+      regex.append(")x");
     }
     return regex.toString();
   }


### PR DESCRIPTION
Fix firstPrefixCandidate to recursively check nested concatenations inside capturing groups. This allows literal prefix acceleration to apply to patterns like `(prefix.*)([^>])`.

The `templateTagMatch` benchmark is an example of the pattern that literal prefix acceleration can apply to with this fix.

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark.runBenchmark -- \
  -p patternName=templateTagMatch \
  -p engine=SafeRE
```

| Input Size | Match | Baseline (ns/op) | Experiment (ns/op) | Speedup Ratio |
| :--- | :---: | :---: | :---: | :---: |
| **1,000** | `false` | 549.8 | 129.0 | **4.26x** |
| | `true` | 6,875.3 | 3,886.4 | **1.77x** |
| **10,000** | `false` | 5,160.2 | 1,021.4 | **5.05x** |
| | `true` | 68,347.5 | 40,152.6 | **1.70x** |
| **100,000** | `false` | 51,113.9 | 9,847.3 | **5.19x** |
| | `true` | 669,484.3 | 406,844.2 | **1.65x** |
