### PR TITLE
Optimize replacement operations with OnePass fast path

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -424,6 +424,19 @@
         "nonMatchInput": {
           "kind": "repeat"
         }
+      },
+      {
+        "name": "onePassReplace",
+        "pattern": "http://[a-z]+/([a-z]+)",
+        "op": "replaceAllGroup1",
+        "match": "http://foo/bar",
+        "nonMatch": "hello world",
+        "matchInput": {
+          "kind": "repeat"
+        },
+        "nonMatchInput": {
+          "kind": "repeat"
+        }
       }
     ]
   },

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -136,6 +136,7 @@ public class RealWorldRegexBenchmark {
     "jsonBlock",
     "charReplace",
     "greedyOnePass",
+    "onePassReplace",
     "layoutBlock",
     "turnTitleWhitespaceCjk",
     "cjkSearch",

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -3268,6 +3268,7 @@ public final class Matcher implements MatchResult {
     private final String replacement;
     private final int maxGroup;
     private ReplacementSegment[] value;
+    private Boolean needsCaptures;
 
     LazyTemplate(String replacement, int maxGroup) {
       this.replacement = replacement;
@@ -3275,6 +3276,13 @@ public final class Matcher implements MatchResult {
     }
 
     boolean needsCaptures() {
+      if (needsCaptures == null) {
+        needsCaptures = computeNeedsCaptures();
+      }
+      return needsCaptures;
+    }
+
+    private boolean computeNeedsCaptures() {
       if (replacement == null) {
         return false;
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2187,13 +2187,13 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
+    reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String result = replaceOnePass(template, 1);
     if (result != null) {
       return result;
     }
 
-    reset();
     result = replaceDfaOptimized(template, 1);
     if (result != null) {
       return result;
@@ -2509,6 +2509,9 @@ public final class Matcher implements MatchResult {
       int matchEnd = matchOffsets[base + 1];
 
       System.arraycopy(matchOffsets, base, groups, 0, ncap);
+      capturesResolved = true;
+      groupZeroResolved = true;
+      resultStatus = ResultStatus.MATCHED;
 
       sb.append(text, appendPos, matchStart);
       applyReplacementTemplate(sb, compiledTemplate);
@@ -2542,13 +2545,13 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
+    reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String result = replaceOnePass(template, Integer.MAX_VALUE);
     if (result != null) {
       return result;
     }
 
-    reset();
     result = replaceDfaOptimized(template, Integer.MAX_VALUE);
     if (result != null) {
       return result;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1490,18 +1490,14 @@ public final class Matcher implements MatchResult {
       int earlyEnd = fwdResult.pos();
 
       if (prog.anchorStart()) {
-        // Anchored: match start is effectiveStart. Run forward DFA (anchored, first-match) to find
-        // actual end, then defer inner captures until requested.
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
-        if (fwdFirst != null && fwdFirst.matched()) {
-          int matchEnd = fwdFirst.pos();
-          return applyDeferredMatchResult(
-              effectiveStart,
-              matchEnd,
-              prog.numCaptures(),
-              parentPattern.dfaGroupZeroReliable(),
-              false);
-        }
+        // Anchored: match start is effectiveStart. Since it is start-anchored, the match end
+        // is guaranteed to be earlyEnd. Avoid redundant third DFA search.
+        return applyDeferredMatchResult(
+            effectiveStart,
+            earlyEnd,
+            prog.numCaptures(),
+            parentPattern.dfaGroupZeroReliable(),
+            false);
       } else {
         if (literalPrefixCandidateStart) {
           // A literal prefix occurrence is a candidate match start, even when the prefix is
@@ -2256,20 +2252,22 @@ public final class Matcher implements MatchResult {
       }
 
       int matchStart;
+      int matchEnd;
       if (isStartAnchored) {
         matchStart = pos;
+        matchEnd = earlyEnd;
       } else {
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched()) {
           return null;
         }
         matchStart = revResult.pos();
+        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+        if (fwdFirst == null || !fwdFirst.matched()) {
+          return null;
+        }
+        matchEnd = fwdFirst.pos();
       }
-      Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
-      if (fwdFirst == null || !fwdFirst.matched()) {
-        return null;
-      }
-      int matchEnd = fwdFirst.pos();
 
       if (compiledTemplate == null) {
         compiledTemplate = template.get();

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -78,6 +78,7 @@ public final class Matcher implements MatchResult {
   private CharSequence inputSequence;
   private String text;
   private int[] groups;
+  private int[] matchOffsets;
   private boolean hasMatch;
   private ResultStatus resultStatus = ResultStatus.RESET_NO_ATTEMPT;
   private int searchFrom;
@@ -2183,9 +2184,9 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
-    LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     reset();
-    String fastResult = charClassReplaceFastPath(replacement, 1);
+    String fastResult = charClassReplaceFastPath(template, 1);
     if (fastResult != null) {
       return fastResult;
     }
@@ -2204,18 +2205,16 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private String replaceDfaOptimized(LazyTemplate template, int limit) {
+  private String replaceDfaOptimized(ReplacementSegment[] compiledTemplate, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
     if (!canUseForwardDfa()
         || !parentPattern.dfaGroupZeroReliable()
         || parentPattern.prog().dollarAnchorEnd()
+        || parentPattern.literalMatch() != null
+        || templateNeedsCaptures(compiledTemplate)
         || regionActive) {
       return null;
     }
-
-    ReplacementSegment[] compiledTemplate = null;
-    int textLen = text.length();
-    int pos = searchFrom;
 
     Dfa fwdDfa = dfa(false);
     if (fwdDfa == null) {
@@ -2234,11 +2233,69 @@ public final class Matcher implements MatchResult {
     String prefix = parentPattern.prefix();
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
-    int matchesFound = 0;
-    int firstMatchStart = -1;
-    int firstMatchEnd = -1;
+
+    int matchesFound =
+        findDfaMatches(
+            fwdDfa, revDfa, isStartAnchored, prefix, foldCase, hasStartAcceleration, limit);
+
+    if (matchesFound < 0) {
+      return null;
+    }
+
+    if (matchesFound == 0) {
+      return text;
+    }
+
+    int textLen = text.length();
+    StringBuilder sb = new StringBuilder(textLen);
     int builderAppendPos = searchFrom;
-    StringBuilder sb = null;
+
+    for (int i = 0; i < matchesFound; i++) {
+      int matchStart = matchOffsets[2 * i];
+      int matchEnd = matchOffsets[2 * i + 1];
+
+      groups[0] = matchStart;
+      groups[1] = matchEnd;
+      sb.append(text, builderAppendPos, matchStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      builderAppendPos = matchEnd;
+    }
+    sb.append(text, builderAppendPos, textLen);
+
+    int firstMatchStart = matchOffsets[0];
+    int firstMatchEnd = matchOffsets[1];
+
+    if (groups == null) {
+      groups = new int[2 * parentPattern.prog().numCaptures()];
+    }
+
+    if (limit == 1) {
+      applyDeferredMatchResult(
+          firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
+      this.appendPos = firstMatchEnd;
+    } else {
+      applyFailedMatchResult();
+      this.appendPos = textLen;
+      this.searchFrom = textLen;
+    }
+    return sb.toString();
+  }
+
+  private int findDfaMatches(
+      Dfa fwdDfa,
+      Dfa revDfa,
+      boolean isStartAnchored,
+      String prefix,
+      boolean foldCase,
+      boolean hasStartAcceleration,
+      int limit) {
+    int textLen = text.length();
+    int pos = searchFrom;
+    int matchesFound = 0;
+
+    if (matchOffsets == null) {
+      matchOffsets = new int[16];
+    }
 
     while (pos <= textLen && matchesFound < limit) {
       if (parentPattern.prog().anchorStart() && pos > 0) {
@@ -2259,7 +2316,7 @@ public final class Matcher implements MatchResult {
 
       int earlyEnd = fwdResult.pos();
       if (earlyEnd <= pos) {
-        return null; // Fallback for empty match
+        return -1;
       }
 
       int matchStart;
@@ -2267,61 +2324,46 @@ public final class Matcher implements MatchResult {
       if (isStartAnchored) {
         matchStart = pos;
         matchEnd = earlyEnd;
+      } else if (hasStartAcceleration) {
+        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, pos, true, false);
+        if (fwdFirst != null && fwdFirst.matched()) {
+          matchStart = pos;
+          matchEnd = fwdFirst.pos();
+        } else {
+          Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+          if (revResult == null || !revResult.matched()) {
+            return -1;
+          }
+          matchStart = revResult.pos();
+          Dfa.SearchResult fwdFirst2 = fwdDfa.doSearch(text, matchStart, true, false);
+          if (fwdFirst2 == null || !fwdFirst2.matched()) {
+            return -1;
+          }
+          matchEnd = fwdFirst2.pos();
+        }
       } else {
         Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched()) {
-          return null;
+          return -1;
         }
         matchStart = revResult.pos();
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, matchStart, true, false);
         if (fwdFirst == null || !fwdFirst.matched()) {
-          return null;
+          return -1;
         }
         matchEnd = fwdFirst.pos();
       }
 
-      if (compiledTemplate == null) {
-        compiledTemplate = template.get();
-        if (templateNeedsCaptures(compiledTemplate)) {
-          return null;
-        }
-        sb = new StringBuilder(textLen);
+      if (2 * matchesFound >= matchOffsets.length) {
+        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
       }
-
-      groups[0] = matchStart;
-      groups[1] = matchEnd;
-      sb.append(text, builderAppendPos, matchStart);
-      applyReplacementTemplate(sb, compiledTemplate);
-      builderAppendPos = matchEnd;
-
-      if (matchesFound == 0) {
-        firstMatchStart = matchStart;
-        firstMatchEnd = matchEnd;
-      }
+      matchOffsets[2 * matchesFound] = matchStart;
+      matchOffsets[2 * matchesFound + 1] = matchEnd;
 
       pos = matchEnd;
       matchesFound++;
     }
-
-    if (matchesFound == 0) {
-      return text;
-    }
-
-    if (groups == null) {
-      groups = new int[2 * parentPattern.prog().numCaptures()];
-    }
-    sb.append(text, builderAppendPos, textLen);
-
-    if (limit == 1) {
-      applyDeferredMatchResult(
-          firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
-      this.appendPos = firstMatchEnd;
-    } else {
-      applyFailedMatchResult();
-      this.appendPos = textLen;
-      this.searchFrom = textLen;
-    }
-    return sb.toString();
+    return matchesFound;
   }
 
   /**
@@ -2356,9 +2398,9 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
-    LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     reset();
-    String fastResult = charClassReplaceFastPath(replacement, Integer.MAX_VALUE);
+    String fastResult = charClassReplaceFastPath(template, Integer.MAX_VALUE);
     if (fastResult != null) {
       return fastResult;
     }
@@ -2372,13 +2414,13 @@ public final class Matcher implements MatchResult {
       return text;
     }
     StringBuilder sb = new StringBuilder(text.length());
-    boolean needsCaptures = templateNeedsCaptures(template.get());
+    boolean needsCaptures = templateNeedsCaptures(template);
     do {
       if (needsCaptures || !groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
-      applyReplacementTemplate(sb, template.get());
+      applyReplacementTemplate(sb, template);
       appendPos = groups[1];
     } while (find());
     appendTail(sb);
@@ -2411,17 +2453,11 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
-  private String charClassReplaceFastPath(String replacement, int limit) {
+  private String charClassReplaceFastPath(ReplacementSegment[] template, int limit) {
     if (!enginePathOptions().charClassReplacementFastPath()
         || parentPattern.charClassMatchRanges() == null
         || parentPattern.charClassMatchAllowEmpty()
         || parentPattern.hasLazyQuantifiers()) {
-      return null;
-    }
-    ReplacementSegment[] template;
-    try {
-      template = compileReplacementTemplate(replacement, 0);
-    } catch (IllegalArgumentException e) {
       return null;
     }
     if (template.length != 1 || !(template[0] instanceof ReplacementSegment.Literal literalSeg)) {
@@ -3032,24 +3068,6 @@ public final class Matcher implements MatchResult {
       if (!hasMatch) {
         throw new IllegalStateException("No match found");
       }
-    }
-  }
-
-  private static final class LazyTemplate {
-    private final String replacement;
-    private final int maxGroup;
-    private ReplacementSegment[] value;
-
-    LazyTemplate(String replacement, int maxGroup) {
-      this.replacement = replacement;
-      this.maxGroup = maxGroup;
-    }
-
-    ReplacementSegment[] get() {
-      if (value == null) {
-        value = compileReplacementTemplate(replacement, maxGroup);
-      }
-      return value;
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -961,7 +961,8 @@ public final class Matcher implements MatchResult {
     return enginePathOptions().dfa()
         && enginePathOptions().reverseDfa()
         && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
-        && !parentPattern.prog().anchorStart();
+        && !parentPattern.prog().anchorStart()
+        && reverseDfa() != null;
   }
 
   /**
@@ -2186,13 +2187,151 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
+    LazyTemplate template = new LazyTemplate(replacement, groupCount());
     reset();
+    String result = replaceDfaOptimized(template, 1);
+    if (result != null) {
+      return result;
+    }
+
     if (!find()) {
       return text;
     }
     StringBuilder sb = new StringBuilder(text.length());
     appendReplacement(sb, replacement);
     appendTail(sb);
+    return sb.toString();
+  }
+
+  private String replaceDfaOptimized(LazyTemplate template, int limit) {
+    boolean regionActive = (regionStart != 0 || regionEnd != text.length());
+    if (!canUseForwardDfa() || !parentPattern.dfaGroupZeroReliable() || regionActive) {
+      return null;
+    }
+
+    ReplacementSegment[] compiledTemplate = null;
+    int textLen = text.length();
+    int pos = searchFrom;
+
+    Dfa fwdDfa = dfa(false);
+    if (fwdDfa == null) {
+      return null;
+    }
+
+    Dfa revDfa = null;
+    boolean isStartAnchored = parentPattern.prog().anchorStart();
+    if (!isStartAnchored) {
+      if (!canUseReverseDfa()) {
+        return null;
+      }
+      revDfa = reverseDfa();
+    }
+
+    String prefix = parentPattern.prefix();
+    boolean foldCase = parentPattern.prefixFoldCase();
+    boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
+    int matchesFound = 0;
+    int[] matchOffsets = null;
+
+    while (pos <= textLen && matchesFound < limit) {
+      if (parentPattern.prog().anchorStart() && pos > 0) {
+        break;
+      }
+      if (hasStartAcceleration && pos < textLen) {
+        int idx = foldCase ? indexOfIgnoreCase(text, prefix, pos) : text.indexOf(prefix, pos);
+        if (idx < 0) {
+          break;
+        }
+        pos = idx;
+      }
+
+      Dfa.SearchResult fwdResult = fwdDfa.doSearch(text, pos, false, false);
+      if (fwdResult == null || !fwdResult.matched()) {
+        break;
+      }
+
+      int earlyEnd = fwdResult.pos();
+      if (earlyEnd <= pos) {
+        return null; // Fallback for empty match
+      }
+
+      int matchStart;
+      if (isStartAnchored) {
+        matchStart = pos;
+      } else {
+        Dfa.SearchResult revResult = revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+        if (revResult == null || !revResult.matched()) {
+          return null;
+        }
+        matchStart = revResult.pos();
+      }
+      Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+      if (fwdFirst == null || !fwdFirst.matched()) {
+        return null;
+      }
+      int matchEnd = fwdFirst.pos();
+
+      if (compiledTemplate == null) {
+        compiledTemplate = template.get();
+        if (templateNeedsCaptures(compiledTemplate)) {
+          return null;
+        }
+        matchOffsets = new int[16];
+      }
+
+      if (2 * matchesFound >= matchOffsets.length) {
+        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
+      }
+
+      matchOffsets[2 * matchesFound] = matchStart;
+      matchOffsets[2 * matchesFound + 1] = matchEnd;
+
+      pos = matchEnd;
+      matchesFound++;
+    }
+
+    if (matchesFound == 0) {
+      return text;
+    }
+
+    if (groups == null) {
+      groups = new int[2 * parentPattern.prog().numCaptures()];
+    }
+    groups[0] = matchOffsets[0];
+    groups[1] = matchOffsets[1];
+
+    int totalMatchLength = 0;
+    for (int i = 0; i < matchesFound; i++) {
+      totalMatchLength += (matchOffsets[2 * i + 1] - matchOffsets[2 * i]);
+    }
+    int replacementLen = 0;
+    for (ReplacementSegment seg : compiledTemplate) {
+      if (seg instanceof ReplacementSegment.Literal literal) {
+        replacementLen += literal.text().length();
+      }
+    }
+    int finalCapacity = textLen - totalMatchLength + (matchesFound * replacementLen);
+
+    StringBuilder sb = new StringBuilder(finalCapacity);
+    int appendPos = searchFrom;
+    for (int i = 0; i < matchesFound; i++) {
+      int mStart = matchOffsets[2 * i];
+      int mEnd = matchOffsets[2 * i + 1];
+      groups[0] = mStart;
+      groups[1] = mEnd;
+      sb.append(text, appendPos, mStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      appendPos = mEnd;
+    }
+    sb.append(text, appendPos, textLen);
+
+    if (limit == 1) {
+      deferredMatchStart = groups[0];
+      deferredMatchEnd = groups[1];
+      capturesResolved = parentPattern.prog().numCaptures() <= 1;
+      groupZeroResolved = true;
+    }
+    resultStatus = (limit == 1) ? ResultStatus.MATCHED : ResultStatus.FAILED;
     return sb.toString();
   }
 
@@ -2228,20 +2367,24 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
+    LazyTemplate template = new LazyTemplate(replacement, groupCount());
     reset();
+    String result = replaceDfaOptimized(template, Integer.MAX_VALUE);
+    if (result != null) {
+      return result;
+    }
+
     if (!find()) {
       return text;
     }
-    // Pre-compile the replacement template once, avoiding per-match parseInt/substring overhead.
-    ReplacementSegment[] template = compileReplacementTemplate(replacement, groupCount());
     StringBuilder sb = new StringBuilder(text.length());
-    boolean needsCaptures = templateNeedsCaptures(template);
+    boolean needsCaptures = templateNeedsCaptures(template.get());
     do {
       if (needsCaptures || !groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
-      applyReplacementTemplate(sb, template);
+      applyReplacementTemplate(sb, template.get());
       appendPos = groups[1];
     } while (find());
     appendTail(sb);
@@ -2796,6 +2939,24 @@ public final class Matcher implements MatchResult {
       if (!hasMatch) {
         throw new IllegalStateException("No match found");
       }
+    }
+  }
+
+  private static final class LazyTemplate {
+    private final String replacement;
+    private final int maxGroup;
+    private ReplacementSegment[] value;
+
+    LazyTemplate(String replacement, int maxGroup) {
+      this.replacement = replacement;
+      this.maxGroup = maxGroup;
+    }
+
+    ReplacementSegment[] get() {
+      if (value == null) {
+        value = compileReplacementTemplate(replacement, maxGroup);
+      }
+      return value;
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2333,8 +2333,14 @@ public final class Matcher implements MatchResult {
     if (limit == 1) {
       deferredMatchStart = groups[0];
       deferredMatchEnd = groups[1];
+      hasMatch = true;
       capturesResolved = parentPattern.prog().numCaptures() <= 1;
       groupZeroResolved = true;
+    } else {
+      hasMatch = false;
+      capturesResolved = false;
+      groupZeroResolved = false;
+      searchFrom = textLen;
     }
     resultStatus = (limit == 1) ? ResultStatus.MATCHED : ResultStatus.FAILED;
     return sb.toString();
@@ -2365,15 +2371,15 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean canUseOnePassReplace(LazyTemplate template) {
-    return template.replacement.indexOf('$') >= 0
+    return template.replacement != null
+        && template.replacement.indexOf('$') >= 0
         && regionStart == 0
         && regionEnd == text.length()
         && !parentPattern.prog().hasGraphemeSemantics()
         && !parentPattern.hasNullableAlternation()
         && parentPattern.canOnePassSubmatch()
         && (parentPattern.prog().anchorStart()
-            || (parentPattern.prefix() != null && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT))
-        && templateNeedsCaptures(template.get());
+            || (parentPattern.prefix() != null && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT));
   }
 
   // Helper for replaceAll using OnePass. Returns null if OnePass cannot be used.
@@ -2382,7 +2388,7 @@ public final class Matcher implements MatchResult {
       return null;
     }
 
-    ReplacementSegment[] compiledTemplate = template.get();
+    ReplacementSegment[] compiledTemplate = null;
 
     OnePass onePass = parentPattern.onePass();
     int textLen = text.length();
@@ -2394,6 +2400,7 @@ public final class Matcher implements MatchResult {
     int matchesFound = 0;
 
     String prefix = parentPattern.prefix();
+    boolean foldCase = parentPattern.prefixFoldCase();
     boolean anchorStart = parentPattern.prog().anchorStart();
 
     while (pos <= textLen && matchesFound < limit) {
@@ -2407,7 +2414,7 @@ public final class Matcher implements MatchResult {
           matchStart = pos;
         }
       } else {
-        int idx = text.indexOf(prefix, pos);
+        int idx = foldCase ? indexOfIgnoreCase(text, prefix, pos) : text.indexOf(prefix, pos);
         if (idx < 0) {
           break;
         }
@@ -2425,6 +2432,10 @@ public final class Matcher implements MatchResult {
       }
 
       if (matchOffsets == null) {
+        compiledTemplate = template.get();
+        if (!templateNeedsCaptures(compiledTemplate)) {
+          return null;
+        }
         matchOffsets = new int[16 * ncap];
       } else if ((matchesFound + 1) * ncap > matchOffsets.length) {
         matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
@@ -2522,6 +2533,7 @@ public final class Matcher implements MatchResult {
     if (limit == 1) {
       deferredMatchStart = groups[0];
       deferredMatchEnd = groups[1];
+      hasMatch = true;
       capturesResolved = parentPattern.prog().numCaptures() <= 1;
       groupZeroResolved = true;
       resultStatus = ResultStatus.MATCHED;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2201,7 +2201,10 @@ public final class Matcher implements MatchResult {
 
   private String replaceDfaOptimized(LazyTemplate template, int limit) {
     boolean regionActive = (regionStart != 0 || regionEnd != text.length());
-    if (!canUseForwardDfa() || !parentPattern.dfaGroupZeroReliable() || regionActive) {
+    if (!canUseForwardDfa()
+        || !parentPattern.dfaGroupZeroReliable()
+        || parentPattern.prog().dollarAnchorEnd()
+        || regionActive) {
       return null;
     }
 
@@ -2227,7 +2230,10 @@ public final class Matcher implements MatchResult {
     boolean foldCase = parentPattern.prefixFoldCase();
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
     int matchesFound = 0;
-    int[] matchOffsets = null;
+    int firstMatchStart = -1;
+    int firstMatchEnd = -1;
+    int builderAppendPos = searchFrom;
+    StringBuilder sb = null;
 
     while (pos <= textLen && matchesFound < limit) {
       if (parentPattern.prog().anchorStart() && pos > 0) {
@@ -2274,15 +2280,19 @@ public final class Matcher implements MatchResult {
         if (templateNeedsCaptures(compiledTemplate)) {
           return null;
         }
-        matchOffsets = new int[16];
+        sb = new StringBuilder(textLen);
       }
 
-      if (2 * matchesFound >= matchOffsets.length) {
-        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
-      }
+      groups[0] = matchStart;
+      groups[1] = matchEnd;
+      sb.append(text, builderAppendPos, matchStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      builderAppendPos = matchEnd;
 
-      matchOffsets[2 * matchesFound] = matchStart;
-      matchOffsets[2 * matchesFound + 1] = matchEnd;
+      if (matchesFound == 0) {
+        firstMatchStart = matchStart;
+        firstMatchEnd = matchEnd;
+      }
 
       pos = matchEnd;
       matchesFound++;
@@ -2295,41 +2305,17 @@ public final class Matcher implements MatchResult {
     if (groups == null) {
       groups = new int[2 * parentPattern.prog().numCaptures()];
     }
-    groups[0] = matchOffsets[0];
-    groups[1] = matchOffsets[1];
-
-    int totalMatchLength = 0;
-    for (int i = 0; i < matchesFound; i++) {
-      totalMatchLength += (matchOffsets[2 * i + 1] - matchOffsets[2 * i]);
-    }
-    int replacementLen = 0;
-    for (ReplacementSegment seg : compiledTemplate) {
-      if (seg instanceof ReplacementSegment.Literal literal) {
-        replacementLen += literal.text().length();
-      }
-    }
-    int finalCapacity = textLen - totalMatchLength + (matchesFound * replacementLen);
-
-    StringBuilder sb = new StringBuilder(finalCapacity);
-    int appendPos = searchFrom;
-    for (int i = 0; i < matchesFound; i++) {
-      int mStart = matchOffsets[2 * i];
-      int mEnd = matchOffsets[2 * i + 1];
-      groups[0] = mStart;
-      groups[1] = mEnd;
-      sb.append(text, appendPos, mStart);
-      applyReplacementTemplate(sb, compiledTemplate);
-      appendPos = mEnd;
-    }
-    sb.append(text, appendPos, textLen);
+    sb.append(text, builderAppendPos, textLen);
 
     if (limit == 1) {
-      deferredMatchStart = groups[0];
-      deferredMatchEnd = groups[1];
-      capturesResolved = parentPattern.prog().numCaptures() <= 1;
-      groupZeroResolved = true;
+      applyDeferredMatchResult(
+          firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
+      this.appendPos = firstMatchEnd;
+    } else {
+      applyFailedMatchResult();
+      this.appendPos = textLen;
+      this.searchFrom = textLen;
     }
-    resultStatus = (limit == 1) ? ResultStatus.MATCHED : ResultStatus.FAILED;
     return sb.toString();
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2653,7 +2653,8 @@ public final class Matcher implements MatchResult {
       return null;
     }
     ReplacementSegment[] compiledTemplate = template.get();
-    if (compiledTemplate.length != 1 || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
+    if (compiledTemplate.length != 1
+        || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
       return null;
     }
     String repText = literalSeg.text();

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2188,8 +2188,13 @@ public final class Matcher implements MatchResult {
    */
   public String replaceFirst(String replacement) {
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    String result = replaceOnePass(template, 1);
+    if (result != null) {
+      return result;
+    }
+
     reset();
-    String result = replaceDfaOptimized(template, 1);
+    result = replaceDfaOptimized(template, 1);
     if (result != null) {
       return result;
     }
@@ -2359,6 +2364,176 @@ public final class Matcher implements MatchResult {
     return sb.toString();
   }
 
+  private boolean canUseOnePassReplace(LazyTemplate template) {
+    return template.replacement.indexOf('$') >= 0
+        && regionStart == 0
+        && regionEnd == text.length()
+        && !parentPattern.prog().hasGraphemeSemantics()
+        && !parentPattern.hasNullableAlternation()
+        && parentPattern.canOnePassSubmatch()
+        && (parentPattern.prog().anchorStart()
+            || (parentPattern.prefix() != null && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT))
+        && templateNeedsCaptures(template.get());
+  }
+
+  // Helper for replaceAll using OnePass. Returns null if OnePass cannot be used.
+  private String replaceOnePass(LazyTemplate template, int limit) {
+    if (!canUseOnePassReplace(template)) {
+      return null;
+    }
+
+    ReplacementSegment[] compiledTemplate = template.get();
+
+    OnePass onePass = parentPattern.onePass();
+    int textLen = text.length();
+    int pos = 0;
+    int nsubmatch = parentPattern.prog().numCaptures();
+    int ncap = 2 * nsubmatch;
+
+    int[] matchOffsets = null;
+    int matchesFound = 0;
+
+    String prefix = parentPattern.prefix();
+    boolean anchorStart = parentPattern.prog().anchorStart();
+
+    while (pos <= textLen && matchesFound < limit) {
+      int matchStart = -1;
+      if (anchorStart) {
+        if (pos > 0) {
+          break;
+        }
+        OnePass.SearchResult result = onePass.search(text, pos, textLen, false, nsubmatch, groups);
+        if (result.groups() != null) {
+          matchStart = pos;
+        }
+      } else {
+        int idx = text.indexOf(prefix, pos);
+        if (idx < 0) {
+          break;
+        }
+        OnePass.SearchResult result = onePass.search(text, idx, textLen, false, nsubmatch, groups);
+        if (result.groups() != null) {
+          matchStart = idx;
+        } else {
+          pos = idx + 1;
+          continue;
+        }
+      }
+
+      if (matchStart < 0) {
+        break;
+      }
+
+      if (matchOffsets == null) {
+        matchOffsets = new int[16 * ncap];
+      } else if ((matchesFound + 1) * ncap > matchOffsets.length) {
+        matchOffsets = Arrays.copyOf(matchOffsets, matchOffsets.length * 2);
+      }
+
+      System.arraycopy(groups, 0, matchOffsets, matchesFound * ncap, ncap);
+      matchesFound++;
+
+      int nextPos = groups[1];
+      if (groups[0] == groups[1]) { // empty match
+        if (nextPos >= textLen) {
+          break;
+        }
+        nextPos++;
+      } else if (parentPattern.hasInternalGraphemeClusterBoundary()
+          && nextPos < textLen
+          && endedAfterCrLf(nextPos)) {
+        nextPos++;
+      }
+      pos = nextPos;
+
+      if (anchorStart) {
+        break;
+      }
+    }
+
+    if (matchesFound == 0) {
+      hasMatch = false;
+      capturesResolved = false;
+      groupZeroResolved = false;
+      searchFrom = 0;
+      return text;
+    }
+
+    // Calculate exact final capacity of the StringBuilder
+    int totalMatchLength = 0;
+    int totalReplacementLength = 0;
+    int literalReplacementLen = 0;
+    for (ReplacementSegment seg : compiledTemplate) {
+      if (seg instanceof ReplacementSegment.Literal literal) {
+        literalReplacementLen += literal.text().length();
+      }
+    }
+
+    for (int i = 0; i < matchesFound; i++) {
+      int base = i * ncap;
+      int matchStart = matchOffsets[base];
+      int matchEnd = matchOffsets[base + 1];
+      totalMatchLength += (matchEnd - matchStart);
+
+      totalReplacementLength += literalReplacementLen;
+      for (ReplacementSegment seg : compiledTemplate) {
+        if (seg instanceof ReplacementSegment.GroupRef groupRef) {
+          int g = groupRef.groupNum();
+          if (g >= 0 && g < nsubmatch) {
+            int gStart = matchOffsets[base + 2 * g];
+            int gEnd = matchOffsets[base + 2 * g + 1];
+            if (gStart >= 0 && gEnd >= 0) {
+              totalReplacementLength += (gEnd - gStart);
+            }
+          }
+        } else if (seg instanceof ReplacementSegment.NamedGroupRef namedRef) {
+          Integer g = parentPattern.namedGroups().get(namedRef.name());
+          if (g != null && g >= 0 && g < nsubmatch) {
+            int gStart = matchOffsets[base + 2 * g];
+            int gEnd = matchOffsets[base + 2 * g + 1];
+            if (gStart >= 0 && gEnd >= 0) {
+              totalReplacementLength += (gEnd - gStart);
+            }
+          }
+        }
+      }
+    }
+
+    int finalCapacity = textLen - totalMatchLength + totalReplacementLength;
+
+    StringBuilder sb = new StringBuilder(finalCapacity);
+    int appendPos = 0;
+    for (int i = 0; i < matchesFound; i++) {
+      int base = i * ncap;
+      int matchStart = matchOffsets[base];
+      int matchEnd = matchOffsets[base + 1];
+
+      System.arraycopy(matchOffsets, base, groups, 0, ncap);
+
+      sb.append(text, appendPos, matchStart);
+      applyReplacementTemplate(sb, compiledTemplate);
+      appendPos = matchEnd;
+    }
+    sb.append(text, appendPos, textLen);
+
+    if (limit == 1) {
+      deferredMatchStart = groups[0];
+      deferredMatchEnd = groups[1];
+      capturesResolved = parentPattern.prog().numCaptures() <= 1;
+      groupZeroResolved = true;
+      resultStatus = ResultStatus.MATCHED;
+      searchFrom = groups[1];
+    } else {
+      hasMatch = false;
+      capturesResolved = false;
+      groupZeroResolved = false;
+      searchFrom = textLen;
+      resultStatus = ResultStatus.FAILED;
+    }
+
+    return sb.toString();
+  }
+
   /**
    * Replaces every subsequence of the input that matches the pattern with the given replacement
    * string.
@@ -2368,8 +2543,13 @@ public final class Matcher implements MatchResult {
    */
   public String replaceAll(String replacement) {
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    String result = replaceOnePass(template, Integer.MAX_VALUE);
+    if (result != null) {
+      return result;
+    }
+
     reset();
-    String result = replaceDfaOptimized(template, Integer.MAX_VALUE);
+    result = replaceDfaOptimized(template, Integer.MAX_VALUE);
     if (result != null) {
       return result;
     }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1156,11 +1156,57 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceFirst() leaves matcher state at the replaced occurrence")
+    void replaceFirstLeavesMatcherAtReplacedOccurrence() {
+      Matcher m = Pattern.compile("a").matcher("aba");
+
+      assertThat(m.replaceFirst("X")).isEqualTo("Xba");
+
+      assertThat(m.toMatchResult().start()).isEqualTo(0);
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("replaceFirst() leaves append position after the replaced occurrence")
+    void replaceFirstLeavesAppendPositionAfterReplacedOccurrence() {
+      Matcher m = Pattern.compile("a").matcher("aba");
+
+      assertThat(m.replaceFirst("X")).isEqualTo("Xba");
+      StringBuilder sb = new StringBuilder();
+      m.appendTail(sb);
+
+      assertThat(sb).hasToString("ba");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() preserves dollar-anchor match before trailing line terminator")
+    void replaceFirstPreservesDollarAnchorBeforeTrailingLineTerminator() {
+      Matcher m = Pattern.compile("([^a](\\s\\s)+)*$").matcher("a\n");
+
+      assertThat(m.replaceFirst("X")).isEqualTo("aX\n");
+    }
+
+    @Test
     @DisplayName("replaceAll() with start-anchored pattern replaces correct match")
     void replaceAllStartAnchored() {
       Pattern p = Pattern.compile("^\\d+");
       Matcher m = p.matcher("123abc456");
       assertThat(m.replaceAll("X")).isEqualTo("Xabc456");
+    }
+
+    @Test
+    @DisplayName("replaceAll() leaves matcher exhausted after the final replacement")
+    void replaceAllLeavesMatcherExhaustedAfterFinalReplacement() {
+      Matcher m = Pattern.compile("a").matcher("aba");
+
+      assertThat(m.replaceAll("X")).isEqualTo("XbX");
+
+      StringBuilder sb = new StringBuilder();
+      m.appendTail(sb);
+      assertThat(sb).hasToString("");
+      assertThat(m.find()).isFalse();
+      assertThatThrownBy(() -> m.toMatchResult().start()).isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1113,6 +1113,17 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceFirst() retains capture group state of the matched occurrence")
+    void replaceFirstRetainsCaptureGroups() {
+      Pattern p = Pattern.compile("testingRecord\\[(.+?)\\]");
+      Matcher m = p.matcher("object.testingDetails.testingRecord[0].result");
+      if (m.find()) {
+        m.replaceFirst("testingRecord");
+        assertThat(m.group(1)).isEqualTo("0");
+      }
+    }
+
+    @Test
     @DisplayName("replaceAll() replaces all matches")
     void replaceAll() {
       Pattern p = Pattern.compile("\\d+");
@@ -1134,6 +1145,22 @@ class MatcherTest {
       Pattern p = Pattern.compile("\\d+");
       Matcher m = p.matcher("abc");
       assertThat(m.replaceAll("X")).isEqualTo("abc");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() with start-anchored pattern replaces correct match")
+    void replaceFirstStartAnchored() {
+      Pattern p = Pattern.compile("^\\d+");
+      Matcher m = p.matcher("123abc456");
+      assertThat(m.replaceFirst("X")).isEqualTo("Xabc456");
+    }
+
+    @Test
+    @DisplayName("replaceAll() with start-anchored pattern replaces correct match")
+    void replaceAllStartAnchored() {
+      Pattern p = Pattern.compile("^\\d+");
+      Matcher m = p.matcher("123abc456");
+      assertThat(m.replaceAll("X")).isEqualTo("Xabc456");
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1172,6 +1172,45 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceAll() using OnePass replace path")
+    void replaceAllOnePass() {
+      // 1. Simple OnePass pattern with backreference
+      Pattern p1 = Pattern.compile("(\\w+)-(\\d+)");
+      Matcher m1 = p1.matcher("apple-123 banana-456 cherry-789");
+      assertThat(m1.replaceAll("$2:$1")).isEqualTo("123:apple 456:banana 789:cherry");
+
+      // 2. Named group reference in OnePass
+      Pattern p2 = Pattern.compile("(?<word>\\w+)-(?<num>\\d+)");
+      Matcher m2 = p2.matcher("apple-123 banana-456");
+      assertThat(m2.replaceAll("${num}:${word}")).isEqualTo("123:apple 456:banana");
+
+      // 3. No match in OnePass path
+      Matcher m3 = p1.matcher("no matches here");
+      assertThat(m3.replaceAll("$2:$1")).isEqualTo("no matches here");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() using OnePass replace path")
+    void replaceFirstOnePass() {
+      Pattern p1 = Pattern.compile("(\\w+)-(\\d+)");
+      Matcher m1 = p1.matcher("apple-123 banana-456 cherry-789");
+      assertThat(m1.replaceFirst("$2:$1")).isEqualTo("123:apple banana-456 cherry-789");
+
+      // Verify that after replaceFirst(OnePass), the matcher state retains the first match
+      assertThat(m1.group(0)).isEqualTo("apple-123");
+      assertThat(m1.group(1)).isEqualTo("apple");
+      assertThat(m1.group(2)).isEqualTo("123");
+      assertThat(m1.start(1)).isEqualTo(0);
+      assertThat(m1.end(2)).isEqualTo(9);
+
+      // Named group in replaceFirst
+      Pattern p2 = Pattern.compile("(?<word>\\w+)-(?<num>\\d+)");
+      Matcher m2 = p2.matcher("apple-123 banana-456");
+      assertThat(m2.replaceFirst("${num}:${word}")).isEqualTo("123:apple banana-456");
+      assertThat(m2.group("word")).isEqualTo("apple");
+    }
+
+    @Test
     @DisplayName("replaceAll with group references preserves start-anchor find semantics")
     void replaceAllWithGroupReferencesPreservesStartAnchorFindSemantics() {
       String[][] cases = {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1132,6 +1132,18 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("replaceAll() optimized paths leave matcher exhausted")
+    void replaceAllOptimizedPathsLeaveMatcherExhausted() {
+      Matcher dfaMatcher = Pattern.compile("a").matcher("aba");
+      assertThat(dfaMatcher.replaceAll("X")).isEqualTo("XbX");
+      assertThat(dfaMatcher.find()).isFalse();
+
+      Matcher onePassMatcher = Pattern.compile("(a)").matcher("aba");
+      assertThat(onePassMatcher.replaceAll("x$1")).isEqualTo("xabxa");
+      assertThat(onePassMatcher.find()).isFalse();
+    }
+
+    @Test
     @DisplayName("replaceFirst() with no match returns original text")
     void replaceFirstNoMatch() {
       Pattern p = Pattern.compile("\\d+");
@@ -1208,6 +1220,44 @@ class MatcherTest {
       Matcher m2 = p2.matcher("apple-123 banana-456");
       assertThat(m2.replaceFirst("${num}:${word}")).isEqualTo("123:apple banana-456");
       assertThat(m2.group("word")).isEqualTo("apple");
+    }
+
+    @Test
+    @DisplayName("replaceFirst() optimized paths preserve match result state")
+    void replaceFirstOptimizedPathsPreserveMatchResultState() {
+      Matcher dfaMatcher = Pattern.compile("a").matcher("ba");
+      assertThat(dfaMatcher.replaceFirst("X")).isEqualTo("bX");
+      assertThat(dfaMatcher.toMatchResult().group()).isEqualTo("a");
+
+      Matcher onePassMatcher = Pattern.compile("(a)").matcher("ba");
+      assertThat(onePassMatcher.replaceFirst("x$1")).isEqualTo("bxa");
+      assertThat(onePassMatcher.toMatchResult().group()).isEqualTo("a");
+    }
+
+    @Test
+    @DisplayName("replaceAll() does not validate malformed replacements without a match")
+    void replaceAllSkipsMalformedReplacementValidationWithoutMatch() {
+      Matcher matcher = Pattern.compile("(a)").matcher("bbb");
+
+      assertThat(matcher.replaceAll("$")).isEqualTo("bbb");
+    }
+
+    @Test
+    @DisplayName("replace operations do not validate null replacements without a match")
+    void replaceOperationsSkipNullReplacementValidationWithoutMatch() {
+      Matcher allMatcher = Pattern.compile("(a)").matcher("bbb");
+      assertThat(allMatcher.replaceAll((String) null)).isEqualTo("bbb");
+
+      Matcher firstMatcher = Pattern.compile("(a)").matcher("bbb");
+      assertThat(firstMatcher.replaceFirst((String) null)).isEqualTo("bbb");
+    }
+
+    @Test
+    @DisplayName("replaceAll() OnePass path honors case-insensitive prefixes")
+    void replaceAllOnePassHonorsCaseInsensitivePrefixes() {
+      Matcher matcher = Pattern.compile("(a)", Pattern.CASE_INSENSITIVE).matcher("A");
+
+      assertThat(matcher.replaceAll("x$1")).isEqualTo("xA");
     }
 
     @Test


### PR DESCRIPTION
This adds a fast path implementation of `replaceAll` and `replaceFirst` for `OnePass`-eligible patterns, which makes a single loop over the input bypassing `find()`.

This PR is currently stacked on top of #547, it is a complementary optimization. See also the comment in https://github.com/eaftan/safere/pull/547#issuecomment-4883237869.

This is a tradeoff, `OnePass` is significantly faster if there are any replacements, but if there are no matches it is slower than the DFA to reject inputs. I think this is the same tradeoff SafeRE is making for methods like `find()` and `match()`, and this optimization uses the same `ONEPASS_ANCHORED_TEXT_LIMIT` threshold to skip `OnePass` for longer inputs.

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark.runBenchmark -- \
  -p patternName=fruitMarkupTag \
  -p engine=SafeRE
```

| Input Size | Match? | `replace-dfa-optimized` (ns/op) | `onepass-replace` (ns/op) | Impact / Speedup |
| :--- | :--- | :--- | :--- | :--- |
| **1,000** | `true` (Match) | 17,822.982 ± 117.086 | 5,816.535 ± 61.866 | **3.06x faster** |
| **1,000** | `false` (Reject) | 1,518.945 ± 8.419 | 1,747.930 ± 9.225 | 1.15x slower |
| **10,000** | `true` (Match) | 171,449.961 ± 855.264 | 56,662.342 ± 558.625 | **3.03x faster** |
| **10,000** | `false` (Reject) | 14,505.678 ± 140.164 | 16,659.245 ± 163.770 | 1.15x slower |
| **100,000** | `true` (Match) | 1,729,575.841 ± 12,071.998 | 566,436.737 ± 2,722.482 | **3.05x faster** |
| **100,000** | `false` (Reject) | 140,874.367 ± 652.474 | 168,235.415 ± 529.088 | 1.19x slower |