### PR TITLE
Revert "Generalize `charClassPrefixAscii` to support non-ASCII character class prefixes (#550)"

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -387,36 +387,6 @@
         }
       },
       {
-        "name": "unicodeClassPrefix",
-        "pattern": "[\\x{4E00}-\\x{9FFF}]+abc",
-        "op": "find",
-        "match": "你好abc",
-        "nonMatch": "hello world",
-        "matchInput": {
-          "kind": "sparseMatch",
-          "nonMatchRepeats": 50,
-          "delimiterAlphabet": " "
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "name": "unicodeClassPrefixNfaFallback",
-        "pattern": "[\\x{4E00}-\\x{9FFF}]+\\Xabc",
-        "op": "find",
-        "match": "好abc",
-        "nonMatch": "a",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "sparseMatch",
-          "nonMatchRepeats": 49995,
-          "delimiterAlphabet": "a"
-        }
-      },
-      {
         "name": "turnTitleWhitespaceCjk",
         "pattern": "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+",
         "op": "replaceAllEmpty",

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -608,12 +608,6 @@ void run_real_world_regex_benchmarks(
     json non_match_input;
     RE2 re;
 
-    static RE2::Options DefaultOptions() {
-      RE2::Options opts;
-      opts.set_log_errors(false);
-      return opts;
-    }
-
     explicit RealWorldCase(const json& item)
         : name(item.at("name").get<std::string>()),
           op(item.at("op").get<std::string>()),
@@ -622,18 +616,12 @@ void run_real_world_regex_benchmarks(
           non_match(item.at("nonMatch").get<std::string>()),
           match_input(item.value("matchInput", json::object())),
           non_match_input(item.value("nonMatchInput", json::object())),
-          re(pattern, DefaultOptions()) {}
+          re(pattern) {}
   };
 
   std::vector<std::unique_ptr<RealWorldCase>> cases;
   for (const auto& item : sec["cases"]) {
-    auto case_ptr = std::make_unique<RealWorldCase>(item);
-    if (!case_ptr->re.ok()) {
-      fprintf(stderr, "WARNING: skipping invalid RE2 real-world regex pattern: %s (%s)\n",
-              case_ptr->name.c_str(), case_ptr->re.error().c_str());
-      continue;
-    }
-    cases.push_back(std::move(case_ptr));
+    cases.push_back(std::make_unique<RealWorldCase>(item));
   }
 
   for (const auto& case_ptr : cases) {

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -461,20 +461,6 @@ func runApplicationBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		pattern := getString(item, "pattern")
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: skipping application benchmark %s: %v\n", getString(item, "name"), err)
-			continue
-		}
-		var fullRe *regexp.Regexp
-		if strings.HasPrefix(getString(item, "op"), "matches") {
-			var err error
-			fullRe, err = regexp.Compile("^(?:" + pattern + ")$")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARNING: skipping application benchmark %s (full match compile): %v\n", getString(item, "name"), err)
-				continue
-			}
-		}
 		c := appCase{
 			name:        getString(item, "name"),
 			op:          getString(item, "op"),
@@ -484,8 +470,10 @@ func runApplicationBenchmarks(data map[string]any, filters []string) {
 			groups:      getIntSlice(item, "groups"),
 			replacement: convertReplacement(getString(item, "replacement")),
 			expected:    item["expected"],
-			re:          re,
-			fullRe:      fullRe,
+			re:          regexp.MustCompile(pattern),
+		}
+		if strings.HasPrefix(c.op, "matches") {
+			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
 		}
 		cases = append(cases, c)
 	}
@@ -617,20 +605,6 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		pattern := getString(item, "pattern")
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: skipping realWorldRegex benchmark %s: %v\n", getString(item, "name"), err)
-			continue
-		}
-		var fullRe *regexp.Regexp
-		if op == "matches" {
-			var err error
-			fullRe, err = regexp.Compile("^(?:" + pattern + ")$")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARNING: skipping realWorldRegex benchmark %s (full match compile): %v\n", getString(item, "name"), err)
-				continue
-			}
-		}
 		matchInput, _ := item["matchInput"].(map[string]any)
 		nonMatchInput, _ := item["nonMatchInput"].(map[string]any)
 		c := realWorldCase{
@@ -641,8 +615,10 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			nonMatch:      getString(item, "nonMatch"),
 			matchInput:    matchInput,
 			nonMatchInput: nonMatchInput,
-			re:            re,
-			fullRe:        fullRe,
+			re:            regexp.MustCompile(pattern),
+		}
+		if op == "matches" {
+			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
 		}
 		cases = append(cases, c)
 	}
@@ -922,11 +898,7 @@ func runReplaceBenchmarks(data map[string]any, filters []string) {
 		// Convert Java-style $N backreferences to Go-style ${N}
 		goReplacement := convertReplacement(replacement)
 
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: skipping replace benchmark %s: %v\n", key, err)
-			continue
-		}
+		re := regexp.MustCompile(pattern)
 		benchName := "ReplaceBenchmark." + key
 
 		if !matchesFilter(benchName, filters) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -137,8 +137,6 @@ public class RealWorldRegexBenchmark {
     "charReplace",
     "greedyOnePass",
     "layoutBlock",
-    "unicodeClassPrefix",
-    "unicodeClassPrefixNfaFallback",
     "turnTitleWhitespaceCjk",
     "cjkSearch",
     "emojiSearch"

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -434,7 +434,7 @@ public final class Matcher implements MatchResult {
     return text.regionMatches(false, offset, literal, 0, length);
   }
 
-  static boolean charClassContains(int[] ranges, long b0, long b1, int cp) {
+  private static boolean charClassContains(int[] ranges, long b0, long b1, int cp) {
     if (cp < 64) {
       return (b0 & (1L << cp)) != 0;
     }
@@ -1303,9 +1303,9 @@ public final class Matcher implements MatchResult {
     // Character-class prefix acceleration: when the pattern starts with a character class (and
     // no literal prefix exists), scan for the first character that could begin a match. This
     // avoids running the full engine on text regions where no match can start.
-    Pattern.CharClassScanInfo charClassPrefix = parentPattern.charClassPrefix();
-    if (options.startAcceleration() && !prog.hasWordBoundary() && charClassPrefix != null) {
-      int idx = indexOfCharClass(text, charClassPrefix, searchFrom);
+    boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
+    if (options.startAcceleration() && !prog.hasWordBoundary() && ccPrefixAscii != null) {
+      int idx = indexOfCharClass(text, ccPrefixAscii, searchFrom);
       if (idx < 0) {
         if (!prog.anchorStart()) {
         } else {
@@ -1722,25 +1722,18 @@ public final class Matcher implements MatchResult {
 
   /**
    * Scans {@code text} for the first character at or after {@code fromIndex} whose code point is
-   * contained in the character class. Returns the index, or {@code -1} if no matching character is
-   * found.
+   * set in the ASCII bitmap. Returns the index, or {@code -1} if no matching character is found.
+   * Non-ASCII characters are skipped (never match).
    */
-  private static int indexOfCharClass(String text, Pattern.CharClassScanInfo cc, int fromIndex) {
-    long b0 = cc.bitmap0;
-    long b1 = cc.bitmap1;
-    int[] ranges = cc.ranges;
-
-    int i = fromIndex;
-    int len = text.length();
-    while (i < len) {
+  private static int indexOfCharClass(String text, boolean[] asciiMap, int fromIndex) {
+    for (int i = fromIndex; i < text.length(); i++) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
       }
-      int cp = text.codePointAt(i);
-      if (charClassContains(ranges, b0, b1, cp)) {
+      char ch = text.charAt(i);
+      if (ch < 128 && asciiMap[ch]) {
         return i;
       }
-      i += Character.charCount(cp);
     }
     return -1;
   }
@@ -3021,9 +3014,9 @@ public final class Matcher implements MatchResult {
       effectiveStart = idx;
     }
 
-    Pattern.CharClassScanInfo charClassPrefix = parentPattern.charClassPrefix();
-    if (options.startAcceleration() && !prog.hasWordBoundary() && charClassPrefix != null) {
-      int idx = indexOfCharClass(text, charClassPrefix, fromIndex);
+    boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
+    if (options.startAcceleration() && !prog.hasWordBoundary() && ccPrefixAscii != null) {
+      int idx = indexOfCharClass(text, ccPrefixAscii, fromIndex);
       if (idx < 0) {
         return -1L;
       }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -109,7 +109,7 @@ public final class Pattern implements Serializable {
   private final transient boolean hasNullableAlternation;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
-  private final transient CharClassScanInfo charClassPrefix;
+  private final transient boolean[] charClassPrefixAscii;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
   private final transient EnginePathOptions enginePathOptions;
@@ -229,7 +229,7 @@ public final class Pattern implements Serializable {
       boolean hasNullableAlternation,
       boolean startsWithGraphemeClusterBoundary,
       boolean hasInternalGraphemeClusterBoundary,
-      CharClassScanInfo charClassPrefix,
+      boolean[] charClassPrefixAscii,
       StartAcceleration startAcceleration,
       KeywordAlternation keywordAlternation,
       int[] charClassMatchRanges,
@@ -277,7 +277,7 @@ public final class Pattern implements Serializable {
     this.hasNullableAlternation = hasNullableAlternation;
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
-    this.charClassPrefix = charClassPrefix;
+    this.charClassPrefixAscii = charClassPrefixAscii;
     this.startAcceleration = startAcceleration;
     this.keywordAlternation = keywordAlternation;
     this.enginePathOptions = enginePathOptions;
@@ -355,10 +355,9 @@ public final class Pattern implements Serializable {
     boolean startsWithGcb = startsWithGraphemeClusterBoundary(metadataAst);
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
     // Extract character-class prefix for acceleration when no literal prefix exists.
-    CharClassScanInfo charClassPrefix =
-        (prefix == null) ? extractCharClassPrefix(metadataAst) : null;
+    boolean[] ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     StartAcceleration startAcceleration =
-        (prefix == null && charClassPrefix == null) ? extractStartAcceleration(metadataAst) : null;
+        (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(metadataAst) : null;
     KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
@@ -379,7 +378,7 @@ public final class Pattern implements Serializable {
         hasNullableAlt,
         startsWithGcb,
         hasInternalGcb,
-        charClassPrefix,
+        ccPrefixAscii,
         startAcceleration,
         keywordAlternation,
         ccMatch != null ? ccMatch.ranges : null,
@@ -868,20 +867,12 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Returns precomputed character-class prefix scan info, or {@code null} if the pattern has no
-   * character-class prefix. Used for prefix acceleration in {@link Matcher#doFind()} when no
-   * literal prefix exists.
+   * Returns a {@code boolean[128]} ASCII bitmap of the character-class prefix, or {@code null} if
+   * the pattern has no character-class prefix. Used for prefix acceleration in {@link
+   * Matcher#doFind()} when no literal prefix exists.
    */
-  CharClassScanInfo charClassPrefix() {
-    return charClassPrefix;
-  }
-
-  boolean charClassPrefixContains(int cp) {
-    if (charClassPrefix == null) {
-      return false;
-    }
-    return Matcher.charClassContains(
-        charClassPrefix.ranges, charClassPrefix.bitmap0, charClassPrefix.bitmap1, cp);
+  boolean[] charClassPrefixAscii() {
+    return charClassPrefixAscii;
   }
 
   /** Returns conservative start-position acceleration data, or {@code null} if unavailable. */
@@ -1582,8 +1573,8 @@ public final class Pattern implements Serializable {
    *
    * @return a {@code boolean[128]} ASCII bitmap, or {@code null} if no suitable prefix exists
    */
-  private static CharClassScanInfo extractCharClassPrefix(Regexp re) {
-    CharClassBuilder builder = new CharClassBuilder();
+  private static boolean[] extractCharClassPrefixAscii(Regexp re) {
+    boolean[] bitmap = new boolean[128];
     Deque<Regexp> work = new ArrayDeque<>();
     work.add(re);
 
@@ -1608,19 +1599,21 @@ public final class Pattern implements Serializable {
 
       switch (node.op) {
         case LITERAL -> {
-          builder.addCharClass(literalCharClass(node.rune, node.flags));
+          if (!addLiteralPrefixAscii(node.rune, node.flags, bitmap)) {
+            return null;
+          }
         }
         case LITERAL_STRING -> {
-          if (node.runes == null || node.runes.length == 0) {
+          if (node.runes == null
+              || node.runes.length == 0
+              || !addLiteralPrefixAscii(node.runes[0], node.flags, bitmap)) {
             return null;
           }
-          builder.addCharClass(literalCharClass(node.runes[0], node.flags));
         }
         case CHAR_CLASS -> {
-          if (node.charClass == null || node.charClass.isEmpty()) {
+          if (!addCharClassPrefixAscii(node.charClass, bitmap)) {
             return null;
           }
-          builder.addCharClass(node.charClass);
         }
         case ALTERNATE -> {
           if (node.nsub() == 0) {
@@ -1636,11 +1629,39 @@ public final class Pattern implements Serializable {
       }
     }
 
-    CharClass cc = builder.build();
-    if (cc.isEmpty()) {
-      return null;
+    return bitmap;
+  }
+
+  private static boolean addLiteralPrefixAscii(int r, int flags, boolean[] bitmap) {
+    if (r >= 128) {
+      return false;
     }
-    return buildCharClassScanInfo(cc);
+    bitmap[r] = true;
+    if ((flags & ParseFlags.FOLD_CASE) != 0) {
+      if (r >= 'a' && r <= 'z') {
+        bitmap[r - 32] = true;
+      } else if (r >= 'A' && r <= 'Z') {
+        bitmap[r + 32] = true;
+      }
+    }
+    return true;
+  }
+
+  private static boolean addCharClassPrefixAscii(CharClass cc, boolean[] bitmap) {
+    if (cc == null || cc.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < cc.numRanges(); i++) {
+      if (cc.hi(i) >= 128) {
+        return false;
+      }
+    }
+    for (int i = 0; i < cc.numRanges(); i++) {
+      for (int cp = cc.lo(i); cp <= cc.hi(i); cp++) {
+        bitmap[cp] = true;
+      }
+    }
+    return true;
   }
 
   private static StartAcceleration extractStartAcceleration(Regexp re) {
@@ -1903,7 +1924,7 @@ public final class Pattern implements Serializable {
   private record CharClassMatchInfo(int[] ranges, long bitmap0, long bitmap1, boolean allowEmpty) {}
 
   /** Holds precomputed data for scanning one character class. */
-  static final class CharClassScanInfo {
+  private static final class CharClassScanInfo {
     final int[] ranges;
     final long bitmap0;
     final long bitmap1;

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -56,8 +56,9 @@ class PatternInternalTest {
   void transparentGroupsPreserveCharacterClassAccelerators() {
     Pattern p = Pattern.compile("(?:[A-Z]+)");
 
-    assertThat(p.charClassPrefix()).isNotNull();
-    assertThat(p.charClassPrefixContains('A')).isTrue();
+    boolean[] prefix = p.charClassPrefixAscii();
+    assertThat(prefix).isNotNull();
+    assertThat(prefix['A']).isTrue();
     assertThat(p.charClassMatchRanges()).isNotNull();
   }
 
@@ -103,44 +104,48 @@ class PatternInternalTest {
   @Test
   void alternatePrefixAcceleration() {
     Pattern p = Pattern.compile("(?:cat|dog|bird)s?");
-    assertThat(p.charClassPrefix()).isNotNull();
-    assertThat(p.charClassPrefixContains('c')).isTrue();
-    assertThat(p.charClassPrefixContains('d')).isTrue();
-    assertThat(p.charClassPrefixContains('b')).isTrue();
-    assertThat(p.charClassPrefixContains('a')).isFalse();
+    boolean[] prefix = p.charClassPrefixAscii();
+    assertThat(prefix).isNotNull();
+    assertThat(prefix['c']).isTrue();
+    assertThat(prefix['d']).isTrue();
+    assertThat(prefix['b']).isTrue();
+    assertThat(prefix['a']).isFalse();
   }
 
   @Test
   void alternatePrefixCaseInsensitiveAcceleration() {
     Pattern p = Pattern.compile("(?i)(?:cat|dog|bird)s?");
-    assertThat(p.charClassPrefix()).isNotNull();
-    assertThat(p.charClassPrefixContains('c')).isTrue();
-    assertThat(p.charClassPrefixContains('C')).isTrue();
-    assertThat(p.charClassPrefixContains('d')).isTrue();
-    assertThat(p.charClassPrefixContains('D')).isTrue();
-    assertThat(p.charClassPrefixContains('b')).isTrue();
-    assertThat(p.charClassPrefixContains('B')).isTrue();
-    assertThat(p.charClassPrefixContains('a')).isFalse();
+    boolean[] prefix = p.charClassPrefixAscii();
+    assertThat(prefix).isNotNull();
+    assertThat(prefix['c']).isTrue();
+    assertThat(prefix['C']).isTrue();
+    assertThat(prefix['d']).isTrue();
+    assertThat(prefix['D']).isTrue();
+    assertThat(prefix['b']).isTrue();
+    assertThat(prefix['B']).isTrue();
+    assertThat(prefix['a']).isFalse();
   }
 
   @Test
   void deeplyNestedRequiredQuantifierPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedRequiredPlusPattern(1_000, "[ab]"));
 
-    assertThat(p.charClassPrefix()).isNotNull();
-    assertThat(p.charClassPrefixContains('a')).isTrue();
-    assertThat(p.charClassPrefixContains('b')).isTrue();
-    assertThat(p.charClassPrefixContains('c')).isFalse();
+    boolean[] prefix = p.charClassPrefixAscii();
+    assertThat(prefix).isNotNull();
+    assertThat(prefix['a']).isTrue();
+    assertThat(prefix['b']).isTrue();
+    assertThat(prefix['c']).isFalse();
   }
 
   @Test
   void deeplyNestedAlternationPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedAlternationPattern(1_000));
 
-    assertThat(p.charClassPrefix()).isNotNull();
-    assertThat(p.charClassPrefixContains('a')).isTrue();
-    assertThat(p.charClassPrefixContains('b')).isTrue();
-    assertThat(p.charClassPrefixContains('c')).isFalse();
+    boolean[] prefix = p.charClassPrefixAscii();
+    assertThat(prefix).isNotNull();
+    assertThat(prefix['a']).isTrue();
+    assertThat(prefix['b']).isTrue();
+    assertThat(prefix['c']).isFalse();
   }
 
   @Test


### PR DESCRIPTION
See #564