### PR TITLE
Optimize DFA inner loops

### DIFF
--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1206,6 +1206,7 @@ final class Dfa {
 
     int[] transitions = this.transitions;
     State[] offsetToState = this.offsetToState;
+    int[] asciiClassMap = this.asciiClassMap;
     int pos = startPos;
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
@@ -1440,6 +1441,7 @@ final class Dfa {
 
     int[] transitions = this.transitions;
     State[] offsetToState = this.offsetToState;
+    int[] asciiClassMap = this.asciiClassMap;
     int pos = endPos;
     // Fast path: scan backward through ASCII characters
     while (pos > startLimit) {
@@ -1704,6 +1706,7 @@ final class Dfa {
     if (s != deadState) {
       int[] transitions = this.transitions;
       State[] offsetToState = this.offsetToState;
+      int[] asciiClassMap = this.asciiClassMap;
       int pos = 0;
       // Fast path: scan forward through ASCII characters
       int sId = s.id * numClasses;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1335,8 +1335,6 @@ final class Dfa {
             return null; // budget exceeded
           }
           addTransition(s, cls, ns);
-          transitions = this.transitions;
-          offsetToState = this.offsetToState;
         }
       }
 
@@ -1607,8 +1605,6 @@ final class Dfa {
             return null; // budget exceeded
           }
           addTransition(s, cls, ns);
-          transitions = this.transitions;
-          offsetToState = this.offsetToState;
         }
       }
       s = ns;
@@ -1817,8 +1813,6 @@ final class Dfa {
               return null; // budget exceeded
             }
             addTransition(s, cls, ns);
-            transitions = this.transitions;
-            offsetToState = this.offsetToState;
           }
         }
         s = ns;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -75,8 +75,6 @@ final class Dfa {
    */
   private static final int FLAG_LAST_UNICODE_WORD = 1 << 14;
 
-  private static final int FLAG_HIGHEST_PRIORITY_MATCH = 1 << 15;
-
   /** Maximum number of DFA states before bailing out to NFA. */
   private static final int DEFAULT_MAX_STATES = 10_000;
 
@@ -102,10 +100,6 @@ final class Dfa {
 
     /** Transitions indexed by equivalence class; null entry = not yet computed. */
     final State[] next;
-
-    State(int id, int[] insts, int flags, int[] wordBoundaryMatchIds, int numClasses) {
-      this(id, insts, flags, wordBoundaryMatchIds, numClasses, false);
-    }
 
     State(
         int id,
@@ -236,10 +230,9 @@ final class Dfa {
   /** Per-search grapheme context. Set only while a search method is active. */
   private GraphemeSupport.Context graphemeContext;
 
-  private final List<State> statesList = new ArrayList<>();
   private int[] transitions;
-  private int[] stateFlags;
   private State[] offsetToState;
+  private int nextStateId;
 
   // ---------------------------------------------------------------------------
   // Construction
@@ -290,25 +283,14 @@ final class Dfa {
     this.expandStack = new int[prog.size()];
     this.expandFrontier = new int[prog.size()];
     this.computeBuf = new int[prog.size()];
-    this.deadState = new State(0, new int[0], 0, null, numClasses);
-    this.statesList.add(deadState);
+    this.deadState = new State(0, EMPTY_INSTS, 0, null, numClasses, false);
+    this.nextStateId = 1;
     this.transitions = new int[1024];
-    this.stateFlags = new int[64];
     this.offsetToState = new State[1024];
     addStateToFlatArrays(deadState);
   }
 
   private void addStateToFlatArrays(State s) {
-    if (s.id >= stateFlags.length) {
-      int newLen = Math.max(stateFlags.length * 2, s.id + 1);
-      stateFlags = Arrays.copyOf(stateFlags, newLen);
-    }
-    int flags = s.flags;
-    if (s.isHighestPriorityMatch) {
-      flags |= FLAG_HIGHEST_PRIORITY_MATCH;
-    }
-    stateFlags[s.id] = flags;
-
     int minTransLen = (s.id + 1) * numClasses;
     if (minTransLen > transitions.length) {
       int newLen = Math.max(transitions.length * 2, minTransLen);
@@ -320,7 +302,8 @@ final class Dfa {
 
   private void setTransition(int fromId, int cls, int toId) {
     int fromBase = fromId * numClasses;
-    boolean isMatch = (stateFlags[toId] & FLAG_MATCH) != 0;
+    State toState = offsetToState[toId * numClasses];
+    boolean isMatch = toState.isMatch();
     int storedId = toId * numClasses;
     if (isMatch) {
       storedId = -storedId;
@@ -696,13 +679,12 @@ final class Dfa {
         insts.length > 0 && prog.inst(insts[0]).opCode == InstOp.OP_MATCH;
     s =
         new State(
-            statesList.size(),
+            nextStateId++,
             insts,
             flags,
             wordBoundaryMatchIds,
             numClasses,
             isHighestPriorityMatch);
-    statesList.add(s);
     addStateToFlatArrays(s);
     cache.put(lookupKey.copy(), s);
     return s;
@@ -1246,14 +1228,12 @@ final class Dfa {
         }
         if (nsId < 0) {
           nsId = -nsId;
-          int sequentialDestId = nsId / numClasses;
-          int nsFlags = stateFlags[sequentialDestId];
-          if ((nsFlags & FLAG_MATCH) != 0 && !needEndMatch) {
+          State ns = offsetToState[nsId];
+          if (ns.isMatch() && !needEndMatch) {
             boolean useBefore =
-                (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+                (ns.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
             int endPos = useBefore ? pos : pos + 1;
-            boolean nsHighestPriorityMatch = (nsFlags & FLAG_HIGHEST_PRIORITY_MATCH) != 0;
-            if (!longest && nsHighestPriorityMatch) {
+            if (!longest && ns.isHighestPriorityMatch) {
               return new SearchResult(true, endPos);
             }
             matched = true;
@@ -1481,29 +1461,28 @@ final class Dfa {
           }
           if (nsId < 0) {
             nsId = -nsId;
-            int sequentialDestId = nsId / numClasses;
-            int nsFlags = stateFlags[sequentialDestId];
-            if ((nsFlags & FLAG_MATCH) != 0) {
-              if ((nsFlags & FLAG_MATCH_BEFORE) != 0) {
+            State ns = offsetToState[nsId];
+            if (ns.isMatch()) {
+              int flags = ns.flags;
+              if ((flags & FLAG_MATCH_BEFORE) != 0) {
                 if (pos >= startLimit && (!needEndMatch || pos == startLimit)) {
                   boolean alreadyMatched = matched;
                   matched = true;
                   matchStart = longest && alreadyMatched ? Math.min(matchStart, pos) : pos;
-                  ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
+                  ambiguous |= (flags & FLAG_MATCH_AFTER_DEFERRED) != 0;
                   if (!longest && !needEndMatch) {
                     return new SearchResult(true, matchStart, ambiguous);
                   }
                 }
               }
               boolean hasOnlyBeforeMatch =
-                  (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+                  (flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
               int prevPos = pos - 1;
               if (!hasOnlyBeforeMatch) {
                 if (prevPos >= startLimit && (!needEndMatch || prevPos == startLimit)) {
                   boolean alreadyMatched = matched;
                   matched = true;
                   matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
-                  ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
                   if (!longest && !needEndMatch) {
                     return new SearchResult(true, matchStart, ambiguous);
                   }
@@ -1752,19 +1731,19 @@ final class Dfa {
         if (nsId == 0) { // deadState
           break;
         }
-        int realNsId = nsId < 0 ? -nsId : nsId;
-        int sequentialDestId = realNsId / numClasses;
-        int nsFlags = stateFlags[sequentialDestId];
-        if ((nsFlags & FLAG_MATCH) != 0) {
+        int realNsId;
+        if (nsId < 0) {
+          realNsId = -nsId;
+          State ns = offsetToState[realNsId];
+          int flags = ns.flags;
           int endPos =
-              ((nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE)
+              ((flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE)
                   ? pos
                   : pos + 1;
           if (!needEndMatch
               || endPos == textLen
               || (trailingTermStart < textLen && endPos == trailingTermStart)) {
             // Collect match IDs from the state's instructions.
-            State ns = statesList.get(sequentialDestId);
             for (int id : collectMatchIds(ns.insts)) {
               seen.set(id);
             }
@@ -1774,6 +1753,8 @@ final class Dfa {
               }
             }
           }
+        } else {
+          realNsId = nsId;
         }
         sId = realNsId;
         pos++;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -239,6 +239,7 @@ final class Dfa {
   private final List<State> statesList = new ArrayList<>();
   private int[] transitions;
   private int[] stateFlags;
+  private State[] offsetToState;
 
   // ---------------------------------------------------------------------------
   // Construction
@@ -293,6 +294,7 @@ final class Dfa {
     this.statesList.add(deadState);
     this.transitions = new int[1024];
     this.stateFlags = new int[64];
+    this.offsetToState = new State[1024];
     addStateToFlatArrays(deadState);
   }
 
@@ -311,7 +313,9 @@ final class Dfa {
     if (minTransLen > transitions.length) {
       int newLen = Math.max(transitions.length * 2, minTransLen);
       transitions = Arrays.copyOf(transitions, newLen);
+      offsetToState = Arrays.copyOf(offsetToState, newLen);
     }
+    offsetToState[s.id * numClasses] = s;
   }
 
   private void setTransition(int fromId, int cls, int toId) {
@@ -1259,7 +1263,7 @@ final class Dfa {
         sId = nsId;
         pos++;
       }
-      s = statesList.get(sId / numClasses);
+      s = offsetToState[sId];
 
       if (pos >= textLen) {
         break;
@@ -1510,7 +1514,7 @@ final class Dfa {
           sId = nsId;
           pos--;
         }
-        s = statesList.get(sId / numClasses);
+        s = offsetToState[sId];
       }
 
       if (pos <= startLimit) {
@@ -1736,7 +1740,7 @@ final class Dfa {
         int cls = asciiClassMap[ch];
         int nsId = transitions[sId + cls];
         if (nsId == 0) {
-          s = statesList.get(sId / numClasses);
+          s = offsetToState[sId];
           int effectiveNextPos = pos + 1;
           State ns = computeNext(s, ch, text, effectiveNextPos);
           if (ns == null) {
@@ -1774,7 +1778,7 @@ final class Dfa {
         sId = realNsId;
         pos++;
       }
-      s = statesList.get(sId / numClasses);
+      s = offsetToState[sId];
 
       // General loop
       while (pos <= textLen) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -315,7 +315,13 @@ final class Dfa {
   }
 
   private void setTransition(int fromId, int cls, int toId) {
-    transitions[fromId * numClasses + cls] = toId;
+    int fromBase = fromId * numClasses;
+    boolean isMatch = (stateFlags[toId] & FLAG_MATCH) != 0;
+    int storedId = toId * numClasses;
+    if (isMatch) {
+      storedId = -storedId;
+    }
+    transitions[fromBase + cls] = storedId;
   }
 
   private void addTransition(State from, int cls, State to) {
@@ -1223,33 +1229,37 @@ final class Dfa {
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
       int limit = Math.min(textLen, posDepThreshold - 1);
-      int sId = s.id;
+      int sId = s.id * numClasses;
       while (pos < limit) {
         char ch = text.charAt(pos);
         if (ch >= 128) {
           break;
         }
         int cls = asciiClassMap[ch];
-        int nsId = transitions[sId * numClasses + cls];
+        int nsId = transitions[sId + cls];
         if (nsId == 0) {
           break;
         }
-        int nsFlags = stateFlags[nsId];
-        if ((nsFlags & FLAG_MATCH) != 0 && !needEndMatch) {
-          boolean useBefore =
-              (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
-          int endPos = useBefore ? pos : pos + 1;
-          boolean nsHighestPriorityMatch = (nsFlags & FLAG_HIGHEST_PRIORITY_MATCH) != 0;
-          if (!longest && nsHighestPriorityMatch) {
-            return new SearchResult(true, endPos);
+        if (nsId < 0) {
+          nsId = -nsId;
+          int sequentialDestId = nsId / numClasses;
+          int nsFlags = stateFlags[sequentialDestId];
+          if ((nsFlags & FLAG_MATCH) != 0 && !needEndMatch) {
+            boolean useBefore =
+                (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+            int endPos = useBefore ? pos : pos + 1;
+            boolean nsHighestPriorityMatch = (nsFlags & FLAG_HIGHEST_PRIORITY_MATCH) != 0;
+            if (!longest && nsHighestPriorityMatch) {
+              return new SearchResult(true, endPos);
+            }
+            matched = true;
+            matchEnd = endPos;
           }
-          matched = true;
-          matchEnd = endPos;
         }
         sId = nsId;
         pos++;
       }
-      s = statesList.get(sId);
+      s = statesList.get(sId / numClasses);
 
       if (pos >= textLen) {
         break;
@@ -1454,41 +1464,45 @@ final class Dfa {
     while (pos > startLimit) {
       if (pos <= posDepThreshold) {
         int limit = startLimit;
-        int sId = s.id;
+        int sId = s.id * numClasses;
         while (pos > limit) {
           char ch = text.charAt(pos - 1);
           if (ch >= 128) {
             break;
           }
           int cls = asciiClassMap[ch];
-          int nsId = transitions[sId * numClasses + cls];
+          int nsId = transitions[sId + cls];
           if (nsId == 0) {
             break;
           }
-          int nsFlags = stateFlags[nsId];
-          if ((nsFlags & FLAG_MATCH) != 0) {
-            if ((nsFlags & FLAG_MATCH_BEFORE) != 0) {
-              if (pos >= startLimit && (!needEndMatch || pos == startLimit)) {
-                boolean alreadyMatched = matched;
-                matched = true;
-                matchStart = longest && alreadyMatched ? Math.min(matchStart, pos) : pos;
-                ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
-                if (!longest && !needEndMatch) {
-                  return new SearchResult(true, matchStart, ambiguous);
+          if (nsId < 0) {
+            nsId = -nsId;
+            int sequentialDestId = nsId / numClasses;
+            int nsFlags = stateFlags[sequentialDestId];
+            if ((nsFlags & FLAG_MATCH) != 0) {
+              if ((nsFlags & FLAG_MATCH_BEFORE) != 0) {
+                if (pos >= startLimit && (!needEndMatch || pos == startLimit)) {
+                  boolean alreadyMatched = matched;
+                  matched = true;
+                  matchStart = longest && alreadyMatched ? Math.min(matchStart, pos) : pos;
+                  ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
+                  if (!longest && !needEndMatch) {
+                    return new SearchResult(true, matchStart, ambiguous);
+                  }
                 }
               }
-            }
-            boolean hasOnlyBeforeMatch =
-                (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
-            int prevPos = pos - 1;
-            if (!hasOnlyBeforeMatch) {
-              if (prevPos >= startLimit && (!needEndMatch || prevPos == startLimit)) {
-                boolean alreadyMatched = matched;
-                matched = true;
-                matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
-                ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
-                if (!longest && !needEndMatch) {
-                  return new SearchResult(true, matchStart, ambiguous);
+              boolean hasOnlyBeforeMatch =
+                  (nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+              int prevPos = pos - 1;
+              if (!hasOnlyBeforeMatch) {
+                if (prevPos >= startLimit && (!needEndMatch || prevPos == startLimit)) {
+                  boolean alreadyMatched = matched;
+                  matched = true;
+                  matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
+                  ambiguous |= (nsFlags & FLAG_MATCH_AFTER_DEFERRED) != 0;
+                  if (!longest && !needEndMatch) {
+                    return new SearchResult(true, matchStart, ambiguous);
+                  }
                 }
               }
             }
@@ -1496,7 +1510,7 @@ final class Dfa {
           sId = nsId;
           pos--;
         }
-        s = statesList.get(sId);
+        s = statesList.get(sId / numClasses);
       }
 
       if (pos <= startLimit) {
@@ -1710,7 +1724,7 @@ final class Dfa {
     if (s != deadState) {
       int pos = 0;
       // Fast path: scan forward through ASCII characters
-      int sId = s.id;
+      int sId = s.id * numClasses;
       while (pos < textLen) {
         if (pos + 1 >= posDepThreshold) {
           break; // fall back to general loop for position-dependent context
@@ -1720,21 +1734,23 @@ final class Dfa {
           break; // fall back
         }
         int cls = asciiClassMap[ch];
-        int nsId = transitions[sId * numClasses + cls];
+        int nsId = transitions[sId + cls];
         if (nsId == 0) {
-          s = statesList.get(sId);
+          s = statesList.get(sId / numClasses);
           int effectiveNextPos = pos + 1;
           State ns = computeNext(s, ch, text, effectiveNextPos);
           if (ns == null) {
             return null; // budget exceeded
           }
           addTransition(s, cls, ns);
-          nsId = ns.id;
+          nsId = transitions[sId + cls];
         }
         if (nsId == 0) { // deadState
           break;
         }
-        int nsFlags = stateFlags[nsId];
+        int realNsId = nsId < 0 ? -nsId : nsId;
+        int sequentialDestId = realNsId / numClasses;
+        int nsFlags = stateFlags[sequentialDestId];
         if ((nsFlags & FLAG_MATCH) != 0) {
           int endPos =
               ((nsFlags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE)
@@ -1744,7 +1760,7 @@ final class Dfa {
               || endPos == textLen
               || (trailingTermStart < textLen && endPos == trailingTermStart)) {
             // Collect match IDs from the state's instructions.
-            State ns = statesList.get(nsId);
+            State ns = statesList.get(sequentialDestId);
             for (int id : collectMatchIds(ns.insts)) {
               seen.set(id);
             }
@@ -1755,10 +1771,10 @@ final class Dfa {
             }
           }
         }
-        sId = nsId;
+        sId = realNsId;
         pos++;
       }
-      s = statesList.get(sId);
+      s = statesList.get(sId / numClasses);
 
       // General loop
       while (pos <= textLen) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1261,6 +1261,8 @@ final class Dfa {
           return null; // budget exceeded
         }
         addTransition(s, cls, ns);
+        transitions = this.transitions;
+        offsetToState = this.offsetToState;
       }
       s = ns;
       if (s == deadState) {
@@ -1333,6 +1335,8 @@ final class Dfa {
             return null; // budget exceeded
           }
           addTransition(s, cls, ns);
+          transitions = this.transitions;
+          offsetToState = this.offsetToState;
         }
       }
 
@@ -1515,6 +1519,8 @@ final class Dfa {
           return null; // budget exceeded
         }
         addTransition(s, cls, ns);
+        transitions = this.transitions;
+        offsetToState = this.offsetToState;
       }
       s = ns;
       if (s == deadState) {
@@ -1601,6 +1607,8 @@ final class Dfa {
             return null; // budget exceeded
           }
           addTransition(s, cls, ns);
+          transitions = this.transitions;
+          offsetToState = this.offsetToState;
         }
       }
       s = ns;
@@ -1728,6 +1736,8 @@ final class Dfa {
             return null; // budget exceeded
           }
           addTransition(s, cls, ns);
+          transitions = this.transitions;
+          offsetToState = this.offsetToState;
           nsId = transitions[sId + cls];
         }
         if (nsId == 0) { // deadState
@@ -1807,6 +1817,8 @@ final class Dfa {
               return null; // budget exceeded
             }
             addTransition(s, cls, ns);
+            transitions = this.transitions;
+            offsetToState = this.offsetToState;
           }
         }
         s = ns;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -5,11 +5,9 @@
 
 package org.safere;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -679,12 +677,7 @@ final class Dfa {
         insts.length > 0 && prog.inst(insts[0]).opCode == InstOp.OP_MATCH;
     s =
         new State(
-            nextStateId++,
-            insts,
-            flags,
-            wordBoundaryMatchIds,
-            numClasses,
-            isHighestPriorityMatch);
+            nextStateId++, insts, flags, wordBoundaryMatchIds, numClasses, isHighestPriorityMatch);
     addStateToFlatArrays(s);
     cache.put(lookupKey.copy(), s);
     return s;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1484,6 +1484,7 @@ final class Dfa {
                   boolean alreadyMatched = matched;
                   matched = true;
                   matchStart = longest && alreadyMatched ? Math.min(matchStart, prevPos) : prevPos;
+                  ambiguous |= (flags & FLAG_MATCH_AFTER_DEFERRED) != 0;
                   if (!longest && !needEndMatch) {
                     return new SearchResult(true, matchStart, ambiguous);
                   }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1204,6 +1204,8 @@ final class Dfa {
       return new SearchResult(matched, matchEnd);
     }
 
+    int[] transitions = this.transitions;
+    State[] offsetToState = this.offsetToState;
     int pos = startPos;
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
@@ -1436,6 +1438,8 @@ final class Dfa {
       return new SearchResult(matched, matchStart);
     }
 
+    int[] transitions = this.transitions;
+    State[] offsetToState = this.offsetToState;
     int pos = endPos;
     // Fast path: scan backward through ASCII characters
     while (pos > startLimit) {
@@ -1698,6 +1702,8 @@ final class Dfa {
     }
 
     if (s != deadState) {
+      int[] transitions = this.transitions;
+      State[] offsetToState = this.offsetToState;
       int pos = 0;
       // Fast path: scan forward through ASCII characters
       int sId = s.id * numClasses;

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -492,4 +492,21 @@ class DfaTest {
     assertThat(first.ambiguous()).isTrue();
     assertThat(second.ambiguous()).isTrue();
   }
+
+  @Test
+  void reverseDfaAsciiFastPathPreservesAcceptedAfterMatchAmbiguity() {
+    Pattern p = Pattern.compile("^(?:\\B|a)b");
+    Dfa revDfa = p.reverseDfa();
+    assertThat(revDfa).isNotNull();
+
+    Dfa.SearchResult first = revDfa.doSearchReverse("ab", 2, 0, true, true);
+    Dfa.SearchResult second = revDfa.doSearchReverse("ab", 2, 0, true, true);
+
+    assertThat(first).isNotNull();
+    assertThat(second).isNotNull();
+    assertThat(first.matched()).isTrue();
+    assertThat(second.matched()).isTrue();
+    assertThat(first.ambiguous()).isTrue();
+    assertThat(second.ambiguous()).isTrue();
+  }
 }


### PR DESCRIPTION
Optimize DFA transition loop using Sign-Bit Tagging. Pre-scales state IDs to transition base offsets and tags match states with the sign bit. This eliminates dynamic multiplication and auxiliary array lookups (stateFlags) from the hot ASCII search loops.

This also defines a few locals for field reads to avoid reading them in hot loops, which seemed to be worth a few percent in the `layoutBlock` and `markupImageLink` benchmarks.

This came out of profiling the DFA loop and looking for micro-optimizations.

```
./run-java-benchmarks.sh --fastbuild RealWorldRegexBenchmark -- \
  -p engine=SafeRE,RE2_FFM \
  -p inputSize=100000 \
  -p patternName=templateTagMatch,layoutBlock,fruitSearchQuery,fruitMarkupTag,jsonBlock,turnTitleWhitespaceCjk
```

| Pattern Name | Match | RE2 (C++ FFM) | Baseline SafeRE | Optimized SafeRE | Speedup (vs. Baseline) | Baseline SafeRE / RE2 Ratio | Optimized SafeRE / RE2 Ratio |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| **layoutBlock** | `true` | 325,488 | 701,478 | 472,206 | **1.49x** (+49%) | 2.16x | 1.45x |
| **layoutBlock** | `false` | 87,770 | 285,557 | 189,288 | **1.51x** (+51%) | 3.25x | 2.16x |
| **fruitSearchQuery** | `false` | 213,721 | 286,540 | 190,727 | **1.50x** (+50%) | 1.34x | **0.89x** (SafeRE faster) |
| **fruitMarkupTag** | `false` | 121,486 | 142,684 | 94,571 | **1.51x** (+51%) | 1.17x | **0.78x** (SafeRE faster) |
| **templateTagMatch** | `true` | 460,314 | 657,983 | 542,294 | **1.21x** (+21%) | 1.43x | 1.18x |
| **templateTagMatch** | `false` | 35,892 | 54,808 | 54,900 | 1.00x | 1.53x | 1.53x |
| **jsonBlock** | `false` | 37,109 | 9,850 | 9,843 | 1.00x | 0.27x | 0.27x |
| **turnTitleWhitespaceCjk**| `true` | 2,317,578 | 2,545,157 | 2,552,608 | 1.00x | 1.10x | 1.10x |
