### PR TITLE
Restore String matching performance after UTF-8 input changes

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -59,6 +59,11 @@
       "multibyteLate": { "pattern": "错误", "text": "请求处理结束：错误" },
       "multibyteNoMatch": { "pattern": "错误", "text": "请求处理成功" }
     },
+    "requiredClassNonmatch": {
+      "pattern": "[一-龥]{3,}",
+      "unit": "This is a sentence containing only English characters. ",
+      "textSize": 10000
+    },
     "repeatedFind": {
       "ascii": { "pattern": "[A-Za-z]+", "text": "one two three four five" },
       "multibyte": { "pattern": "\\p{L}+", "text": "one café 東京 naïve" }

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -33,6 +33,23 @@
     }
   },
 
+  "matcherApi": {
+    "lookingAt": {
+      "pattern": "[A-Za-z]+:\\s+\\d+",
+      "text": "requests: 1234 completed"
+    },
+    "regionFind": {
+      "pattern": "\\b[A-Za-z]+ing\\b",
+      "text": "IGNORE morning shining IGNORE",
+      "start": 7,
+      "end": 22
+    },
+    "resetAndFind": {
+      "pattern": "[A-Za-z]+\\d+",
+      "text": "item1 item22 item333"
+    }
+  },
+
   "utf8Matching": {
     "captureFreeFind": {
       "asciiEarly": { "pattern": "ERROR", "text": "ERROR request completed" },

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MatcherApiBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MatcherApiBenchmark.java
@@ -1,0 +1,106 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Benchmarks String matcher API paths not covered by the core regex benchmarks. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class MatcherApiBenchmark {
+
+  private org.safere.Pattern safeLookingAt;
+  private java.util.regex.Pattern jdkLookingAt;
+  private String lookingAtText;
+
+  private org.safere.Matcher safeRegionMatcher;
+  private java.util.regex.Matcher jdkRegionMatcher;
+  private int regionStart;
+  private int regionEnd;
+
+  private org.safere.Matcher safeResetMatcher;
+  private java.util.regex.Matcher jdkResetMatcher;
+
+  @Setup
+  public void setup() {
+    BenchmarkData data = BenchmarkData.get();
+
+    String lookingAtPattern = data.getString("matcherApi.lookingAt.pattern");
+    lookingAtText = data.getString("matcherApi.lookingAt.text");
+    safeLookingAt = org.safere.Pattern.compile(lookingAtPattern);
+    jdkLookingAt = java.util.regex.Pattern.compile(lookingAtPattern);
+
+    String regionPattern = data.getString("matcherApi.regionFind.pattern");
+    String regionText = data.getString("matcherApi.regionFind.text");
+    regionStart = data.getInt("matcherApi.regionFind.start");
+    regionEnd = data.getInt("matcherApi.regionFind.end");
+    safeRegionMatcher = org.safere.Pattern.compile(regionPattern).matcher(regionText);
+    jdkRegionMatcher = java.util.regex.Pattern.compile(regionPattern).matcher(regionText);
+
+    String resetPattern = data.getString("matcherApi.resetAndFind.pattern");
+    String resetText = data.getString("matcherApi.resetAndFind.text");
+    safeResetMatcher = org.safere.Pattern.compile(resetPattern).matcher(resetText);
+    jdkResetMatcher = java.util.regex.Pattern.compile(resetPattern).matcher(resetText);
+
+    if (!lookingAt_safere() || !lookingAt_jdk()) {
+      throw new IllegalStateException("lookingAt benchmark input must match");
+    }
+    if (!regionFind_safere() || !regionFind_jdk()) {
+      throw new IllegalStateException("region benchmark input must match");
+    }
+    if (resetAndFind_safere() != 3 || resetAndFind_jdk() != 3) {
+      throw new IllegalStateException("reset benchmark input must contain three matches");
+    }
+  }
+
+  @Benchmark
+  public boolean lookingAt_safere() {
+    return safeLookingAt.matcher(lookingAtText).lookingAt();
+  }
+
+  @Benchmark
+  public boolean lookingAt_jdk() {
+    return jdkLookingAt.matcher(lookingAtText).lookingAt();
+  }
+
+  @Benchmark
+  public boolean regionFind_safere() {
+    return safeRegionMatcher.region(regionStart, regionEnd).find();
+  }
+
+  @Benchmark
+  public boolean regionFind_jdk() {
+    return jdkRegionMatcher.region(regionStart, regionEnd).find();
+  }
+
+  @Benchmark
+  public int resetAndFind_safere() {
+    safeResetMatcher.reset();
+    int count = 0;
+    while (safeResetMatcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  @Benchmark
+  public int resetAndFind_jdk() {
+    jdkResetMatcher.reset();
+    int count = 0;
+    while (jdkResetMatcher.find()) {
+      count++;
+    }
+    return count;
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/Utf8MatchingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/Utf8MatchingBenchmark.java
@@ -93,6 +93,24 @@ public class Utf8MatchingBenchmark extends ByteMatchingBenchmark {
     return state.pattern.find(state.input);
   }
 
+  /** Measures a required non-ASCII class absent from direct UTF-8 input. */
+  @Benchmark
+  public boolean requiredClassNonmatchBytes(RequiredClassNonmatchState state) {
+    return state.pattern.find(state.input);
+  }
+
+  /** Measures required-class rejection through a stateful UTF-8 matcher. */
+  @Benchmark
+  public boolean requiredClassNonmatchMatcher(RequiredClassNonmatchState state) {
+    return state.pattern.matcher(state.input).find();
+  }
+
+  /** Measures the same required-class rejection over a predecoded String. */
+  @Benchmark
+  public boolean requiredClassNonmatchString(RequiredClassNonmatchState state) {
+    return state.pattern.matcher(state.text).find();
+  }
+
   @State(Scope.Thread)
   public static class CaptureFreeState {
     @Param({
@@ -200,6 +218,25 @@ public class Utf8MatchingBenchmark extends ByteMatchingBenchmark {
       pattern = org.safere.Pattern.compile(data.getString("utf8Matching.hardFailure.pattern"));
       String unit = data.getString("utf8Matching.hardFailure.unit");
       String text = unit.repeat((size + unit.length() - 1) / unit.length()).substring(0, size);
+      input = org.safere.Utf8Input.trusted(text.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class RequiredClassNonmatchState {
+    private org.safere.Pattern pattern;
+    private String text;
+    private org.safere.Utf8Input input;
+
+    /** Builds the frozen required-class nonmatch input. */
+    @Setup
+    public void setup() {
+      BenchmarkData data = BenchmarkData.get();
+      String prefix = "utf8Matching.requiredClassNonmatch.";
+      pattern = org.safere.Pattern.compile(data.getString(prefix + "pattern"));
+      String unit = data.getString(prefix + "unit");
+      int size = data.getInt(prefix + "textSize");
+      text = unit.repeat((size + unit.length() - 1) / unit.length()).substring(0, size);
       input = org.safere.Utf8Input.trusted(text.getBytes(StandardCharsets.UTF_8));
     }
   }

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -113,6 +113,7 @@
                         <!-- Compile-time structural excludes. Each excluded test class is also
                              annotated with @DisabledForCrosscheck in the original source. -->
                         <exclude name="AnchorOptTest.java"/>
+                        <exclude name="AnchoredDfaCachingTest.java"/>
                         <exclude name="BitStateTest.java"/>
                         <exclude name="CharClassTest.java"/>
                         <exclude name="CompilerTest.java"/>
@@ -123,6 +124,7 @@
                         <exclude name="GraphemeLinearTimeTest.java"/>
                         <exclude name="InstOpTest.java"/>
                         <exclude name="InstTest.java"/>
+                        <exclude name="InputScannerTest.java"/>
                         <exclude name="MatcherDeferredCaptureStateTest.java"/>
                         <exclude name="MatcherTransitionInventoryTest.java"/>
                         <exclude name="NfaTest.java"/>

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -50,6 +50,7 @@ final class MatchFuzzer {
     assertUnicodeBoundaryStartCacheMatchesJdk();
     assertTrailingLineTerminatorEndAnchorFindsMatchJdk();
     assertUnicodeLineStartAnchorsMatchJdk();
+    assertMixedCarriageReturnLineStartsMatchJdk(data);
     assertZeroWidthAlternationFindsLeftmostStartJdk();
     assertZeroWidthPossessiveCaptureRetentionJdk();
     assertDfaSandwichLeftmostStartCasesMatchJdk();
@@ -133,6 +134,36 @@ final class MatchFuzzer {
             pattern.matcher("header" + terminator + "\tat alpha" + terminator + "\tat beta");
         while (matcher.find()) {}
       }
+    }
+  }
+
+  private static void assertMixedCarriageReturnLineStartsMatchJdk(FuzzedDataProvider data) {
+    List<RegressionCase> regressions =
+        List.of(
+            new RegressionCase("(?m)^.X", 0, List.of("a".repeat(500) + "\r\nqq\rqX")),
+            new RegressionCase("(?m)^\\nX", 0, List.of("a".repeat(500) + "\rqY\r\nX")));
+    for (RegressionCase regression : regressions) {
+      FuzzSupport.CompiledPattern pattern =
+          FuzzSupport.compileCompatibleOrSkip(regression.regex(), regression.flags());
+      if (pattern != null) {
+        for (String input : regression.inputs()) {
+          pattern.matcher(input).find();
+        }
+      }
+    }
+
+    String firstTerminator = data.consumeBoolean() ? "\r\n" : "\r";
+    String secondTerminator = firstTerminator.length() == 2 ? "\r" : "\r\n";
+    String regex = data.consumeBoolean() ? "(?m)^.X" : "(?m)^\\nX";
+    String input =
+        "a".repeat(data.consumeInt(257, 1024))
+            + firstTerminator
+            + data.consumeString(8)
+            + secondTerminator
+            + data.consumeString(8);
+    FuzzSupport.CompiledPattern generated = FuzzSupport.compileCompatibleOrSkip(regex, 0);
+    if (generated != null) {
+      generated.matcher(input).find();
     }
   }
 

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -558,10 +558,14 @@ final class BitState {
 
         case InstOp.OP_CHAR_RANGE -> {
           if (pos < endPos) {
-            long decoded = text.decodeForward(pos);
-            int cp = InputScanner.codePoint(decoded);
+            int cp = WorkCounterConfig.ENABLED ? -1 : text.asciiAt(pos);
+            int nextPos = pos + 1;
+            if (cp < 0) {
+              long decoded = text.decodeForward(pos);
+              cp = InputScanner.codePoint(decoded);
+              nextPos = InputScanner.position(decoded);
+            }
             if (ip.matchesChar(cp)) {
-              int nextPos = InputScanner.position(decoded);
               if (shouldVisit(ip.out, nextPos)) {
                 push(ip.out, nextPos);
               }
@@ -571,10 +575,14 @@ final class BitState {
 
         case InstOp.OP_CHAR_CLASS -> {
           if (pos < endPos) {
-            long decoded = text.decodeForward(pos);
-            int cp = InputScanner.codePoint(decoded);
+            int cp = WorkCounterConfig.ENABLED ? -1 : text.asciiAt(pos);
+            int nextPos = pos + 1;
+            if (cp < 0) {
+              long decoded = text.decodeForward(pos);
+              cp = InputScanner.codePoint(decoded);
+              nextPos = InputScanner.position(decoded);
+            }
             if (ip.matchesCharClass(cp)) {
-              int nextPos = InputScanner.position(decoded);
               if (shouldVisit(ip.out, nextPos)) {
                 push(ip.out, nextPos);
               }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -161,6 +161,10 @@ final class Dfa {
   private final int maxStates;
   private final boolean longest;
   private final boolean hasGraphemeSemantics;
+
+  /** Whether consuming transitions can depend on the absolute input position. */
+  private final boolean hasPositionDependentTransitions;
+
   private final int stateEmptyFlagsMask;
   private final int startCacheEmptyFlagsMask;
   private final int anchoredCacheBit;
@@ -261,6 +265,7 @@ final class Dfa {
     this.maxStates = maxStates;
     this.longest = longest;
     this.hasGraphemeSemantics = prog.hasGraphemeSemantics();
+    this.hasPositionDependentTransitions = hasGraphemeSemantics || prog.hasTextAnchor();
     this.stateEmptyFlagsMask =
         hasGraphemeSemantics
             ? EmptyOp.ALL_FLAGS
@@ -818,9 +823,6 @@ final class Dfa {
     if (hasGraphemeSemantics) {
       return 0;
     }
-    if (!prog.hasTextAnchor()) {
-      return Integer.MAX_VALUE;
-    }
     // BEGIN_TEXT is represented by the start state, and BEGIN_LINE is normally derived from the
     // consumed character. The only position-dependent transitions are therefore near text end:
     // END_TEXT/DOLLAR_END, plus the exception that a final line terminator must not create a
@@ -1333,7 +1335,7 @@ final class Dfa {
       // is always safe to cache because it always means "at text end".
       int effectiveNextPos = Math.min(nextPos, textLen);
       State ns;
-      if (cp >= 0 && effectiveNextPos >= posDepThreshold) {
+      if (hasPositionDependentTransitions && cp >= 0 && effectiveNextPos >= posDepThreshold) {
         ns = computeNext(s, cp, text, effectiveNextPos);
         if (ns == null) {
           return null; // budget exceeded
@@ -1605,7 +1607,7 @@ final class Dfa {
       // Bypass cache for position-dependent transitions (same invariant as doSearch).
       int effectivePrevPos = Math.max(prevPos, startLimit);
       State ns;
-      if (cp >= 0 && effectivePrevPos >= posDepThreshold) {
+      if (hasPositionDependentTransitions && cp >= 0 && effectivePrevPos >= posDepThreshold) {
         ns = computeNext(s, cp, text, effectivePrevPos);
         if (ns == null) {
           return null; // budget exceeded
@@ -1815,7 +1817,7 @@ final class Dfa {
         // Bypass cache for position-dependent transitions (same invariant as doSearch).
         int effectiveNextPos = Math.min(nextPos, textLen);
         State ns;
-        if (cp >= 0 && effectiveNextPos >= posDepThreshold) {
+        if (hasPositionDependentTransitions && cp >= 0 && effectiveNextPos >= posDepThreshold) {
           ns = computeNext(s, cp, text, effectiveNextPos);
           if (ns == null) {
             return null; // budget exceeded

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -815,17 +815,11 @@ final class Dfa {
     if (hasGraphemeSemantics) {
       return 0;
     }
-    if (!prog.hasTextAnchor() && !prog.dollarAnchorEnd()) {
-      return Integer.MAX_VALUE;
-    }
-    int threshold = Integer.MAX_VALUE;
-    if (prog.hasTextAnchor()) {
-      threshold = 1;
-    }
-    if (prog.dollarAnchorEnd()) {
-      threshold = Math.min(threshold, trailingLineStart(text));
-    }
-    return threshold;
+    // BEGIN_TEXT is represented by the start state, and BEGIN_LINE is normally derived from the
+    // consumed character. The only position-dependent transitions are therefore near text end:
+    // END_TEXT/DOLLAR_END, plus the exception that a final line terminator must not create a
+    // BEGIN_LINE assertion past the end of the input.
+    return trailingLineStart(text);
   }
 
   private int trailingLineStart(InputScanner text) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -695,6 +695,9 @@ final class Dfa {
   }
 
   private int emptyFlags(InputScanner text, int pos) {
+    if (!hasGraphemeSemantics && !prog.hasWordBoundary() && !prog.hasTextAnchor()) {
+      return 0;
+    }
     int flags =
         Nfa.emptyFlags(
             text,
@@ -814,6 +817,9 @@ final class Dfa {
   private int positionDependentThreshold(InputScanner text) {
     if (hasGraphemeSemantics) {
       return 0;
+    }
+    if (!prog.hasTextAnchor()) {
+      return Integer.MAX_VALUE;
     }
     // BEGIN_TEXT is represented by the start state, and BEGIN_LINE is normally derived from the
     // consumed character. The only position-dependent transitions are therefore near text end:

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1300,12 +1300,14 @@ final class Dfa {
       int nextPos;
       int cls;
       if (pos < textLen) {
-        int ch = text.asciiAt(pos);
-        if (ch >= 0) {
-          // ASCII fast path: no surrogate handling, use pre-computed class map.
-          cp = ch;
+        int singleUnitCodePoint = text.singleUnitCodePointAt(pos);
+        if (singleUnitCodePoint >= 0) {
+          cp = singleUnitCodePoint;
           nextPos = pos + 1;
-          cls = asciiClassMap[ch];
+          cls =
+              singleUnitCodePoint < asciiClassMap.length
+                  ? asciiClassMap[singleUnitCodePoint]
+                  : classOf(singleUnitCodePoint);
         } else {
           long decoded = text.decodeForward(pos);
           cp = InputScanner.codePoint(decoded);
@@ -1573,12 +1575,14 @@ final class Dfa {
       int cls;
       if (pos > 0) {
         // Read the code point just before pos (scanning backward).
-        int ch = text.asciiAt(pos - 1);
-        if (ch >= 0) {
-          // ASCII fast path.
-          cp = ch;
+        int singleUnitCodePoint = text.singleUnitCodePointBefore(pos);
+        if (singleUnitCodePoint >= 0) {
+          cp = singleUnitCodePoint;
           prevPos = pos - 1;
-          cls = asciiClassMap[ch];
+          cls =
+              singleUnitCodePoint < asciiClassMap.length
+                  ? asciiClassMap[singleUnitCodePoint]
+                  : classOf(singleUnitCodePoint);
         } else {
           long decoded = text.decodeBackward(pos);
           cp = InputScanner.codePoint(decoded);
@@ -1782,11 +1786,14 @@ final class Dfa {
         int nextPos;
         int cls;
         if (pos < textLen) {
-          int c = text.asciiAt(pos);
-          if (c >= 0) {
-            cp = c;
+          int singleUnitCodePoint = text.singleUnitCodePointAt(pos);
+          if (singleUnitCodePoint >= 0) {
+            cp = singleUnitCodePoint;
             nextPos = pos + 1;
-            cls = asciiClassMap[c];
+            cls =
+                singleUnitCodePoint < asciiClassMap.length
+                    ? asciiClassMap[singleUnitCodePoint]
+                    : classOf(singleUnitCodePoint);
           } else {
             long decoded = text.decodeForward(pos);
             cp = InputScanner.codePoint(decoded);

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -839,6 +839,16 @@ final class Dfa {
     return trailing >= 0 ? trailing : len;
   }
 
+  private boolean transitionDependsOnPosition(int cp, int position, int threshold) {
+    if (!hasPositionDependentTransitions || cp < 0) {
+      return false;
+    }
+    // In the default line-ending mode, BEGIN_LINE after a carriage return depends on whether the
+    // following character is a line feed. A transition cached for CRLF therefore cannot be reused
+    // for a standalone carriage return, or vice versa.
+    return position >= threshold || (!prog.unixLines() && cp == '\r');
+  }
+
   /**
    * Computes the next DFA state from the current state for a given code point.
    *
@@ -1230,7 +1240,7 @@ final class Dfa {
       int sId = s.id * numClasses;
       while (pos < limit) {
         int ch = text.asciiAt(pos);
-        if (ch < 0) {
+        if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
           break;
         }
         int cls = asciiClassMap[ch];
@@ -1265,7 +1275,7 @@ final class Dfa {
       }
 
       int ch = text.asciiAt(pos);
-      if (ch < 0) {
+      if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
         break; // fall back to general loop
       }
       int cls = asciiClassMap[ch];
@@ -1335,7 +1345,7 @@ final class Dfa {
       // is always safe to cache because it always means "at text end".
       int effectiveNextPos = Math.min(nextPos, textLen);
       State ns;
-      if (hasPositionDependentTransitions && cp >= 0 && effectiveNextPos >= posDepThreshold) {
+      if (transitionDependsOnPosition(cp, effectiveNextPos, posDepThreshold)) {
         ns = computeNext(s, cp, text, effectiveNextPos);
         if (ns == null) {
           return null; // budget exceeded
@@ -1470,7 +1480,7 @@ final class Dfa {
         int sId = s.id * numClasses;
         while (pos > limit) {
           int ch = text.asciiAt(pos - 1);
-          if (ch < 0) {
+          if (ch < 0 || transitionDependsOnPosition(ch, pos - 1, posDepThreshold)) {
             break;
           }
           int cls = asciiClassMap[ch];
@@ -1524,7 +1534,7 @@ final class Dfa {
       }
 
       int ch = text.asciiAt(pos - 1);
-      if (ch < 0) {
+      if (ch < 0 || transitionDependsOnPosition(ch, pos - 1, posDepThreshold)) {
         break; // fall back
       }
       int cls = asciiClassMap[ch];
@@ -1607,7 +1617,7 @@ final class Dfa {
       // Bypass cache for position-dependent transitions (same invariant as doSearch).
       int effectivePrevPos = Math.max(prevPos, startLimit);
       State ns;
-      if (hasPositionDependentTransitions && cp >= 0 && effectivePrevPos >= posDepThreshold) {
+      if (transitionDependsOnPosition(cp, effectivePrevPos, posDepThreshold)) {
         ns = computeNext(s, cp, text, effectivePrevPos);
         if (ns == null) {
           return null; // budget exceeded
@@ -1738,7 +1748,7 @@ final class Dfa {
           break; // fall back to general loop for position-dependent context
         }
         int ch = text.asciiAt(pos);
-        if (ch < 0) {
+        if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
           break; // fall back
         }
         int cls = asciiClassMap[ch];
@@ -1817,7 +1827,7 @@ final class Dfa {
         // Bypass cache for position-dependent transitions (same invariant as doSearch).
         int effectiveNextPos = Math.min(nextPos, textLen);
         State ns;
-        if (hasPositionDependentTransitions && cp >= 0 && effectiveNextPos >= posDepThreshold) {
+        if (transitionDependsOnPosition(cp, effectiveNextPos, posDepThreshold)) {
           ns = computeNext(s, cp, text, effectiveNextPos);
           if (ns == null) {
             return null; // budget exceeded

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -14,6 +14,18 @@ interface InputScanner {
   /** Returns the ASCII value at {@code pos}, or {@code -1} if the unit is not ASCII. */
   int asciiAt(int pos);
 
+  /**
+   * Returns the code point at {@code pos} when it can be read directly from one index unit, or
+   * {@code -1} when full decoding is required.
+   */
+  int singleUnitCodePointAt(int pos);
+
+  /**
+   * Returns the code point before {@code pos} when it can be read directly from one index unit, or
+   * {@code -1} when full decoding is required.
+   */
+  int singleUnitCodePointBefore(int pos);
+
   /** Decodes the scalar at {@code pos} and packs it with the following logical position. */
   long decodeForward(int pos);
 

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -26,6 +26,9 @@ interface InputScanner {
    */
   int singleUnitCodePointBefore(int pos);
 
+  /** Returns the first position at or after {@code start} in the supplied code-point class. */
+  int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start);
+
   /** Decodes the scalar at {@code pos} and packs it with the following logical position. */
   long decodeForward(int pos);
 
@@ -63,5 +66,29 @@ interface InputScanner {
 
   static int position(long decoded) {
     return (int) decoded;
+  }
+
+  static boolean classContains(int[] ranges, long bitmap0, long bitmap1, int codePoint) {
+    if (codePoint < 64) {
+      return (bitmap0 & (1L << codePoint)) != 0;
+    }
+    if (codePoint < 128) {
+      return (bitmap1 & (1L << (codePoint - 64))) != 0;
+    }
+    int low = 0;
+    int high = ranges.length / 2 - 1;
+    while (low <= high) {
+      int middle = (low + high) >>> 1;
+      int rangeLow = ranges[middle * 2];
+      int rangeHigh = ranges[middle * 2 + 1];
+      if (codePoint < rangeLow) {
+        high = middle - 1;
+      } else if (codePoint > rangeHigh) {
+        low = middle + 1;
+      } else {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -245,10 +245,12 @@ public final class Matcher implements MatchResult {
   }
 
   private void resetStateForCurrentInput() {
+    if (!(inputSequence instanceof String)) {
+      textScanner = null;
+      graphemeContextText = null;
+      graphemeContext = null;
+    }
     text = charSequenceToString(inputSequence);
-    textScanner = null;
-    graphemeContextText = null;
-    graphemeContext = null;
     regionStart = 0;
     regionEnd = text.length();
     resetSearchStateForInputStart();
@@ -284,6 +286,7 @@ public final class Matcher implements MatchResult {
   }
 
   private void invalidateInputDependentCaches() {
+    textScanner = null;
     bitStateBorrowed = false;
     cachedBitState = null;
     bitStateResult = null;
@@ -410,6 +413,20 @@ public final class Matcher implements MatchResult {
   private boolean containsRequiredMatchClass(int[] ranges, int fromIndex) {
     long b0 = parentPattern.requiredMatchClassBitmap0();
     long b1 = parentPattern.requiredMatchClassBitmap1();
+    if (text != null) {
+      int position = Math.max(0, fromIndex);
+      while (position < text.length()) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
+        int codePoint = text.codePointAt(position);
+        if (charClassContains(ranges, b0, b1, codePoint)) {
+          return true;
+        }
+        position += Character.charCount(codePoint);
+      }
+      return false;
+    }
     return activeScanner().indexOfCodePointClass(ranges, b0, b1, fromIndex) >= 0;
   }
 
@@ -719,17 +736,20 @@ public final class Matcher implements MatchResult {
 
     Prog prog = parentPattern.prog();
 
-    InputScanner scanner = activeScanner();
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
     EnginePathOptions options = enginePathOptions();
     OnePass onePass = options.onePass() ? parentPattern.onePass() : null;
     if (onePass != null
         && !prog.hasGraphemeSemantics()
         && !parentPattern.hasNullableAlternation()) {
-      int[] result = onePass.search(scanner, true, prog.numCaptures(), this.groups);
+      int[] result =
+          text != null
+              ? onePass.search(text, true, prog.numCaptures(), this.groups)
+              : onePass.search(activeScanner(), true, prog.numCaptures(), this.groups);
       return applyFullMatchResult(result);
     }
 
+    InputScanner scanner = activeScanner();
     // Medium path: use DFA to check if a full match exists.
     if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
       Dfa.SearchResult dfaResult = dfa(true).doSearch(scanner, true, true);
@@ -859,17 +879,20 @@ public final class Matcher implements MatchResult {
     }
 
     Prog prog = parentPattern.prog();
-    InputScanner scanner = activeScanner();
 
     // Fast path: try one-pass engine (anchored, with captures, O(n) time).
     if (enginePathOptions().onePass()
         && parentPattern.canOnePassPrimary()
         && !prog.hasGraphemeSemantics()) {
       OnePass onePass = parentPattern.onePass();
-      int[] result = onePass.search(scanner, false, prog.numCaptures(), this.groups);
+      int[] result =
+          text != null
+              ? onePass.search(text, false, prog.numCaptures(), this.groups)
+              : onePass.search(activeScanner(), false, prog.numCaptures(), this.groups);
       return applyFullMatchResult(result);
     }
 
+    InputScanner scanner = activeScanner();
     // Medium path: use DFA to check if an anchored match exists.
     if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -154,7 +154,7 @@ public final class Matcher implements MatchResult {
     this.parentPattern = pattern;
     this.inputSequence = input;
     this.text = charSequenceToString(input);
-    this.textScanner = new StringInputScanner(text);
+    this.textScanner = null;
     this.regionEnd = text.length();
     this.groups = new int[2 * pattern.prog().numCaptures()];
   }
@@ -653,7 +653,7 @@ public final class Matcher implements MatchResult {
     searchFrom = regionStart;
 
     // --- Region setup ---
-    boolean regionActive = (regionStart != 0 || regionEnd != activeScanner().length());
+    boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     String savedText = text;
     boolean regionSubstituted = false;
 
@@ -805,7 +805,7 @@ public final class Matcher implements MatchResult {
     searchFrom = regionStart;
 
     // --- Region setup ---
-    boolean regionActive = (regionStart != 0 || regionEnd != activeScanner().length());
+    boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     String savedText = text;
     boolean regionSubstituted = false;
 
@@ -950,9 +950,11 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean endedAfterCrLf(int pos) {
-    return pos >= 2
-        && activeScanner().asciiAt(pos - 2) == '\r'
-        && activeScanner().asciiAt(pos - 1) == '\n';
+    if (pos < 2) {
+      return false;
+    }
+    InputScanner scanner = activeScanner();
+    return scanner.asciiAt(pos - 2) == '\r' && scanner.asciiAt(pos - 1) == '\n';
   }
 
   private GraphemeSupport.Context graphemeContext() {
@@ -970,7 +972,7 @@ public final class Matcher implements MatchResult {
   }
 
   private int getTextLength() {
-    return activeScanner().length();
+    return text != null ? text.length() : textScanner.length();
   }
 
   /**
@@ -1043,7 +1045,7 @@ public final class Matcher implements MatchResult {
   /** Runs the engine search from {@link #searchFrom} and stores the result. */
   private boolean doFind() {
     // --- Region setup: temporarily substitute text with the region substring ---
-    boolean regionActive = (regionStart != 0 || regionEnd != activeScanner().length());
+    boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     String savedText = text;
     int savedSearchFrom = searchFrom;
     boolean regionSubstituted = false;
@@ -1102,7 +1104,8 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean regionEndCanSatisfyTextEnd(Prog prog) {
-    if (regionEnd == activeScanner().length()) {
+    int textLength = getTextLength();
+    if (regionEnd == textLength) {
       return true;
     }
     if (prog.hasGraphemeSemantics() && regionEndsInsideSurrogatePair()) {
@@ -1111,21 +1114,21 @@ public final class Matcher implements MatchResult {
     if (!prog.dollarAnchorEnd()) {
       return false;
     }
-    int dollarEndPos =
-        activeScanner().trailingLineTerminatorStart(prog.unixLines(), activeScanner().length());
+    int dollarEndPos = activeScanner().trailingLineTerminatorStart(prog.unixLines(), textLength);
     return dollarEndPos >= regionStart && dollarEndPos <= regionEnd;
   }
 
   private boolean regionEndsInsideSurrogatePair() {
-    return regionEnd > 0
-        && regionEnd < activeScanner().length()
-        && !activeScanner().isCodePointBoundary(regionEnd);
+    if (regionEnd <= 0 || regionEnd >= getTextLength()) {
+      return false;
+    }
+    return !activeScanner().isCodePointBoundary(regionEnd);
   }
 
   private int graphemeConsumeEndPos(Prog prog, int endPos) {
     if (!prog.hasGraphemeClusterInstruction()
         || endPos <= 0
-        || endPos >= activeScanner().length()
+        || endPos >= getTextLength()
         || activeScanner().isCodePointBoundary(endPos)) {
       return endPos;
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -418,12 +418,17 @@ public final class Matcher implements MatchResult {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
       }
-      long decoded = scanner.decodeForward(i);
-      int cp = InputScanner.codePoint(decoded);
+      int cp = scanner.asciiAt(i);
+      if (cp >= 0) {
+        i++;
+      } else {
+        long decoded = scanner.decodeForward(i);
+        cp = InputScanner.codePoint(decoded);
+        i = InputScanner.position(decoded);
+      }
       if (charClassContains(ranges, b0, b1, cp)) {
         return true;
       }
-      i = InputScanner.position(decoded);
     }
     return false;
   }
@@ -1873,8 +1878,8 @@ public final class Matcher implements MatchResult {
    * step after DFA/OnePass have been tried or are not applicable.
    *
    * @param prog the compiled program
-   * @param text the full input text
-   * @param startPos the char index at which to begin searching
+   * @param text the full input scanner
+   * @param startPos the input index at which to begin searching
    * @param searchLimit upper bound on positions where new candidate starts are tried. Use {@code
    *     text.length()} for unbounded search.
    * @param endPos logical match end and ordinary-atom consumption limit. Use {@code text.length()}
@@ -1885,28 +1890,6 @@ public final class Matcher implements MatchResult {
    * @param nsubmatch number of submatch groups to track (including group 0)
    * @return submatch positions relative to {@code text}, or null if no match
    */
-  private int[] searchWithBitStateOrNfa(
-      Prog prog,
-      String text,
-      int startPos,
-      int searchLimit,
-      int endPos,
-      boolean anchored,
-      boolean longest,
-      boolean endMatch,
-      int nsubmatch) {
-    return searchWithBitStateOrNfa(
-        prog,
-        new StringInputScanner(text),
-        startPos,
-        searchLimit,
-        endPos,
-        anchored,
-        longest,
-        endMatch,
-        nsubmatch);
-  }
-
   private int[] searchWithBitStateOrNfa(
       Prog prog,
       InputScanner text,
@@ -2481,7 +2464,8 @@ public final class Matcher implements MatchResult {
       boolean foldCase,
       boolean hasStartAcceleration,
       DfaMatchCursor cursor) {
-    int textLen = text.length();
+    InputScanner scanner = activeScanner();
+    int textLen = scanner.length();
     int pos = cursor.pos;
 
     if (matchOffsets == null) {
@@ -2500,7 +2484,7 @@ public final class Matcher implements MatchResult {
         pos = idx;
       }
 
-      Dfa.SearchResult fwdResult = fwdDfa.doSearch(text, pos, false, false);
+      Dfa.SearchResult fwdResult = fwdDfa.doSearch(scanner, pos, false, false);
       if (fwdResult == null || !fwdResult.matched()) {
         break;
       }
@@ -2516,7 +2500,7 @@ public final class Matcher implements MatchResult {
         matchStart = pos;
         matchEnd = earlyEnd;
       } else if (hasStartAcceleration) {
-        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, pos, true, false);
+        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(scanner, pos, true, false);
         if (fwdFirst != null && fwdFirst.matched()) {
           matchStart = pos;
           matchEnd = fwdFirst.pos();
@@ -2531,12 +2515,12 @@ public final class Matcher implements MatchResult {
             }
           }
           Dfa.SearchResult revResult =
-              cursor.revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+              cursor.revDfa.doSearchReverse(scanner, earlyEnd, pos, true, true);
           if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
             return -1;
           }
           matchStart = revResult.pos();
-          Dfa.SearchResult fwdFirst2 = fwdDfa.doSearch(text, matchStart, true, false);
+          Dfa.SearchResult fwdFirst2 = fwdDfa.doSearch(scanner, matchStart, true, false);
           if (fwdFirst2 == null || !fwdFirst2.matched()) {
             return -1;
           }
@@ -2552,12 +2536,13 @@ public final class Matcher implements MatchResult {
             return -1;
           }
         }
-        Dfa.SearchResult revResult = cursor.revDfa.doSearchReverse(text, earlyEnd, pos, true, true);
+        Dfa.SearchResult revResult =
+            cursor.revDfa.doSearchReverse(scanner, earlyEnd, pos, true, true);
         if (revResult == null || !revResult.matched() || revResult.ambiguous()) {
           return -1;
         }
         matchStart = revResult.pos();
-        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(text, matchStart, true, false);
+        Dfa.SearchResult fwdFirst = fwdDfa.doSearch(scanner, matchStart, true, false);
         if (fwdFirst == null || !fwdFirst.matched()) {
           return -1;
         }
@@ -3403,7 +3388,8 @@ public final class Matcher implements MatchResult {
   }
 
   private long findNextMatchPacked(int fromIndex) {
-    if (fromIndex > text.length()) {
+    InputScanner scanner = activeScanner();
+    if (fromIndex > scanner.length()) {
       return -1L;
     }
     Prog prog = parentPattern.prog();
@@ -3478,7 +3464,7 @@ public final class Matcher implements MatchResult {
 
     Dfa.SearchResult fwdResult = null;
     if (canUseForwardDfa()) {
-      fwdResult = dfa(false).doSearch(text, effectiveStart, false, false);
+      fwdResult = dfa(false).doSearch(scanner, effectiveStart, false, false);
       if (fwdResult != null && !fwdResult.matched()) {
         return -1L;
       }
@@ -3491,7 +3477,7 @@ public final class Matcher implements MatchResult {
       int earlyEnd = fwdResult.pos();
 
       if (prog.anchorStart()) {
-        Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, effectiveStart, true, false);
+        Dfa.SearchResult fwdFirst = dfa(false).doSearch(scanner, effectiveStart, true, false);
         if (fwdFirst != null && fwdFirst.matched()) {
           return packPositions(effectiveStart, fwdFirst.pos());
         }
@@ -3499,10 +3485,10 @@ public final class Matcher implements MatchResult {
         Dfa revDfa = reverseDfa();
         if (revDfa != null) {
           Dfa.SearchResult revResult =
-              revDfa.doSearchReverse(text, earlyEnd, effectiveStart, true, true);
+              revDfa.doSearchReverse(scanner, earlyEnd, effectiveStart, true, true);
           if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
             int matchStart = revResult.pos();
-            Dfa.SearchResult fwdFirst = dfa(false).doSearch(text, matchStart, true, false);
+            Dfa.SearchResult fwdFirst = dfa(false).doSearch(scanner, matchStart, true, false);
             if (fwdFirst != null && fwdFirst.matched()) {
               return packPositions(matchStart, fwdFirst.pos());
             }
@@ -3515,10 +3501,10 @@ public final class Matcher implements MatchResult {
     int[] result =
         searchWithBitStateOrNfa(
             prog,
-            text,
+            scanner,
             effectiveStart,
-            text.length(),
-            text.length(),
+            scanner.length(),
+            scanner.length(),
             false,
             false,
             false,

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -410,27 +410,7 @@ public final class Matcher implements MatchResult {
   private boolean containsRequiredMatchClass(int[] ranges, int fromIndex) {
     long b0 = parentPattern.requiredMatchClassBitmap0();
     long b1 = parentPattern.requiredMatchClassBitmap1();
-    InputScanner scanner = activeScanner();
-
-    int i = Math.max(0, fromIndex);
-    int len = scanner.length();
-    while (i < len) {
-      if (WorkCounterConfig.ENABLED) {
-        WorkCounter.record();
-      }
-      int cp = scanner.asciiAt(i);
-      if (cp >= 0) {
-        i++;
-      } else {
-        long decoded = scanner.decodeForward(i);
-        cp = InputScanner.codePoint(decoded);
-        i = InputScanner.position(decoded);
-      }
-      if (charClassContains(ranges, b0, b1, cp)) {
-        return true;
-      }
-    }
-    return false;
+    return activeScanner().indexOfCodePointClass(ranges, b0, b1, fromIndex) >= 0;
   }
 
   /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -77,7 +77,7 @@ public final class Matcher implements MatchResult {
   private Pattern parentPattern;
   private CharSequence inputSequence;
   private String text;
-  private final InputScanner textScanner;
+  private InputScanner textScanner;
   private int[] groups;
   private int[] matchOffsets;
   private boolean hasMatch;
@@ -246,6 +246,7 @@ public final class Matcher implements MatchResult {
 
   private void resetStateForCurrentInput() {
     text = charSequenceToString(inputSequence);
+    textScanner = null;
     graphemeContextText = null;
     graphemeContext = null;
     regionStart = 0;
@@ -655,6 +656,7 @@ public final class Matcher implements MatchResult {
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     String savedText = text;
+    InputScanner savedTextScanner = textScanner;
     boolean regionSubstituted = false;
 
     try {
@@ -666,12 +668,14 @@ public final class Matcher implements MatchResult {
       }
       if (regionActive && text != null) {
         text = savedText.substring(regionStart, regionEnd);
+        textScanner = null;
         regionSubstituted = true;
       }
       return matchesCore();
     } finally {
       if (regionSubstituted) {
         text = savedText;
+        textScanner = savedTextScanner;
         if (hasMatch) {
           for (int i = 0; i < groups.length; i++) {
             if (groups[i] >= 0) {
@@ -807,6 +811,7 @@ public final class Matcher implements MatchResult {
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     String savedText = text;
+    InputScanner savedTextScanner = textScanner;
     boolean regionSubstituted = false;
 
     try {
@@ -818,12 +823,14 @@ public final class Matcher implements MatchResult {
       }
       if (regionActive && text != null) {
         text = savedText.substring(regionStart, regionEnd);
+        textScanner = null;
         regionSubstituted = true;
       }
       return lookingAtCore();
     } finally {
       if (regionSubstituted) {
         text = savedText;
+        textScanner = savedTextScanner;
         if (hasMatch) {
           for (int i = 0; i < groups.length; i++) {
             if (groups[i] >= 0) {
@@ -1047,6 +1054,7 @@ public final class Matcher implements MatchResult {
     // --- Region setup: temporarily substitute text with the region substring ---
     boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     String savedText = text;
+    InputScanner savedTextScanner = textScanner;
     int savedSearchFrom = searchFrom;
     boolean regionSubstituted = false;
 
@@ -1059,6 +1067,7 @@ public final class Matcher implements MatchResult {
       }
       if (regionActive && text != null) {
         text = savedText.substring(regionStart, regionEnd);
+        textScanner = null;
         searchFrom = Math.max(0, savedSearchFrom - regionStart);
         regionSubstituted = true;
       }
@@ -1066,6 +1075,7 @@ public final class Matcher implements MatchResult {
     } finally {
       if (regionSubstituted) {
         text = savedText;
+        textScanner = savedTextScanner;
         searchFrom = savedSearchFrom;
         if (hasMatch) {
           for (int i = 0; i < groups.length; i++) {
@@ -3085,10 +3095,10 @@ public final class Matcher implements MatchResult {
   }
 
   private InputScanner activeScanner() {
-    if (text == null) {
-      return textScanner;
+    if (textScanner == null) {
+      textScanner = new StringInputScanner(text);
     }
-    return new StringInputScanner(text);
+    return textScanner;
   }
 
   private void checkMatch() {

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -556,6 +556,8 @@ final class OnePass {
     long[] ma = matchAction;
     int[] ascMap = asciiClassMap;
     long msb = matchStateBits;
+    String stringText =
+        text instanceof StringInputScanner stringScanner ? stringScanner.text() : null;
 
     int pos = startPos;
     // Main loop: process characters from startPos to endPos-1.  The match check at endPos is
@@ -586,15 +588,31 @@ final class OnePass {
       // Read next character — ASCII fast path avoids codePointAt/charCount overhead.
       int nextPos;
       int cls;
-      int c = text.asciiAt(pos);
-      if (c >= 0) {
-        nextPos = pos + 1;
-        cls = ascMap[c];
+      if (stringText != null) {
+        char ch = stringText.charAt(pos);
+        if (ch < 128) {
+          nextPos = pos + 1;
+          cls = ascMap[ch];
+        } else if (Character.isHighSurrogate(ch)
+            && pos + 1 < endPos
+            && Character.isLowSurrogate(stringText.charAt(pos + 1))) {
+          nextPos = pos + 2;
+          cls = classOf(Character.toCodePoint(ch, stringText.charAt(pos + 1)));
+        } else {
+          nextPos = pos + 1;
+          cls = classOf(ch);
+        }
       } else {
-        long decoded = text.decodeForward(pos);
-        int cp = InputScanner.codePoint(decoded);
-        nextPos = InputScanner.position(decoded);
-        cls = classOf(cp);
+        int c = text.asciiAt(pos);
+        if (c >= 0) {
+          nextPos = pos + 1;
+          cls = ascMap[c];
+        } else {
+          long decoded = text.decodeForward(pos);
+          int cp = InputScanner.codePoint(decoded);
+          nextPos = InputScanner.position(decoded);
+          cls = classOf(cp);
+        }
       }
 
       // Equivalence classes and state indices are always valid for a well-formed OnePass

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -505,6 +505,15 @@ public final class Pattern implements Serializable {
     if (literalMatchUtf8 != null && !prefixFoldCase) {
       return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
     }
+    if (enginePathOptions.charClassMatchFastPaths()
+        && requiredMatchClassRanges != null
+        && prefixUtf8 == null
+        && charClassPrefixAscii == null
+        && scanner.indexOfCodePointClass(
+                requiredMatchClassRanges, requiredMatchClassBitmap0, requiredMatchClassBitmap1, 0)
+            < 0) {
+      return false;
+    }
     int searchStart = 0;
     if (prefixUtf8 != null && !prefixFoldCase) {
       searchStart = scanner.indexOf(prefixUtf8, prefixUtf8Failure, prefixUtf8Shifts);

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -48,6 +48,22 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
+  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
+    int position = Math.max(0, start);
+    while (position < text.length()) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      int codePoint = text.codePointAt(position);
+      if (InputScanner.classContains(ranges, bitmap0, bitmap1, codePoint)) {
+        return position;
+      }
+      position += Character.charCount(codePoint);
+    }
+    return -1;
+  }
+
+  @Override
   public long decodeForward(int pos) {
     if (pos >= text.length()) {
       return InputScanner.decoded(END_OF_INPUT, text.length());

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -46,6 +46,16 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
+  public int codePointAt(int pos) {
+    return pos >= text.length() ? END_OF_INPUT : text.codePointAt(pos);
+  }
+
+  @Override
+  public int codePointBefore(int pos) {
+    return pos <= 0 ? END_OF_INPUT : text.codePointBefore(pos);
+  }
+
+  @Override
   public boolean isCodePointBoundary(int pos) {
     if (pos < 0 || pos > text.length()) {
       return false;

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -28,6 +28,26 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
+  public int singleUnitCodePointAt(int pos) {
+    char c = text.charAt(pos);
+    return Character.isHighSurrogate(c)
+            && pos + 1 < text.length()
+            && Character.isLowSurrogate(text.charAt(pos + 1))
+        ? -1
+        : c;
+  }
+
+  @Override
+  public int singleUnitCodePointBefore(int pos) {
+    char c = text.charAt(pos - 1);
+    return Character.isLowSurrogate(c)
+            && pos >= 2
+            && Character.isHighSurrogate(text.charAt(pos - 2))
+        ? -1
+        : c;
+  }
+
+  @Override
   public long decodeForward(int pos) {
     if (pos >= text.length()) {
       return InputScanner.decoded(END_OF_INPUT, text.length());

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -71,6 +71,59 @@ final class Utf8InputScanner implements InputScanner {
     return asciiAt(pos - 1);
   }
 
+  @Override
+  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
+    int position = Math.max(0, start);
+    if (!WorkCounterConfig.ENABLED && bitmap0 == 0 && bitmap1 == 0) {
+      return indexOfNonAsciiCodePointClass(ranges, position);
+    }
+    while (position < length) {
+      int codePointPosition = position;
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      int codePoint = asciiAt(position);
+      if (codePoint >= 0) {
+        position++;
+      } else {
+        long decoded = decodeForward(position);
+        codePoint = InputScanner.codePoint(decoded);
+        position = InputScanner.position(decoded);
+      }
+      if (InputScanner.classContains(ranges, bitmap0, bitmap1, codePoint)) {
+        return codePointPosition;
+      }
+    }
+    return -1;
+  }
+
+  private int indexOfNonAsciiCodePointClass(int[] ranges, int start) {
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position < length) {
+      if (position <= wordEnd) {
+        long word = (long) LONG_VIEW.get(bytes, offset + position);
+        if ((word & BYTE_HIGH_BITS) == 0) {
+          position += Long.BYTES;
+          continue;
+        }
+      }
+      int value = unsignedByteAt(position);
+      if (value < 0x80) {
+        position++;
+        continue;
+      }
+      int codePointPosition = position;
+      long decoded = decodeForward(position);
+      int codePoint = InputScanner.codePoint(decoded);
+      position = InputScanner.position(decoded);
+      if (InputScanner.classContains(ranges, 0, 0, codePoint)) {
+        return codePointPosition;
+      }
+    }
+    return -1;
+  }
+
   int indexOf(byte[] literal, int[] failure, int[] shifts) {
     return indexOf(literal, failure, shifts, 0);
   }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -61,6 +61,16 @@ final class Utf8InputScanner implements InputScanner {
     return value < 0x80 ? value : -1;
   }
 
+  @Override
+  public int singleUnitCodePointAt(int pos) {
+    return asciiAt(pos);
+  }
+
+  @Override
+  public int singleUnitCodePointBefore(int pos) {
+    return asciiAt(pos - 1);
+  }
+
   int indexOf(byte[] literal, int[] failure, int[] shifts) {
     return indexOf(literal, failure, shifts, 0);
   }

--- a/safere/src/test/java/org/safere/AnchoredDfaCachingTest.java
+++ b/safere/src/test/java/org/safere/AnchoredDfaCachingTest.java
@@ -1,0 +1,89 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.IntConsumer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Work-bound tests for DFA transition caching in anchored patterns. */
+@DisabledForCrosscheck("WorkCounter and the UTF-8 input API are SafeRE-specific")
+@Tag("work-counter")
+class AnchoredDfaCachingTest {
+  private static final int FLAGS =
+      ParseFlags.PERL_X | ParseFlags.PERL_CLASSES | ParseFlags.PERL_B | ParseFlags.UNICODE_GROUPS;
+  private static final String FRUIT_MARKUP_PATTERN =
+      "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$";
+  private static final String MULTILINE_LINE_PATTERN = "(?m)(?:^|,)(?:\"(target)\"|(target))";
+
+  @Test
+  void stringAnchorsKeepOrdinaryDfaTransitionsCached() {
+    Pattern pattern = Pattern.compile(FRUIT_MARKUP_PATTERN);
+    assertCachedTransitionWork(
+        size -> {
+          String input = nonMatchingInput(size);
+          assertThat(pattern.matcher(input).replaceAll("$1")).isEqualTo(input);
+        });
+  }
+
+  @Test
+  void utf8AnchorsKeepOrdinaryDfaTransitionsCached() {
+    Prog prog = Compiler.compile(Parser.parse(FRUIT_MARKUP_PATTERN, FLAGS));
+    Dfa dfa = new Dfa(prog, 10_000, Dfa.buildSetup(prog), false);
+    assertCachedTransitionWork(
+        size -> {
+          byte[] input = nonMatchingInput(size).getBytes(UTF_8);
+          Dfa.SearchResult result = dfa.doSearch(new Utf8InputScanner(input), true, false);
+          assertThat(result).isNotNull();
+          assertThat(result.matched()).isFalse();
+        });
+  }
+
+  @Test
+  void multilineBeginningAnchorKeepsStringTransitionsCached() {
+    Pattern pattern = Pattern.compile(MULTILINE_LINE_PATTERN);
+    assertCachedTransitionWork(
+        size -> assertThat(pattern.matcher(multilineNonMatchingInput(size)).find()).isFalse());
+  }
+
+  @Test
+  void multilineBeginningAnchorKeepsUtf8TransitionsCached() {
+    Prog prog = Compiler.compile(Parser.parse(MULTILINE_LINE_PATTERN, FLAGS));
+    Dfa dfa = new Dfa(prog, 10_000, Dfa.buildSetup(prog), false);
+    assertCachedTransitionWork(
+        size -> {
+          byte[] input = multilineNonMatchingInput(size).getBytes(UTF_8);
+          Dfa.SearchResult result = dfa.doSearch(new Utf8InputScanner(input), false, false);
+          assertThat(result).isNotNull();
+          assertThat(result.matched()).isFalse();
+        });
+  }
+
+  private static void assertCachedTransitionWork(IntConsumer operation) {
+    operation.accept(1_000);
+    operation.accept(10_000);
+
+    long smallerWork = WorkCounter.countForTesting(() -> operation.accept(1_000));
+    long largerWork = WorkCounter.countForTesting(() -> operation.accept(10_000));
+
+    assertThat(largerWork)
+        .as("ordinary anchored transitions should use the DFA cache independent of input length")
+        .isLessThanOrEqualTo(smallerWork * 2 + 10);
+  }
+
+  private static String nonMatchingInput(int size) {
+    String tag = "<Orange>";
+    int leadingSpaces = (size - tag.length()) / 2;
+    return " ".repeat(leadingSpaces) + tag + " ".repeat(size - tag.length() - leadingSpaces);
+  }
+
+  private static String multilineNonMatchingInput(int size) {
+    return "value,other\n".repeat((size + 11) / 12).substring(0, size);
+  }
+}

--- a/safere/src/test/java/org/safere/InputScannerTest.java
+++ b/safere/src/test/java/org/safere/InputScannerTest.java
@@ -35,4 +35,24 @@ class InputScannerTest {
     assertThat(scanner.singleUnitCodePointBefore(scanner.length())).isEqualTo('Z');
     assertThat(scanner.singleUnitCodePointBefore(scanner.length() - 1)).isEqualTo(-1);
   }
+
+  @Test
+  void codePointClassSearchUsesRepresentationCoordinates() {
+    int[] cjk = {'中', '中'};
+    int[] supplementary = {0x1F600, 0x1F600};
+    String text = "aé😀中z";
+    StringInputScanner stringScanner = new StringInputScanner(text);
+    Utf8InputScanner utf8Scanner = new Utf8InputScanner(text.getBytes(UTF_8));
+
+    assertThat(stringScanner.indexOfCodePointClass(cjk, 0, 0, 0)).isEqualTo(4);
+    assertThat(stringScanner.indexOfCodePointClass(supplementary, 0, 0, 0)).isEqualTo(2);
+    assertThat(stringScanner.indexOfCodePointClass(cjk, 0, 0, 5)).isEqualTo(-1);
+    assertThat(utf8Scanner.indexOfCodePointClass(cjk, 0, 0, 0)).isEqualTo(7);
+    assertThat(utf8Scanner.indexOfCodePointClass(supplementary, 0, 0, 0)).isEqualTo(3);
+    assertThat(utf8Scanner.indexOfCodePointClass(cjk, 0, 0, 10)).isEqualTo(-1);
+
+    Utf8InputScanner paddedUtf8Scanner =
+        new Utf8InputScanner(("a".repeat(24) + "中").getBytes(UTF_8));
+    assertThat(paddedUtf8Scanner.indexOfCodePointClass(cjk, 0, 0, 0)).isEqualTo(24);
+  }
 }

--- a/safere/src/test/java/org/safere/InputScannerTest.java
+++ b/safere/src/test/java/org/safere/InputScannerTest.java
@@ -1,0 +1,38 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+@DisabledForCrosscheck("package-private input scanner tests exercise SafeRE internals")
+class InputScannerTest {
+  @Test
+  void stringScannerReadsSingleCharCodePointsWithoutFullDecoding() {
+    StringInputScanner scanner = new StringInputScanner("Aé😀\uD800Z");
+
+    assertThat(scanner.singleUnitCodePointAt(0)).isEqualTo('A');
+    assertThat(scanner.singleUnitCodePointAt(1)).isEqualTo('é');
+    assertThat(scanner.singleUnitCodePointAt(2)).isEqualTo(-1);
+    assertThat(scanner.singleUnitCodePointAt(4)).isEqualTo('\uD800');
+    assertThat(scanner.singleUnitCodePointBefore(6)).isEqualTo('Z');
+    assertThat(scanner.singleUnitCodePointBefore(5)).isEqualTo('\uD800');
+    assertThat(scanner.singleUnitCodePointBefore(4)).isEqualTo(-1);
+  }
+
+  @Test
+  void utf8ScannerReadsOnlyAsciiWithoutFullDecoding() {
+    Utf8InputScanner scanner = new Utf8InputScanner("Aé😀Z".getBytes(UTF_8));
+
+    assertThat(scanner.singleUnitCodePointAt(0)).isEqualTo('A');
+    assertThat(scanner.singleUnitCodePointAt(1)).isEqualTo(-1);
+    assertThat(scanner.singleUnitCodePointAt(3)).isEqualTo(-1);
+    assertThat(scanner.singleUnitCodePointBefore(scanner.length())).isEqualTo('Z');
+    assertThat(scanner.singleUnitCodePointBefore(scanner.length() - 1)).isEqualTo(-1);
+  }
+}

--- a/safere/src/test/java/org/safere/MultilineCrLfDfaCachingTest.java
+++ b/safere/src/test/java/org/safere/MultilineCrLfDfaCachingTest.java
@@ -1,0 +1,61 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Compatibility coverage for CRLF-sensitive multiline anchors in cached DFA transitions. */
+class MultilineCrLfDfaCachingTest {
+  private static final String LONG_PREFIX = "a".repeat(500);
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("mixedCarriageReturnCases")
+  @DisplayName("multiline ^ distinguishes CRLF from standalone carriage returns")
+  void multilineBeginningAnchorDistinguishesCrLfFromStandaloneCarriageReturns(
+      String description, String regex, String input, boolean expected) {
+    boolean jdkResult = java.util.regex.Pattern.compile(regex).matcher(input).find();
+    assertThat(jdkResult).as("JDK result for %s", description).isEqualTo(expected);
+
+    Pattern pattern = Pattern.compile(regex);
+    assertThat(pattern.matcher(input).find())
+        .as("String result for %s", description)
+        .isEqualTo(jdkResult);
+    assertThat(pattern.matcher(Utf8Input.validated(input.getBytes(UTF_8))).find())
+        .as("UTF-8 result for %s", description)
+        .isEqualTo(jdkResult);
+  }
+
+  private static Stream<Arguments> mixedCarriageReturnCases() {
+    return Stream.of(
+        Arguments.of(
+            "CRLF before standalone CR must not suppress a line start",
+            "(?m)^.X",
+            LONG_PREFIX + "\r\nqq\rqX",
+            true),
+        Arguments.of(
+            "standalone CR before CRLF must not create a line start inside CRLF",
+            "(?m)^\\nX",
+            LONG_PREFIX + "\rqY\r\nX",
+            false),
+        Arguments.of(
+            "repeated CRLF before standalone CR must preserve the standalone line start",
+            "(?m)^qX",
+            LONG_PREFIX + "\r\nqY\r\nqY\rqX",
+            true),
+        Arguments.of(
+            "repeated standalone CR before CRLF must not split the CRLF pair",
+            "(?m)^\\nX",
+            LONG_PREFIX + "\rqY\rqY\r\nX",
+            false));
+  }
+}

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -119,6 +119,18 @@ class Utf8MatcherStateMachineTest {
   }
 
   @Test
+  void requiredNonAsciiClassRejectsAsciiInputAcrossUtf8EntryPoints() {
+    Pattern pattern = Pattern.compile("[一-龥]{3,}");
+    Utf8Input absent = Utf8Input.trusted("ordinary ASCII text".getBytes(UTF_8));
+    Utf8Input present = Utf8Input.validated("prefix中文测试suffix".getBytes(UTF_8));
+
+    assertThat(pattern.find(absent)).isFalse();
+    assertThat(pattern.matcher(absent).find()).isFalse();
+    assertThat(pattern.find(present)).isTrue();
+    assertThat(pattern.matcher(present).find()).isTrue();
+  }
+
+  @Test
   void graphemePatternsWorkAcrossUtf8Scalars() {
     for (String input : List.of("a\r\nb", "a\u0301b", "👩‍💻x", "🇺🇸x", "क्‍षx")) {
       byte[] bytes = input.getBytes(UTF_8);


### PR DESCRIPTION
## Summary

This PR is stacked on #569 and restores String-input performance that regressed when the
UTF-8 input abstraction was introduced. Keeping it separate leaves #569 focused on the
UTF-8 API while making the performance changes independently reviewable. Across the broad
matrix, the complete stack is slightly faster than main was before the UTF-8 work.

The changes restore String-native fast paths, reduce scanner and decoding overhead, improve
matcher engine dispatch, accelerate required-character-class scans, and make DFA transition
caching sensitive only to boundary context that can affect the result. The stack also adds
focused String API and real-world benchmark coverage.

A correctness review found that an intermediate DFA cache optimization mishandled the
position-dependent `\r` transition in multiline mode when `\r\n` must be treated atomically.
The final commit fixes that class of behavior for String and UTF-8 inputs and adds systematic
regression and fuzz coverage.

Part of #516.

## Benchmark methodology

The comparison uses:

- Baseline library: `4ca426c57d75e83ee01b917a71a646b50f9f465d`
- Optimized library: `0b681c6b44928c65cd1b08490bfefcb4d348e1cb`
- The benchmark harness and `benchmark-data.json` from `0b681c6` for both revisions
- OpenJDK 25.0.2
- `./run-java-benchmarks.sh`, with every invocation run sequentially
- Standard configuration: 2 forks, 2 warmup iterations of 500 ms, and 5 measurement
  iterations of 500 ms

After #569 was squash-merged, the 12 optimization commits were rebased onto `main`. The
current head, `769c01cb791f6d1c26dde903b1131a5e3d7744be`, has the identical Git tree as the
benchmarked pre-rebase head `0b681c6b44928c65cd1b08490bfefcb4d348e1cb`.

Only benchmark sources and data were overlaid in the temporary baseline worktree; its
library source remained at `4ca426c`. Selected String API and application results are
normalized by the corresponding JDK control from the same run. Real-world results are
direct SafeRE-to-SafeRE comparisons because that benchmark has no JDK control. Every ratio
below is time for the revision named first divided by time for the comparison revision, so
values below 1.0 are faster.

The standard matrix ran these exact benchmarks:

- `RegexBenchmark`: `alternationFind`, `captureGroups`, `charClassMatch`, `emailFind`,
  `findInText`, and `literalMatch`, each for SafeRE and the JDK.
- `ReplaceBenchmark`: `digitReplaceAll`, `literalReplaceAll`, `literalReplaceFirst`, and
  `pigLatinReplaceAll`, each for SafeRE and the JDK.
- `MatcherApiBenchmark`: `lookingAt`, `regionFind`, and `resetAndFind`, each for SafeRE and
  the JDK.
- `ApplicationBenchmark`: `apiRouteMatch`, `caseInsensitiveKeywords`, `csvFieldScan`,
  `logLineParse`, `secretRedaction`, `stackTraceExtract`, `urlExtraction`, and
  `uuidValidation`, each for SafeRE and the JDK.
- `RealWorldRegexBenchmark.runBenchmark` with SafeRE for every combination of input size
  1,000, 10,000, and 100,000; `match=true` and `match=false`; and these 25 pattern names:
  `blockedTags1`, `blockedTags2`, `boundedNameMatch`, `caseInsensitiveKeyword`,
  `charReplace`, `cjkSearch`, `customProtocolLink`, `emojiSearch`, `fruitMarkupTag`,
  `fruitSearchQuery`, `greedyOnePass`, `jsonBlock`, `layoutBlock`, `malformedEntity`,
  `mapFieldPath`, `markupEntity`, `markupImageLink`, `metadataBlock`, `overlappingUrl`,
  `sparseUrl`, `templateTagMatch`, `turnTitleWhitespaceCjk`, `unprefixedWordBoundary`,
  `versionList`, and `wildcardSearch`.

## Three-way performance comparison

The same benchmark harness had previously measured main at
`c8f51f3fa99976566ac9a3260df371caedec929e`. This makes it possible to show both the
regression introduced by #569 and the result after applying this optimization PR:

| Workload group | Cases | #569 / main | #572 / main | #572 / #569 |
|---|---:|---:|---:|---:|
| Selected String API operations | 13 | 0.987 (1.3% faster) | 0.939 (6.1% faster) | 0.952 (4.8% faster) |
| Application workloads | 8 | 2.475 (147.5% slower) | 0.982 (1.8% faster) | 0.397 (60.3% faster) |
| Real-world regex workloads | 150 | 1.189 (18.9% slower) | 0.945 (5.5% faster) | 0.795 (20.5% faster) |

Here, main is `c8f51f3`, #569 is `4ca426c`, and #572 is `0b681c6`. The selected and
application comparisons are JDK-normalized; the real-world comparisons are direct.

For #572 versus #569, 9 of the 150 real-world cases were at least 5% slower and 4 were at
least 10% slower, while 38 were at least 5% faster and 20 were at least 10% faster. For the
complete #572 stack versus main, 13 of the 150 real-world cases were at least 5% slower and
1 was at least 10% slower, while 97 were at least 5% faster and 18 were at least 10% faster.
Including the selected String API and application groups, the complete matrix has 17 cases
at least 5% slower than main, as listed below.

The following are all standard-matrix cases where #572 was at least 5% slower than main,
sorted by regression. Selected String API and application results are JDK-normalized;
real-world results are direct.

| Benchmark case | Slowdown vs. main | Comparison |
|---|---:|---|
| `ApplicationBenchmark.logLineParse` | 16.83% | JDK-normalized |
| `ApplicationBenchmark.csvFieldScan` | 12.16% | JDK-normalized |
| `RealWorldRegexBenchmark.versionList[100000, match=false]` | 10.05% | Direct |
| `RealWorldRegexBenchmark.cjkSearch[1000, match=true]` | 9.09% | Direct |
| `ReplaceBenchmark.literalReplaceFirst` | 8.86% | JDK-normalized |
| `RealWorldRegexBenchmark.turnTitleWhitespaceCjk[10000, match=false]` | 8.84% | Direct |
| `RealWorldRegexBenchmark.overlappingUrl[100000, match=true]` | 8.54% | Direct |
| `RealWorldRegexBenchmark.versionList[10000, match=false]` | 7.23% | Direct |
| `RealWorldRegexBenchmark.unprefixedWordBoundary[100000, match=true]` | 7.08% | Direct |
| `RegexBenchmark.emailFind` | 7.05% | JDK-normalized |
| `RealWorldRegexBenchmark.unprefixedWordBoundary[1000, match=true]` | 7.04% | Direct |
| `RealWorldRegexBenchmark.cjkSearch[100000, match=true]` | 6.90% | Direct |
| `RealWorldRegexBenchmark.cjkSearch[10000, match=true]` | 6.69% | Direct |
| `RealWorldRegexBenchmark.wildcardSearch[100000, match=true]` | 6.24% | Direct |
| `RealWorldRegexBenchmark.unprefixedWordBoundary[10000, match=true]` | 5.15% | Direct |
| `RealWorldRegexBenchmark.charReplace[1000, match=true]` | 5.07% | Direct |
| `RealWorldRegexBenchmark.templateTagMatch[10000, match=true]` | 5.01% | Direct |

### Investigation of remaining regressions

These cases were not simply left unexplored. CPU and allocation profiles were collected for
the shared DFA, OnePass, character-class, word-boundary, matcher-reset, and application paths
behind the regressions. The experiments targeted those shared paths rather than adding
benchmark- or pattern-specific special cases. Changes were retained only when the relevant
benchmarks demonstrated a repeatable improvement.

The following candidates were measured and discarded because they were flat, inconsistent
across the targeted workloads, or regressive:

| Candidate | Targeted path | Measured outcome |
|---|---|---|
| Direct character-class scanning instead of the normal required-prefix path | CJK matching | No consistent improvement |
| Unswitching input representation outside the DFA loops | DFA-heavy real-world cases | No consistent improvement |
| Reusing a scanner directly inside the DFA | Shared String DFA path | Flat overall |
| Passing raw decoded units through the DFA transition loop | Shared String DFA path | Flat overall |
| A String-specific DFA cache-hit loop | DFA cache-heavy cases | Regressed `overlappingUrl` substantially |
| A direct String entry point for OnePass | OnePass workloads | No repeatable long-run benefit |
| Preserving additional matcher/DFA cache state across `Matcher.reset()` | Repeated matcher use | Change was within measurement noise |
| Two additional DFA transition/context variants for `versionList` | `versionList` | No improvement over the retained implementation |

Several other profile-driven changes did improve the matrix and are included in this PR,
including lazy scanner reuse, String-specialized decoding, restored String engine fast paths,
ASCII BitState decoding, required-character-class acceleration, and reduced DFA boundary
context. The table above records the alternatives that were tried but intentionally not kept.

## Trino validation

Because this PR changes shared execution paths used by both String and UTF-8 inputs, the
complete Trino comparison matrix was rerun with the final SafeRE revision. The matrix covers
five pattern families, two input sizes, matching and replacement, and all three engines in
the same invocation. It used 2 forks, 3 one-second warmups, and 5 one-second measurements.
Lower values are better.

| Workload group | SafeRE compared with RE2/J | SafeRE compared with Joni |
|---|---:|---:|
| Matching | **2.48× faster** | **2.93× faster** |
| Replacement | **2.34× faster** | **1.08× slower** |
| Across all benchmark cases | **2.41× faster** | **1.64× faster** |

Each comparison is the geometric mean of the per-benchmark speed ratios, giving every
pattern and input-size combination equal weight. The replacement gap versus Joni narrowed
from 1.45× slower in the #569 run to 1.08× slower with this optimization stack.

Full results, in nanoseconds per operation:

| Operation | Pattern | Bytes | SafeRE | RE2/J | Joni |
|---|---|---:|---:|---:|---:|
| Match | `.*x.*` | 1,024 | **46.6** | 317.1 | 569.9 |
| Match | `.*(x\|y).*` | 1,024 | **120.2** | 316.5 | 692.7 |
| Match | `longdotstar` | 1,024 | **246.1** | 439.2 | 257.5 |
| Match | `phone` | 1,024 | **475.0** | 982.7 | 1,360.5 |
| Match | `literal` | 1,024 | 454.0 | **431.9** | 471.0 |
| Match | `.*x.*` | 32,768 | **1,262** | 9,283 | 17,563 |
| Match | `.*(x\|y).*` | 32,768 | **3,510** | 9,591 | 21,140 |
| Match | `longdotstar` | 32,768 | 7,408 | 17,745 | **7,011** |
| Match | `phone` | 32,768 | **474.3** | 981.4 | 1,362.7 |
| Match | `literal` | 32,768 | 15,403 | 21,935 | **14,193** |
| Replace | `.*x.*` | 1,024 | **491.7** | 2,935 | 700.3 |
| Replace | `.*(x\|y).*` | 1,024 | 1,348 | 3,002 | **803.8** |
| Replace | `longdotstar` | 1,024 | 1,370 | 3,053 | **329.2** |
| Replace | `phone` | 1,024 | **1,615** | 2,953 | 4,442 |
| Replace | `literal` | 1,024 | 468.8 | **464.8** | 555.1 |
| Replace | `.*x.*` | 32,768 | **14,890** | 93,462 | 21,607 |
| Replace | `.*(x\|y).*` | 32,768 | 41,864 | 93,098 | **25,113** |
| Replace | `longdotstar` | 32,768 | 42,078 | 93,962 | **10,909** |
| Replace | `phone` | 32,768 | **57,326** | 114,941 | 144,746 |
| Replace | `literal` | 32,768 | **14,940** | 21,847 | 17,980 |

The improvement relative to #569 is concentrated in `.*x.*` replacement: SafeRE improved
from approximately 2,015 to 492 ns/op at 1 KiB and from 63,849 to 14,890 ns/op at 32 KiB.
The other replacement families are broadly similar to the earlier run.

Benchmark provenance:

- SafeRE: `0b681c6b44928c65cd1b08490bfefcb4d348e1cb`
- Trino: `94a6dfabb4192a7763d25765c7924228b7fc8f73` (benchmark code unchanged from
  `4e070738fd759ef7cb909177bda24884b7d00dc1`)
- Runtime: OpenJDK 25.0.2

## Verification

Passed at the final revision:

- `mvn -pl safere test -q`
- `mvn -pl safere install -DskipTests -q`
- `mvn -pl safere-crosscheck test -Pcrosscheck-public-api-tests -q`
- Focused multiline CR/LF DFA caching tests for String and UTF-8 inputs
- Focused MatchFuzzer regression coverage for the multiline CR/LF cases
- The standard three-way benchmark comparison described above
- The complete Trino JMH matrix reported above
- A two-pass review/fix loop against `4ca426c`; the second review reported no findings

Not run for this optimization stack:

- The complete multi-module Maven reactor in one invocation
- Trino tests; the benchmark matrix was rerun, but the focused Trino integration tests were
  not rerun for this optimization stack
