### PR TITLE
Add static and runtime regex diagnostics

### DIFF
--- a/DIAGNOSTICS.md
+++ b/DIAGNOSTICS.md
@@ -1,0 +1,257 @@
+# SafeRE Diagnostics
+
+SafeRE provides two complementary diagnostics APIs:
+
+- **Static analysis** describes a compiled pattern's features, possible execution strategies, and
+  known limitations without matching an input.
+- **Runtime diagnostics** reports which strategies actually participated in a public matching or
+  replacement operation.
+
+Static analysis answers “what can this pattern do?” Runtime diagnostics answers “what happened for
+this operation and input?” Engine selection can depend on the operation, input length, match result,
+regions and bounds, captures, and runtime engine budgets, so static capabilities do not predict one
+specific strategy for every call.
+
+## Static pattern analysis
+
+Call `Pattern.analysis()` on a compiled pattern:
+
+```java
+import org.safere.Pattern;
+import org.safere.PatternAnalysis;
+import org.safere.PatternCapability;
+import org.safere.PatternFeature;
+import org.safere.PatternLimitation;
+
+Pattern pattern = Pattern.compile("^(?:(a)?)*$");
+PatternAnalysis analysis = pattern.analysis();
+
+if (analysis.features().contains(PatternFeature.CAPTURES_IN_QUANTIFIER)) {
+  System.out.println("The pattern captures inside a quantified expression");
+}
+
+if (analysis.capabilities().contains(PatternCapability.DFA_REJECT_PREFILTER)) {
+  System.out.println("A DFA may reject non-matches before an exact engine runs");
+}
+
+if (analysis.limitations().contains(PatternLimitation.NULLABLE_LOOP_REQUIRES_EXACT_ENGINE)) {
+  System.out.println("Successful matches require exact nullable-loop semantics");
+}
+
+System.out.printf(
+    "program instructions=%d, capturing groups=%d%n",
+    analysis.programSize(), analysis.captureCount());
+```
+
+`PatternAnalysis` is immutable and contains:
+
+| Field | Meaning |
+|---|---|
+| `features()` | Semantic and structural properties such as literals, captures, alternation, anchors, nullable expressions, and grapheme operations. |
+| `capabilities()` | Strategies that can participate in at least one operation or input for this pattern. |
+| `limitations()` | Stable reasons certain optimized strategies cannot be authoritative. |
+| `programSize()` | Size of the compiled SafeRE instruction program. |
+| `captureCount()` | Number of user capturing groups, excluding group 0. |
+
+The returned sets and analysis object are safe to retain and share between threads. Complete
+analysis is computed lazily when explicitly requested or when an enabled listener needs a
+compilation event, then cached on the `Pattern`. Repeated `analysis()` calls return the cached
+immutable result.
+
+Capabilities are possibilities, not execution promises. For example, a pattern can support both
+DFA boundary search and NFA matching. A long search might use a DFA to discover group 0 boundaries,
+while a capture access or a semantically ambiguous case can require an exact engine.
+
+## Runtime diagnostics
+
+Runtime diagnostics use one process-wide synchronous listener. Subclass `SafeReMatchDiagnostics`,
+install it with `Pattern.setDiagnostics`, and restore the previous listener when the observation
+scope ends:
+
+```java
+import org.safere.OperationDiagnostics;
+import org.safere.Pattern;
+import org.safere.PatternCompiledEvent;
+import org.safere.SafeReMatchDiagnostics;
+
+SafeReMatchDiagnostics listener =
+    new SafeReMatchDiagnostics() {
+      @Override
+      public void onPatternCompiled(PatternCompiledEvent event) {
+        System.out.printf(
+            "compiled patternId=%d capabilities=%s%n",
+            event.pattern().patternId(),
+            event.pattern().analysis().capabilities());
+      }
+
+      @Override
+      public void onOperationCompleted(OperationDiagnostics event) {
+        System.out.printf(
+            "%s outcome=%s boundary=%s captures=%s/%s matches=%d%n",
+            event.operation(),
+            event.outcome(),
+            event.boundaryStrategy(),
+            event.captureStrategy(),
+            event.captureMode(),
+            event.matchCount());
+      }
+    };
+
+SafeReMatchDiagnostics previous = Pattern.diagnostics();
+Pattern.setDiagnostics(listener);
+try {
+  Pattern pattern = Pattern.compile("(a+)b");
+  pattern.matcher("xxaaab").find();
+} finally {
+  Pattern.setDiagnostics(previous);
+}
+```
+
+Use `SafeReMatchDiagnostics.NONE` to disable runtime diagnostics explicitly:
+
+```java
+Pattern.setDiagnostics(SafeReMatchDiagnostics.NONE);
+```
+
+The listener is process-wide rather than attached to one pattern or matcher. Replacing it is
+immediately visible across threads. Each public operation snapshots the listener once, so a
+listener change does not split one operation between two listeners. Applications and libraries
+sharing a process should coordinate listener ownership rather than independently replacing it.
+
+### Compilation events
+
+`onPatternCompiled` runs after a pattern is compiled while the listener is installed. Its
+`PatternDescriptor` contains:
+
+- `patternId()`: an opaque, positive, process-local identity;
+- `analysis()`: the same cached immutable analysis returned by `Pattern.analysis()`.
+
+The descriptor intentionally contains no pattern text. Use `patternId` to join compilation metadata
+to later operation events without exposing a regex or using it as a high-cardinality metric label.
+
+A listener installed after a pattern was compiled does not receive a historical compilation event.
+Operation events still carry the pattern descriptor and analysis, so late listeners do not depend
+on replay.
+
+### Operation events
+
+`onOperationCompleted` receives one immutable `OperationDiagnostics` event after a normally
+completed supported public operation:
+
+- `matches()`
+- `lookingAt()`
+- `find()` and `find(int)`
+- string and functional `replaceFirst()`
+- string and functional `replaceAll()`
+
+Internal searches performed by replacement methods do not emit nested `FIND` events. A replacement
+emits one event whose `matchCount()` is the total number of replaced matches. An operation that
+throws does not emit an event. If the listener throws, its exception propagates after the matcher
+state and regex result have been finalized.
+
+| Field | Meaning |
+|---|---|
+| `pattern()` | Opaque pattern descriptor and static analysis. |
+| `operation()` | Public operation being summarized. |
+| `outcome()` | `MATCH` when one or more matches were found; otherwise `NO_MATCH`. |
+| `boundaryStrategy()` | Strategy authoritative for the reported group 0 match boundaries or rejection. |
+| `captureStrategy()` | Strategy that resolved capturing groups, or `NONE`. |
+| `auxiliaryStrategies()` | Ordered first participation by strategies used for acceleration, rejection, or candidate verification. |
+| `strategyDecisions()` | Bounded explanations for bypasses and fallbacks. |
+| `captureMode()` | Whether captures were absent, resolved eagerly, or left deferred. |
+| `inputLength()` | Input length using Java `String.length()` semantics (UTF-16 code units). |
+| `matchCount()` | Zero or one for single-result operations; aggregate count for replacements. |
+
+Events contain neither regex text nor input text. They are immutable and safe for a listener to
+retain, although retaining every event can itself create substantial memory and cardinality costs.
+
+### Interpreting strategies
+
+One operation can involve more than one engine. Do not describe an event using only the first
+strategy that appears.
+
+```java
+OperationDiagnostics event = /* received by the listener */;
+
+System.out.println("authoritative boundaries: " + event.boundaryStrategy());
+System.out.println("capture extraction: " + event.captureStrategy());
+
+event.auxiliaryStrategies()
+    .forEach(
+        participation ->
+            System.out.printf(
+                "auxiliary %s as %s%n",
+                participation.strategy(), participation.role()));
+
+event.strategyDecisions()
+    .forEach(
+        decision ->
+            System.out.printf(
+                "%s was %s because %s%n",
+                decision.strategy(), decision.disposition(), decision.reason()));
+```
+
+Typical examples include:
+
+- a literal or character-class strategy performing start acceleration before DFA candidate
+  verification;
+- a DFA authoritatively rejecting a non-match before an exact engine is needed;
+- a DFA finding group 0 boundaries while captures remain deferred;
+- a DFA exceeding its state budget and falling back to BitState or NFA;
+- BitState being bypassed for a large input before NFA matching.
+
+`MatchStrategy` deliberately exposes stable strategy-level concepts rather than every internal
+pass. Reverse DFA work, cache layout, and other implementation details are not separate public
+strategies.
+
+### Thread-safe aggregation
+
+Callbacks execute synchronously on the thread compiling or matching. SafeRE does not serialize
+listener calls. Listener implementations must provide their own thread safety and should avoid
+blocking the matching thread.
+
+For low-cardinality aggregate metrics, use thread-safe counters and stable enum keys:
+
+```java
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
+import org.safere.MatchStrategy;
+import org.safere.OperationDiagnostics;
+import org.safere.SafeReMatchDiagnostics;
+
+final class AggregatingDiagnostics extends SafeReMatchDiagnostics {
+  private final ConcurrentMap<MatchStrategy, LongAdder> operationsByBoundary =
+      new ConcurrentHashMap<>();
+  private final LongAdder matchedResults = new LongAdder();
+
+  @Override
+  public void onOperationCompleted(OperationDiagnostics event) {
+    operationsByBoundary
+        .computeIfAbsent(event.boundaryStrategy(), ignored -> new LongAdder())
+        .increment();
+    matchedResults.add(event.matchCount());
+  }
+}
+```
+
+Avoid using `patternId`, input length, or full event values as unbounded metric labels. Prefer
+aggregating by enums such as operation, outcome, strategy, role, disposition, and reason.
+
+## Performance guidance
+
+Runtime diagnostics are disabled by default. With `SafeReMatchDiagnostics.NONE`, the disabled path
+does not allocate diagnostic events or bookkeeping objects and has no statistically convincing
+material throughput regression in the production benchmark matrix.
+
+Enabled diagnostics construct bounded immutable state once per public operation. The measured fixed
+cost is approximately 150–200 ns per operation. This is significant for tiny literal operations and
+becomes a small fraction of longer DFA or NFA work. Enable runtime diagnostics for targeted
+observation, controlled profiling windows, or workloads where that fixed cost is acceptable.
+
+Static analysis has a different cost model. The first explicit `analysis()` request performs and
+caches the analysis. Cached retrieval is effectively a field access, and matching does not perform
+complete analysis merely because the static API exists.
+
+Detailed benchmark methodology and results are in
+[`design/ISSUE_474_PHASE_7_PERFORMANCE.md`](design/ISSUE_474_PHASE_7_PERFORMANCE.md).

--- a/DIAGNOSTICS.md
+++ b/DIAGNOSTICS.md
@@ -158,6 +158,8 @@ state and regex result have been finalized.
 | `captureStrategy()` | Strategy that resolved capturing groups, or `NONE`. |
 | `auxiliaryStrategies()` | Ordered first participation by strategies used for acceleration, rejection, or candidate verification. |
 | `strategyDecisions()` | Bounded explanations for bypasses and fallbacks. |
+| `forwardDfaSearchCount()` | Number of attempted forward DFA searches, including budget-exhausted attempts. |
+| `reverseDfaSearchCount()` | Number of attempted reverse DFA searches, including budget-exhausted attempts. |
 | `captureMode()` | Whether captures were absent, resolved eagerly, or left deferred. |
 | `inputLength()` | Input length using Java `String.length()` semantics (UTF-16 code units). |
 | `matchCount()` | Zero or one for single-result operations; aggregate count for replacements. |
@@ -201,8 +203,24 @@ Typical examples include:
 - BitState being bypassed for a large input before NFA matching.
 
 `MatchStrategy` deliberately exposes stable strategy-level concepts rather than every internal
-pass. Reverse DFA work, cache layout, and other implementation details are not separate public
-strategies.
+engine implementation detail. Reverse DFA work is not a separate public strategy, but the forward
+and reverse DFA search counts expose how many searches an operation attempted. Cache layout and
+transition-level work remain internal.
+
+### Golden strategy tests
+
+The immutable event fields can also serve as golden expectations for benchmark patterns and
+performance regression tests. For example:
+
+```java
+assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+assertThat(event.forwardDfaSearchCount()).isEqualTo(1);
+assertThat(event.reverseDfaSearchCount()).isEqualTo(1);
+```
+
+These counts describe search invocations, not input scans: one invocation may terminate early,
+scan the available input, or exceed the DFA state budget. Replacement events aggregate searches
+across all replaced matches.
 
 ### Thread-safe aggregation
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ if (m.find()) {
 SafeRE is a drop-in replacement for `java.util.regex.Pattern` and
 `java.util.regex.Matcher`. Just change your imports.
 
+## Diagnostics
+
+SafeRE can inspect a compiled pattern's static features and capabilities with
+`Pattern.analysis()`, and can report the strategies actually used by matching and replacement
+operations through a process-wide `SafeReMatchDiagnostics` listener.
+
+See [SafeRE Diagnostics](DIAGNOSTICS.md) for examples, event semantics, thread-safe aggregation,
+privacy guarantees, and performance guidance.
+
 ## Development
 
 SafeRE uses google-java-format through Spotless. To format Java sources, run:

--- a/design/ENGINE_DIAGNOSTICS_DECISION_TABLE.md
+++ b/design/ENGINE_DIAGNOSTICS_DECISION_TABLE.md
@@ -1,0 +1,26 @@
+# Engine Diagnostics Decision Table
+
+This table defines the stable diagnostics meaning for each public operation path. It is an
+implementation inventory for issue #474, not a promise that the internal engine cascade will keep
+the same branches.
+
+| Public operation path | Authoritative boundary strategy | Capture strategy | Auxiliary participation | Representative decisions | Event scope |
+|---|---|---|---|---|---|
+| Literal `matches`, `lookingAt`, or `find` | `LITERAL` | `NONE` | none | disabled paths may report `OPTIMIZED_PATH_DISABLED` | one event per call |
+| Character-class match/find fast path | `CHARACTER_CLASS` | `NONE` | optional reject prefilter | none | one event per call |
+| Keyword-alternation find | `KEYWORD` | `KEYWORD` when it fills captures, otherwise `NONE` | none | none | one event per call |
+| Anchored OnePass | `ONE_PASS` | `ONE_PASS` when captures exist | none | input/operation bypass where reported | one event per call |
+| DFA rejection | `DFA` | `NONE` | `DFA/REJECT_PREFILTER` | budget fallback when applicable | one event per call |
+| DFA authoritative group-zero bounds | `DFA` | `NONE` until deferred extraction | start acceleration and candidate verification in execution order | exact bounds or capture requirements where applicable | one event per call |
+| DFA bounds plus deferred extraction | `DFA` | `ONE_PASS`, `BIT_STATE`, or `NFA` if extraction occurs before return | DFA prefilter/candidate verification | capture or budget fallback where applicable | one event per call; later `group()` emits no event |
+| Nullable-loop DFA over-approximation rejects | `DFA` | `NONE` | `DFA/REJECT_PREFILTER` | exact nullable-loop semantics required for non-rejection | one event per call |
+| BitState exact match | `BIT_STATE` | `BIT_STATE` when following authoritative DFA bounds | optional earlier DFA work | input-too-large or work-budget fallback only if BitState is bypassed | one event per call |
+| Pike NFA exact match | `NFA` | `NFA` when following authoritative DFA bounds | optional earlier acceleration/DFA work | prior engine fallback reason | one event per call |
+| Character-class replacement | `CHARACTER_CLASS` | `NONE` | `CHARACTER_CLASS/CANDIDATE_VERIFICATION` | none | one `REPLACE_FIRST` or `REPLACE_ALL` event with total match count |
+| DFA replacement loop | `DFA` | `ONE_PASS`, `BIT_STATE`, or `NFA` when replacement references captures | start acceleration and DFA candidate verification | budget fallback where applicable | one replacement event with total match count |
+| Replacement through ordinary find loop | strategy used by the authoritative internal finds | exact capture strategy if replacement observes captures | accumulated first participation order | accumulated bounded decisions | one replacement event; no nested `FIND` events |
+
+Region and transparent-bound paths use the exact BitState/NFA selector when optimized engines cannot
+provide the public contract. A public event is emitted only after a normal return. Listener failures
+propagate after matcher state has been finalized; regex-operation failures do not emit a misleading
+`MATCH` or `NO_MATCH` event.

--- a/design/ENGINE_DIAGNOSTICS_DECISION_TABLE.md
+++ b/design/ENGINE_DIAGNOSTICS_DECISION_TABLE.md
@@ -20,6 +20,11 @@ the same branches.
 | DFA replacement loop | `DFA` | `ONE_PASS`, `BIT_STATE`, or `NFA` when replacement references captures | start acceleration and DFA candidate verification | budget fallback where applicable | one replacement event with total match count |
 | Replacement through ordinary find loop | strategy used by the authoritative internal finds | exact capture strategy if replacement observes captures | accumulated first participation order | accumulated bounded decisions | one replacement event; no nested `FIND` events |
 
+Each event also reports attempted forward and reverse DFA search counts. The counts include
+budget-exhausted attempts and aggregate across replacement matches. They intentionally count search
+invocations rather than transitions or input positions so golden tests can detect added engine
+passes without exposing cache implementation details.
+
 Region and transparent-bound paths use the exact BitState/NFA selector when optimized engines cannot
 provide the public contract. A public event is emitted only after a normal return. Listener failures
 propagate after matcher state has been finalized; regex-operation failures do not emit a misleading

--- a/design/ISSUE_474_DIAGNOSTICS_PLAN.md
+++ b/design/ISSUE_474_DIAGNOSTICS_PLAN.md
@@ -419,7 +419,9 @@ does not need to change its normal return type. DFA and replacement paths need t
 
 ### Phase 4: Add runtime listener plumbing
 
-1. Store `SafeReMatchDiagnostics.NONE` in a `volatile` static field.
+1. Store the process-wide listener behind a synchronized mutable call site whose disabled target is
+   `SafeReMatchDiagnostics.NONE`. Listener replacement must be immediately visible across threads,
+   while the stable disabled target must remain optimizable by the JIT.
 2. Snapshot the listener once at the beginning of each public operation.
 3. Pass that snapshot through the operation; do not reread the global listener at every internal step.
 4. Allocate no event, `EnumSet`, varargs array, lambda, or carrier solely for diagnostics when the snapshot is `NONE`.
@@ -430,11 +432,11 @@ does not need to change its normal return type. DFA and replacement paths need t
 7. Do not perform additional matching, scanning, capture resolution, or eligibility analysis to fill
    diagnostic fields. Every field must come from state the operation already computed or from
    bounded bookkeeping in the enabled branch.
-8. Treat one volatile read and one bounded enabled check per top-level public operation as the
-   intended disabled-path overhead. The operation-context null check also prevents internal
-   replacement searches from rereading the global listener. If production-mode benchmarks show a
-   material regression for very cheap operations, revisit the global listener design before
-   merging.
+8. Treat one stable call-site lookup and one bounded enabled check per top-level public operation as
+   the intended disabled-path overhead. The operation-context null check also prevents internal
+   replacement searches from rereading the global listener. Production-mode benchmarking showed
+   that a volatile listener read materially regressed very cheap operations, so the implementation
+   uses the mutable-call-site design above.
 
 Listener exception policy should be explicit. My recommendation is to let listener exceptions
 propagate, matching ordinary synchronous callback behavior, but invoke the listener only after the
@@ -482,7 +484,7 @@ Tests should cover:
 
 - disabled diagnostics use `NONE` and allocate no public event objects;
 - listener registration, replacement, and reset;
-- visibility across threads through the volatile reference;
+- immediate listener visibility across threads after call-site synchronization;
 - one listener snapshot per operation;
 - exactly one event per public operation;
 - listener exception behavior;

--- a/design/ISSUE_474_DIAGNOSTICS_PLAN.md
+++ b/design/ISSUE_474_DIAGNOSTICS_PLAN.md
@@ -1,0 +1,562 @@
+# Issue 474 Diagnostics Plan
+
+I reviewed issue 474 and the full linked chain of issues and PRs, including the links introduced in their comments. The core conclusion is that the original API sketch is directionally right, but its current model is too coarse to answer several of the motivating questions.
+
+The best design is a two-part API:
+
+1. A stable, queryable static pattern analysis API for tooling and eligibility inspection.
+2. A lightweight runtime listener that reports the strategy actually used and, in a bounded form, why more desirable strategies were unavailable or bypassed.
+
+A single `dfaEligible` boolean or `primaryEngine` enum cannot cover all the use cases raised in the linked work.
+
+## What the linked history adds
+
+I reviewed:
+
+- [Issue #474](https://github.com/eaftan/safere/issues/474): original diagnostics proposal.
+- [Issue #469](https://github.com/eaftan/safere/issues/469): measuring real NFA use before prioritizing Pike VM allocation work.
+- [Issue #477](https://github.com/eaftan/safere/issues/477): nullable loops, progress registers, capture costs, and possible future Pike VM extensions.
+- [Issue #465](https://github.com/eaftan/safere/issues/465), [PR #468](https://github.com/eaftan/safere/pull/468), and [PR #470](https://github.com/eaftan/safere/pull/470): word-boundary patterns unexpectedly falling off the DFA path and the scrubber workload that exposed it.
+- [Issue #481](https://github.com/eaftan/safere/issues/481) and [PR #500](https://github.com/eaftan/safere/pull/500): representative real-world benchmark workloads.
+- [Issue #488](https://github.com/eaftan/safere/issues/488): replacement workloads that reached NFA because of semantic guards.
+- [PR #494](https://github.com/eaftan/safere/pull/494): leftmost-longest support, ultimately judged low priority.
+- [PR #505](https://github.com/eaftan/safere/pull/505), [PR #506](https://github.com/eaftan/safere/pull/506), [PR #531](https://github.com/eaftan/safere/pull/531), [PR #532](https://github.com/eaftan/safere/pull/532), and [issue #538](https://github.com/eaftan/safere/issues/538): latent DFA correctness problems, removal of broad semantic guards, and the distinction between a DFA candidate and authoritative match bounds.
+- [Issue #518](https://github.com/eaftan/safere/issues/518): the need to separate engine-selection tests, forced-engine conformance tests, and unsupported-path bailout tests through an explicit capability matrix.
+- [Issue #528](https://github.com/eaftan/safere/issues/528) and [PR #529](https://github.com/eaftan/safere/pull/529): nested nullable loops where a DFA over-approximation can reject safely but cannot supply authoritative match bounds.
+- [PR #541](https://github.com/eaftan/safere/pull/541): a pattern was DFA-capable, but control flow incorrectly abandoned the DFA after prefix verification failed.
+- [PR #555](https://github.com/eaftan/safere/pull/555): OnePass was theoretically eligible but disabled by a stale eligibility check.
+- [PR #547](https://github.com/eaftan/safere/pull/547), [PR #556](https://github.com/eaftan/safere/pull/556), and [PR #560](https://github.com/eaftan/safere/pull/560): replacement-specific DFA, character-class, and proposed OnePass paths, including density-dependent tradeoffs.
+- [PR #478](https://github.com/eaftan/safere/pull/478): no-match replacement optimization.
+- [PR #510](https://github.com/eaftan/safere/pull/510): merged Pike NFA pooling and execution optimizations that substantially reduced fallback-engine allocations, making production prevalence and remaining tail-latency impact the relevant questions for further NFA work.
+
+These items expose five distinct questions consumers want to answer:
+
+- What semantic features does the pattern contain?
+- Which engines or accelerators could ever participate?
+- Which strategies were applicable for this particular operation and input?
+- Which strategies actually participated?
+- Why did execution use a slower or unexpected path?
+
+Those cannot be collapsed into one eligibility flag.
+
+## Use-case inventory
+
+| Use case | Required information |
+|---|---|
+| Decide whether further Pike NFA optimization matters after #510 | Counts of operations where NFA actually performed authoritative matching or capture extraction, plus input sizes and operations; production prevalence complements forced-NFA microbenchmarks and allocation profiles |
+| Static Error Prone-style analysis | Pattern features, structural hazards, and operation-sensitive capabilities without executing a match |
+| Find patterns that cannot use DFA | Static DFA capability and stable limitation reasons |
+| Detect regressions like #555 | Static OnePass capability compared with runtime strategy selection |
+| Detect fallback bugs like #541 | Ordered runtime strategy participation, not just final engine |
+| Explain nested nullable loops like #529 | `PROGRESS_CHECK`/nullable-loop feature plus “DFA reject prefilter only” capability |
+| Understand replacement performance | `replaceAll`/`replaceFirst` as first-class operations and replacement strategy reporting |
+| Distinguish matching from capture cost | Separate boundary-selection and capture-resolution strategies |
+| Detect DFA budget behavior | A bounded skip/fallback reason and whether the budget was exhausted |
+| Aggregate safely in production | No input or regex text, low-cardinality enums, synchronous listener, consumer-owned storage |
+| Preserve future implementation freedom | Stable semantic roles, not reverse-DFA pass names or internal branch names |
+
+## Recommended API shape
+
+### 1. Static `PatternAnalysis`
+
+Expose analysis directly from a compiled `Pattern`:
+
+```java
+public PatternAnalysis analysis();
+```
+
+I would make this a normal immutable value object rather than emit it only through `onPatternCompiled`. A compilation listener is useful for fleet-wide aggregation, but it does not satisfy the static-analysis use case well: tooling needs to ask a compiled pattern a question deterministically.
+
+A first-cut shape:
+
+```java
+public record PatternAnalysis(
+    Set<PatternFeature> features,
+    Set<PatternCapability> capabilities,
+    Set<PatternLimitation> limitations,
+    int programSize,
+    int captureCount) {
+  public PatternAnalysis {
+    features = Set.copyOf(features);
+    capabilities = Set.copyOf(capabilities);
+    limitations = Set.copyOf(limitations);
+  }
+}
+```
+
+Suggested capabilities:
+
+```java
+public enum PatternCapability {
+  LITERAL_MATCH,
+  CHARACTER_CLASS_MATCH,
+  KEYWORD_MATCH,
+  ONE_PASS_PRIMARY,
+  ONE_PASS_CAPTURE_EXTRACTION,
+  DFA_BOUNDARY_SEARCH,
+  DFA_REJECT_PREFILTER,
+  BIT_STATE,
+  NFA
+}
+```
+
+The distinction between `DFA_BOUNDARY_SEARCH` and `DFA_REJECT_PREFILTER` is essential for #529. Saying merely “DFA eligible” would misleadingly imply that the DFA can return authoritative bounds.
+
+Capabilities mean that a strategy can participate for some supported operation and input; they are
+not promises that every call will select it. Runtime conditions still matter. In particular,
+BitState depends on the program/input budget, OnePass primary selection depends on the operation and
+input-length policy, and DFA execution can exceed its state budget. `PatternAnalysis` must document
+those conditional semantics, while `strategyDecisions` explains the decision for an actual call.
+
+Suggested features should include the original list plus:
+
+```java
+NULLABLE,
+NULLABLE_ALTERNATION,
+NESTED_NULLABLE_QUANTIFIER,
+PROGRESS_CHECK,
+START_ANCHOR,
+END_ANCHOR,
+CAPTURES_IN_QUANTIFIER
+```
+
+These are more actionable for tooling than only `ANCHOR`, `BOUNDED_REPEAT`, and `CAPTURES`.
+
+Suggested static limitations should be semantic and low-cardinality:
+
+```java
+public enum PatternLimitation {
+  GRAPHEME_REQUIRES_EXACT_ENGINE,
+  NULLABLE_LOOP_REQUIRES_EXACT_ENGINE,
+  LAZY_SEMANTICS_LIMIT_ONE_PASS,
+  NULLABLE_ALTERNATION_LIMITS_ONE_PASS,
+  CAPTURE_PRIORITY_REQUIRES_EXACT_ENGINE,
+  PROGRAM_TOO_LARGE_FOR_BIT_STATE
+}
+```
+
+Avoid promises such as “this pattern will be expensive.” Expense depends on operation, input size, match density, replacement contents, cache state, and enabled engine paths. Static analysis should expose facts and capabilities; Error Prone or another consumer can impose policy.
+
+### 2. Runtime diagnostics
+
+Keep the global listener model, but report an operation summary rather than only a “primary engine”:
+
+```java
+public class SafeReMatchDiagnostics {
+  public static final SafeReMatchDiagnostics NONE = new SafeReMatchDiagnostics(false);
+
+  protected SafeReMatchDiagnostics() {}
+
+  private SafeReMatchDiagnostics(boolean enabled) {}
+
+  public void onPatternCompiled(PatternCompiledEvent event) {}
+
+  public void onOperationCompleted(OperationDiagnostics event) {}
+}
+```
+
+The issue sketch called this listener `SafeReDiagnostics`, but that name is already occupied by
+SafeRE's public bytecode-export utility. The implementation therefore uses
+`SafeReMatchDiagnostics` for the listener and preserves the existing API. Registration remains
+`Pattern.setDiagnostics(...)` and `Pattern.diagnostics()`. It is a subclassable listener class
+rather than an interface because Error Prone rejects an interface-owned `NONE` implementation as a
+possible class-initialization deadlock under this project's warnings-as-errors build.
+
+The event should distinguish three roles:
+
+```java
+public record OperationDiagnostics(
+    PatternDescriptor pattern,
+    MatchOperation operation,
+    MatchOutcome outcome,
+    MatchStrategy boundaryStrategy,
+    MatchStrategy captureStrategy,
+    List<StrategyParticipation> auxiliaryStrategies,
+    Set<StrategyDecision> strategyDecisions,
+    CaptureMode captureMode,
+    int inputLength,
+    int matchCount) {
+  public OperationDiagnostics {
+    auxiliaryStrategies = List.copyOf(auxiliaryStrategies);
+    strategyDecisions = Set.copyOf(strategyDecisions);
+  }
+}
+
+public record PatternCompiledEvent(
+    PatternDescriptor pattern) {}
+
+public record PatternDescriptor(
+    long patternId,
+    PatternAnalysis analysis) {}
+
+public record StrategyParticipation(
+    MatchStrategy strategy,
+    StrategyRole role) {}
+
+public record StrategyDecision(
+    MatchStrategy strategy,
+    StrategyDisposition disposition,
+    StrategyReason reason) {}
+```
+
+All public records must validate required components and defensively copy collection components in
+their canonical constructors. A record's component references are final, but the record is not
+deeply immutable unless collections are copied. This is required because cached analysis and
+descriptors are shared across matchers, threads, and listener invocations. Do not expose internal
+mutable arrays, `EnumSet`s, lists, or sets through record accessors.
+
+This exact record can be refined during implementation, but the conceptual separation should remain:
+
+- `pattern`: the pattern's cached immutable descriptor, shared with `PatternCompiledEvent`. Its
+  opaque process-local identifier lets a global listener correlate operations, while its analysis
+  lets a listener installed or replaced after pattern compilation interpret the first operation it
+  observes. The descriptor contains no pattern text, is not stable across processes, and does not
+  promise to encode pattern contents.
+- `boundaryStrategy`: who produced authoritative group-zero bounds.
+- `captureStrategy`: who produced capturing-group bounds, or `NONE`.
+- `auxiliaryStrategies`: bounded strategy/role pairs for auxiliary work in first-participation
+  execution order, such as literal start acceleration followed by a DFA reject prefilter. Both
+  dimensions are required: a role such as start acceleration alone would not say whether the
+  literal, character-class, or keyword strategy performed it. Ordering is required to diagnose
+  control-flow regressions where an accelerator runs and execution then continues through a
+  different engine, as in #541.
+- `strategyDecisions`: bounded explanations associated with the affected strategy. The disposition
+  distinguishes a strategy that was statically inapplicable, bypassed for this operation or input,
+  or attempted and fell back. A global reason without the strategy association would be ambiguous;
+  for example, `INPUT_TOO_LARGE` could otherwise refer to OnePass or BitState.
+- `matchCount`: particularly useful for replacement and split operations.
+
+A single `primaryEngine` loses important cases:
+
+- DFA finds group-zero boundaries, then OnePass extracts captures.
+- DFA finds boundaries, then BitState or NFA extracts captures.
+- An over-approximation DFA runs only as a negative prefilter.
+- Literal-prefix acceleration proposes a candidate, but reverse DFA supplies the authoritative start.
+- Replacement uses its own character-class loop and never invokes ordinary `find()`.
+
+Assign the identifier once when constructing `Pattern`, using a thread-safe monotonic source with
+defined overflow behavior. Cache one immutable `PatternDescriptor` when complete analysis is first
+needed. This adds a small unconditional identifier cost and one field per pattern; constructing the
+descriptor and complete analysis remains lazy when diagnostics are disabled. The production-mode
+benchmark gate must measure pattern compilation as well as matching. Do not use
+`System.identityHashCode`, a truncated pattern hash, or another collision-prone surrogate.
+
+Every enabled operation event carries the cached descriptor reference, even if a compilation event
+was previously emitted. This is deliberate: a global listener may be installed or replaced after a
+long-lived pattern was compiled, and there is no safe bounded replay log of earlier compilation
+events. Reusing the cached descriptor adds no per-operation descriptor allocation.
+
+### 3. Operations
+
+At minimum:
+
+```java
+public enum MatchOperation {
+  MATCHES,
+  LOOKING_AT,
+  FIND,
+  REPLACE_FIRST,
+  REPLACE_ALL
+}
+```
+
+If the goal is truly “all use cases mentioned,” replacement operations cannot be deferred: #488, #547, #556, and #560 are central motivating cases.
+
+Both string and functional replacement overloads use the replacement operation values. `split`,
+predicate methods, and streams can be added later, but the implementation should funnel operations
+through an internal diagnostic scope so future additions do not require redesigning every event
+site.
+
+### 4. Strategies
+
+Prefer stable externally meaningful strategies:
+
+```java
+public enum MatchStrategy {
+  NONE,
+  LITERAL,
+  CHARACTER_CLASS,
+  KEYWORD,
+  ONE_PASS,
+  DFA,
+  BIT_STATE,
+  NFA
+}
+```
+
+Do not expose `REVERSE_DFA`, `DFA_SANDWICH`, thread queues, or exact fallback branches as public enums. Those are implementation mechanisms. Represent their semantic role through `boundaryStrategy` and auxiliary roles.
+
+### 5. Runtime reasons
+
+The original proposal rejects a fallback enum, which is sensible if the alternative is exposing every branch. But a small stable reason set is necessary for the linked use cases:
+
+```java
+public enum StrategyReason {
+  INPUT_TOO_SMALL,
+  INPUT_TOO_LARGE,
+  CAPTURES_REQUIRED,
+  AUTHORITATIVE_BOUNDS_REQUIRED,
+  EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED,
+  DFA_BUDGET_EXCEEDED,
+  OPTIMIZED_PATH_DISABLED
+}
+
+public enum StrategyDisposition {
+  INAPPLICABLE,
+  BYPASSED,
+  FALLBACK
+}
+```
+
+These should describe semantic decisions rather than implementation locations. Emit each reason as
+part of a `StrategyDecision`, not as an unassociated global set. Multiple decisions may apply to one
+operation, and a strategy may have more than one relevant decision, so this should not be a single
+fallback enum.
+
+For the first release, it would be reasonable to emit reasons only when an expected major engine is skipped or fallback occurs. Do not emit a complete decision-tree trace.
+
+## Specific examples the API must represent
+
+The implementation tests should explicitly cover these shapes:
+
+- A pure literal uses `LITERAL`.
+- A simple character class uses `CHARACTER_CLASS`.
+- An anchored HTTP-like pattern uses OnePass, protecting against a recurrence of #555.
+- A normal unanchored pattern uses DFA for authoritative bounds.
+- A pattern with captures uses DFA bounds followed by OnePass, BitState, or NFA capture extraction.
+- A nested nullable-loop negative match uses `DFA_REJECT_PREFILTER`, reflecting #529.
+- A nested nullable-loop positive candidate falls through to an exact engine.
+- A literal-prefix candidate verification failure continues through DFA rather than being reported as NFA-only, reflecting #541.
+- DFA budget exhaustion records the budget reason and final exact strategy.
+- A word-boundary pattern records DFA usage where currently supported.
+- A grapheme pattern records exact-engine use and its stable limitation.
+- Character-class replacement reports its replacement fast path, reflecting #556.
+- General replacement reports DFA boundary scanning and separate capture extraction, reflecting #547.
+- No-match replacement produces one completed operation event, not a misleading series of public `find` events.
+- Deferred captures return `DEFERRED`; a later `group()` resolution does not emit a second event in version one.
+
+## Implementation plan
+
+### Phase 1: Define semantics before adding event sites
+
+1. Inventory every return path in `matches()`, `lookingAt()`, `find()`, `replaceFirst()`, and `replaceAll()`.
+2. For each path, record:
+
+   - authoritative boundary producer;
+   - capture producer;
+   - auxiliary accelerators/prefilters;
+   - applicable skip/fallback reasons;
+   - whether the operation is one public invocation or an internal repeated search.
+
+3. Write this as an internal decision table and tests before defining public enums. This avoids shaping the API around only the most obvious `doFindCore()` branches.
+
+### Phase 2: Build reusable internal carriers
+
+Do not infer diagnostics after the fact from the returned group array. When diagnostics are enabled,
+pass an optional accumulator through the existing engine calls:
+
+```java
+final class DiagnosticAccumulator {
+  InternalStrategy boundaryStrategy;
+  InternalStrategy captureStrategy;
+  int[] orderedParticipation;
+  int participationCount;
+  long[] seenParticipationWords;
+  long[] decisionReasonWords;
+}
+```
+
+This is an implementation shape, not a required public class. The arrays have fixed sizes derived
+only from the bounded public enums, never from the pattern or input. Encode each strategy/role pair
+as an integer token, append it only on first participation, and use the seen-participation words for
+bounded deduplication without losing order. Define a collision-free ordinal mapping for every
+strategy/role pair and every strategy/disposition/reason tuple, and allocate enough 64-bit words for
+the complete Cartesian products. Do not assume either decision space fits in one `int` or one
+`long`; for example, the initially proposed strategy decisions already have more than 64 possible
+tuples.
+
+Do not allocate the accumulator unconditionally. The disabled diagnostics path must preserve the
+existing engine return types and allocation behavior. Snapshot the listener once at the public
+operation boundary and use the listener's bounded enabled check to gate all diagnostic bookkeeping.
+The implementation uses an internal boolean on the subclassable listener class because Error Prone
+rejects the originally sketched interface-owned `NONE` implementation and reference comparisons
+under the warnings-as-errors build.
+
+When diagnostics are enabled, track first participation in the fixed-size primitive token array and
+track seen pairs and strategy/disposition/reason tuples with fixed-size primitive word arrays. Reuse
+existing engine-selection locals where possible. Because the enums are bounded, each pair or tuple
+can map to a stable position without allocating a public record during matching. Do not construct
+`EnumSet`s, collections, varargs arrays, lambdas, or diagnostic records inside the engine cascade.
+Convert the primitive state into an immutable ordered public participation list and decision records
+only when emitting the completed operation event.
+
+If a reusable carrier makes enabled-path implementation clearer, create it only inside the enabled
+branch. It must not add an allocation to the disabled path.
+
+The shared BitState/NFA helper must report which engine actually ran to the enabled accumulator; it
+does not need to change its normal return type. DFA and replacement paths need the same treatment.
+
+### Phase 3: Add static analysis
+
+1. Extract feature collection from the parsed/simplified AST and compiled program.
+2. Reuse existing OnePass analysis and DFA program metadata.
+3. Make the analysis immutable and cached on `Pattern`.
+4. Keep complete analysis lazy. Calling `Pattern.analysis()` may deliberately trigger OnePass or
+   other eligibility analysis, but ordinary compilation and matching must not pay that cost unless
+   it was already required by execution.
+5. When diagnostics are disabled, do not force lazy engine initialization during compilation. When
+   a listener is enabled, the compilation event may deliberately request and cache the complete
+   `PatternAnalysis` so the listener can correlate it with later operation events. Document this as
+   enabled-diagnostics overhead.
+6. Cache the complete result after the first explicit request or enabled compilation event so
+   repeated tooling queries do not repeat the analysis.
+7. Keep `Pattern.analysis()` as the primary direct API for tools even though an enabled compilation
+   listener receives the same cached analysis.
+8. Include the pattern's opaque identifier in both the compilation event and every operation event
+   so consumers can join static metadata to runtime behavior.
+9. Carry the cached descriptor, including analysis, in every enabled operation event so listeners
+   installed after compilation do not depend on replaying historical compilation events.
+
+### Phase 4: Add runtime listener plumbing
+
+1. Store `SafeReMatchDiagnostics.NONE` in a `volatile` static field.
+2. Snapshot the listener once at the beginning of each public operation.
+3. Pass that snapshot through the operation; do not reread the global listener at every internal step.
+4. Allocate no event, `EnumSet`, varargs array, lambda, or carrier solely for diagnostics when the snapshot is `NONE`.
+5. Emit exactly once through centralized normal-completion logic after the operation's matcher state
+   and return value are finalized. Do not emit a `MATCH` or `NO_MATCH` event when the regex operation
+   itself throws, because the first-version outcome enum cannot represent exceptional completion.
+6. Do not emit public `FIND` events for internal searches performed by `replaceAll`.
+7. Do not perform additional matching, scanning, capture resolution, or eligibility analysis to fill
+   diagnostic fields. Every field must come from state the operation already computed or from
+   bounded bookkeeping in the enabled branch.
+8. Treat one volatile read and one bounded enabled check per top-level public operation as the
+   intended disabled-path overhead. The operation-context null check also prevents internal
+   replacement searches from rereading the global listener. If production-mode benchmarks show a
+   material regression for very cheap operations, revisit the global listener design before
+   merging.
+
+Listener exception policy should be explicit. My recommendation is to let listener exceptions
+propagate, matching ordinary synchronous callback behavior, but invoke the listener only after the
+successful regex operation has finalized its matcher state. The match result remains internally
+established even if delivery fails. Silently swallowing listener exceptions makes telemetry failures
+invisible and complicates testing. Reentrant matching from a listener should be permitted but
+documented as the listener’s responsibility.
+
+### Phase 5: Replacement integration
+
+Treat replacement as its own operation scope:
+
+- Literal replacement fast paths.
+- Character-class replacement.
+- DFA replacement loop.
+- DFA boundary discovery plus exact capture extraction.
+- Ordinary repeated-find fallback.
+
+Emit one operation event with `matchCount`, not one event per internal match. That gives useful match-density information for the tradeoff raised in #560 without exposing inputs or storing counters in SafeRE.
+
+Replacement loops already know their match count, so recording it must not require another pass over
+the input. For ordinary single-result operations, use the existing match outcome rather than adding
+separate counting work.
+
+### Phase 6: Verification
+
+Follow the testing separation from #518 rather than treating end-to-end routing coverage as proof of
+each engine's semantic contract:
+
+1. **Selection tests:** verify that each representative pattern, operation, and input shape reports
+   the strategy participation and decisions expected from normal routing.
+2. **Engine conformance tests:** force each engine for capability-matrix entries it claims to
+   support, compare observable behavior with the appropriate JDK/SafeRE oracle, and verify that the
+   reported strategy agrees with the forced path.
+3. **Unsupported-path tests:** force or directly exercise unsupported engine/feature combinations
+   and verify that they bail out or fall back with the expected decision instead of returning trusted
+   incorrect bounds or captures.
+
+The capability matrix should cover literal and character-class fast paths, OnePass, forward and
+reverse DFA roles, the complete DFA boundary-search path, BitState, and NFA across pattern features,
+public API modes, region/bounds configurations, and small versus large inputs. Reverse DFA remains an
+internal test dimension, not a public `MatchStrategy` value.
+
+Tests should cover:
+
+- disabled diagnostics use `NONE` and allocate no public event objects;
+- listener registration, replacement, and reset;
+- visibility across threads through the volatile reference;
+- one listener snapshot per operation;
+- exactly one event per public operation;
+- listener exception behavior;
+- no regex text or input text in events;
+- feature and capability classification;
+- all representative strategies;
+- distinct boundary and capture strategies;
+- DFA reject-prefilter reporting;
+- DFA-budget fallback;
+- replacement paths and match counts;
+- OnePass eligibility regression coverage;
+- literal-prefix fallback coverage;
+- concurrent listener aggregation with `LongAdder`.
+
+For zero-allocation verification, prefer an allocation-sensitive JFR/JMH check outside the unit suite rather than a brittle elapsed-time or heap-delta assertion.
+
+Run focused unit tests first, then:
+
+```bash
+mvn -pl safere test -q
+mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests
+```
+
+### Phase 7: Production-mode performance regression gate
+
+Before implementation, collect a baseline from the target base commit. After implementation, rerun
+the same benchmark filters on the final branch. Always use `./run-java-benchmarks.sh` with its default
+production benchmark configuration: two forks, two 500 ms warmup iterations, and five 500 ms
+measurement iterations. Do not use smoke mode, fast-build shortcuts, direct JMH invocation, or
+parallel benchmark runs for this regression decision.
+
+Run benchmark classes sequentially in small batches and include at least:
+
+- tiny literal `matches()` and successful and unsuccessful `find()` operations, where the fixed
+  listener check will be the largest fraction of total work;
+- representative OnePass, DFA, BitState, and NFA paths;
+- short and long inputs;
+- no-match, sparse-match, and dense-match replacement workloads;
+- character-class and general DFA replacement fast paths.
+
+Measure four configurations against the pre-change baseline:
+
+1. Diagnostics implementation present and disabled with `SafeReMatchDiagnostics.NONE`.
+2. Diagnostics enabled with a no-op listener.
+3. Diagnostics enabled with representative `LongAdder` aggregation.
+4. Explicit `Pattern.analysis()` calls measured separately from pattern compilation and matching.
+
+Use allocation profiling or JFR alongside the production-mode run to verify that disabled
+diagnostics allocate no event objects or diagnostic bookkeeping objects. Enabled diagnostics should
+allocate at most one bounded event per public operation, independent of the number of internal
+matches or engine passes.
+
+The merge gate is:
+
+- disabled diagnostics introduce no diagnostic allocations;
+- disabled diagnostics show no statistically convincing material throughput regression across the
+  benchmark matrix;
+- complete static analysis adds no cost unless explicitly requested or already needed by execution;
+- enabled no-op and aggregation overhead is measured and documented;
+- any surprising or close result is confirmed with the script's `--long` mode before deciding.
+
+If the disabled volatile read materially regresses tiny operations, stop and reconsider the global
+listener design, such as a per-pattern listener snapshot or an explicitly instrumented pattern,
+rather than accepting the regression without review.
+
+## Scope recommendation
+
+I would deliver this in two PRs:
+
+1. `PatternAnalysis` and its static features/capabilities.
+2. Runtime diagnostics listener and operation events.
+
+That keeps the static API independently reviewable and gives runtime instrumentation a settled vocabulary. It also addresses the caution in issue 474: stable concepts can be added incrementally, while avoiding premature exposure of reverse-DFA details, budget implementation structure, or internal fallback branches.
+
+The main change I recommend relative to the original sketch is therefore:
+
+> Keep the listener-only aggregation model, but do not make the listener the only inspection API, and do not model execution as one primary engine. Expose static capabilities separately, then report authoritative boundary strategy, capture strategy, ordered auxiliary strategy/role participation, and a small set of strategy-associated decisions at runtime.

--- a/design/ISSUE_474_PHASE_6_VERIFICATION.md
+++ b/design/ISSUE_474_PHASE_6_VERIFICATION.md
@@ -10,8 +10,8 @@ counts, which would become stale as the suite evolves.
 `DiagnosticsTest` covers:
 
 - static feature, capability, and limitation classification;
-- listener registration after compilation, replacement, reset, volatile cross-thread visibility,
-  and one listener snapshot per operation;
+- listener registration after compilation, replacement, reset, synchronized cross-thread
+  visibility, and one listener snapshot per operation;
 - opaque pattern identity and the absence of pattern/input text in events;
 - literal, character-class, keyword, OnePass, DFA, BitState, and NFA routing;
 - separate boundary and capture strategies, including deferred capture extraction;

--- a/design/ISSUE_474_PHASE_6_VERIFICATION.md
+++ b/design/ISSUE_474_PHASE_6_VERIFICATION.md
@@ -1,0 +1,68 @@
+# Issue 474 Phase 6 Verification
+
+Phase 6 is complete as of 2026-07-12. This report records the verification evidence without test
+counts, which would become stale as the suite evolves.
+
+## Verification layers
+
+### Selection and diagnostics tests
+
+`DiagnosticsTest` covers:
+
+- static feature, capability, and limitation classification;
+- listener registration after compilation, replacement, reset, volatile cross-thread visibility,
+  and one listener snapshot per operation;
+- opaque pattern identity and the absence of pattern/input text in events;
+- literal, character-class, keyword, OnePass, DFA, BitState, and NFA routing;
+- separate boundary and capture strategies, including deferred capture extraction;
+- DFA candidate verification and authoritative reject-prefilter behavior;
+- DFA state-budget exhaustion followed by an exact-engine fallback, compared with the JDK oracle;
+- nullable-loop and grapheme cases that require an exact engine;
+- literal-prefix candidate failure followed by DFA continuation;
+- small and large input routing, including the BitState input-size decision;
+- region and anchoring-bounds behavior on a forced exact path;
+- replacement fast paths, ordinary replacement loops, functional replacements, and aggregate match
+  counts with one event per public operation;
+- listener exception behavior after matcher state finalization; and
+- concurrent listener aggregation using `LongAdder`.
+
+### Engine conformance and unsupported paths
+
+`EnginePathEquivalenceTest` remains the engine-conformance layer. It forces optimized and exact
+paths and compares their observable traces with the canonical engine. Its internal matrix includes
+OnePass, forward DFA, reverse DFA, BitState, NFA, replacement paths, lazy capture extraction,
+nullable loops, ambiguous reverse starts, and boundary-sensitive cases. Reverse DFA remains an
+internal path and is intentionally not exposed as a public `MatchStrategy`.
+
+`DfaTest` independently verifies the DFA state-budget bailout contract. `DiagnosticsTest` verifies
+that the same bailout is surfaced by a public operation as `DFA_BUDGET_EXCEEDED` and that fallback
+preserves the JDK result.
+
+## Commands run
+
+The following commands completed successfully and were run serially:
+
+```bash
+mvn -pl safere spotless:check -q
+mvn -pl safere -Dtest=DiagnosticsTest test -q
+mvn -pl safere test -q
+mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q
+```
+
+After adding the final DFA-budget diagnostics case, the focused diagnostics command was rerun and
+passed. The added change was test-only; the implementation covered by the full suite and public
+crosscheck did not change afterward.
+
+## Disabled-path allocation check
+
+A standalone JFR probe warmed a literal match, installed `SafeReMatchDiagnostics.NONE`, and then
+recorded allocation events while repeatedly creating matchers and calling `matches()`. The
+recording contained no allocations of `DiagnosticAccumulator`, `OperationDiagnostics`,
+`PatternCompiledEvent`, `StrategyDecision`, or `StrategyParticipation`.
+
+The probe artifacts are intentionally outside the repository:
+
+- `/tmp/safere-disabled-diagnostics.jfr`
+- `/tmp/safere-disabled-diagnostics-allocations.txt`
+
+Production-mode throughput and enabled-listener overhead remain Phase 7 work.

--- a/design/ISSUE_474_PHASE_7_PERFORMANCE.md
+++ b/design/ISSUE_474_PHASE_7_PERFORMANCE.md
@@ -1,0 +1,123 @@
+# Issue 474 Phase 7 Performance Verification
+
+Phase 7 passed on 2026-07-12. All JMH invocations ran serially through
+`./run-java-benchmarks.sh`. Routine evidence used the standard configuration; close or surprising
+results used `--long` confirmation.
+
+## Revisions and method
+
+- Baseline: `c8f51f3fa99976566ac9a3260df371caedec929e`, committed
+  `2026-07-08T02:24:42Z`.
+- Issue branch starting point: `6e427eee3eb1ae6666a0080946c0b3428b559c94`, committed
+  `2026-07-12T17:20:33Z`, plus the Phase 7 benchmark and disabled-path optimization changes in this
+  worktree.
+- The baseline ran in a detached worktree with the identical
+  `DiagnosticsDisabledBenchmark` source added as benchmark-only scaffolding.
+- Ratios below are issue-branch time divided by baseline time; values below 1.0 favor the issue
+  branch.
+
+## Disabled diagnostics regression matrix
+
+| Workload | Baseline ns/op | Branch ns/op | Branch / baseline |
+|---|---:|---:|---:|
+| BitState-sized ambiguous match | 89.412 | 89.369 | 1.000 |
+| Dense character-class replacement | 105.013 | 103.021 | 0.981 |
+| No-match character-class replacement | 20.690 | 20.449 | 0.988 |
+| Long DFA find | 579.022 | 605.815 | 1.046 |
+| Sparse DFA replacement | 1,596.580 | 1,638.242 | 1.026 |
+| Long NFA match | 13,336.972 | 13,449.810 | 1.008 |
+| OnePass match | 59.551 | 59.468 | 0.999 |
+| Tiny literal find hit | 17.010 | 15.664 | 0.921 |
+| Tiny literal find miss | 15.806 | 15.338 | 0.970 |
+| Tiny literal full match | 14.141 | 14.157 | 1.001 |
+
+The geometric mean branch/baseline ratio is 0.994. Individual confidence intervals overlap for the
+slower results, so the matrix does not show a statistically convincing material regression.
+
+An initial implementation using a volatile global listener did regress the smallest operations.
+CPU profiling showed listener lookup and diagnostics helper frames on the disabled hot path. A
+synchronized mutable call site replaced the volatile lookup, and direct local accumulator guards
+were used in the literal and character-class fast paths. The final results above include those
+changes.
+
+Long-mode confirmation covered the initially regressed no-match replacement and OnePass cases:
+
+| Workload | Baseline ns/op | Branch ns/op |
+|---|---:|---:|
+| No-match character-class replacement | 20.312 ± 0.248 | 20.716 ± 0.338 |
+| OnePass match | 59.697 ± 0.990 | 60.904 ± 1.687 |
+
+The long-mode confidence intervals overlap in both cases.
+
+## Enabled diagnostics overhead
+
+The standard matrix measured an enabled no-op listener and representative `LongAdder` aggregation.
+Enabled diagnostics intentionally pay for bounded operation bookkeeping and immutable event
+materialization. The full standard-configuration matrix was:
+
+| Workload | Disabled ns/op | No-op ns/op | No-op overhead | LongAdder ns/op | LongAdder overhead |
+|---|---:|---:|---:|---:|---:|
+| BitState-sized ambiguous match | 89.369 | 254.405 | 2.85× | 260.225 | 2.91× |
+| Dense character-class replacement | 103.021 | 255.950 | 2.48× | 262.858 | 2.55× |
+| No-match character-class replacement | 20.449 | 161.648 | 7.90× | 171.883 | 8.41× |
+| Long DFA find | 605.815 | 800.373 | 1.32× | 799.383 | 1.32× |
+| Sparse DFA replacement | 1,638.242 | 1,832.636 | 1.12× | 1,812.957 | 1.11× |
+| Long NFA match | 13,449.810 | 13,731.093 | 1.02× | 13,562.986 | 1.01× |
+| OnePass match | 59.468 | 213.447 | 3.59× | 218.884 | 3.68× |
+| Tiny literal find hit | 15.664 | 169.111 | 10.80× | 172.314 | 11.00× |
+| Tiny literal find miss | 15.338 | 213.742 | 13.94× | 161.021 | 10.50× |
+| Tiny literal full match | 14.157 | 162.858 | 11.50× | 167.083 | 11.80× |
+
+The fixed event cost dominates tiny operations and becomes a small fraction of long NFA work.
+Long-mode confirmation of failed literal find measured 209.789 ± 3.955 ns/op for the no-op listener
+and 159.768 ± 1.935 ns/op for `LongAdder`. This counterintuitive ordering persisted across forks and
+is attributed to listener-specific JIT escape-analysis and dispatch shape; it does not affect the
+disabled-path merge gate.
+
+### Future enabled-mode optimization
+
+Enabled diagnostics currently add approximately 150–200 ns of fixed work per public operation.
+This is a possible follow-up issue or PR discussion item, not part of the Phase 7 merge gate.
+
+A reasonable estimate is that allocation-conscious implementation work could reduce the fixed cost
+to roughly 60–100 ns without changing the public semantics. Candidate work includes reusing
+per-thread accumulator storage, avoiding fresh primitive bookkeeping arrays, lazily materializing
+empty or unused collections, specializing events with one strategy and no decisions, and reducing
+intermediate record allocation.
+
+A more aggressive callback or API redesign might reach roughly 20–50 ns, but could require an
+ephemeral event view, primitive callback fields, sampling, or restrictions on listeners retaining
+events. Those tradeoffs would weaken some combination of immutability, listener simplicity, and
+retainability, so the allocation-conscious approach should be profiled and attempted first.
+
+## Static analysis cost
+
+| Workload | ns/op |
+|---|---:|
+| Cached `Pattern.analysis()` | 0.528 ± 0.020 |
+| Compile only | 35,494.045 ± 3,523.521 |
+| Compile plus first analysis | 36,484.973 ± 2,757.395 |
+
+Compile-only and compile-plus-analysis confidence intervals overlap broadly. Complete analysis is
+lazy unless explicitly requested or required by an enabled compilation event, and cached retrieval
+is effectively a field access.
+
+## Allocation verification
+
+A final JFR allocation probe installed `SafeReMatchDiagnostics.NONE`, warmed the literal matching
+path, and recorded repeated public operations. It found no allocations of diagnostic event or
+bookkeeping classes. Enabled operation-count tests separately verify exactly one callback per public
+operation regardless of internal match count.
+
+Artifacts are outside the repository under `/tmp/issue474-*`, including the raw standard and long
+JMH logs, CPU profile, JFR recording, and printed allocation events.
+
+## Gate decision
+
+Phase 7 passes:
+
+- disabled diagnostics have no diagnostic allocations;
+- the final standard matrix has no statistically convincing material throughput regression;
+- initially surprising tiny-operation results were confirmed with `--long` after optimization;
+- enabled no-op and `LongAdder` costs are measured and documented; and
+- explicit static analysis cost is isolated from compilation and matching.

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DiagnosticsDisabledBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DiagnosticsDisabledBenchmark.java
@@ -1,0 +1,107 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Production-path benchmarks used to measure disabled diagnostics overhead. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class DiagnosticsDisabledBenchmark {
+  private org.safere.Pattern literal;
+  private org.safere.Pattern onePass;
+  private org.safere.Pattern ambiguous;
+  private org.safere.Pattern dfa;
+  private org.safere.Pattern charClassReplacement;
+  private org.safere.Pattern dfaReplacement;
+  private String dfaInput;
+  private String nfaInput;
+  private String sparseReplacementInput;
+  private String denseReplacementInput;
+
+  /** Initializes patterns and inputs outside measured invocations. */
+  @Setup
+  public void setup() {
+    literal = org.safere.Pattern.compile("abc");
+    onePass = org.safere.Pattern.compile("^([A-Z]+):(\\d+)$");
+    ambiguous = org.safere.Pattern.compile("(?:a|aa)+b");
+    dfa = org.safere.Pattern.compile("a+b");
+    charClassReplacement = org.safere.Pattern.compile("[0-9]+");
+    dfaReplacement = org.safere.Pattern.compile("a+b");
+    dfaInput = "x".repeat(512) + "aaab";
+    nfaInput = "a".repeat(8_192) + "b";
+    sparseReplacementInput = "x".repeat(512) + " aaab " + "x".repeat(512);
+    denseReplacementInput = "1 22 333 4444 55555 666666";
+  }
+
+  /** Measures the smallest successful literal full match. */
+  @Benchmark
+  public boolean tinyLiteralMatches() {
+    return literal.matcher("abc").matches();
+  }
+
+  /** Measures the smallest successful literal search. */
+  @Benchmark
+  public boolean tinyLiteralFindHit() {
+    return literal.matcher("xabc").find();
+  }
+
+  /** Measures the smallest unsuccessful literal search. */
+  @Benchmark
+  public boolean tinyLiteralFindMiss() {
+    return literal.matcher("xyz").find();
+  }
+
+  /** Measures an anchored OnePass match with captures. */
+  @Benchmark
+  public boolean onePassMatches() {
+    return onePass.matcher("HEADER:12345").matches();
+  }
+
+  /** Measures an unanchored DFA search on a long input. */
+  @Benchmark
+  public boolean dfaLongFind() {
+    return dfa.matcher(dfaInput).find();
+  }
+
+  /** Measures exact matching on a small ambiguous input, which is BitState-sized. */
+  @Benchmark
+  public boolean bitStateShortMatches() {
+    return ambiguous.matcher("aaaaab").matches();
+  }
+
+  /** Measures exact matching on an input too large for BitState. */
+  @Benchmark
+  public boolean nfaLongMatches() {
+    return ambiguous.matcher(nfaInput).matches();
+  }
+
+  /** Measures a general DFA replacement with sparse matches. */
+  @Benchmark
+  public String dfaSparseReplaceAll() {
+    return dfaReplacement.matcher(sparseReplacementInput).replaceAll("z");
+  }
+
+  /** Measures a character-class replacement with dense matches. */
+  @Benchmark
+  public String charClassDenseReplaceAll() {
+    return charClassReplacement.matcher(denseReplacementInput).replaceAll("#");
+  }
+
+  /** Measures a character-class replacement with no matches. */
+  @Benchmark
+  public String charClassNoMatchReplaceAll() {
+    return charClassReplacement.matcher("no digits here").replaceAll("#");
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DiagnosticsEnabledBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DiagnosticsEnabledBenchmark.java
@@ -1,0 +1,138 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/** Measures enabled diagnostics overhead with representative listeners. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class DiagnosticsEnabledBenchmark {
+  private static final org.safere.SafeReMatchDiagnostics NO_OP =
+      new org.safere.SafeReMatchDiagnostics() {};
+
+  /** Listener implementation selected for the trial. */
+  @Param({"noop", "longAdder"})
+  public String listenerMode;
+
+  private org.safere.Pattern literal;
+  private org.safere.Pattern onePass;
+  private org.safere.Pattern ambiguous;
+  private org.safere.Pattern dfa;
+  private org.safere.Pattern charClassReplacement;
+  private org.safere.Pattern dfaReplacement;
+  private String dfaInput;
+  private String nfaInput;
+  private String sparseReplacementInput;
+  private String denseReplacementInput;
+
+  /** Initializes the workload and installs the selected listener. */
+  @Setup(Level.Trial)
+  public void setup() {
+    org.safere.Pattern.setDiagnostics(org.safere.SafeReMatchDiagnostics.NONE);
+    literal = org.safere.Pattern.compile("abc");
+    onePass = org.safere.Pattern.compile("^([A-Z]+):(\\d+)$");
+    ambiguous = org.safere.Pattern.compile("(?:a|aa)+b");
+    dfa = org.safere.Pattern.compile("a+b");
+    charClassReplacement = org.safere.Pattern.compile("[0-9]+");
+    dfaReplacement = org.safere.Pattern.compile("a+b");
+    dfaInput = "x".repeat(512) + "aaab";
+    nfaInput = "a".repeat(8_192) + "b";
+    sparseReplacementInput = "x".repeat(512) + " aaab " + "x".repeat(512);
+    denseReplacementInput = "1 22 333 4444 55555 666666";
+    org.safere.Pattern.setDiagnostics(
+        listenerMode.equals("noop") ? NO_OP : new AggregatingDiagnostics());
+  }
+
+  /** Restores the disabled listener after each trial. */
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    org.safere.Pattern.setDiagnostics(org.safere.SafeReMatchDiagnostics.NONE);
+  }
+
+  /** Measures the smallest successful literal full match. */
+  @Benchmark
+  public boolean tinyLiteralMatches() {
+    return literal.matcher("abc").matches();
+  }
+
+  /** Measures the smallest successful literal search. */
+  @Benchmark
+  public boolean tinyLiteralFindHit() {
+    return literal.matcher("xabc").find();
+  }
+
+  /** Measures the smallest unsuccessful literal search. */
+  @Benchmark
+  public boolean tinyLiteralFindMiss() {
+    return literal.matcher("xyz").find();
+  }
+
+  /** Measures an anchored OnePass match with captures. */
+  @Benchmark
+  public boolean onePassMatches() {
+    return onePass.matcher("HEADER:12345").matches();
+  }
+
+  /** Measures an unanchored DFA search on a long input. */
+  @Benchmark
+  public boolean dfaLongFind() {
+    return dfa.matcher(dfaInput).find();
+  }
+
+  /** Measures exact matching on a small ambiguous input, which is BitState-sized. */
+  @Benchmark
+  public boolean bitStateShortMatches() {
+    return ambiguous.matcher("aaaaab").matches();
+  }
+
+  /** Measures exact matching on an input too large for BitState. */
+  @Benchmark
+  public boolean nfaLongMatches() {
+    return ambiguous.matcher(nfaInput).matches();
+  }
+
+  /** Measures a general DFA replacement with sparse matches. */
+  @Benchmark
+  public String dfaSparseReplaceAll() {
+    return dfaReplacement.matcher(sparseReplacementInput).replaceAll("z");
+  }
+
+  /** Measures a character-class replacement with dense matches. */
+  @Benchmark
+  public String charClassDenseReplaceAll() {
+    return charClassReplacement.matcher(denseReplacementInput).replaceAll("#");
+  }
+
+  /** Measures a character-class replacement with no matches. */
+  @Benchmark
+  public String charClassNoMatchReplaceAll() {
+    return charClassReplacement.matcher("no digits here").replaceAll("#");
+  }
+
+  private static final class AggregatingDiagnostics extends org.safere.SafeReMatchDiagnostics {
+    private final LongAdder operations = new LongAdder();
+    private final LongAdder matches = new LongAdder();
+
+    @Override
+    public void onOperationCompleted(org.safere.OperationDiagnostics event) {
+      operations.increment();
+      matches.add(event.matchCount());
+    }
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternAnalysisBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternAnalysisBenchmark.java
@@ -1,0 +1,50 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Measures explicit cached static pattern analysis independently of compilation and matching. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class PatternAnalysisBenchmark {
+  private static final String REGEX = "^(?:(a)?)*$|(?i)\\b(error|warning|timeout)\\b";
+
+  private org.safere.Pattern pattern;
+
+  /** Compiles and analyzes the pattern before measurement. */
+  @Setup
+  public void setup() {
+    pattern = org.safere.Pattern.compile(REGEX);
+    pattern.analysis();
+  }
+
+  /** Measures retrieval of the cached immutable analysis. */
+  @Benchmark
+  public org.safere.PatternAnalysis cachedAnalysis() {
+    return pattern.analysis();
+  }
+
+  /** Measures compilation without requesting static diagnostics analysis. */
+  @Benchmark
+  public org.safere.Pattern compileOnly() {
+    return org.safere.Pattern.compile(REGEX);
+  }
+
+  /** Measures compilation followed by the first explicit static analysis request. */
+  @Benchmark
+  public org.safere.PatternAnalysis compileAndAnalyze() {
+    return org.safere.Pattern.compile(REGEX).analysis();
+  }
+}

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -118,6 +118,7 @@
                         <exclude name="CompilerTest.java"/>
                         <exclude name="DfaNfaTest.java"/>
                         <exclude name="DfaTest.java"/>
+                        <exclude name="DiagnosticsTest.java"/>
                         <exclude name="EmptyOpTest.java"/>
                         <exclude name="EnginePathEquivalenceTest.java"/>
                         <exclude name="GraphemeLinearTimeTest.java"/>

--- a/safere/src/main/java/org/safere/CaptureMode.java
+++ b/safere/src/main/java/org/safere/CaptureMode.java
@@ -1,0 +1,13 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Capture state when a public operation returns. */
+public enum CaptureMode {
+  NONE,
+  EAGER,
+  DEFERRED
+}

--- a/safere/src/main/java/org/safere/DiagnosticAccumulator.java
+++ b/safere/src/main/java/org/safere/DiagnosticAccumulator.java
@@ -1,0 +1,187 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Enabled-only, bounded primitive diagnostics state for one public operation. */
+final class DiagnosticAccumulator {
+  private static final MatchStrategy[] STRATEGIES = {
+    MatchStrategy.NONE,
+    MatchStrategy.LITERAL,
+    MatchStrategy.CHARACTER_CLASS,
+    MatchStrategy.KEYWORD,
+    MatchStrategy.ONE_PASS,
+    MatchStrategy.DFA,
+    MatchStrategy.BIT_STATE,
+    MatchStrategy.NFA
+  };
+  private static final StrategyRole[] ROLES = {
+    StrategyRole.START_ACCELERATION,
+    StrategyRole.REJECT_PREFILTER,
+    StrategyRole.CANDIDATE_VERIFICATION
+  };
+  private static final StrategyDisposition[] DISPOSITIONS = {
+    StrategyDisposition.INAPPLICABLE, StrategyDisposition.BYPASSED, StrategyDisposition.FALLBACK
+  };
+  private static final StrategyReason[] REASONS = {
+    StrategyReason.INPUT_TOO_SMALL,
+    StrategyReason.INPUT_TOO_LARGE,
+    StrategyReason.CAPTURES_REQUIRED,
+    StrategyReason.AUTHORITATIVE_BOUNDS_REQUIRED,
+    StrategyReason.EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED,
+    StrategyReason.DFA_BUDGET_EXCEEDED,
+    StrategyReason.WORK_BUDGET_EXCEEDED,
+    StrategyReason.OPTIMIZED_PATH_DISABLED
+  };
+  private static final int STRATEGY_COUNT = STRATEGIES.length;
+  private static final int ROLE_COUNT = ROLES.length;
+  private static final int DISPOSITION_COUNT = DISPOSITIONS.length;
+  private static final int REASON_COUNT = REASONS.length;
+  private static final int PARTICIPATION_COUNT = STRATEGY_COUNT * ROLE_COUNT;
+  private static final int DECISION_COUNT = STRATEGY_COUNT * DISPOSITION_COUNT * REASON_COUNT;
+
+  private MatchStrategy boundaryStrategy = MatchStrategy.NONE;
+  private MatchStrategy captureStrategy = MatchStrategy.NONE;
+  private final int[] orderedParticipation = new int[PARTICIPATION_COUNT];
+  private int participationSize;
+  private final long[] seenParticipation = new long[wordCount(PARTICIPATION_COUNT)];
+  private final long[] decisions = new long[wordCount(DECISION_COUNT)];
+  private int matchCount;
+
+  private static int wordCount(int bits) {
+    return (bits + Long.SIZE - 1) / Long.SIZE;
+  }
+
+  void boundary(MatchStrategy strategy) {
+    if (boundaryStrategy == MatchStrategy.NONE) {
+      boundaryStrategy = strategy;
+    }
+  }
+
+  void replaceBoundary(MatchStrategy strategy) {
+    boundaryStrategy = strategy;
+  }
+
+  void capture(MatchStrategy strategy) {
+    if (captureStrategy == MatchStrategy.NONE) {
+      captureStrategy = strategy;
+    }
+  }
+
+  void participate(MatchStrategy strategy, StrategyRole role) {
+    int token = strategyIndex(strategy) * ROLE_COUNT + roleIndex(role);
+    int word = token / Long.SIZE;
+    long bit = 1L << (token % Long.SIZE);
+    if ((seenParticipation[word] & bit) != 0) {
+      return;
+    }
+    seenParticipation[word] |= bit;
+    orderedParticipation[participationSize++] = token;
+  }
+
+  void decision(MatchStrategy strategy, StrategyDisposition disposition, StrategyReason reason) {
+    int token =
+        (strategyIndex(strategy) * DISPOSITION_COUNT + dispositionIndex(disposition)) * REASON_COUNT
+            + reasonIndex(reason);
+    decisions[token / Long.SIZE] |= 1L << (token % Long.SIZE);
+  }
+
+  void incrementMatchCount() {
+    matchCount++;
+  }
+
+  void matchCount(int count) {
+    matchCount = count;
+  }
+
+  int matchCount() {
+    return matchCount;
+  }
+
+  OperationDiagnostics toEvent(
+      PatternDescriptor pattern,
+      MatchOperation operation,
+      MatchOutcome outcome,
+      CaptureMode captureMode,
+      int inputLength) {
+    List<StrategyParticipation> participation = new ArrayList<>(participationSize);
+    for (int i = 0; i < participationSize; i++) {
+      int token = orderedParticipation[i];
+      participation.add(
+          new StrategyParticipation(STRATEGIES[token / ROLE_COUNT], ROLES[token % ROLE_COUNT]));
+    }
+    Set<StrategyDecision> decisionSet = new LinkedHashSet<>();
+    for (int token = 0; token < DECISION_COUNT; token++) {
+      if ((decisions[token / Long.SIZE] & (1L << (token % Long.SIZE))) == 0) {
+        continue;
+      }
+      int strategyOrdinal = token / (DISPOSITION_COUNT * REASON_COUNT);
+      int remainder = token % (DISPOSITION_COUNT * REASON_COUNT);
+      decisionSet.add(
+          new StrategyDecision(
+              STRATEGIES[strategyOrdinal],
+              DISPOSITIONS[remainder / REASON_COUNT],
+              REASONS[remainder % REASON_COUNT]));
+    }
+    return new OperationDiagnostics(
+        pattern,
+        operation,
+        outcome,
+        boundaryStrategy,
+        captureStrategy,
+        participation,
+        decisionSet,
+        captureMode,
+        inputLength,
+        matchCount);
+  }
+
+  private static int strategyIndex(MatchStrategy strategy) {
+    return switch (strategy) {
+      case NONE -> 0;
+      case LITERAL -> 1;
+      case CHARACTER_CLASS -> 2;
+      case KEYWORD -> 3;
+      case ONE_PASS -> 4;
+      case DFA -> 5;
+      case BIT_STATE -> 6;
+      case NFA -> 7;
+    };
+  }
+
+  private static int roleIndex(StrategyRole role) {
+    return switch (role) {
+      case START_ACCELERATION -> 0;
+      case REJECT_PREFILTER -> 1;
+      case CANDIDATE_VERIFICATION -> 2;
+    };
+  }
+
+  private static int dispositionIndex(StrategyDisposition disposition) {
+    return switch (disposition) {
+      case INAPPLICABLE -> 0;
+      case BYPASSED -> 1;
+      case FALLBACK -> 2;
+    };
+  }
+
+  private static int reasonIndex(StrategyReason reason) {
+    return switch (reason) {
+      case INPUT_TOO_SMALL -> 0;
+      case INPUT_TOO_LARGE -> 1;
+      case CAPTURES_REQUIRED -> 2;
+      case AUTHORITATIVE_BOUNDS_REQUIRED -> 3;
+      case EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED -> 4;
+      case DFA_BUDGET_EXCEEDED -> 5;
+      case WORK_BUDGET_EXCEEDED -> 6;
+      case OPTIMIZED_PATH_DISABLED -> 7;
+    };
+  }
+}

--- a/safere/src/main/java/org/safere/DiagnosticAccumulator.java
+++ b/safere/src/main/java/org/safere/DiagnosticAccumulator.java
@@ -105,6 +105,10 @@ final class DiagnosticAccumulator {
     return matchCount;
   }
 
+  boolean captured() {
+    return captureStrategy != MatchStrategy.NONE;
+  }
+
   OperationDiagnostics toEvent(
       PatternDescriptor pattern,
       MatchOperation operation,

--- a/safere/src/main/java/org/safere/DiagnosticAccumulator.java
+++ b/safere/src/main/java/org/safere/DiagnosticAccumulator.java
@@ -53,6 +53,8 @@ final class DiagnosticAccumulator {
   private int participationSize;
   private final long[] seenParticipation = new long[wordCount(PARTICIPATION_COUNT)];
   private final long[] decisions = new long[wordCount(DECISION_COUNT)];
+  private int forwardDfaSearchCount;
+  private int reverseDfaSearchCount;
   private int matchCount;
 
   private static int wordCount(int bits) {
@@ -95,6 +97,18 @@ final class DiagnosticAccumulator {
 
   void incrementMatchCount() {
     matchCount++;
+  }
+
+  void incrementForwardDfaSearchCount() {
+    if (forwardDfaSearchCount < Integer.MAX_VALUE) {
+      forwardDfaSearchCount++;
+    }
+  }
+
+  void incrementReverseDfaSearchCount() {
+    if (reverseDfaSearchCount < Integer.MAX_VALUE) {
+      reverseDfaSearchCount++;
+    }
   }
 
   void matchCount(int count) {
@@ -142,6 +156,8 @@ final class DiagnosticAccumulator {
         captureStrategy,
         participation,
         decisionSet,
+        forwardDfaSearchCount,
+        reverseDfaSearchCount,
         captureMode,
         inputLength,
         matchCount);

--- a/safere/src/main/java/org/safere/MatchOperation.java
+++ b/safere/src/main/java/org/safere/MatchOperation.java
@@ -1,0 +1,15 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Public operation summarized by a diagnostics event. */
+public enum MatchOperation {
+  MATCHES,
+  LOOKING_AT,
+  FIND,
+  REPLACE_FIRST,
+  REPLACE_ALL
+}

--- a/safere/src/main/java/org/safere/MatchOutcome.java
+++ b/safere/src/main/java/org/safere/MatchOutcome.java
@@ -1,0 +1,12 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Whether a completed operation found at least one match. */
+public enum MatchOutcome {
+  MATCH,
+  NO_MATCH
+}

--- a/safere/src/main/java/org/safere/MatchStrategy.java
+++ b/safere/src/main/java/org/safere/MatchStrategy.java
@@ -1,0 +1,18 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Stable strategy-level description of matching work. */
+public enum MatchStrategy {
+  NONE,
+  LITERAL,
+  CHARACTER_CLASS,
+  KEYWORD,
+  ONE_PASS,
+  DFA,
+  BIT_STATE,
+  NFA
+}

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -129,7 +129,7 @@ public final class Matcher implements MatchResult {
     if (matchCount == 0 || parentPattern.numGroups() == 0) {
       captureMode = CaptureMode.NONE;
     } else {
-      captureMode = capturesResolved ? CaptureMode.EAGER : CaptureMode.DEFERRED;
+      captureMode = accumulator.captured() ? CaptureMode.EAGER : CaptureMode.DEFERRED;
     }
     OperationDiagnostics event =
         accumulator.toEvent(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -90,6 +90,123 @@ public final class Matcher implements MatchResult {
   private boolean fullTextRegionContext;
   private boolean findExhaustedAfterTerminalEmptyMatch;
   private int modCount;
+  private DiagnosticOperation diagnosticOperation;
+  private boolean diagnosticCaptureSearch;
+
+  private record DiagnosticOperation(
+      SafeReMatchDiagnostics listener,
+      MatchOperation operation,
+      DiagnosticAccumulator accumulator) {}
+
+  private DiagnosticOperation beginDiagnostics(MatchOperation operation) {
+    if (diagnosticOperation != null) {
+      return null;
+    }
+    SafeReMatchDiagnostics listener = Pattern.diagnostics();
+    if (!SafeReMatchDiagnostics.isEnabled(listener)) {
+      return null;
+    }
+    DiagnosticOperation started =
+        new DiagnosticOperation(listener, operation, new DiagnosticAccumulator());
+    diagnosticOperation = started;
+    return started;
+  }
+
+  private void abortDiagnostics(DiagnosticOperation operation) {
+    if (operation != null) {
+      diagnosticOperation = null;
+    }
+  }
+
+  private void completeDiagnostics(DiagnosticOperation operation, int matchCount) {
+    if (operation == null) {
+      return;
+    }
+    DiagnosticAccumulator accumulator = operation.accumulator();
+    accumulator.matchCount(matchCount);
+    MatchOutcome outcome = matchCount == 0 ? MatchOutcome.NO_MATCH : MatchOutcome.MATCH;
+    CaptureMode captureMode;
+    if (matchCount == 0 || parentPattern.numGroups() == 0) {
+      captureMode = CaptureMode.NONE;
+    } else {
+      captureMode = capturesResolved ? CaptureMode.EAGER : CaptureMode.DEFERRED;
+    }
+    OperationDiagnostics event =
+        accumulator.toEvent(
+            parentPattern.descriptor(), operation.operation(), outcome, captureMode, text.length());
+    diagnosticOperation = null;
+    operation.listener().onOperationCompleted(event);
+  }
+
+  private DiagnosticAccumulator diagnosticsAccumulator() {
+    return diagnosticOperation == null ? null : diagnosticOperation.accumulator();
+  }
+
+  private void diagnosticBoundary(MatchStrategy strategy) {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.boundary(strategy);
+    }
+  }
+
+  private void diagnosticExact(MatchStrategy strategy) {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      if (diagnosticCaptureSearch) {
+        accumulator.capture(strategy);
+      } else {
+        accumulator.boundary(strategy);
+      }
+    }
+  }
+
+  private void diagnosticBoundaryOverride(MatchStrategy strategy) {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.replaceBoundary(strategy);
+    }
+  }
+
+  private void diagnosticCapture(MatchStrategy strategy) {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.capture(strategy);
+    }
+  }
+
+  private void diagnosticParticipation(MatchStrategy strategy, StrategyRole role) {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.participate(strategy, role);
+    }
+  }
+
+  private void diagnosticDecision(
+      MatchStrategy strategy, StrategyDisposition disposition, StrategyReason reason) {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.decision(strategy, disposition, reason);
+    }
+  }
+
+  private void diagnosticDfaBudget(Dfa.SearchResult result) {
+    if (result == null) {
+      diagnosticDecision(
+          MatchStrategy.DFA, StrategyDisposition.FALLBACK, StrategyReason.DFA_BUDGET_EXCEEDED);
+    }
+  }
+
+  private void diagnosticIncrementMatchCount() {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.incrementMatchCount();
+    }
+  }
+
+  private int diagnosticMatchCount() {
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    return accumulator == null ? 0 : accumulator.matchCount();
+  }
 
   /**
    * Cached BitState instance borrowed from the parent Pattern's thread-local cache, reused across
@@ -637,6 +754,18 @@ public final class Matcher implements MatchResult {
    * @return {@code true} if the entire input sequence matches this matcher's pattern
    */
   public boolean matches() {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.MATCHES);
+    try {
+      boolean matched = matchesImpl();
+      completeDiagnostics(operation, matched ? 1 : 0);
+      return matched;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private boolean matchesImpl() {
     modCount++;
     findExhaustedAfterTerminalEmptyMatch = false;
     searchFrom = regionStart;
@@ -686,6 +815,7 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().literalFastPaths()
         && literal != null
         && parentPattern.numGroups() == 0) {
+      diagnosticBoundary(MatchStrategy.LITERAL);
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched =
@@ -705,6 +835,7 @@ public final class Matcher implements MatchResult {
     // Character-class fast path: for patterns like [a-zA-Z]+, \d+, \w*, etc.
     int[] ccRanges = parentPattern.charClassMatchRanges();
     if (enginePathOptions().charClassMatchFastPaths() && ccRanges != null) {
+      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
       return charClassMatchFastPath(ccRanges);
     }
 
@@ -712,6 +843,8 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().charClassMatchFastPaths()
         && requiredRanges != null
         && !containsRequiredMatchClass(requiredRanges)) {
+      diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
+      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
       return applyFailedMatchResult();
     }
 
@@ -723,22 +856,39 @@ public final class Matcher implements MatchResult {
     if (onePass != null
         && !prog.hasGraphemeSemantics()
         && !parentPattern.hasNullableAlternation()) {
+      diagnosticBoundary(MatchStrategy.ONE_PASS);
+      if (parentPattern.numGroups() > 0) {
+        diagnosticCapture(MatchStrategy.ONE_PASS);
+      }
       int[] result = onePass.search(text, true, prog.numCaptures(), this.groups);
       return applyFullMatchResult(result);
     }
 
     // Medium path: use DFA to check if a full match exists.
     if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
-
+      diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
       Dfa.SearchResult dfaResult = dfa(true).doSearch(text, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
+        diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
       }
       if (dfaResult != null && dfaResult.pos() != text.length()) {
+        diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
       }
       if (dfaResult != null && prog.numLoopRegs() == 0) {
+        diagnosticBoundary(MatchStrategy.DFA);
         return applyDeferredMatchResult(0, text.length(), prog.numCaptures(), true, true);
+      }
+      if (dfaResult != null && dfaResult.matched() && prog.numLoopRegs() > 0) {
+        diagnosticDecision(
+            MatchStrategy.DFA,
+            StrategyDisposition.BYPASSED,
+            StrategyReason.EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED);
+      }
+      if (dfaResult == null) {
+        diagnosticDecision(
+            MatchStrategy.DFA, StrategyDisposition.FALLBACK, StrategyReason.DFA_BUDGET_EXCEEDED);
       }
     }
 
@@ -761,6 +911,7 @@ public final class Matcher implements MatchResult {
     // may accept a match ending before a trailing \n. In that case, fall back to the NFA
     // which uses longest-match mode for FULL_MATCH and finds the correct full-text match.
     if (result != null && result[1] != text.length()) {
+      diagnosticBoundaryOverride(MatchStrategy.NFA);
       int[] nfaResult =
           searchNfa(
               prog,
@@ -787,6 +938,18 @@ public final class Matcher implements MatchResult {
    * @return {@code true} if a prefix of the input sequence matches this matcher's pattern
    */
   public boolean lookingAt() {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.LOOKING_AT);
+    try {
+      boolean matched = lookingAtImpl();
+      completeDiagnostics(operation, matched ? 1 : 0);
+      return matched;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private boolean lookingAtImpl() {
     modCount++;
     findExhaustedAfterTerminalEmptyMatch = false;
     searchFrom = regionStart;
@@ -836,6 +999,7 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().literalFastPaths()
         && literal != null
         && parentPattern.numGroups() == 0) {
+      diagnosticBoundary(MatchStrategy.LITERAL);
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched =
@@ -858,6 +1022,10 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().onePass()
         && parentPattern.canOnePassPrimary()
         && !prog.hasGraphemeSemantics()) {
+      diagnosticBoundary(MatchStrategy.ONE_PASS);
+      if (parentPattern.numGroups() > 0) {
+        diagnosticCapture(MatchStrategy.ONE_PASS);
+      }
       OnePass onePass = parentPattern.onePass();
       int[] result = onePass.search(text, false, prog.numCaptures(), this.groups);
       return applyFullMatchResult(result);
@@ -865,10 +1033,21 @@ public final class Matcher implements MatchResult {
 
     // Medium path: use DFA to check if an anchored match exists.
     if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
-
+      diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
       Dfa.SearchResult dfaResult = dfa(false).doSearch(text, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
+        diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
+      }
+      if (dfaResult == null) {
+        diagnosticDecision(
+            MatchStrategy.DFA, StrategyDisposition.FALLBACK, StrategyReason.DFA_BUDGET_EXCEEDED);
+      }
+      if (dfaResult != null && dfaResult.matched() && prog.numLoopRegs() > 0) {
+        diagnosticDecision(
+            MatchStrategy.DFA,
+            StrategyDisposition.BYPASSED,
+            StrategyReason.EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED);
       }
     }
 
@@ -900,6 +1079,18 @@ public final class Matcher implements MatchResult {
    * @return {@code true} if a subsequence of the input sequence matches this matcher's pattern
    */
   public boolean find() {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.FIND);
+    try {
+      boolean matched = findImpl();
+      completeDiagnostics(operation, matched ? 1 : 0);
+      return matched;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private boolean findImpl() {
     modCount++;
     if (findExhaustedAfterTerminalEmptyMatch) {
       applyFailedMatchResult();
@@ -975,6 +1166,18 @@ public final class Matcher implements MatchResult {
    * @throws IndexOutOfBoundsException if start is negative or greater than the length of the input
    */
   public boolean find(int start) {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.FIND);
+    try {
+      boolean matched = findFromImpl(start);
+      completeDiagnostics(operation, matched ? 1 : 0);
+      return matched;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private boolean findFromImpl(int start) {
     if (start < 0 || start > text.length()) {
       throw new IndexOutOfBoundsException("start=" + start + ", length=" + text.length());
     }
@@ -1200,6 +1403,7 @@ public final class Matcher implements MatchResult {
     String literal = parentPattern.literalMatch();
     EnginePathOptions options = enginePathOptions();
     if (options.literalFastPaths() && literal != null && parentPattern.numGroups() == 0) {
+      diagnosticBoundary(MatchStrategy.LITERAL);
       int idx;
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, literal, searchFrom);
@@ -1210,6 +1414,7 @@ public final class Matcher implements MatchResult {
         idx = text.indexOf(literal, searchFrom);
       }
       if (idx < 0) {
+        diagnosticBoundary(MatchStrategy.LITERAL);
         if (!prog.anchorStart()) {
         } else {
           if (isPartialLiteralMatch(literal, searchFrom)) {}
@@ -1221,11 +1426,16 @@ public final class Matcher implements MatchResult {
 
     int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
     if (options.charClassMatchFastPaths() && singleCharClassRanges != null) {
+      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
       return singleCharClassFindFastPath(singleCharClassRanges, searchFrom);
     }
 
     Pattern.KeywordAlternation keywordAlternation = parentPattern.keywordAlternation();
     if (options.keywordAlternationFastPath() && !regionActive && keywordAlternation != null) {
+      diagnosticBoundary(MatchStrategy.KEYWORD);
+      if (keywordAlternation.captureGroup > 0) {
+        diagnosticCapture(MatchStrategy.KEYWORD);
+      }
       return findKeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures());
     }
 
@@ -1245,6 +1455,8 @@ public final class Matcher implements MatchResult {
         && requiredRanges != null
         && !hasAcceleratedSearchPath
         && !containsRequiredMatchClass(requiredRanges, searchFrom)) {
+      diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
+      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
       return applyFailedMatchResult();
     }
 
@@ -1266,6 +1478,10 @@ public final class Matcher implements MatchResult {
     if (options.onePass()
         && parentPattern.canOnePassFind()
         && text.length() <= ONEPASS_ANCHORED_TEXT_LIMIT) {
+      diagnosticBoundary(MatchStrategy.ONE_PASS);
+      if (parentPattern.numGroups() > 0) {
+        diagnosticCapture(MatchStrategy.ONE_PASS);
+      }
       int[] result =
           parentPattern
               .onePass()
@@ -1279,6 +1495,7 @@ public final class Matcher implements MatchResult {
     boolean literalPrefixCandidateStart = false;
     String prefix = parentPattern.prefix();
     if (options.startAcceleration() && prefix != null) {
+      diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
       int idx;
       if (parentPattern.prefixFoldCase()) {
         idx = indexOfIgnoreCase(text, prefix, searchFrom);
@@ -1289,6 +1506,7 @@ public final class Matcher implements MatchResult {
         idx = text.indexOf(prefix, searchFrom);
       }
       if (idx < 0) {
+        diagnosticBoundary(MatchStrategy.LITERAL);
         if (!prog.anchorStart()) {
         } else {
           int remainingLen = text.length() - searchFrom;
@@ -1306,8 +1524,10 @@ public final class Matcher implements MatchResult {
     // avoids running the full engine on text regions where no match can start.
     boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
     if (options.startAcceleration() && !prog.hasWordBoundary() && ccPrefixAscii != null) {
+      diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
       int idx = indexOfCharClass(text, ccPrefixAscii, searchFrom);
       if (idx < 0) {
+        diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
         if (!prog.anchorStart()) {
         } else {
           if (searchFrom == text.length()) {}
@@ -1353,6 +1573,7 @@ public final class Matcher implements MatchResult {
         && canUseReverseDfa()) {
       Dfa revDfa = reverseDfa();
       if (revDfa != null) {
+        diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
         int textLen = text.length();
         boolean budgetExceeded = false;
 
@@ -1419,11 +1640,16 @@ public final class Matcher implements MatchResult {
         if (!budgetExceeded) {
           if (matchStart < 0) {
             // No match possible at end of text — fail immediately without forward scan.
+            diagnosticBoundary(MatchStrategy.DFA);
             return applyFailedMatchResult();
           }
           if (matchStartAmbiguous) {
             // The reverse DFA can prove that a suffix match exists, but not which accepted
             // candidate supplies the leftmost start. Fall through to the normal engine path.
+            diagnosticDecision(
+                MatchStrategy.DFA,
+                StrategyDisposition.BYPASSED,
+                StrategyReason.AUTHORITATIVE_BOUNDS_REQUIRED);
           } else {
             // Reverse DFA found a match start. It proposes the left edge only; resolve the public
             // group(0) end with the exact engine anchored at that start so lazy alternatives and
@@ -1438,6 +1664,10 @@ public final class Matcher implements MatchResult {
             }
           }
         }
+        if (budgetExceeded) {
+          diagnosticDecision(
+              MatchStrategy.DFA, StrategyDisposition.FALLBACK, StrategyReason.DFA_BUDGET_EXCEEDED);
+        }
         // DFA budget exceeded or forward DFA disagreed — fall through to normal path.
       }
     }
@@ -1448,9 +1678,15 @@ public final class Matcher implements MatchResult {
     if (!options.dfa() || !dfaSupportsProgram(parentPattern.flatDfaProg())) {
       fwdResult = null;
     } else {
+      diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
       fwdResult = dfa(false).doSearch(text, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
+        diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
+      }
+      if (fwdResult == null) {
+        diagnosticDecision(
+            MatchStrategy.DFA, StrategyDisposition.FALLBACK, StrategyReason.DFA_BUDGET_EXCEEDED);
       }
     }
 
@@ -1492,6 +1728,7 @@ public final class Matcher implements MatchResult {
       if (prog.anchorStart()) {
         // Anchored: match start is effectiveStart. Since it is start-anchored, the match end
         // is guaranteed to be earlyEnd. Avoid redundant third DFA search.
+        diagnosticBoundary(MatchStrategy.DFA);
         return applyDeferredMatchResult(
             effectiveStart,
             earlyEnd,
@@ -1504,9 +1741,12 @@ public final class Matcher implements MatchResult {
           // preceded by zero-width assertions. Verify that candidate directly; if it matches,
           // return it. Otherwise, fall through to the reverse DFA search below to find the correct
           // start.
+          diagnosticParticipation(MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION);
           Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+          diagnosticDfaBudget(fwdFirst);
           if (fwdFirst != null && fwdFirst.matched()) {
             int matchEnd = fwdFirst.pos();
+            diagnosticBoundary(MatchStrategy.DFA);
             return applyDeferredMatchResult(
                 effectiveStart,
                 matchEnd,
@@ -1518,9 +1758,11 @@ public final class Matcher implements MatchResult {
         if (canUseReverseDfa()) {
           Dfa revDfa = reverseDfa();
           if (revDfa != null) {
+            diagnosticParticipation(MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION);
             // Step 2: Reverse DFA backward from earliest match end to find match start.
             Dfa.SearchResult revResult =
                 revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
+            diagnosticDfaBudget(revResult);
             if (revResult != null && revResult.matched()) {
               int matchStart = revResult.pos();
               boolean reliableStart = !revResult.ambiguous();
@@ -1548,6 +1790,7 @@ public final class Matcher implements MatchResult {
                   if (!isAtomicCrLf) {
                     Dfa.SearchResult altRevResult =
                         revDfa.doSearchReverse(text, earlyEnd - 1, effectiveStart, true, true);
+                    diagnosticDfaBudget(altRevResult);
                     if (altRevResult != null
                         && altRevResult.matched()
                         && altRevResult.pos() < matchStart) {
@@ -1559,6 +1802,7 @@ public final class Matcher implements MatchResult {
                   if (isAtomicCrLf && earlyEnd - 2 >= effectiveStart) {
                     Dfa.SearchResult altRevResult2 =
                         revDfa.doSearchReverse(text, earlyEnd - 2, effectiveStart, true, true);
+                    diagnosticDfaBudget(altRevResult2);
                     if (altRevResult2 != null
                         && altRevResult2.matched()
                         && altRevResult2.pos() < matchStart) {
@@ -1570,15 +1814,21 @@ public final class Matcher implements MatchResult {
               }
 
               if (!reliableStart) {
+                diagnosticDecision(
+                    MatchStrategy.DFA,
+                    StrategyDisposition.BYPASSED,
+                    StrategyReason.AUTHORITATIVE_BOUNDS_REQUIRED);
                 matchStart = -1;
               }
 
               // Step 3: Forward DFA anchored at matchStart with longest=false to find actual end.
               if (matchStart >= 0) {
                 Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+                diagnosticDfaBudget(fwdFirst);
                 if (fwdFirst != null && fwdFirst.matched()) {
                   int matchEnd = fwdFirst.pos();
                   // Step 4: Store group(0) boundaries, defer inner captures until requested.
+                  diagnosticBoundary(MatchStrategy.DFA);
                   return applyDeferredMatchResult(
                       matchStart,
                       matchEnd,
@@ -1593,6 +1843,13 @@ public final class Matcher implements MatchResult {
           }
         }
       }
+    }
+
+    if (fwdResult != null && fwdResult.matched() && prog.numLoopRegs() > 0) {
+      diagnosticDecision(
+          MatchStrategy.DFA,
+          StrategyDisposition.BYPASSED,
+          StrategyReason.EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED);
     }
 
     // Fallback: DFA bailed out or reverse DFA unavailable. Search only for group 0 first, then
@@ -1878,10 +2135,18 @@ public final class Matcher implements MatchResult {
       // Return to Pattern's cache for reuse by future Matchers.
       parentPattern.returnBitState(bs);
       if (!bs.budgetExceeded()) {
+        diagnosticExact(MatchStrategy.BIT_STATE);
         // BitState is a complete engine — if it searched and found no match, NFA won't either.
         if (result == null) {}
         return result;
       }
+      diagnosticDecision(
+          MatchStrategy.BIT_STATE,
+          StrategyDisposition.FALLBACK,
+          StrategyReason.WORK_BUDGET_EXCEEDED);
+    } else if (canUseBitState && maxBitStateLen >= 0 && searchRange > maxBitStateLen) {
+      diagnosticDecision(
+          MatchStrategy.BIT_STATE, StrategyDisposition.BYPASSED, StrategyReason.INPUT_TOO_LARGE);
     }
 
     // Fall back to the general NFA when BitState cannot be used or when capture semantics need
@@ -1895,6 +2160,7 @@ public final class Matcher implements MatchResult {
     } else {
       nfaKind = Nfa.MatchKind.FIRST_MATCH;
     }
+    diagnosticExact(MatchStrategy.NFA);
     return searchNfa(
         prog,
         startPos,
@@ -2183,6 +2449,18 @@ public final class Matcher implements MatchResult {
    * @return the string with the first match replaced
    */
   public String replaceFirst(String replacement) {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.REPLACE_FIRST);
+    try {
+      String result = replaceFirstImpl(replacement);
+      completeDiagnostics(operation, diagnosticMatchCount());
+      return result;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private String replaceFirstImpl(String replacement) {
     Objects.requireNonNull(replacement, "replacement");
     reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
@@ -2199,6 +2477,7 @@ public final class Matcher implements MatchResult {
     if (!find()) {
       return text;
     }
+    diagnosticIncrementMatchCount();
     StringBuilder sb = new StringBuilder(text.length());
     appendReplacement(sb, replacement);
     appendTail(sb);
@@ -2217,6 +2496,7 @@ public final class Matcher implements MatchResult {
         || regionActive) {
       return null;
     }
+    diagnosticParticipation(MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION);
 
     boolean isStartAnchored = parentPattern.prog().anchorStart();
     String prefix = parentPattern.prefix();
@@ -2224,9 +2504,11 @@ public final class Matcher implements MatchResult {
     boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
     int startPos = searchFrom;
     if (hasStartAcceleration) {
+      diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
       int firstIdx =
           foldCase ? indexOfIgnoreCase(text, prefix, searchFrom) : text.indexOf(prefix, searchFrom);
       if (firstIdx < 0) {
+        diagnosticBoundary(MatchStrategy.LITERAL);
         return text;
       }
       startPos = firstIdx;
@@ -2245,8 +2527,10 @@ public final class Matcher implements MatchResult {
       return null;
     }
     if (matchResult == 0) {
+      diagnosticBoundary(MatchStrategy.DFA);
       return text;
     }
+    diagnosticBoundary(MatchStrategy.DFA);
 
     Prog prog = parentPattern.prog();
     int numCaptures = prog.numCaptures();
@@ -2285,25 +2569,32 @@ public final class Matcher implements MatchResult {
         Arrays.fill(groups, 2, groups.length, -1);
         int[] resultGroups;
         if (useOnePass) {
+          diagnosticCapture(MatchStrategy.ONE_PASS);
           resultGroups =
               parentPattern
                   .onePass()
                   .search(text, matchStart, matchEnd, false, numCaptures, groups);
         } else {
-          resultGroups =
-              searchWithBitStateOrNfa(
-                  prog,
-                  text,
-                  matchStart,
-                  matchEnd,
-                  matchEnd,
-                  matchEnd,
-                  true,
-                  false,
-                  false,
-                  numCaptures,
-                  true,
-                  groups);
+          boolean savedCaptureSearch = diagnosticCaptureSearch;
+          diagnosticCaptureSearch = true;
+          try {
+            resultGroups =
+                searchWithBitStateOrNfa(
+                    prog,
+                    text,
+                    matchStart,
+                    matchEnd,
+                    matchEnd,
+                    matchEnd,
+                    true,
+                    false,
+                    false,
+                    numCaptures,
+                    true,
+                    groups);
+          } finally {
+            diagnosticCaptureSearch = savedCaptureSearch;
+          }
         }
         if (resultGroups != null) {
           System.arraycopy(resultGroups, 0, groups, 0, groups.length);
@@ -2339,6 +2630,11 @@ public final class Matcher implements MatchResult {
       this.appendPos = textLen;
       this.searchFrom = textLen;
     }
+    diagnosticBoundary(MatchStrategy.DFA);
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.matchCount(matchesFound);
+    }
     return sb.toString();
   }
 
@@ -2369,6 +2665,7 @@ public final class Matcher implements MatchResult {
       }
 
       Dfa.SearchResult fwdResult = fwdDfa.doSearch(text, pos, false, false);
+      diagnosticDfaBudget(fwdResult);
       if (fwdResult == null || !fwdResult.matched()) {
         break;
       }
@@ -2385,6 +2682,7 @@ public final class Matcher implements MatchResult {
         matchEnd = earlyEnd;
       } else if (hasStartAcceleration) {
         Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, pos, true, false);
+        diagnosticDfaBudget(fwdFirst);
         if (fwdFirst != null && fwdFirst.matched()) {
           matchStart = pos;
           matchEnd = fwdFirst.pos();
@@ -2400,11 +2698,19 @@ public final class Matcher implements MatchResult {
           }
           Dfa.SearchResult revResult =
               cursor.revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+          diagnosticDfaBudget(revResult);
           if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
+            if (revResult != null && revResult.ambiguous()) {
+              diagnosticDecision(
+                  MatchStrategy.DFA,
+                  StrategyDisposition.BYPASSED,
+                  StrategyReason.AUTHORITATIVE_BOUNDS_REQUIRED);
+            }
             return -1;
           }
           matchStart = revResult.pos();
           Dfa.SearchResult fwdFirst2 = fwdDfa.doSearch(text, matchStart, true, false);
+          diagnosticDfaBudget(fwdFirst2);
           if (fwdFirst2 == null || !fwdFirst2.matched()) {
             return -1;
           }
@@ -2421,11 +2727,19 @@ public final class Matcher implements MatchResult {
           }
         }
         Dfa.SearchResult revResult = cursor.revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+        diagnosticDfaBudget(revResult);
         if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
+          if (revResult != null && revResult.ambiguous()) {
+            diagnosticDecision(
+                MatchStrategy.DFA,
+                StrategyDisposition.BYPASSED,
+                StrategyReason.AUTHORITATIVE_BOUNDS_REQUIRED);
+          }
           return -1;
         }
         matchStart = revResult.pos();
         Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, matchStart, true, false);
+        diagnosticDfaBudget(fwdFirst);
         if (fwdFirst == null || !fwdFirst.matched()) {
           return -1;
         }
@@ -2449,11 +2763,24 @@ public final class Matcher implements MatchResult {
    * @throws NullPointerException if the replacer function is null
    */
   public String replaceFirst(Function<MatchResult, String> replacer) {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.REPLACE_FIRST);
+    try {
+      String result = replaceFirstFunctionImpl(replacer);
+      completeDiagnostics(operation, diagnosticMatchCount());
+      return result;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private String replaceFirstFunctionImpl(Function<MatchResult, String> replacer) {
     requireNonNull(replacer, "replacer");
     reset();
     if (!find()) {
       return text;
     }
+    diagnosticIncrementMatchCount();
     StringBuilder sb = new StringBuilder(text.length());
     int expectedModCount = modCount;
     String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
@@ -2471,6 +2798,18 @@ public final class Matcher implements MatchResult {
    * @return the string with all matches replaced
    */
   public String replaceAll(String replacement) {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.REPLACE_ALL);
+    try {
+      String result = replaceAllImpl(replacement);
+      completeDiagnostics(operation, diagnosticMatchCount());
+      return result;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private String replaceAllImpl(String replacement) {
     reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String fastResult = charClassReplaceFastPath(template, Integer.MAX_VALUE);
@@ -2486,6 +2825,7 @@ public final class Matcher implements MatchResult {
     if (!find()) {
       return text;
     }
+    diagnosticIncrementMatchCount();
     StringBuilder sb = new StringBuilder(text.length());
     ReplacementSegment[] compiledTemplate = template.get();
     boolean needsCaptures = templateNeedsCaptures(compiledTemplate);
@@ -2496,9 +2836,17 @@ public final class Matcher implements MatchResult {
       sb.append(text, appendPos, groups[0]);
       applyReplacementTemplate(sb, compiledTemplate);
       appendPos = groups[1];
-    } while (find());
+    } while (findAndRecordReplacementMatch());
     appendTail(sb);
     return sb.toString();
+  }
+
+  private boolean findAndRecordReplacementMatch() {
+    boolean found = find();
+    if (found) {
+      diagnosticIncrementMatchCount();
+    }
+    return found;
   }
 
   /**
@@ -2511,18 +2859,31 @@ public final class Matcher implements MatchResult {
    * @throws NullPointerException if the replacer function is null
    */
   public String replaceAll(Function<MatchResult, String> replacer) {
+    DiagnosticOperation operation = beginDiagnostics(MatchOperation.REPLACE_ALL);
+    try {
+      String result = replaceAllFunctionImpl(replacer);
+      completeDiagnostics(operation, diagnosticMatchCount());
+      return result;
+    } catch (RuntimeException | Error e) {
+      abortDiagnostics(operation);
+      throw e;
+    }
+  }
+
+  private String replaceAllFunctionImpl(Function<MatchResult, String> replacer) {
     requireNonNull(replacer, "replacer");
     reset();
     if (!find()) {
       return text;
     }
+    diagnosticIncrementMatchCount();
     StringBuilder sb = new StringBuilder(text.length());
     do {
       int expectedModCount = modCount;
       String replacement = Objects.requireNonNull(replacer.apply(toMatchResult()));
       checkConcurrentModification(expectedModCount);
       appendReplacement(sb, replacement);
-    } while (find());
+    } while (findAndRecordReplacementMatch());
     appendTail(sb);
     return sb.toString();
   }
@@ -2534,6 +2895,7 @@ public final class Matcher implements MatchResult {
         || parentPattern.hasLazyQuantifiers()) {
       return null;
     }
+    diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.CANDIDATE_VERIFICATION);
     String repText = null;
 
     int textLen = text.length();
@@ -2602,6 +2964,7 @@ public final class Matcher implements MatchResult {
     }
 
     if (sb == null) {
+      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
       applyFailedMatchResult();
       return text;
     }
@@ -2614,6 +2977,12 @@ public final class Matcher implements MatchResult {
     } else {
       searchFrom = regionEnd;
       applyFailedMatchResult();
+    }
+
+    diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
+    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
+    if (accumulator != null) {
+      accumulator.matchCount(matchesFound);
     }
 
     return sb.toString();
@@ -2932,26 +3301,33 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().onePass()
         && parentPattern.canOnePassSubmatch()
         && !parentPattern.hasNullableAlternation()) {
+      diagnosticCapture(MatchStrategy.ONE_PASS);
       result =
           parentPattern
               .onePass()
               .search(
                   text, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures(), groups);
     } else {
-      result =
-          searchWithBitStateOrNfa(
-              prog,
-              text,
-              deferredMatchStart,
-              deferredMatchEnd,
-              deferredMatchEnd,
-              deferredMatchEnd,
-              true,
-              false,
-              deferredEndMatch,
-              prog.numCaptures(),
-              true,
-              groups);
+      boolean savedCaptureSearch = diagnosticCaptureSearch;
+      diagnosticCaptureSearch = true;
+      try {
+        result =
+            searchWithBitStateOrNfa(
+                prog,
+                text,
+                deferredMatchStart,
+                deferredMatchEnd,
+                deferredMatchEnd,
+                deferredMatchEnd,
+                true,
+                false,
+                deferredEndMatch,
+                prog.numCaptures(),
+                true,
+                groups);
+      } finally {
+        diagnosticCaptureSearch = savedCaptureSearch;
+      }
     }
     if (result != null && result != groups) {
       groups = result;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -755,6 +755,9 @@ public final class Matcher implements MatchResult {
    */
   public boolean matches() {
     DiagnosticOperation operation = beginDiagnostics(MatchOperation.MATCHES);
+    if (operation == null) {
+      return matchesImpl();
+    }
     try {
       boolean matched = matchesImpl();
       completeDiagnostics(operation, matched ? 1 : 0);
@@ -815,7 +818,10 @@ public final class Matcher implements MatchResult {
     if (enginePathOptions().literalFastPaths()
         && literal != null
         && parentPattern.numGroups() == 0) {
-      diagnosticBoundary(MatchStrategy.LITERAL);
+      DiagnosticOperation activeDiagnostics = diagnosticOperation;
+      if (activeDiagnostics != null) {
+        activeDiagnostics.accumulator().boundary(MatchStrategy.LITERAL);
+      }
       boolean matched;
       if (parentPattern.prefixFoldCase()) {
         matched =
@@ -856,9 +862,13 @@ public final class Matcher implements MatchResult {
     if (onePass != null
         && !prog.hasGraphemeSemantics()
         && !parentPattern.hasNullableAlternation()) {
-      diagnosticBoundary(MatchStrategy.ONE_PASS);
-      if (parentPattern.numGroups() > 0) {
-        diagnosticCapture(MatchStrategy.ONE_PASS);
+      DiagnosticOperation activeDiagnostics = diagnosticOperation;
+      if (activeDiagnostics != null) {
+        DiagnosticAccumulator accumulator = activeDiagnostics.accumulator();
+        accumulator.boundary(MatchStrategy.ONE_PASS);
+        if (parentPattern.numGroups() > 0) {
+          accumulator.capture(MatchStrategy.ONE_PASS);
+        }
       }
       int[] result = onePass.search(text, true, prog.numCaptures(), this.groups);
       return applyFullMatchResult(result);
@@ -2799,6 +2809,9 @@ public final class Matcher implements MatchResult {
    */
   public String replaceAll(String replacement) {
     DiagnosticOperation operation = beginDiagnostics(MatchOperation.REPLACE_ALL);
+    if (operation == null) {
+      return replaceAllImpl(replacement);
+    }
     try {
       String result = replaceAllImpl(replacement);
       completeDiagnostics(operation, diagnosticMatchCount());
@@ -2895,7 +2908,12 @@ public final class Matcher implements MatchResult {
         || parentPattern.hasLazyQuantifiers()) {
       return null;
     }
-    diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.CANDIDATE_VERIFICATION);
+    DiagnosticOperation activeDiagnostics = diagnosticOperation;
+    DiagnosticAccumulator accumulator =
+        activeDiagnostics == null ? null : activeDiagnostics.accumulator();
+    if (accumulator != null) {
+      accumulator.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.CANDIDATE_VERIFICATION);
+    }
     String repText = null;
 
     int textLen = text.length();
@@ -2964,7 +2982,9 @@ public final class Matcher implements MatchResult {
     }
 
     if (sb == null) {
-      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
+      if (accumulator != null) {
+        accumulator.boundary(MatchStrategy.CHARACTER_CLASS);
+      }
       applyFailedMatchResult();
       return text;
     }
@@ -2979,9 +2999,8 @@ public final class Matcher implements MatchResult {
       applyFailedMatchResult();
     }
 
-    diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
-    DiagnosticAccumulator accumulator = diagnosticsAccumulator();
     if (accumulator != null) {
+      accumulator.boundary(MatchStrategy.CHARACTER_CLASS);
       accumulator.matchCount(matchesFound);
     }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -197,6 +197,38 @@ public final class Matcher implements MatchResult {
     }
   }
 
+  private Dfa.SearchResult searchForwardDfa(
+      Dfa dfa, InputScanner scanner, boolean anchored, boolean longest) {
+    return searchForwardDfa(dfa, scanner, 0, anchored, longest);
+  }
+
+  private Dfa.SearchResult searchForwardDfa(
+      Dfa dfa, InputScanner scanner, int startPos, boolean anchored, boolean longest) {
+    Dfa.SearchResult result = dfa.doSearch(scanner, startPos, anchored, longest);
+    DiagnosticOperation activeDiagnostics = diagnosticOperation;
+    if (activeDiagnostics != null) {
+      activeDiagnostics.accumulator().incrementForwardDfaSearchCount();
+      diagnosticDfaBudget(result);
+    }
+    return result;
+  }
+
+  private Dfa.SearchResult searchReverseDfa(
+      Dfa dfa,
+      InputScanner scanner,
+      int endPos,
+      int startLimit,
+      boolean anchored,
+      boolean longest) {
+    Dfa.SearchResult result = dfa.doSearchReverse(scanner, endPos, startLimit, anchored, longest);
+    DiagnosticOperation activeDiagnostics = diagnosticOperation;
+    if (activeDiagnostics != null) {
+      activeDiagnostics.accumulator().incrementReverseDfaSearchCount();
+      diagnosticDfaBudget(result);
+    }
+    return result;
+  }
+
   private void diagnosticDfaBudget(Dfa.SearchResult result) {
     if (result == null) {
       diagnosticDecision(
@@ -929,7 +961,7 @@ public final class Matcher implements MatchResult {
         && enginePathOptions().dfa()
         && dfaSupportsProgram(parentPattern.flatDfaProg())) {
       diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
-      Dfa.SearchResult dfaResult = dfa(true).doSearch(scanner, true, true);
+      Dfa.SearchResult dfaResult = searchForwardDfa(dfa(true), scanner, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
         diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
@@ -1104,7 +1136,7 @@ public final class Matcher implements MatchResult {
     // Medium path: use DFA to check if an anchored match exists.
     if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
       diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
-      Dfa.SearchResult dfaResult = dfa(false).doSearch(scanner, true, false);
+      Dfa.SearchResult dfaResult = searchForwardDfa(dfa(false), scanner, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
         diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
@@ -1747,7 +1779,7 @@ public final class Matcher implements MatchResult {
 
         // Try reverse DFA from end of text (anchored at end position).
         Dfa.SearchResult revResult =
-            revDfa.doSearchReverse(scanner, textLen, effectiveStart, true, true);
+            searchReverseDfa(revDfa, scanner, textLen, effectiveStart, true, true);
         int matchStart;
         boolean matchStartAmbiguous;
         if (revResult == null) {
@@ -1779,7 +1811,7 @@ public final class Matcher implements MatchResult {
                     && scanner.asciiAt(textLen - 1) == '\n';
             if (!isAtomicCrLf) {
               Dfa.SearchResult altRev =
-                  revDfa.doSearchReverse(scanner, textLen - 1, effectiveStart, true, true);
+                  searchReverseDfa(revDfa, scanner, textLen - 1, effectiveStart, true, true);
               if (altRev == null) {
                 budgetExceeded = true;
               } else if (altRev.matched()
@@ -1792,7 +1824,7 @@ public final class Matcher implements MatchResult {
             // For \r\n, try position before \r.
             if (!budgetExceeded && isAtomicCrLf) {
               Dfa.SearchResult altRev2 =
-                  revDfa.doSearchReverse(scanner, textLen - 2, effectiveStart, true, true);
+                  searchReverseDfa(revDfa, scanner, textLen - 2, effectiveStart, true, true);
               if (altRev2 == null) {
                 budgetExceeded = true;
               } else if (altRev2.matched()
@@ -1847,7 +1879,7 @@ public final class Matcher implements MatchResult {
       fwdResult = null;
     } else {
       diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
-      fwdResult = dfa(false).doSearch(scanner, effectiveStart, false, false);
+      fwdResult = searchForwardDfa(dfa(false), scanner, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
         diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
@@ -1911,8 +1943,8 @@ public final class Matcher implements MatchResult {
           // return it. Otherwise, fall through to the reverse DFA search below to find the correct
           // start.
           diagnosticParticipation(MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION);
-          Dfa.SearchResult fwdFirst = dfa(false).doSearch(scanner, effectiveStart, true, false);
-          diagnosticDfaBudget(fwdFirst);
+          Dfa.SearchResult fwdFirst =
+              searchForwardDfa(dfa(false), scanner, effectiveStart, true, false);
           if (fwdFirst != null && fwdFirst.matched()) {
             int matchEnd = fwdFirst.pos();
             diagnosticBoundary(MatchStrategy.DFA);
@@ -1930,8 +1962,7 @@ public final class Matcher implements MatchResult {
             diagnosticParticipation(MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION);
             // Step 2: Reverse DFA backward from earliest match end to find match start.
             Dfa.SearchResult revResult =
-                revDfa.doSearchReverse(scanner, earlyEnd, effectiveStart, true, true);
-            diagnosticDfaBudget(revResult);
+                searchReverseDfa(revDfa, scanner, earlyEnd, effectiveStart, true, true);
             if (revResult != null && revResult.matched()) {
               int matchStart = revResult.pos();
               boolean reliableStart = !revResult.ambiguous();
@@ -1958,8 +1989,7 @@ public final class Matcher implements MatchResult {
                           && scanner.asciiAt(len - 1) == '\n';
                   if (!isAtomicCrLf) {
                     Dfa.SearchResult altRevResult =
-                        revDfa.doSearchReverse(scanner, earlyEnd - 1, effectiveStart, true, true);
-                    diagnosticDfaBudget(altRevResult);
+                        searchReverseDfa(revDfa, scanner, earlyEnd - 1, effectiveStart, true, true);
                     if (altRevResult != null
                         && altRevResult.matched()
                         && altRevResult.pos() < matchStart) {
@@ -1970,8 +2000,7 @@ public final class Matcher implements MatchResult {
                   // For \r\n, try position before \r.
                   if (isAtomicCrLf && earlyEnd - 2 >= effectiveStart) {
                     Dfa.SearchResult altRevResult2 =
-                        revDfa.doSearchReverse(scanner, earlyEnd - 2, effectiveStart, true, true);
-                    diagnosticDfaBudget(altRevResult2);
+                        searchReverseDfa(revDfa, scanner, earlyEnd - 2, effectiveStart, true, true);
                     if (altRevResult2 != null
                         && altRevResult2.matched()
                         && altRevResult2.pos() < matchStart) {
@@ -1992,8 +2021,8 @@ public final class Matcher implements MatchResult {
 
               if (matchStart >= 0) {
                 if (prog.hasTextAnchor()) {
-                  Dfa.SearchResult exactEnd = dfa(false).doSearch(scanner, matchStart, true, false);
-                  diagnosticDfaBudget(exactEnd);
+                  Dfa.SearchResult exactEnd =
+                      searchForwardDfa(dfa(false), scanner, matchStart, true, false);
                   if (exactEnd == null || !exactEnd.matched()) {
                     matchStart = -1;
                   } else {
@@ -2923,8 +2952,7 @@ public final class Matcher implements MatchResult {
         pos = idx;
       }
 
-      Dfa.SearchResult fwdResult = fwdDfa.doSearch(scanner, pos, false, false);
-      diagnosticDfaBudget(fwdResult);
+      Dfa.SearchResult fwdResult = searchForwardDfa(fwdDfa, scanner, pos, false, false);
       if (fwdResult == null || !fwdResult.matched()) {
         break;
       }
@@ -2940,8 +2968,7 @@ public final class Matcher implements MatchResult {
         matchStart = pos;
         matchEnd = earlyEnd;
       } else if (hasStartAcceleration) {
-        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(scanner, pos, true, false);
-        diagnosticDfaBudget(fwdFirst);
+        Dfa.SearchResult fwdFirst = searchForwardDfa(fwdDfa, scanner, pos, true, false);
         if (fwdFirst != null && fwdFirst.matched()) {
           matchStart = pos;
           matchEnd = fwdFirst.pos();
@@ -2956,8 +2983,7 @@ public final class Matcher implements MatchResult {
             }
           }
           Dfa.SearchResult revResult =
-              cursor.revDfa.doSearchReverse(scanner, earlyEnd, pos, true, true);
-          diagnosticDfaBudget(revResult);
+              searchReverseDfa(cursor.revDfa, scanner, earlyEnd, pos, true, true);
           if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
             if (revResult != null && revResult.ambiguous()) {
               diagnosticDecision(
@@ -2981,8 +3007,7 @@ public final class Matcher implements MatchResult {
           }
         }
         Dfa.SearchResult revResult =
-            cursor.revDfa.doSearchReverse(scanner, earlyEnd, pos, true, true);
-        diagnosticDfaBudget(revResult);
+            searchReverseDfa(cursor.revDfa, scanner, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
           if (revResult != null && revResult.ambiguous()) {
             diagnosticDecision(

--- a/safere/src/main/java/org/safere/OperationDiagnostics.java
+++ b/safere/src/main/java/org/safere/OperationDiagnostics.java
@@ -1,0 +1,38 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable summary of one normally completed public matching operation. */
+public record OperationDiagnostics(
+    PatternDescriptor pattern,
+    MatchOperation operation,
+    MatchOutcome outcome,
+    MatchStrategy boundaryStrategy,
+    MatchStrategy captureStrategy,
+    List<StrategyParticipation> auxiliaryStrategies,
+    Set<StrategyDecision> strategyDecisions,
+    CaptureMode captureMode,
+    int inputLength,
+    int matchCount) {
+  /** Creates an immutable operation summary. */
+  public OperationDiagnostics {
+    Objects.requireNonNull(pattern, "pattern");
+    Objects.requireNonNull(operation, "operation");
+    Objects.requireNonNull(outcome, "outcome");
+    Objects.requireNonNull(boundaryStrategy, "boundaryStrategy");
+    Objects.requireNonNull(captureStrategy, "captureStrategy");
+    auxiliaryStrategies = List.copyOf(auxiliaryStrategies);
+    strategyDecisions = Set.copyOf(strategyDecisions);
+    Objects.requireNonNull(captureMode, "captureMode");
+    if (inputLength < 0 || matchCount < 0) {
+      throw new IllegalArgumentException("lengths and counts must be non-negative");
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/OperationDiagnostics.java
+++ b/safere/src/main/java/org/safere/OperationDiagnostics.java
@@ -9,7 +9,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-/** Immutable summary of one normally completed public matching operation. */
+/**
+ * Immutable summary of one normally completed public matching operation.
+ *
+ * <p>DFA search counts include every attempted search, including attempts that exceed the DFA state
+ * budget. Replacement operations aggregate searches across all matches into their single event.
+ */
 public record OperationDiagnostics(
     PatternDescriptor pattern,
     MatchOperation operation,
@@ -18,6 +23,8 @@ public record OperationDiagnostics(
     MatchStrategy captureStrategy,
     List<StrategyParticipation> auxiliaryStrategies,
     Set<StrategyDecision> strategyDecisions,
+    int forwardDfaSearchCount,
+    int reverseDfaSearchCount,
     CaptureMode captureMode,
     int inputLength,
     int matchCount) {
@@ -31,8 +38,11 @@ public record OperationDiagnostics(
     auxiliaryStrategies = List.copyOf(auxiliaryStrategies);
     strategyDecisions = Set.copyOf(strategyDecisions);
     Objects.requireNonNull(captureMode, "captureMode");
-    if (inputLength < 0 || matchCount < 0) {
-      throw new IllegalArgumentException("lengths and counts must be non-negative");
+    if (forwardDfaSearchCount < 0
+        || reverseDfaSearchCount < 0
+        || inputLength < 0
+        || matchCount < 0) {
+      throw new IllegalArgumentException("counts and lengths must be non-negative");
     }
   }
 }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -12,12 +12,14 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
@@ -44,6 +46,8 @@ import java.util.stream.StreamSupport;
 public final class Pattern implements Serializable {
 
   private static final long serialVersionUID = 1L;
+  private static final AtomicLong NEXT_PATTERN_ID = new AtomicLong(1);
+  private static volatile SafeReMatchDiagnostics diagnostics = SafeReMatchDiagnostics.NONE;
 
   /**
    * Enables Unix lines mode. In this mode, only {@code '\n'} is recognized as a line terminator.
@@ -114,6 +118,9 @@ public final class Pattern implements Serializable {
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
   private final transient EnginePathOptions enginePathOptions;
+  private final long patternId;
+  private transient volatile PatternAnalysis patternAnalysis;
+  private transient volatile PatternDescriptor patternDescriptor;
 
   /**
    * Precomputed character class data for the "repeated character class" fast path in {@code
@@ -245,6 +252,7 @@ public final class Pattern implements Serializable {
       long requiredMatchClassBitmap0,
       long requiredMatchClassBitmap1,
       EnginePathOptions enginePathOptions) {
+    this.patternId = nextPatternId();
     this.pattern = pattern;
     this.flags = flags;
     this.prog = prog;
@@ -301,6 +309,40 @@ public final class Pattern implements Serializable {
     if (!prog.anchorStart()) {
       flatReverseDfaProg();
     }
+
+    SafeReMatchDiagnostics listener = diagnostics;
+    if (SafeReMatchDiagnostics.isEnabled(listener)) {
+      listener.onPatternCompiled(new PatternCompiledEvent(descriptor()));
+    }
+  }
+
+  private static long nextPatternId() {
+    long id = NEXT_PATTERN_ID.getAndIncrement();
+    if (id <= 0) {
+      throw new IllegalStateException("pattern diagnostics identifier space exhausted");
+    }
+    return id;
+  }
+
+  /**
+   * Installs the process-wide synchronous match diagnostics listener.
+   *
+   * <p>The listener is invoked on compiling and matching threads and remains installed until
+   * replaced. Use {@link SafeReMatchDiagnostics#NONE} to disable diagnostics.
+   *
+   * @param listener the listener to install
+   */
+  public static void setDiagnostics(SafeReMatchDiagnostics listener) {
+    diagnostics = Objects.requireNonNull(listener, "listener");
+  }
+
+  /**
+   * Returns the currently installed process-wide match diagnostics listener.
+   *
+   * @return the installed listener
+   */
+  public static SafeReMatchDiagnostics diagnostics() {
+    return diagnostics;
   }
 
   /**
@@ -1063,6 +1105,172 @@ public final class Pattern implements Serializable {
    */
   public Map<String, Integer> namedGroups() {
     return namedGroups;
+  }
+
+  /**
+   * Returns immutable static diagnostics for this pattern.
+   *
+   * <p>Capabilities describe strategies that can participate for at least one supported operation
+   * and input; runtime input length, operation shape, and engine budgets can still affect
+   * selection.
+   */
+  public PatternAnalysis analysis() {
+    PatternAnalysis result = patternAnalysis;
+    if (result == null) {
+      synchronized (this) {
+        result = patternAnalysis;
+        if (result == null) {
+          result = buildPatternAnalysis();
+          patternAnalysis = result;
+        }
+      }
+    }
+    return result;
+  }
+
+  PatternDescriptor descriptor() {
+    PatternDescriptor result = patternDescriptor;
+    if (result == null) {
+      synchronized (this) {
+        result = patternDescriptor;
+        if (result == null) {
+          result = new PatternDescriptor(patternId, analysis());
+          patternDescriptor = result;
+        }
+      }
+    }
+    return result;
+  }
+
+  private PatternAnalysis buildPatternAnalysis() {
+    EnumSet<PatternFeature> features = EnumSet.noneOf(PatternFeature.class);
+    EnumSet<PatternCapability> capabilities = EnumSet.noneOf(PatternCapability.class);
+    EnumSet<PatternLimitation> limitations = EnumSet.noneOf(PatternLimitation.class);
+
+    if (literalMatch != null) {
+      features.add(PatternFeature.LITERAL);
+      capabilities.add(PatternCapability.LITERAL_MATCH);
+    }
+    if (prog.numCaptures() > 1) {
+      features.add(PatternFeature.CAPTURES);
+    }
+    if (hasAlternation) {
+      features.add(PatternFeature.ALTERNATION);
+    }
+    if (hasLazy) {
+      features.add(PatternFeature.LAZY_QUANTIFIER);
+      limitations.add(PatternLimitation.LAZY_SEMANTICS_LIMIT_ONE_PASS);
+    }
+    if (canMatchEmpty) {
+      features.add(PatternFeature.NULLABLE);
+    }
+    if (hasNullableAlternation) {
+      features.add(PatternFeature.NULLABLE_ALTERNATION);
+      limitations.add(PatternLimitation.NULLABLE_ALTERNATION_LIMITS_ONE_PASS);
+    }
+    if (prog.anchorStart()) {
+      features.add(PatternFeature.ANCHOR);
+      features.add(PatternFeature.START_ANCHOR);
+    }
+    if (prog.anchorEnd()) {
+      features.add(PatternFeature.ANCHOR);
+      features.add(PatternFeature.END_ANCHOR);
+    }
+    if (prog.hasWordBoundary()) {
+      features.add(PatternFeature.WORD_BOUNDARY);
+    }
+    if (prog.hasGraphemeSemantics()) {
+      features.add(PatternFeature.GRAPHEME);
+      limitations.add(PatternLimitation.GRAPHEME_REQUIRES_EXACT_ENGINE);
+    }
+    if ((flags & CASE_INSENSITIVE) != 0) {
+      features.add(PatternFeature.CASE_INSENSITIVE);
+    }
+    if ((flags & UNICODE_CHARACTER_CLASS) != 0) {
+      features.add(PatternFeature.UNICODE_CHARACTER_CLASS);
+    }
+    addAstAnalysisFeatures(features);
+
+    if (charClassMatchRanges != null || singleCharClassRanges != null) {
+      capabilities.add(PatternCapability.CHARACTER_CLASS_MATCH);
+    }
+    if (keywordAlternation != null) {
+      capabilities.add(PatternCapability.KEYWORD_MATCH);
+    }
+    if (canOnePassPrimary()) {
+      capabilities.add(PatternCapability.ONE_PASS_PRIMARY);
+    }
+    if (canOnePassSubmatch()) {
+      capabilities.add(PatternCapability.ONE_PASS_CAPTURE_EXTRACTION);
+    }
+    if (flatDfaProg != null && !prog.hasGraphemeSemantics()) {
+      if (prog.numLoopRegs() == 0) {
+        capabilities.add(PatternCapability.DFA_BOUNDARY_SEARCH);
+      } else {
+        capabilities.add(PatternCapability.DFA_REJECT_PREFILTER);
+      }
+    }
+    int maxBitStateText = BitState.maxTextSize(prog);
+    if (maxBitStateText >= 0) {
+      capabilities.add(PatternCapability.BIT_STATE);
+    } else {
+      limitations.add(PatternLimitation.PROGRAM_TOO_LARGE_FOR_BIT_STATE);
+    }
+    capabilities.add(PatternCapability.NFA);
+
+    if (prog.numLoopRegs() > 0) {
+      features.add(PatternFeature.NESTED_NULLABLE_QUANTIFIER);
+      features.add(PatternFeature.PROGRESS_CHECK);
+      limitations.add(PatternLimitation.NULLABLE_LOOP_REQUIRES_EXACT_ENGINE);
+    }
+    if (features.contains(PatternFeature.CAPTURES)
+        && (hasAlternation || hasLazy || prog.numLoopRegs() > 0)) {
+      limitations.add(PatternLimitation.CAPTURE_PRIORITY_REQUIRES_EXACT_ENGINE);
+    }
+
+    return new PatternAnalysis(
+        features, capabilities, limitations, prog.size(), prog.numCaptures() - 1);
+  }
+
+  private record AstAnalysisNode(Regexp regexp, boolean insideQuantifier) {}
+
+  private void addAstAnalysisFeatures(EnumSet<PatternFeature> features) {
+    Deque<AstAnalysisNode> stack = new ArrayDeque<>();
+    stack.push(new AstAnalysisNode(ast, false));
+    while (!stack.isEmpty()) {
+      AstAnalysisNode current = stack.pop();
+      Regexp node = current.regexp();
+      boolean quantifier =
+          node.op == RegexpOp.STAR
+              || node.op == RegexpOp.PLUS
+              || node.op == RegexpOp.QUEST
+              || node.op == RegexpOp.REPEAT;
+      if (node.op == RegexpOp.REPEAT) {
+        features.add(PatternFeature.BOUNDED_REPEAT);
+      }
+      switch (node.op) {
+        case LITERAL, LITERAL_STRING -> features.add(PatternFeature.LITERAL);
+        case BEGIN_LINE, BEGIN_TEXT -> {
+          features.add(PatternFeature.ANCHOR);
+          features.add(PatternFeature.START_ANCHOR);
+        }
+        case END_LINE, END_TEXT -> {
+          features.add(PatternFeature.ANCHOR);
+          features.add(PatternFeature.END_ANCHOR);
+        }
+        case WORD_BOUNDARY, NO_WORD_BOUNDARY -> features.add(PatternFeature.WORD_BOUNDARY);
+        case GRAPHEME_CLUSTER, GRAPHEME_CLUSTER_BOUNDARY -> features.add(PatternFeature.GRAPHEME);
+        default -> {}
+      }
+      if (node.op == RegexpOp.CAPTURE && node.cap > 0 && current.insideQuantifier()) {
+        features.add(PatternFeature.CAPTURES_IN_QUANTIFIER);
+      }
+      if (node.subs != null) {
+        for (Regexp sub : node.subs) {
+          stack.push(new AstAnalysisNode(sub, current.insideQuantifier() || quantifier));
+        }
+      }
+    }
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -8,6 +8,10 @@
 package org.safere;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +51,14 @@ public final class Pattern implements Serializable {
 
   private static final long serialVersionUID = 1L;
   private static final AtomicLong NEXT_PATTERN_ID = new AtomicLong(1);
-  private static volatile SafeReMatchDiagnostics diagnostics = SafeReMatchDiagnostics.NONE;
+  private static final MethodType DIAGNOSTICS_TYPE =
+      MethodType.methodType(SafeReMatchDiagnostics.class);
+  private static final MutableCallSite DIAGNOSTICS_SITE = new MutableCallSite(DIAGNOSTICS_TYPE);
+  private static final MethodHandle DIAGNOSTICS_INVOKER = DIAGNOSTICS_SITE.dynamicInvoker();
+
+  static {
+    setDiagnosticsTarget(SafeReMatchDiagnostics.NONE);
+  }
 
   /**
    * Enables Unix lines mode. In this mode, only {@code '\n'} is recognized as a line terminator.
@@ -310,7 +321,7 @@ public final class Pattern implements Serializable {
       flatReverseDfaProg();
     }
 
-    SafeReMatchDiagnostics listener = diagnostics;
+    SafeReMatchDiagnostics listener = diagnostics();
     if (SafeReMatchDiagnostics.isEnabled(listener)) {
       listener.onPatternCompiled(new PatternCompiledEvent(descriptor()));
     }
@@ -333,7 +344,8 @@ public final class Pattern implements Serializable {
    * @param listener the listener to install
    */
   public static void setDiagnostics(SafeReMatchDiagnostics listener) {
-    diagnostics = Objects.requireNonNull(listener, "listener");
+    setDiagnosticsTarget(Objects.requireNonNull(listener, "listener"));
+    MutableCallSite.syncAll(new MutableCallSite[] {DIAGNOSTICS_SITE});
   }
 
   /**
@@ -342,7 +354,15 @@ public final class Pattern implements Serializable {
    * @return the installed listener
    */
   public static SafeReMatchDiagnostics diagnostics() {
-    return diagnostics;
+    try {
+      return (SafeReMatchDiagnostics) DIAGNOSTICS_INVOKER.invokeExact();
+    } catch (Throwable impossible) {
+      throw new AssertionError(impossible);
+    }
+  }
+
+  private static void setDiagnosticsTarget(SafeReMatchDiagnostics listener) {
+    DIAGNOSTICS_SITE.setTarget(MethodHandles.constant(SafeReMatchDiagnostics.class, listener));
   }
 
   /**

--- a/safere/src/main/java/org/safere/PatternAnalysis.java
+++ b/safere/src/main/java/org/safere/PatternAnalysis.java
@@ -1,0 +1,30 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable static analysis of a compiled pattern. */
+public record PatternAnalysis(
+    Set<PatternFeature> features,
+    Set<PatternCapability> capabilities,
+    Set<PatternLimitation> limitations,
+    int programSize,
+    int captureCount) {
+  /** Creates an immutable pattern analysis. */
+  public PatternAnalysis {
+    features = Set.copyOf(Objects.requireNonNull(features, "features"));
+    capabilities = Set.copyOf(Objects.requireNonNull(capabilities, "capabilities"));
+    limitations = Set.copyOf(Objects.requireNonNull(limitations, "limitations"));
+    if (programSize < 0) {
+      throw new IllegalArgumentException("programSize must be non-negative");
+    }
+    if (captureCount < 0) {
+      throw new IllegalArgumentException("captureCount must be non-negative");
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/PatternCapability.java
+++ b/safere/src/main/java/org/safere/PatternCapability.java
@@ -1,0 +1,19 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Matching strategies that can participate for at least one operation and input. */
+public enum PatternCapability {
+  LITERAL_MATCH,
+  CHARACTER_CLASS_MATCH,
+  KEYWORD_MATCH,
+  ONE_PASS_PRIMARY,
+  ONE_PASS_CAPTURE_EXTRACTION,
+  DFA_BOUNDARY_SEARCH,
+  DFA_REJECT_PREFILTER,
+  BIT_STATE,
+  NFA
+}

--- a/safere/src/main/java/org/safere/PatternCompiledEvent.java
+++ b/safere/src/main/java/org/safere/PatternCompiledEvent.java
@@ -1,0 +1,16 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Objects;
+
+/** Event emitted after a pattern is compiled while diagnostics are enabled. */
+public record PatternCompiledEvent(PatternDescriptor pattern) {
+  /** Creates a pattern compilation event. */
+  public PatternCompiledEvent {
+    Objects.requireNonNull(pattern, "pattern");
+  }
+}

--- a/safere/src/main/java/org/safere/PatternDescriptor.java
+++ b/safere/src/main/java/org/safere/PatternDescriptor.java
@@ -1,0 +1,19 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Objects;
+
+/** Opaque process-local pattern identity paired with its static analysis. */
+public record PatternDescriptor(long patternId, PatternAnalysis analysis) {
+  /** Creates a descriptor. */
+  public PatternDescriptor {
+    if (patternId <= 0) {
+      throw new IllegalArgumentException("patternId must be positive");
+    }
+    Objects.requireNonNull(analysis, "analysis");
+  }
+}

--- a/safere/src/main/java/org/safere/PatternFeature.java
+++ b/safere/src/main/java/org/safere/PatternFeature.java
@@ -1,0 +1,27 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Stable semantic and structural features found in a compiled pattern. */
+public enum PatternFeature {
+  LITERAL,
+  CAPTURES,
+  ALTERNATION,
+  LAZY_QUANTIFIER,
+  BOUNDED_REPEAT,
+  ANCHOR,
+  WORD_BOUNDARY,
+  GRAPHEME,
+  CASE_INSENSITIVE,
+  UNICODE_CHARACTER_CLASS,
+  NULLABLE,
+  NULLABLE_ALTERNATION,
+  NESTED_NULLABLE_QUANTIFIER,
+  PROGRESS_CHECK,
+  START_ANCHOR,
+  END_ANCHOR,
+  CAPTURES_IN_QUANTIFIER
+}

--- a/safere/src/main/java/org/safere/PatternLimitation.java
+++ b/safere/src/main/java/org/safere/PatternLimitation.java
@@ -1,0 +1,16 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Stable reasons a compiled pattern requires or limits particular matching strategies. */
+public enum PatternLimitation {
+  GRAPHEME_REQUIRES_EXACT_ENGINE,
+  NULLABLE_LOOP_REQUIRES_EXACT_ENGINE,
+  LAZY_SEMANTICS_LIMIT_ONE_PASS,
+  NULLABLE_ALTERNATION_LIMITS_ONE_PASS,
+  CAPTURE_PRIORITY_REQUIRES_EXACT_ENGINE,
+  PROGRAM_TOO_LARGE_FOR_BIT_STATE
+}

--- a/safere/src/main/java/org/safere/SafeReMatchDiagnostics.java
+++ b/safere/src/main/java/org/safere/SafeReMatchDiagnostics.java
@@ -1,0 +1,52 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/**
+ * Receives synchronous, low-cardinality diagnostics about pattern compilation and matching.
+ *
+ * <p>Callbacks run on the compiling or matching thread. Implementations are responsible for their
+ * own thread safety, aggregation, storage, and cardinality policy. Callback exceptions propagate to
+ * the caller; operation callbacks run only after matcher state has been finalized.
+ *
+ * <p>When {@link #NONE} is installed, matching allocates no diagnostics objects. Enabled listeners
+ * receive one bounded event per supported public operation, irrespective of internal engine passes
+ * or replacement match count.
+ */
+public class SafeReMatchDiagnostics {
+  /** Listener used when match diagnostics are disabled. */
+  public static final SafeReMatchDiagnostics NONE = new SafeReMatchDiagnostics(false);
+
+  private final boolean enabled;
+
+  /** Creates an enabled diagnostics listener. */
+  protected SafeReMatchDiagnostics() {
+    this(true);
+  }
+
+  private SafeReMatchDiagnostics(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  /** Returns whether the given listener is enabled. */
+  static boolean isEnabled(SafeReMatchDiagnostics listener) {
+    return listener.enabled;
+  }
+
+  /**
+   * Called after a pattern is compiled while this listener is installed.
+   *
+   * @param event immutable pattern compilation event
+   */
+  public void onPatternCompiled(PatternCompiledEvent event) {}
+
+  /**
+   * Called after a supported public operation completes normally.
+   *
+   * @param event immutable operation summary
+   */
+  public void onOperationCompleted(OperationDiagnostics event) {}
+}

--- a/safere/src/main/java/org/safere/StrategyDecision.java
+++ b/safere/src/main/java/org/safere/StrategyDecision.java
@@ -1,0 +1,19 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Objects;
+
+/** A strategy-specific explanation of routing or fallback. */
+public record StrategyDecision(
+    MatchStrategy strategy, StrategyDisposition disposition, StrategyReason reason) {
+  /** Creates a strategy decision. */
+  public StrategyDecision {
+    Objects.requireNonNull(strategy, "strategy");
+    Objects.requireNonNull(disposition, "disposition");
+    Objects.requireNonNull(reason, "reason");
+  }
+}

--- a/safere/src/main/java/org/safere/StrategyDisposition.java
+++ b/safere/src/main/java/org/safere/StrategyDisposition.java
@@ -1,0 +1,13 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** How a strategy was excluded from or left the authoritative execution path. */
+public enum StrategyDisposition {
+  INAPPLICABLE,
+  BYPASSED,
+  FALLBACK
+}

--- a/safere/src/main/java/org/safere/StrategyParticipation.java
+++ b/safere/src/main/java/org/safere/StrategyParticipation.java
@@ -1,0 +1,17 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Objects;
+
+/** A strategy performing an auxiliary role during an operation. */
+public record StrategyParticipation(MatchStrategy strategy, StrategyRole role) {
+  /** Creates a participation pair. */
+  public StrategyParticipation {
+    Objects.requireNonNull(strategy, "strategy");
+    Objects.requireNonNull(role, "role");
+  }
+}

--- a/safere/src/main/java/org/safere/StrategyReason.java
+++ b/safere/src/main/java/org/safere/StrategyReason.java
@@ -1,0 +1,18 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Stable reason for a strategy decision. */
+public enum StrategyReason {
+  INPUT_TOO_SMALL,
+  INPUT_TOO_LARGE,
+  CAPTURES_REQUIRED,
+  AUTHORITATIVE_BOUNDS_REQUIRED,
+  EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED,
+  DFA_BUDGET_EXCEEDED,
+  WORK_BUDGET_EXCEEDED,
+  OPTIMIZED_PATH_DISABLED
+}

--- a/safere/src/main/java/org/safere/StrategyRole.java
+++ b/safere/src/main/java/org/safere/StrategyRole.java
@@ -1,0 +1,13 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Auxiliary role performed by a matching strategy. */
+public enum StrategyRole {
+  START_ACCELERATION,
+  REJECT_PREFILTER,
+  CANDIDATE_VERIFICATION
+}

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -1,0 +1,549 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+@DisabledForCrosscheck("match diagnostics are a SafeRE-specific public API")
+class DiagnosticsTest {
+  private final RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+
+  @AfterEach
+  void disableDiagnostics() {
+    Pattern.setDiagnostics(SafeReMatchDiagnostics.NONE);
+  }
+
+  @Test
+  void staticAnalysisReportsFeaturesCapabilitiesAndLimitations() {
+    Pattern pattern = Pattern.compile("^(?:(a)?)*$");
+
+    PatternAnalysis analysis = pattern.analysis();
+
+    assertThat(analysis.features())
+        .contains(
+            PatternFeature.CAPTURES,
+            PatternFeature.ANCHOR,
+            PatternFeature.START_ANCHOR,
+            PatternFeature.END_ANCHOR,
+            PatternFeature.NULLABLE,
+            PatternFeature.NESTED_NULLABLE_QUANTIFIER,
+            PatternFeature.PROGRESS_CHECK,
+            PatternFeature.CAPTURES_IN_QUANTIFIER);
+    assertThat(analysis.capabilities())
+        .contains(PatternCapability.DFA_REJECT_PREFILTER, PatternCapability.NFA);
+    assertThat(analysis.limitations())
+        .contains(
+            PatternLimitation.NULLABLE_LOOP_REQUIRES_EXACT_ENGINE,
+            PatternLimitation.CAPTURE_PRIORITY_REQUIRES_EXACT_ENGINE);
+    assertThat(analysis.captureCount()).isEqualTo(1);
+    assertThatThrownBy(() -> analysis.features().clear())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void listenerInstalledAfterCompilationStillReceivesPatternAnalysis() {
+    Pattern pattern = Pattern.compile("abc");
+    Pattern.setDiagnostics(diagnostics);
+
+    assertThat(pattern.matcher("abc").matches()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.pattern().analysis()).isSameAs(pattern.analysis());
+              assertThat(event.pattern().patternId()).isPositive();
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+            });
+  }
+
+  @Test
+  void compilationAndOperationsShareDescriptor() {
+    Pattern.setDiagnostics(diagnostics);
+
+    Pattern pattern = Pattern.compile("^GET ([^ ]+)");
+    assertThat(pattern.matcher("GET /index").lookingAt()).isTrue();
+
+    PatternCompiledEvent compilation =
+        diagnostics.compilations.stream()
+            .filter(event -> event.pattern().patternId() == pattern.descriptor().patternId())
+            .findFirst()
+            .orElseThrow();
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.pattern()).isSameAs(compilation.pattern());
+              assertThat(event.operation()).isEqualTo(MatchOperation.LOOKING_AT);
+              assertThat(event.outcome()).isEqualTo(MatchOutcome.MATCH);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.ONE_PASS);
+              assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.ONE_PASS);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.EAGER);
+            });
+  }
+
+  @Test
+  void forcedBitStateAndNfaReportTheExactEngine() {
+    Pattern.setDiagnostics(diagnostics);
+    EnginePathOptions bitStateOnly =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .keywordAlternationFastPath(false)
+            .onePass(false)
+            .dfa(false)
+            .build();
+    Pattern bitState = Pattern.compile("a+b", 0, bitStateOnly);
+
+    assertThat(bitState.matcher("aaab").matches()).isTrue();
+    assertThat(operationsFor(bitState).getLast().boundaryStrategy())
+        .isEqualTo(MatchStrategy.BIT_STATE);
+
+    EnginePathOptions nfaOnly =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .keywordAlternationFastPath(false)
+            .onePass(false)
+            .dfa(false)
+            .bitState(false)
+            .build();
+    Pattern nfa = Pattern.compile("a+b", 0, nfaOnly);
+
+    assertThat(nfa.matcher("aaab").matches()).isTrue();
+    assertThat(operationsFor(nfa).getLast().boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+  }
+
+  @Test
+  void replacementFastPathEmitsOneOperationWithTotalMatchCount() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("[a-z]+");
+
+    assertThat(pattern.matcher("a 22 bb").replaceAll("x")).isEqualTo("x 22 x");
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(MatchOperation.REPLACE_ALL);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.CHARACTER_CLASS);
+              assertThat(event.matchCount()).isEqualTo(2);
+              assertThat(event.auxiliaryStrategies())
+                  .containsExactly(
+                      new StrategyParticipation(
+                          MatchStrategy.CHARACTER_CLASS, StrategyRole.CANDIDATE_VERIFICATION));
+            });
+  }
+
+  @Test
+  void ordinaryReplacementLoopSuppressesNestedFindEvents() {
+    Pattern.setDiagnostics(diagnostics);
+    EnginePathOptions exactOnly =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .charClassReplacementFastPath(false)
+            .keywordAlternationFastPath(false)
+            .onePass(false)
+            .dfa(false)
+            .build();
+    Pattern pattern = Pattern.compile("(a)", 0, exactOnly);
+
+    assertThat(pattern.matcher("aba").replaceAll("$1x")).isEqualTo("axbax");
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(MatchOperation.REPLACE_ALL);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.BIT_STATE);
+              assertThat(event.matchCount()).isEqualTo(2);
+            });
+  }
+
+  @Test
+  void dfaReplacementReportsOneEventAndAllMatches() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("a+b");
+
+    assertThat(pattern.matcher("aaab xx ab").replaceAll("z")).isEqualTo("z xx z");
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(MatchOperation.REPLACE_ALL);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.matchCount()).isEqualTo(2);
+              assertThat(event.auxiliaryStrategies())
+                  .contains(
+                      new StrategyParticipation(
+                          MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION));
+            });
+  }
+
+  @Test
+  void functionalReplacementAlsoSuppressesNestedFindEvents() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("a");
+
+    assertThat(pattern.matcher("aba").replaceAll(result -> result.group() + "x"))
+        .isEqualTo("axbax");
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(MatchOperation.REPLACE_ALL);
+              assertThat(event.matchCount()).isEqualTo(2);
+            });
+  }
+
+  @Test
+  void nullableLoopDfaCanAuthoritativelyReject() {
+    Pattern.setDiagnostics(diagnostics);
+    EnginePathOptions dfaOnly =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .keywordAlternationFastPath(false)
+            .startAcceleration(false)
+            .onePass(false)
+            .bitState(false)
+            .build();
+    Pattern pattern = Pattern.compile("(?:(a)?)*X", 0, dfaOnly);
+
+    assertThat(pattern.matcher("aaaa").find()).isFalse();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.auxiliaryStrategies())
+                  .contains(
+                      new StrategyParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER));
+            });
+
+    assertThat(pattern.matcher("aaaaX").find()).isTrue();
+    assertThat(operationsFor(pattern).getLast())
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+              assertThat(event.strategyDecisions())
+                  .contains(
+                      new StrategyDecision(
+                          MatchStrategy.DFA,
+                          StrategyDisposition.BYPASSED,
+                          StrategyReason.EXACT_NULLABLE_LOOP_SEMANTICS_REQUIRED));
+            });
+  }
+
+  @Test
+  void prefixCandidateFailureContinuesThroughDfa() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern =
+        Pattern.compile("(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>");
+    String input =
+        "<block>\n  # comment\n</block> " + "<block>\n  # category_defined: alpha\n</block>";
+
+    assertThat(pattern.matcher(input).find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.auxiliaryStrategies())
+                  .startsWith(
+                      new StrategyParticipation(
+                          MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION))
+                  .contains(
+                      new StrategyParticipation(
+                          MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION));
+            });
+  }
+
+  @Test
+  void dfaBoundsCanLeaveCapturesDeferred() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("(a+)b");
+    Matcher matcher = pattern.matcher("xxaaab");
+
+    assertThat(matcher.find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.NONE);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.DEFERRED);
+            });
+    assertThat(matcher.group(1)).isEqualTo("aaa");
+    assertThat(operationsFor(pattern)).hasSize(1);
+  }
+
+  @Test
+  void failedRegexOperationDoesNotEmitAnEvent() {
+    Pattern.setDiagnostics(diagnostics);
+    Matcher matcher = Pattern.compile("a").matcher("a");
+
+    assertThatThrownBy(() -> matcher.find(2)).isInstanceOf(IndexOutOfBoundsException.class);
+
+    assertThat(operationsFor(matcher.pattern())).isEmpty();
+  }
+
+  @Test
+  void listenerCanAggregateOperationsFromMultipleThreads() {
+    Pattern pattern = Pattern.compile("abc");
+    ConcurrentLinkedQueue<OperationDiagnostics> events = new ConcurrentLinkedQueue<>();
+    Pattern.setDiagnostics(
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            events.add(event);
+          }
+        });
+
+    IntStream.range(0, 32)
+        .parallel()
+        .forEach(ignored -> assertThat(pattern.matcher("abc").matches()).isTrue());
+
+    assertThat(events)
+        .filteredOn(event -> event.pattern().patternId() == pattern.descriptor().patternId())
+        .hasSize(32);
+  }
+
+  @Test
+  void listenerFailurePropagatesAfterMatcherStateIsFinalized() {
+    Pattern pattern = Pattern.compile("abc");
+    Matcher matcher = pattern.matcher("abc");
+    Pattern.setDiagnostics(
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            throw new IllegalStateException("listener failed");
+          }
+        });
+
+    assertThatThrownBy(matcher::matches)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("listener failed");
+    assertThat(matcher.group()).isEqualTo("abc");
+  }
+
+  @Test
+  void listenerReplacementResetAndOperationSnapshotAreStable() {
+    Pattern pattern = Pattern.compile("abc");
+    RecordingDiagnostics replacement = new RecordingDiagnostics();
+    SafeReMatchDiagnostics replacingListener =
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            diagnostics.operations.add(event);
+            Pattern.setDiagnostics(replacement);
+          }
+        };
+    Pattern.setDiagnostics(replacingListener);
+
+    assertThat(pattern.matcher("abc").matches()).isTrue();
+    assertThat(diagnostics.operations).hasSize(1);
+    assertThat(replacement.operations).isEmpty();
+
+    assertThat(pattern.matcher("abc").matches()).isTrue();
+    assertThat(replacement.operations).hasSize(1);
+
+    Pattern.setDiagnostics(SafeReMatchDiagnostics.NONE);
+    assertThat(pattern.matcher("abc").matches()).isTrue();
+    assertThat(replacement.operations).hasSize(1);
+  }
+
+  @Test
+  void eventsContainOnlyOpaqueIdentityAnalysisAndAggregateInputFacts() {
+    String regexSecret = "diagnosticPatternSecret";
+    String inputSecret = "prefix-diagnosticInputSecret-suffix";
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile(regexSecret);
+
+    assertThat(pattern.matcher(inputSecret).find()).isFalse();
+
+    OperationDiagnostics event = operationsFor(pattern).getFirst();
+    assertThat(event.toString()).doesNotContain(regexSecret, inputSecret);
+    assertThat(OperationDiagnostics.class.getRecordComponents())
+        .noneMatch(component -> component.getType() == String.class);
+    assertThat(PatternDescriptor.class.getRecordComponents())
+        .noneMatch(component -> component.getType() == String.class);
+    assertThat(event.inputLength()).isEqualTo(inputSecret.length());
+  }
+
+  @Test
+  void keywordAlternationReportsKeywordStrategy() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("(?i)\\b(error|warning|timeout|failed)\\b");
+
+    assertThat(pattern.matcher("Info: Warning").find()).isTrue();
+
+    assertThat(operationsFor(pattern).getFirst().boundaryStrategy())
+        .isEqualTo(MatchStrategy.KEYWORD);
+  }
+
+  @Test
+  void largeInputBypassesBitStateAndReportsNfaFallback() {
+    Pattern.setDiagnostics(diagnostics);
+    EnginePathOptions exactOnly =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .keywordAlternationFastPath(false)
+            .onePass(false)
+            .dfa(false)
+            .build();
+    Pattern pattern = Pattern.compile("a+b", 0, exactOnly);
+
+    assertThat(pattern.matcher("a".repeat(100_000) + "b").matches()).isTrue();
+
+    assertThat(operationsFor(pattern).getFirst())
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+              assertThat(event.strategyDecisions())
+                  .contains(
+                      new StrategyDecision(
+                          MatchStrategy.BIT_STATE,
+                          StrategyDisposition.BYPASSED,
+                          StrategyReason.INPUT_TOO_LARGE));
+            });
+  }
+
+  @Test
+  void graphemeSemanticsReportUnsupportedOptimizedPathsAndExactFallback() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("\\X");
+
+    assertThat(pattern.matcher("a\u0301").matches()).isTrue();
+
+    assertThat(pattern.analysis().features()).contains(PatternFeature.GRAPHEME);
+    assertThat(pattern.analysis().limitations())
+        .contains(PatternLimitation.GRAPHEME_REQUIRES_EXACT_ENGINE);
+    assertThat(operationsFor(pattern).getFirst().boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+  }
+
+  @Test
+  void dfaBudgetExhaustionReportsFallbackToAnExactEngine() {
+    String regex = "[ab]*a" + "[ab]".repeat(14) + "X";
+    Pattern pattern = Pattern.compile(regex);
+    java.util.regex.Pattern oracle = java.util.regex.Pattern.compile(regex);
+    AtomicBoolean observedBudgetFallback = new AtomicBoolean();
+    Pattern.setDiagnostics(
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            if (event
+                .strategyDecisions()
+                .contains(
+                    new StrategyDecision(
+                        MatchStrategy.DFA,
+                        StrategyDisposition.FALLBACK,
+                        StrategyReason.DFA_BUDGET_EXCEEDED))) {
+              observedBudgetFallback.set(true);
+            }
+          }
+        });
+
+    for (int bits = 0; bits < 1 << 15 && !observedBudgetFallback.get(); bits++) {
+      StringBuilder input = new StringBuilder(16);
+      for (int index = 0; index < 15; index++) {
+        input.append((bits & (1 << index)) == 0 ? 'a' : 'b');
+      }
+      input.append('X');
+      String text = input.toString();
+      assertThat(pattern.matcher(text).matches()).isEqualTo(oracle.matcher(text).matches());
+    }
+
+    assertThat(observedBudgetFallback).isTrue();
+  }
+
+  @Test
+  void exactEngineRespectsRegionAndAnchoringBoundsAndReportsItsStrategy() {
+    Pattern.setDiagnostics(diagnostics);
+    EnginePathOptions exactOnly =
+        EnginePathOptions.builder()
+            .literalFastPaths(false)
+            .charClassMatchFastPaths(false)
+            .keywordAlternationFastPath(false)
+            .onePass(false)
+            .dfa(false)
+            .build();
+    Pattern pattern = Pattern.compile("^a", 0, exactOnly);
+    Matcher matcher = pattern.matcher("za").region(1, 2).useAnchoringBounds(true);
+
+    assertThat(matcher.matches()).isTrue();
+
+    assertThat(operationsFor(pattern).getFirst().boundaryStrategy())
+        .isEqualTo(MatchStrategy.BIT_STATE);
+  }
+
+  @Test
+  void listenerCanAggregateStrategiesWithLongAdders() {
+    Pattern pattern = Pattern.compile("abc");
+    Map<MatchStrategy, LongAdder> counts = new ConcurrentHashMap<>();
+    Pattern.setDiagnostics(
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            counts
+                .computeIfAbsent(event.boundaryStrategy(), ignored -> new LongAdder())
+                .increment();
+          }
+        });
+
+    IntStream.range(0, 64)
+        .parallel()
+        .forEach(ignored -> assertThat(pattern.matcher("abc").matches()).isTrue());
+
+    assertThat(counts.get(MatchStrategy.LITERAL).sum()).isEqualTo(64);
+  }
+
+  private List<OperationDiagnostics> operationsFor(Pattern pattern) {
+    long patternId = pattern.descriptor().patternId();
+    return diagnostics.operations.stream()
+        .filter(event -> event.pattern().patternId() == patternId)
+        .toList();
+  }
+
+  private static final class RecordingDiagnostics extends SafeReMatchDiagnostics {
+    final List<PatternCompiledEvent> compilations = new ArrayList<>();
+    final List<OperationDiagnostics> operations = new ArrayList<>();
+
+    @Override
+    public void onPatternCompiled(PatternCompiledEvent event) {
+      compilations.add(event);
+    }
+
+    @Override
+    public void onOperationCompleted(OperationDiagnostics event) {
+      operations.add(event);
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -203,6 +203,32 @@ class DiagnosticsTest {
   }
 
   @Test
+  void replacementCaptureModeAgreesWithCaptureStrategyAcrossTerminalFindFailure() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern deferredPattern = Pattern.compile("(a+)b");
+
+    assertThat(deferredPattern.matcher("aaab xx ab").replaceAll("x")).isEqualTo("x xx x");
+
+    assertThat(operationsFor(deferredPattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.NONE);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.DEFERRED);
+            });
+
+    Pattern eagerPattern = Pattern.compile("(a+)b");
+    assertThat(eagerPattern.matcher("aaab xx ab").replaceAll("$1")).isEqualTo("aaa xx a");
+    assertThat(operationsFor(eagerPattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.captureStrategy()).isNotEqualTo(MatchStrategy.NONE);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.EAGER);
+            });
+  }
+
+  @Test
   void functionalReplacementAlsoSuppressesNestedFindEvents() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile("a");

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
@@ -74,6 +75,8 @@ class DiagnosticsTest {
               assertThat(event.pattern().analysis()).isSameAs(pattern.analysis());
               assertThat(event.pattern().patternId()).isPositive();
               assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+              assertThat(event.forwardDfaSearchCount()).isZero();
+              assertThat(event.reverseDfaSearchCount()).isZero();
             });
   }
 
@@ -195,10 +198,29 @@ class DiagnosticsTest {
               assertThat(event.operation()).isEqualTo(MatchOperation.REPLACE_ALL);
               assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
               assertThat(event.matchCount()).isEqualTo(2);
+              assertThat(event.forwardDfaSearchCount()).isEqualTo(3);
+              assertThat(event.reverseDfaSearchCount()).isEqualTo(2);
               assertThat(event.auxiliaryStrategies())
                   .contains(
                       new StrategyParticipation(
                           MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION));
+            });
+  }
+
+  @Test
+  void dfaSandwichReportsForwardAndReverseSearchCounts() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("[ab]+c");
+
+    assertThat(pattern.matcher("xxabc").find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.forwardDfaSearchCount()).isEqualTo(1);
+              assertThat(event.reverseDfaSearchCount()).isEqualTo(1);
             });
   }
 
@@ -481,6 +503,7 @@ class DiagnosticsTest {
     Pattern pattern = Pattern.compile(regex);
     java.util.regex.Pattern oracle = java.util.regex.Pattern.compile(regex);
     AtomicBoolean observedBudgetFallback = new AtomicBoolean();
+    AtomicInteger observedForwardSearchCount = new AtomicInteger();
     Pattern.setDiagnostics(
         new SafeReMatchDiagnostics() {
           @Override
@@ -493,6 +516,7 @@ class DiagnosticsTest {
                         StrategyDisposition.FALLBACK,
                         StrategyReason.DFA_BUDGET_EXCEEDED))) {
               observedBudgetFallback.set(true);
+              observedForwardSearchCount.set(event.forwardDfaSearchCount());
             }
           }
         });
@@ -508,6 +532,7 @@ class DiagnosticsTest {
     }
 
     assertThat(observedBudgetFallback).isTrue();
+    assertThat(observedForwardSearchCount).hasPositiveValue();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add immutable static pattern analysis through `Pattern.analysis()`;
- add a process-wide synchronous runtime diagnostics listener with compilation and operation events;
- report authoritative boundary strategy, capture strategy/mode, auxiliary participation, routing decisions, input length, and replacement match counts without exposing regex or input text;
- keep diagnostics disabled by default with no diagnostic allocations;
- use a synchronized mutable call site and guarded fast paths to eliminate measurable disabled-mode overhead;
- add selection, conformance, fallback, lifecycle, concurrency, privacy, and replacement regression coverage;
- add standard JMH coverage and user documentation for both static and runtime APIs.

Fixes #474

## API overview

Static analysis exposes stable pattern features, possible engine capabilities, limitations, program size, and capture count. Runtime diagnostics emit one bounded immutable event per normally completed public operation. Replacement methods emit one aggregate event rather than nested `find()` events.

The listener is process-wide, synchronous, visible across threads, and snapshotted once per operation. Listener exceptions propagate after matcher state is finalized. `SafeReMatchDiagnostics.NONE` is installed by default.

See `DIAGNOSTICS.md` for usage examples and `design/ENGINE_DIAGNOSTICS_DECISION_TABLE.md` for routing semantics.

## Performance

All JMH invocations ran serially through `./run-java-benchmarks.sh`. Routine evidence used the standard configuration: 2 forks, 2 × 500 ms warmup iterations, and 5 × 500 ms measurement iterations. Close or surprising cases were confirmed with `--long`.

The disabled matrix compared base commit `c8f51f3fa99976566ac9a3260df371caedec929e` with this branch using identical benchmark source. Branch/base geometric mean was `0.994`, and no slower result had a statistically convincing material regression.

| Workload | Baseline ns/op | Branch ns/op | Branch / baseline |
|---|---:|---:|---:|
| Tiny literal full match | 14.141 | 14.157 | 1.001 |
| OnePass match | 59.551 | 59.468 | 0.999 |
| BitState-sized ambiguous match | 89.412 | 89.369 | 1.000 |
| Long DFA find | 579.022 | 605.815 | 1.046 |
| Long NFA match | 13,336.972 | 13,449.810 | 1.008 |
| No-match character-class replacement | 20.690 | 20.449 | 0.988 |
| Sparse DFA replacement | 1,596.580 | 1,638.242 | 1.026 |

Long-mode confirmation of the initially sensitive cases had overlapping confidence intervals:

| Workload | Baseline ns/op | Branch ns/op |
|---|---:|---:|
| No-match character-class replacement | 20.312 ± 0.248 | 20.716 ± 0.338 |
| OnePass match | 59.697 ± 0.990 | 60.904 ± 1.687 |

A JFR allocation probe found no diagnostic event or bookkeeping allocations with diagnostics disabled.

Enabled diagnostics add approximately 150–200 ns of fixed work per public operation. This is significant for tiny operations and proportionally small for longer work; for example, a no-op listener measured 162.858 ns/op for a tiny literal full match, 800.373 ns/op for a long DFA find, and 13,731.093 ns/op for a long NFA match. The complete disabled, no-op, and `LongAdder` tables are in `design/ISSUE_474_PHASE_7_PERFORMANCE.md`.

Cached `Pattern.analysis()` retrieval measured 0.528 ± 0.020 ns/op. Compile-only and compile-plus-first-analysis confidence intervals overlapped broadly.

## Verification

Passed before the final documentation-only commit:

```text
mvn -pl safere spotless:check -q
mvn -pl safere -Dtest=DiagnosticsTest test -q
mvn -pl safere test -q
mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q
```

Additional verification:

- JFR disabled-allocation probe: no diagnostic event or bookkeeping allocations found.
- Codex review of the implementation against `main`: no actionable correctness findings.
- Codex review of the Phase 7 diff against `6e427ee`: no actionable correctness findings.
- `git diff --check` and documentation link checks passed after the final documentation commit.

Not rerun after the final documentation-only commit:

- full SafeRE test suite;
- public API crosscheck;
- JMH benchmarks.

No external-project validation was run for this change.
