### PR TITLE
Crosscheck UTF-8 matching against String and JDK oracles

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -153,7 +153,7 @@
                       <filterchain>
                         <replaceregex
                             pattern="package org\.safere;"
-                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.safere.Utf8Input;&#10;import org.safere.Utf8Matcher;&#10;import org.safere.Utf8Sink;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;"/>
+                            replace="package org.safere.crosscheck.generated;&#10;&#10;import org.safere.crosscheck.Matcher;&#10;import org.safere.crosscheck.Pattern;&#10;import org.safere.crosscheck.Utf8Input;&#10;import org.safere.crosscheck.Utf8Matcher;&#10;import org.safere.crosscheck.Utf8Sink;"/>
                       </filterchain>
                     </copy>
                   </target>

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/CrosscheckException.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/CrosscheckException.java
@@ -30,11 +30,34 @@ public class CrosscheckException extends RuntimeException {
    */
   public CrosscheckException(
       String method, String args, String safereResult, String jdkResult, String trace) {
-    super(formatMessage(method, args, safereResult, jdkResult, trace));
+    this(method, args, "SafeRE", safereResult, "JDK", jdkResult, trace);
+  }
+
+  static CrosscheckException comparison(
+      String method,
+      String args,
+      String firstLabel,
+      String firstResult,
+      String secondLabel,
+      String secondResult,
+      String trace) {
+    return new CrosscheckException(
+        method, args, firstLabel, firstResult, secondLabel, secondResult, trace);
+  }
+
+  private CrosscheckException(
+      String method,
+      String args,
+      String firstLabel,
+      String firstResult,
+      String secondLabel,
+      String secondResult,
+      String trace) {
+    super(formatMessage(method, args, firstLabel, firstResult, secondLabel, secondResult, trace));
     this.method = method;
     this.args = args;
-    this.safereResult = safereResult;
-    this.jdkResult = jdkResult;
+    this.safereResult = firstResult;
+    this.jdkResult = secondResult;
     this.trace = trace;
   }
 
@@ -64,17 +87,27 @@ public class CrosscheckException extends RuntimeException {
   }
 
   private static String formatMessage(
-      String method, String args, String safereResult, String jdkResult, String trace) {
+      String method,
+      String args,
+      String firstLabel,
+      String firstResult,
+      String secondLabel,
+      String secondResult,
+      String trace) {
     return "Crosscheck divergence in "
         + method
         + "("
         + args
         + "):\n"
-        + "  SafeRE: "
-        + safereResult
+        + "  "
+        + firstLabel
+        + ": "
+        + firstResult
         + "\n"
-        + "  JDK:    "
-        + jdkResult
+        + "  "
+        + secondLabel
+        + ": "
+        + secondResult
         + "\n\n"
         + trace;
   }

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -30,11 +30,14 @@ public final class Matcher implements MatchResult {
   private final org.safere.Matcher safereMatcher;
   private final java.util.regex.Matcher jdkMatcher;
   private final TraceRecorder trace = new TraceRecorder();
+  private CharSequence utf8ShadowInput;
+  private Utf8Shadow utf8Shadow;
 
   Matcher(Pattern pattern, CharSequence input) {
     this.crosscheckPattern = pattern;
     this.safereMatcher = pattern.saferePattern().matcher(input);
     this.jdkMatcher = pattern.jdkPattern().matcher(input);
+    resetUtf8Shadow(input);
   }
 
   // ---------------------------------------------------------------------------
@@ -43,6 +46,7 @@ public final class Matcher implements MatchResult {
 
   /** Attempts to match the entire input against the pattern. */
   public boolean matches() {
+    disableUtf8Shadow();
     boolean sr = safereMatcher.matches();
     boolean jr = jdkMatcher.matches();
     checkBoolean("matches", "", sr, jr);
@@ -51,6 +55,7 @@ public final class Matcher implements MatchResult {
 
   /** Attempts to match the input, starting at the beginning, against the pattern. */
   public boolean lookingAt() {
+    disableUtf8Shadow();
     boolean sr = safereMatcher.lookingAt();
     boolean jr = jdkMatcher.lookingAt();
     checkBoolean("lookingAt", "", sr, jr);
@@ -61,15 +66,25 @@ public final class Matcher implements MatchResult {
   public boolean find() {
     boolean sr = safereMatcher.find();
     boolean jr = jdkMatcher.find();
+    Boolean ur = utf8Shadow == null ? null : utf8Shadow.find();
     checkBoolean("find", "", sr, jr);
+    if (ur != null && sr && !utf8Shadow.canRepresent(safereMatcher)) {
+      disableUtf8Shadow();
+      ur = null;
+    }
+    if (ur != null) {
+      checkUtf8Equal("find", "", sr, ur);
+    }
     if (sr && jr) {
       checkMatchState("find");
+      checkUtf8MatchState("find");
     }
     return sr;
   }
 
   /** Resets and finds starting at the given index. */
   public boolean find(int start) {
+    disableUtf8Shadow();
     boolean sr = safereMatcher.find(start);
     boolean jr = jdkMatcher.find(start);
     checkBoolean("find", String.valueOf(start), sr, jr);
@@ -89,6 +104,9 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.groupCount();
     int jr = jdkMatcher.groupCount();
     checkEqual("groupCount", "", sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("groupCount", "", sr, utf8Shadow.groupCount());
+    }
     return sr;
   }
 
@@ -98,6 +116,9 @@ public final class Matcher implements MatchResult {
     String sr = safereMatcher.group();
     String jr = jdkMatcher.group();
     checkEqual("group", "", sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("group", "", sr, utf8Shadow.group(0));
+    }
     return sr;
   }
 
@@ -107,6 +128,9 @@ public final class Matcher implements MatchResult {
     String sr = safereMatcher.group(group);
     String jr = jdkMatcher.group(group);
     checkEqual("group", String.valueOf(group), sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("group", String.valueOf(group), sr, utf8Shadow.group(group));
+    }
     return sr;
   }
 
@@ -115,6 +139,10 @@ public final class Matcher implements MatchResult {
     String sr = safereMatcher.group(name);
     String jr = jdkMatcher.group(name);
     checkEqual("group", quote(name), sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal(
+          "group", quote(name), sr, utf8Shadow.group(crosscheckPattern.namedGroups().get(name)));
+    }
     return sr;
   }
 
@@ -124,6 +152,9 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.start();
     int jr = jdkMatcher.start();
     checkEqual("start", "", sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("start", "", sr, utf8Shadow.start(0));
+    }
     return sr;
   }
 
@@ -133,6 +164,9 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.start(group);
     int jr = jdkMatcher.start(group);
     checkEqual("start", String.valueOf(group), sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("start", String.valueOf(group), sr, utf8Shadow.start(group));
+    }
     return sr;
   }
 
@@ -141,6 +175,10 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.start(name);
     int jr = jdkMatcher.start(name);
     checkEqual("start", quote(name), sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal(
+          "start", quote(name), sr, utf8Shadow.start(crosscheckPattern.namedGroups().get(name)));
+    }
     return sr;
   }
 
@@ -150,6 +188,9 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.end();
     int jr = jdkMatcher.end();
     checkEqual("end", "", sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("end", "", sr, utf8Shadow.end(0));
+    }
     return sr;
   }
 
@@ -159,6 +200,9 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.end(group);
     int jr = jdkMatcher.end(group);
     checkEqual("end", String.valueOf(group), sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("end", String.valueOf(group), sr, utf8Shadow.end(group));
+    }
     return sr;
   }
 
@@ -167,6 +211,10 @@ public final class Matcher implements MatchResult {
     int sr = safereMatcher.end(name);
     int jr = jdkMatcher.end(name);
     checkEqual("end", quote(name), sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal(
+          "end", quote(name), sr, utf8Shadow.end(crosscheckPattern.namedGroups().get(name)));
+    }
     return sr;
   }
 
@@ -179,6 +227,13 @@ public final class Matcher implements MatchResult {
     String sr = safereMatcher.replaceFirst(replacement);
     String jr = jdkMatcher.replaceFirst(replacement);
     checkEqual("replaceFirst", quote(replacement), sr, jr);
+    if (utf8Shadow != null) {
+      if (utf8Shadow.canEncode(replacement)) {
+        checkUtf8Equal(
+            "replaceFirst", quote(replacement), sr, utf8Shadow.replaceFirst(replacement));
+      }
+      disableUtf8Shadow();
+    }
     return sr;
   }
 
@@ -187,11 +242,18 @@ public final class Matcher implements MatchResult {
     String sr = safereMatcher.replaceAll(replacement);
     String jr = jdkMatcher.replaceAll(replacement);
     checkEqual("replaceAll", quote(replacement), sr, jr);
+    if (utf8Shadow != null) {
+      if (utf8Shadow.canEncode(replacement)) {
+        checkUtf8Equal("replaceAll", quote(replacement), sr, utf8Shadow.replaceAll(replacement));
+      }
+      disableUtf8Shadow();
+    }
     return sr;
   }
 
   /** Replaces the first match with a replacement computed from the match result. */
   public String replaceFirst(Function<MatchResult, String> replacer) {
+    disableUtf8Shadow();
     String sr = safereMatcher.replaceFirst(replacer);
     String jr = jdkMatcher.replaceFirst(replacer);
     checkEqual("replaceFirst", "<function>", sr, jr);
@@ -200,6 +262,7 @@ public final class Matcher implements MatchResult {
 
   /** Replaces all matches with replacements computed from match results. */
   public String replaceAll(Function<MatchResult, String> replacer) {
+    disableUtf8Shadow();
     String sr = safereMatcher.replaceAll(replacer);
     String jr = jdkMatcher.replaceAll(replacer);
     checkEqual("replaceAll", "<function>", sr, jr);
@@ -220,6 +283,14 @@ public final class Matcher implements MatchResult {
     String sr = safeSb.toString();
     String jr = jdkSb.toString();
     checkEqual("appendReplacement", quote(replacement), sr, jr);
+    if (utf8Shadow != null) {
+      if (utf8Shadow.canEncode(replacement)) {
+        checkUtf8Equal(
+            "appendReplacement", quote(replacement), sr, utf8Shadow.appendReplacement(replacement));
+      } else {
+        disableUtf8Shadow();
+      }
+    }
     sb.append(sr);
     return this;
   }
@@ -237,6 +308,9 @@ public final class Matcher implements MatchResult {
     String sr = safeSb.toString();
     String jr = jdkSb.toString();
     checkEqual("appendTail", "", sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("appendTail", "", sr, utf8Shadow.appendTail());
+    }
     sb.append(sr);
     return sb;
   }
@@ -250,6 +324,14 @@ public final class Matcher implements MatchResult {
     String sr = safeSbuf.toString();
     String jr = jdkSbuf.toString();
     checkEqual("appendReplacement", quote(replacement), sr, jr);
+    if (utf8Shadow != null) {
+      if (utf8Shadow.canEncode(replacement)) {
+        checkUtf8Equal(
+            "appendReplacement", quote(replacement), sr, utf8Shadow.appendReplacement(replacement));
+      } else {
+        disableUtf8Shadow();
+      }
+    }
     sb.append(sr);
     return this;
   }
@@ -263,6 +345,9 @@ public final class Matcher implements MatchResult {
     String sr = safeSbuf.toString();
     String jr = jdkSbuf.toString();
     checkEqual("appendTail", "", sr, jr);
+    if (utf8Shadow != null) {
+      checkUtf8Equal("appendTail", "", sr, utf8Shadow.appendTail());
+    }
     sb.append(sr);
     return sb;
   }
@@ -280,6 +365,7 @@ public final class Matcher implements MatchResult {
   public Matcher reset() {
     safereMatcher.reset();
     jdkMatcher.reset();
+    resetUtf8Shadow(utf8ShadowInput);
     trace.recordMatch("reset", "", "void");
     return this;
   }
@@ -288,12 +374,14 @@ public final class Matcher implements MatchResult {
   public Matcher reset(CharSequence input) {
     safereMatcher.reset(input);
     jdkMatcher.reset(input);
+    resetUtf8Shadow(input);
     trace.recordMatch("reset", quote(input), "void");
     return this;
   }
 
   /** Sets the region of the input for matching. */
   public Matcher region(int start, int end) {
+    disableUtf8Shadow();
     safereMatcher.region(start, end);
     jdkMatcher.region(start, end);
     trace.recordMatch("region", start + ", " + end, "void");
@@ -326,6 +414,7 @@ public final class Matcher implements MatchResult {
 
   /** Sets whether this matcher uses transparent bounds. */
   public Matcher useTransparentBounds(boolean b) {
+    disableUtf8Shadow();
     safereMatcher.useTransparentBounds(b);
     jdkMatcher.useTransparentBounds(b);
     trace.recordMatch("useTransparentBounds", String.valueOf(b), "void");
@@ -342,6 +431,7 @@ public final class Matcher implements MatchResult {
 
   /** Sets whether this matcher uses anchoring bounds. */
   public Matcher useAnchoringBounds(boolean b) {
+    disableUtf8Shadow();
     safereMatcher.useAnchoringBounds(b);
     jdkMatcher.useAnchoringBounds(b);
     trace.recordMatch("useAnchoringBounds", String.valueOf(b), "void");
@@ -360,6 +450,7 @@ public final class Matcher implements MatchResult {
     }
     safereMatcher.usePattern(newPattern.saferePattern());
     jdkMatcher.usePattern(newPattern.jdkPattern());
+    disableUtf8Shadow();
     crosscheckPattern = newPattern;
     trace.recordMatch("usePattern", newPattern.pattern(), "void");
     return this;
@@ -378,6 +469,7 @@ public final class Matcher implements MatchResult {
 
   /** Returns a stream of match-result snapshots. */
   public Stream<MatchResult> results() {
+    disableUtf8Shadow();
     Stream<MatchResult> safereResults = safereMatcher.results();
     Stream<MatchResult> jdkResults = jdkMatcher.results();
     Iterator<MatchResult> safereIterator = safereResults.iterator();
@@ -455,6 +547,56 @@ public final class Matcher implements MatchResult {
     }
 
     trace.recordMatch(context, "", "start=" + srStart + ", end=" + srEnd);
+  }
+
+  private void checkUtf8MatchState(String context) {
+    if (utf8Shadow == null) {
+      return;
+    }
+    int groupCount = safereMatcher.groupCount();
+    checkUtf8Equal(context + " → groupCount()", "", groupCount, utf8Shadow.groupCount());
+    for (int group = 0; group <= groupCount; group++) {
+      checkUtf8Equal(
+          context + " → start(" + group + ")",
+          "",
+          safereMatcher.start(group),
+          utf8Shadow.start(group));
+      checkUtf8Equal(
+          context + " → end(" + group + ")", "", safereMatcher.end(group), utf8Shadow.end(group));
+      checkUtf8Equal(
+          context + " → group(" + group + ")",
+          "",
+          safereMatcher.group(group),
+          utf8Shadow.group(group));
+    }
+  }
+
+  private void checkUtf8Equal(String method, String args, Object stringResult, Object utf8Result) {
+    if (!Objects.equals(stringResult, utf8Result)) {
+      String traceMethod = method + " [SafeRE String vs SafeRE UTF-8]";
+      trace.recordDivergence(traceMethod, args, stringResult, utf8Result);
+      throw CrosscheckException.comparison(
+          method,
+          args,
+          "SafeRE String",
+          Objects.toString(stringResult),
+          "SafeRE UTF-8",
+          Objects.toString(utf8Result),
+          trace.format());
+    }
+  }
+
+  private void resetUtf8Shadow(CharSequence input) {
+    utf8ShadowInput = input;
+    utf8Shadow = Utf8Shadow.create(crosscheckPattern, input);
+  }
+
+  private void disableUtf8Shadow() {
+    utf8Shadow = null;
+  }
+
+  boolean utf8ShadowActive() {
+    return utf8Shadow != null;
   }
 
   private void checkBoolean(String method, String args, boolean sr, boolean jr) {

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
@@ -136,14 +136,17 @@ public final class Pattern implements Serializable {
     return new Matcher(this, input);
   }
 
-  /** Returns the SafeRE-only UTF-8 matcher, outside the JDK differential surface. */
-  public org.safere.Utf8Matcher matcher(org.safere.Utf8Input input) {
-    return saferePattern.matcher(input);
+  /** Creates a UTF-8 matcher crosschecked against decoded SafeRE String and JDK matchers. */
+  public Utf8Matcher matcher(Utf8Input input) {
+    return new Utf8Matcher(this, input);
   }
 
-  /** Runs the SafeRE-only capture-free UTF-8 search outside the JDK differential surface. */
-  public boolean find(org.safere.Utf8Input input) {
-    return saferePattern.find(input);
+  /** Runs capture-free UTF-8 search and compares it with decoded String and JDK oracles. */
+  public boolean find(Utf8Input input) {
+    Objects.requireNonNull(input, "input");
+    boolean result = saferePattern.find(input.delegate());
+    Utf8Matcher.crosscheckFind(this, input, result);
+    return result;
   }
 
   /** Returns the flags this pattern was compiled with. */

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Coordinates.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Coordinates.java
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.crosscheck;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.Arrays;
+
+/** Exact coordinate conversion at Unicode scalar boundaries. */
+final class Utf8Coordinates {
+  private final int[] utf16ByUtf8Offset;
+  private final int[] utf8ByUtf16Offset;
+
+  private Utf8Coordinates(int[] utf16ByUtf8Offset, int[] utf8ByUtf16Offset) {
+    this.utf16ByUtf8Offset = utf16ByUtf8Offset;
+    this.utf8ByUtf16Offset = utf8ByUtf16Offset;
+  }
+
+  static Utf8Coordinates create(String text) {
+    byte[] utf8 = text.getBytes(UTF_8);
+    int[] utf16ByUtf8Offset = new int[utf8.length + 1];
+    int[] utf8ByUtf16Offset = new int[text.length() + 1];
+    Arrays.fill(utf16ByUtf8Offset, -1);
+    Arrays.fill(utf8ByUtf16Offset, -1);
+    int utf8Offset = 0;
+    for (int utf16Offset = 0; utf16Offset < text.length(); ) {
+      char first = text.charAt(utf16Offset);
+      if (Character.isSurrogate(first)
+          && !(Character.isHighSurrogate(first)
+              && utf16Offset + 1 < text.length()
+              && Character.isLowSurrogate(text.charAt(utf16Offset + 1)))) {
+        return null;
+      }
+      utf16ByUtf8Offset[utf8Offset] = utf16Offset;
+      utf8ByUtf16Offset[utf16Offset] = utf8Offset;
+      int codePoint = text.codePointAt(utf16Offset);
+      utf8Offset += utf8Length(codePoint);
+      utf16Offset += Character.charCount(codePoint);
+    }
+    utf16ByUtf8Offset[utf8Offset] = text.length();
+    utf8ByUtf16Offset[text.length()] = utf8Offset;
+    if (utf8Offset != utf8.length) {
+      throw new IllegalStateException("UTF-8 coordinate map length mismatch");
+    }
+    return new Utf8Coordinates(utf16ByUtf8Offset, utf8ByUtf16Offset);
+  }
+
+  int toUtf16(int utf8Offset) {
+    if (utf8Offset < 0 || utf8Offset >= utf16ByUtf8Offset.length) {
+      throw new IllegalStateException("UTF-8 matcher returned out-of-range offset " + utf8Offset);
+    }
+    int utf16Offset = utf16ByUtf8Offset[utf8Offset];
+    if (utf16Offset < 0) {
+      throw new IllegalStateException(
+          "UTF-8 matcher returned a non-scalar-boundary offset " + utf8Offset);
+    }
+    return utf16Offset;
+  }
+
+  int toUtf8(int utf16Offset) {
+    if (!isUtf16Boundary(utf16Offset)) {
+      throw new IllegalArgumentException(
+          "UTF-16 offset is not a Unicode scalar boundary: " + utf16Offset);
+    }
+    return utf8ByUtf16Offset[utf16Offset];
+  }
+
+  boolean isUtf16Boundary(int utf16Offset) {
+    return utf16Offset >= 0
+        && utf16Offset < utf8ByUtf16Offset.length
+        && utf8ByUtf16Offset[utf16Offset] >= 0;
+  }
+
+  String describe() {
+    StringBuilder result = new StringBuilder();
+    for (int utf16Offset = 0; utf16Offset < utf8ByUtf16Offset.length; utf16Offset++) {
+      int utf8Offset = utf8ByUtf16Offset[utf16Offset];
+      if (utf8Offset >= 0) {
+        if (!result.isEmpty()) {
+          result.append(", ");
+        }
+        result.append(utf16Offset).append("->").append(utf8Offset);
+      }
+    }
+    return result.toString();
+  }
+
+  private static int utf8Length(int codePoint) {
+    if (codePoint <= 0x7f) {
+      return 1;
+    }
+    if (codePoint <= 0x7ff) {
+      return 2;
+    }
+    if (codePoint <= 0xffff) {
+      return 3;
+    }
+    return 4;
+  }
+}

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Input.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Input.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.crosscheck;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/** Crosscheck view of caller-owned UTF-8 storage. */
+public final class Utf8Input {
+  private final org.safere.Utf8Input delegate;
+  private final byte[] bytes;
+  private final int offset;
+  private final int length;
+  private final String decoded;
+
+  private Utf8Input(
+      org.safere.Utf8Input delegate, byte[] bytes, int offset, int length, String decoded) {
+    this.delegate = delegate;
+    this.bytes = bytes;
+    this.offset = offset;
+    this.length = length;
+    this.decoded = decoded;
+  }
+
+  /** Creates a trusted whole-array input without semantic oracle comparison. */
+  public static Utf8Input trusted(byte[] bytes) {
+    requireNonNull(bytes, "bytes");
+    return trusted(bytes, 0, bytes.length);
+  }
+
+  /** Creates a trusted logical window without semantic oracle comparison. */
+  public static Utf8Input trusted(byte[] bytes, int offset, int length) {
+    org.safere.Utf8Input delegate = org.safere.Utf8Input.trusted(bytes, offset, length);
+    return new Utf8Input(delegate, bytes, offset, length, null);
+  }
+
+  /** Creates a strictly validated whole-array input with String and JDK oracles. */
+  public static Utf8Input validated(byte[] bytes) {
+    requireNonNull(bytes, "bytes");
+    return validated(bytes, 0, bytes.length);
+  }
+
+  /** Creates a strictly validated logical window with String and JDK oracles. */
+  public static Utf8Input validated(byte[] bytes, int offset, int length) {
+    org.safere.Utf8Input delegate = org.safere.Utf8Input.validated(bytes, offset, length);
+    return new Utf8Input(delegate, bytes, offset, length, new String(bytes, offset, length, UTF_8));
+  }
+
+  /** Returns the logical input length in UTF-8 bytes. */
+  public int length() {
+    return length;
+  }
+
+  org.safere.Utf8Input delegate() {
+    return delegate;
+  }
+
+  byte[] bytes() {
+    return bytes;
+  }
+
+  int offset() {
+    return offset;
+  }
+
+  boolean validated() {
+    return decoded != null;
+  }
+
+  String decoded() {
+    if (decoded == null) {
+      throw new IllegalStateException("trusted UTF-8 input has no semantic oracle");
+    }
+    return decoded;
+  }
+}

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Matcher.java
@@ -1,0 +1,397 @@
+// Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.crosscheck;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.MatchResult;
+
+/** Crosscheck matcher over UTF-8 input with relative byte coordinates. */
+public final class Utf8Matcher {
+  private final Pattern pattern;
+  private final Utf8Input input;
+  private final org.safere.Utf8Matcher delegate;
+  private final TraceRecorder trace = new TraceRecorder();
+  private Oracles oracles;
+
+  Utf8Matcher(Pattern pattern, Utf8Input input) {
+    this.pattern = requireNonNull(pattern, "pattern");
+    this.input = requireNonNull(input, "input");
+    delegate = pattern.saferePattern().matcher(input.delegate());
+    if (input.validated()) {
+      String decoded = input.decoded();
+      Utf8Coordinates coordinates = Utf8Coordinates.create(decoded);
+      if (coordinates == null) {
+        throw new IllegalStateException("validated UTF-8 decoded to malformed UTF-16");
+      }
+      oracles =
+          new Oracles(
+              pattern.saferePattern().matcher(decoded),
+              pattern.jdkPattern().matcher(decoded),
+              coordinates);
+    }
+  }
+
+  /** Attempts to find the next matching subsequence. */
+  public boolean find() {
+    boolean actual = delegate.find();
+    if (oracles == null) {
+      return actual;
+    }
+    boolean stringResult = findNextScalarAligned(oracles.safereString(), oracles.coordinates());
+    boolean jdkResult = findNextScalarAligned(oracles.jdk(), oracles.coordinates());
+    compare("find", "", "SafeRE UTF-8", actual, "SafeRE String", stringResult);
+    compare("find", "", "SafeRE String", stringResult, "JDK", jdkResult);
+    if (actual) {
+      checkMatchState("find");
+    }
+    trace.recordMatch("find", "", actual);
+    return actual;
+  }
+
+  /** Returns the previous full match's relative byte start. */
+  public int start() {
+    return observeBoundary("start", "", 0, true);
+  }
+
+  /** Returns a numbered group's relative byte start. */
+  public int start(int group) {
+    return observeBoundary("start", String.valueOf(group), group, true);
+  }
+
+  /** Returns the previous full match's relative byte end. */
+  public int end() {
+    return observeBoundary("end", "", 0, false);
+  }
+
+  /** Returns a numbered group's relative byte end. */
+  public int end(int group) {
+    return observeBoundary("end", String.valueOf(group), group, false);
+  }
+
+  /** Returns the pattern's capturing-group count. */
+  public int groupCount() {
+    int actual = delegate.groupCount();
+    if (oracles != null) {
+      int stringResult = oracles.safereString().groupCount();
+      int jdkResult = oracles.jdk().groupCount();
+      compare("groupCount", "", "SafeRE UTF-8", actual, "SafeRE String", stringResult);
+      compare("groupCount", "", "SafeRE String", stringResult, "JDK", jdkResult);
+      trace.recordMatch("groupCount", "", actual);
+    }
+    return actual;
+  }
+
+  /** Appends the unmatched prefix and expanded replacement for the current match. */
+  public Utf8Matcher appendReplacement(Utf8Sink sink, Utf8Input replacement) {
+    requireNonNull(sink, "sink");
+    requireNonNull(replacement, "replacement");
+    ByteArrayOutputStream actualOutput = new ByteArrayOutputStream();
+    delegate.appendReplacement(
+        (bytes, offset, length) -> {
+          actualOutput.write(bytes, offset, length);
+          sink.append(bytes, offset, length);
+        },
+        replacement.delegate());
+    if (oracles == null) {
+      return this;
+    }
+    if (!replacement.validated()) {
+      oracles = null;
+      return this;
+    }
+
+    StringBuilder stringOutput = new StringBuilder();
+    StringBuilder jdkOutput = new StringBuilder();
+    String decodedReplacement = replacement.decoded();
+    oracles.safereString().appendReplacement(stringOutput, decodedReplacement);
+    oracles.jdk().appendReplacement(jdkOutput, decodedReplacement);
+    String actual = actualOutput.toString(UTF_8);
+    compare(
+        "appendReplacement",
+        quote(decodedReplacement),
+        "SafeRE UTF-8",
+        actual,
+        "SafeRE String",
+        stringOutput);
+    compare(
+        "appendReplacement",
+        quote(decodedReplacement),
+        "SafeRE String",
+        stringOutput,
+        "JDK",
+        jdkOutput);
+    trace.recordMatch("appendReplacement", quote(decodedReplacement), actual);
+    return this;
+  }
+
+  /** Appends the subject tail following the last replacement. */
+  public void appendTail(Utf8Sink sink) {
+    requireNonNull(sink, "sink");
+    ByteArrayOutputStream actualOutput = new ByteArrayOutputStream();
+    delegate.appendTail(
+        (bytes, offset, length) -> {
+          actualOutput.write(bytes, offset, length);
+          sink.append(bytes, offset, length);
+        });
+    if (oracles == null) {
+      return;
+    }
+    StringBuilder stringOutput = new StringBuilder();
+    StringBuilder jdkOutput = new StringBuilder();
+    oracles.safereString().appendTail(stringOutput);
+    oracles.jdk().appendTail(jdkOutput);
+    String actual = actualOutput.toString(UTF_8);
+    compare("appendTail", "", "SafeRE UTF-8", actual, "SafeRE String", stringOutput);
+    compare("appendTail", "", "SafeRE String", stringOutput, "JDK", jdkOutput);
+    trace.recordMatch("appendTail", "", actual);
+  }
+
+  static void crosscheckFind(Pattern pattern, Utf8Input input, boolean actual) {
+    if (!input.validated()) {
+      return;
+    }
+    String decoded = input.decoded();
+    Utf8Coordinates coordinates = Utf8Coordinates.create(decoded);
+    if (coordinates == null) {
+      throw new IllegalStateException("validated UTF-8 decoded to malformed UTF-16");
+    }
+    boolean stringResult =
+        findNextScalarAligned(pattern.saferePattern().matcher(decoded), coordinates);
+    boolean jdkResult = findNextScalarAligned(pattern.jdkPattern().matcher(decoded), coordinates);
+    if (actual != stringResult) {
+      throw directDivergence(
+          pattern,
+          input,
+          coordinates,
+          "Pattern.find",
+          "SafeRE UTF-8",
+          actual,
+          "SafeRE String",
+          stringResult);
+    }
+    if (stringResult != jdkResult) {
+      throw directDivergence(
+          pattern,
+          input,
+          coordinates,
+          "Pattern.find",
+          "SafeRE String",
+          stringResult,
+          "JDK",
+          jdkResult);
+    }
+  }
+
+  private int observeBoundary(String method, String args, int group, boolean start) {
+    if (oracles == null) {
+      return start ? delegate.start(group) : delegate.end(group);
+    }
+    Observation actual = observe(() -> start ? delegate.start(group) : delegate.end(group));
+    Observation stringResult =
+        observe(
+            () -> start ? oracles.safereString().start(group) : oracles.safereString().end(group));
+    Observation jdkResult =
+        observe(() -> start ? oracles.jdk().start(group) : oracles.jdk().end(group));
+    compareObservations(method, args, "SafeRE UTF-8", actual, "SafeRE String", stringResult);
+    compareObservations(method, args, "SafeRE String", stringResult, "JDK", jdkResult);
+    if (actual.failure() != null) {
+      throw actual.failure();
+    }
+
+    int actualOffset = actual.value();
+    if (actualOffset >= 0) {
+      oracles.coordinates().toUtf16(actualOffset);
+    }
+    compareOracleBoundary(method, args, actualOffset, "SafeRE String", stringResult.value());
+    compareOracleBoundary(method, args, actualOffset, "JDK", jdkResult.value());
+    trace.recordMatch(method, args, actualOffset);
+    return actualOffset;
+  }
+
+  private void checkMatchState(String context) {
+    int actualGroupCount = delegate.groupCount();
+    compare(
+        context + " -> groupCount",
+        "",
+        "SafeRE UTF-8",
+        actualGroupCount,
+        "SafeRE String",
+        oracles.safereString().groupCount());
+    compare(
+        context + " -> groupCount",
+        "",
+        "SafeRE String",
+        oracles.safereString().groupCount(),
+        "JDK",
+        oracles.jdk().groupCount());
+    for (int group = 0; group <= actualGroupCount; group++) {
+      compareCurrentBoundary(context, group, true);
+      compareCurrentBoundary(context, group, false);
+    }
+  }
+
+  private void compareCurrentBoundary(String context, int group, boolean start) {
+    int actual = start ? delegate.start(group) : delegate.end(group);
+    if (actual >= 0) {
+      oracles.coordinates().toUtf16(actual);
+    }
+    int stringResult =
+        start ? oracles.safereString().start(group) : oracles.safereString().end(group);
+    int jdkResult = start ? oracles.jdk().start(group) : oracles.jdk().end(group);
+    String method = context + " -> " + (start ? "start" : "end") + "(" + group + ")";
+    compareOracleBoundary(method, "", actual, "SafeRE String", stringResult);
+    compareOracleBoundary(method, "", actual, "JDK", jdkResult);
+  }
+
+  private void compareOracleBoundary(
+      String method, String args, int actual, String oracleLabel, int utf16Offset) {
+    if (utf16Offset < 0) {
+      compare(method, args, "SafeRE UTF-8", actual, oracleLabel, -1);
+    } else if (oracles.coordinates().isUtf16Boundary(utf16Offset)) {
+      compare(
+          method,
+          args,
+          "SafeRE UTF-8",
+          actual,
+          oracleLabel,
+          oracles.coordinates().toUtf8(utf16Offset));
+    }
+  }
+
+  private void compareObservations(
+      String method,
+      String args,
+      String firstLabel,
+      Observation first,
+      String secondLabel,
+      Observation second) {
+    if (first.failure() == null && second.failure() == null) {
+      return;
+    }
+    Object firstResult =
+        first.failure() == null ? first.value() : "throws " + first.failure().getClass().getName();
+    Object secondResult =
+        second.failure() == null
+            ? second.value()
+            : "throws " + second.failure().getClass().getName();
+    compare(method, args, firstLabel, firstResult, secondLabel, secondResult);
+  }
+
+  private void compare(
+      String method,
+      String args,
+      String firstLabel,
+      Object first,
+      String secondLabel,
+      Object second) {
+    if (Objects.equals(Objects.toString(first), Objects.toString(second))) {
+      return;
+    }
+    trace.recordDivergence(method, args, first, second);
+    throw CrosscheckException.comparison(
+        method,
+        args,
+        firstLabel,
+        Objects.toString(first),
+        secondLabel,
+        Objects.toString(second),
+        trace.format() + "\n" + context());
+  }
+
+  private String context() {
+    int shownLength = Math.min(input.length(), 256);
+    byte[] shown = Arrays.copyOfRange(input.bytes(), input.offset(), input.offset() + shownLength);
+    String suffix = shownLength == input.length() ? "" : " ...";
+    return "pattern: /"
+        + pattern.pattern()
+        + "/\n"
+        + "decoded input: "
+        + quote(input.decoded())
+        + "\n"
+        + "logical byte window: offset="
+        + input.offset()
+        + ", length="
+        + input.length()
+        + "\n"
+        + "logical bytes: "
+        + Arrays.toString(shown)
+        + suffix
+        + "\n"
+        + "UTF-16->UTF-8 boundaries: "
+        + oracles.coordinates().describe();
+  }
+
+  private static CrosscheckException directDivergence(
+      Pattern pattern,
+      Utf8Input input,
+      Utf8Coordinates coordinates,
+      String method,
+      String firstLabel,
+      Object first,
+      String secondLabel,
+      Object second) {
+    return CrosscheckException.comparison(
+        method,
+        "",
+        firstLabel,
+        Objects.toString(first),
+        secondLabel,
+        Objects.toString(second),
+        "pattern: /"
+            + pattern.pattern()
+            + "/\n"
+            + "decoded input: "
+            + quote(input.decoded())
+            + "\nlogical byte window: offset="
+            + input.offset()
+            + ", length="
+            + input.length()
+            + "\nUTF-16->UTF-8 boundaries: "
+            + coordinates.describe());
+  }
+
+  private static boolean findNextScalarAligned(MatchResult matcher, Utf8Coordinates coordinates) {
+    while (find(matcher)) {
+      if (coordinates.isUtf16Boundary(matcher.start())
+          && coordinates.isUtf16Boundary(matcher.end())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean find(MatchResult matcher) {
+    if (matcher instanceof org.safere.Matcher safereMatcher) {
+      return safereMatcher.find();
+    }
+    return ((java.util.regex.Matcher) matcher).find();
+  }
+
+  private static Observation observe(IntOperation operation) {
+    try {
+      return new Observation(operation.get(), null);
+    } catch (RuntimeException failure) {
+      return new Observation(0, failure);
+    }
+  }
+
+  private static String quote(String text) {
+    return "\"" + text + "\"";
+  }
+
+  private record Oracles(
+      org.safere.Matcher safereString, java.util.regex.Matcher jdk, Utf8Coordinates coordinates) {}
+
+  private record Observation(int value, RuntimeException failure) {}
+
+  @FunctionalInterface
+  private interface IntOperation {
+    int get();
+  }
+}

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Shadow.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Shadow.java
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.crosscheck;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
+
+/** A UTF-8 matcher shadow for String crosscheck operations with equivalent UTF-8 APIs. */
+final class Utf8Shadow {
+  private final org.safere.Pattern pattern;
+  private final byte[] bytes;
+  private final Utf8Coordinates coordinates;
+  private org.safere.Utf8Matcher matcher;
+
+  private Utf8Shadow(org.safere.Pattern pattern, byte[] bytes, Utf8Coordinates coordinates) {
+    this.pattern = pattern;
+    this.bytes = bytes;
+    this.coordinates = coordinates;
+    matcher = newMatcher();
+  }
+
+  static Utf8Shadow create(Pattern pattern, CharSequence input) {
+    if (!(input instanceof String text)) {
+      return null;
+    }
+    Utf8Coordinates coordinates = Utf8Coordinates.create(text);
+    if (coordinates == null) {
+      return null;
+    }
+    byte[] bytes = text.getBytes(UTF_8);
+    return new Utf8Shadow(pattern.saferePattern(), bytes, coordinates);
+  }
+
+  boolean find() {
+    return matcher.find();
+  }
+
+  int groupCount() {
+    return matcher.groupCount();
+  }
+
+  int start(int group) {
+    return toUtf16(matcher.start(group));
+  }
+
+  int end(int group) {
+    return toUtf16(matcher.end(group));
+  }
+
+  boolean canRepresent(org.safere.Matcher stringMatcher) {
+    for (int group = 0; group <= stringMatcher.groupCount(); group++) {
+      int start = stringMatcher.start(group);
+      int end = stringMatcher.end(group);
+      if (start >= 0
+          && (!coordinates.isUtf16Boundary(start) || !coordinates.isUtf16Boundary(end))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  String group(int group) {
+    int start = matcher.start(group);
+    if (start < 0) {
+      return null;
+    }
+    int end = matcher.end(group);
+    coordinates.toUtf16(start);
+    coordinates.toUtf16(end);
+    return new String(bytes, start, end - start, UTF_8);
+  }
+
+  boolean canEncode(String text) {
+    return Utf8Coordinates.create(text) != null;
+  }
+
+  String appendReplacement(String replacement) {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    matcher.appendReplacement(
+        output::write, org.safere.Utf8Input.validated(replacement.getBytes(UTF_8)));
+    return output.toString(UTF_8);
+  }
+
+  String appendTail() {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    matcher.appendTail(output::write);
+    return output.toString(UTF_8);
+  }
+
+  String replaceFirst(String replacement) {
+    org.safere.Utf8Matcher replacementMatcher = newMatcher();
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    if (replacementMatcher.find()) {
+      replacementMatcher.appendReplacement(
+          output::write, org.safere.Utf8Input.validated(replacement.getBytes(UTF_8)));
+    }
+    replacementMatcher.appendTail(output::write);
+    return output.toString(UTF_8);
+  }
+
+  String replaceAll(String replacement) {
+    org.safere.Utf8Matcher replacementMatcher = newMatcher();
+    org.safere.Utf8Input utf8Replacement =
+        org.safere.Utf8Input.validated(replacement.getBytes(UTF_8));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    while (replacementMatcher.find()) {
+      replacementMatcher.appendReplacement(output::write, utf8Replacement);
+    }
+    replacementMatcher.appendTail(output::write);
+    return output.toString(UTF_8);
+  }
+
+  private org.safere.Utf8Matcher newMatcher() {
+    return pattern.matcher(org.safere.Utf8Input.validated(bytes));
+  }
+
+  private int toUtf16(int utf8Offset) {
+    return utf8Offset < 0 ? -1 : coordinates.toUtf16(utf8Offset);
+  }
+}

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Sink.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Sink.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.crosscheck;
+
+/** Synchronous destination for borrowed UTF-8 ranges emitted by a crosscheck matcher. */
+@FunctionalInterface
+public interface Utf8Sink extends org.safere.Utf8Sink {
+  /** Consumes the supplied borrowed byte range before returning. */
+  @Override
+  void append(byte[] bytes, int offset, int length);
+}

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -119,6 +119,57 @@ class CrosscheckTest {
   class MatcherMatchingTests {
 
     @Test
+    @DisplayName("String find operations keep a UTF-8 shadow for scalar-valid input")
+    void utf8ShadowChecksFindAndCaptures() {
+      Matcher m = Pattern.compile("(?<letter>é)|(😀)").matcher("xé😀y");
+
+      assertThat(m.utf8ShadowActive()).isTrue();
+      assertThat(m.find()).isTrue();
+      assertThat(m.group("letter")).isEqualTo("é");
+      assertThat(m.start("letter")).isEqualTo(1);
+      assertThat(m.end("letter")).isEqualTo(2);
+      assertThat(m.find()).isTrue();
+      assertThat(m.group(2)).isEqualTo("😀");
+      assertThat(m.start(2)).isEqualTo(2);
+      assertThat(m.end(2)).isEqualTo(4);
+      assertThat(m.find()).isFalse();
+      assertThat(m.utf8ShadowActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("UTF-8 shadow excludes inputs that cannot round-trip through UTF-8")
+    void utf8ShadowExcludesUnpairedSurrogatesAndMutableInputs() {
+      assertThat(Pattern.compile(".").matcher("a\ud800b").utf8ShadowActive()).isFalse();
+      assertThat(Pattern.compile(".").matcher(new StringBuilder("abc")).utf8ShadowActive())
+          .isFalse();
+    }
+
+    @Test
+    @DisplayName("reset re-enables the UTF-8 shadow after an unsupported operation")
+    void resetReenablesUtf8Shadow() {
+      Matcher m = Pattern.compile("a").matcher("a");
+
+      assertThat(m.utf8ShadowActive()).isTrue();
+      assertThat(m.matches()).isTrue();
+      assertThat(m.utf8ShadowActive()).isFalse();
+      m.reset();
+      assertThat(m.utf8ShadowActive()).isTrue();
+      assertThat(m.find()).isTrue();
+    }
+
+    @Test
+    @DisplayName("String matches inside surrogate pairs disable the UTF-8 shadow")
+    void scalarInternalStringMatchDisablesUtf8Shadow() {
+      Matcher m = Pattern.compile("\\X\\X").matcher("🇺🇸");
+
+      assertThat(m.utf8ShadowActive()).isTrue();
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(1);
+      assertThat(m.end()).isEqualTo(4);
+      assertThat(m.utf8ShadowActive()).isFalse();
+    }
+
+    @Test
     @DisplayName("matches() returns true for full match")
     void matchesFull() {
       Matcher m = Pattern.compile("\\w+").matcher("hello");
@@ -210,6 +261,22 @@ class CrosscheckTest {
   @Nested
   @DisplayName("Matcher replace")
   class MatcherReplaceTests {
+
+    @Test
+    @DisplayName("String replacement operations are checked against UTF-8 output")
+    void utf8ShadowChecksReplacement() {
+      Matcher incremental = Pattern.compile("(?<letter>é)").matcher("xéyéz");
+      StringBuilder output = new StringBuilder();
+
+      while (incremental.find()) {
+        incremental.appendReplacement(output, "${letter}${letter}");
+      }
+      incremental.appendTail(output);
+
+      assertThat(output).hasToString("xééyééz");
+      assertThat(incremental.utf8ShadowActive()).isTrue();
+      assertThat(Pattern.compile("😀").matcher("a😀b😀c").replaceAll("é")).isEqualTo("aébéc");
+    }
 
     @Test
     @DisplayName("replaceAll replaces all occurrences")

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/Utf8CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/Utf8CrosscheckTest.java
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.crosscheck;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+
+class Utf8CrosscheckTest {
+  @Test
+  void validatedInputCrosschecksRepeatedFindAndCaptureByteBounds() {
+    Utf8Matcher matcher =
+        Pattern.compile("(é)|(😀)").matcher(Utf8Input.validated("xé😀y".getBytes(UTF_8)));
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(1);
+    assertThat(matcher.end()).isEqualTo(3);
+    assertThat(matcher.start(1)).isEqualTo(1);
+    assertThat(matcher.end(1)).isEqualTo(3);
+    assertThat(matcher.start(2)).isEqualTo(-1);
+    assertThat(matcher.end(2)).isEqualTo(-1);
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(3);
+    assertThat(matcher.end()).isEqualTo(7);
+    assertThat(matcher.start(1)).isEqualTo(-1);
+    assertThat(matcher.start(2)).isEqualTo(3);
+    assertThat(matcher.end(2)).isEqualTo(7);
+    assertThat(matcher.find()).isFalse();
+  }
+
+  @Test
+  void emptyFindSkipsJdkPositionsInsideSupplementaryScalars() {
+    Utf8Matcher matcher = Pattern.compile("").matcher(Utf8Input.validated("😀".getBytes(UTF_8)));
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isZero();
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(4);
+    assertThat(matcher.find()).isFalse();
+  }
+
+  @Test
+  void logicalWindowCoordinatesRemainRelative() {
+    byte[] logical = "xéy".getBytes(UTF_8);
+    byte[] storage = new byte[logical.length + 8];
+    System.arraycopy(logical, 0, storage, 4, logical.length);
+
+    Utf8Matcher matcher =
+        Pattern.compile("é").matcher(Utf8Input.validated(storage, 4, logical.length));
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(1);
+    assertThat(matcher.end()).isEqualTo(3);
+  }
+
+  @Test
+  void observationsCrosscheckSuccessAndExceptionStates() {
+    Utf8Matcher matcher = Pattern.compile("(a)").matcher(input("a"));
+
+    assertThatThrownBy(matcher::start).isInstanceOf(IllegalStateException.class);
+    assertThat(matcher.groupCount()).isEqualTo(1);
+    assertThat(matcher.find()).isTrue();
+    assertThatThrownBy(() -> matcher.start(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+    assertThatThrownBy(() -> matcher.end(2)).isInstanceOf(IndexOutOfBoundsException.class);
+    assertThat(matcher.find()).isFalse();
+    assertThatThrownBy(matcher::end).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void replacementOutputIsCrosscheckedCallByCall() {
+    Utf8Matcher matcher = Pattern.compile("(?<letter>é)").matcher(input("xéyéz"));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    while (matcher.find()) {
+      matcher.appendReplacement(output::write, input("${letter}${letter}"));
+    }
+    matcher.appendTail(output::write);
+
+    assertThat(output.toString(UTF_8)).isEqualTo("xééyééz");
+  }
+
+  @Test
+  void captureFreeFindUsesDecodedOraclesForValidatedInput() {
+    Pattern pattern = Pattern.compile("😀$");
+
+    assertThat(pattern.find(input("x😀"))).isTrue();
+    assertThat(pattern.find(input("😀x"))).isFalse();
+  }
+
+  @Test
+  void trustedMalformedInputRunsWithoutSemanticOracle() {
+    Utf8Input malformed = Utf8Input.trusted(new byte[] {'a', (byte) 0x80, 'b'});
+
+    Utf8Matcher matcher = Pattern.compile(".").matcher(malformed);
+    while (matcher.find()) {
+      assertThat(matcher.start()).isBetween(0, malformed.length());
+      assertThat(matcher.end()).isBetween(matcher.start(), malformed.length());
+    }
+    Pattern.compile("a").find(malformed);
+  }
+
+  private static Utf8Input input(String text) {
+    return Utf8Input.validated(text.getBytes(UTF_8));
+  }
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -10,6 +10,7 @@ import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.nio.ByteBuffer;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.regex.PatternSyntaxException;
 import org.safere.Pattern;
 import org.safere.Utf8Input;
@@ -19,6 +20,13 @@ import org.safere.Utf8Matcher;
 final class Utf8InputFuzzer {
   @FuzzTest(maxDuration = "30s")
   void arbitraryWindow(FuzzedDataProvider data) {
+    assertLiteralSearchMatchesString("XXXXXX", "..XXXXXX");
+    String repeatedLiteral =
+        String.valueOf((char) data.consumeInt('A', 'Z')).repeat(data.consumeInt(2, 32));
+    String suffix = new String(data.consumeBytes(data.consumeInt(0, 64)), StandardCharsets.UTF_8);
+    String literalInput = ".".repeat(data.consumeInt(0, 64)) + repeatedLiteral + suffix;
+    assertLiteralSearchMatchesString(repeatedLiteral, literalInput);
+
     Pattern pattern;
     try {
       pattern = Pattern.compile(data.consumeString(128), FuzzSupport.consumeFlags(data));
@@ -43,6 +51,31 @@ final class Utf8InputFuzzer {
         throw new AssertionError("strict validation rejected valid UTF-8", e);
       }
     }
+  }
+
+  private static void assertLiteralSearchMatchesString(String regex, String input) {
+    Pattern pattern = Pattern.compile(regex);
+    org.safere.Matcher stringMatcher = pattern.matcher(input);
+    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+    Utf8Input utf8Input = Utf8Input.validated(bytes);
+    Utf8Matcher utf8Matcher = pattern.matcher(utf8Input);
+
+    boolean stringFound = stringMatcher.find();
+    boolean utf8Found = utf8Matcher.find();
+    if (stringFound != utf8Found || pattern.find(utf8Input) != stringFound) {
+      throw new AssertionError("UTF-8 literal search result differs from String search");
+    }
+    if (stringFound
+        && (!Objects.equals(stringMatcher.group(), decodeGroup(bytes, utf8Matcher))
+            || utf8Matcher.start() < 0
+            || utf8Matcher.end() > bytes.length)) {
+      throw new AssertionError("UTF-8 literal search bounds differ from String search");
+    }
+  }
+
+  private static String decodeGroup(byte[] bytes, Utf8Matcher matcher) {
+    return new String(
+        bytes, matcher.start(), matcher.end() - matcher.start(), StandardCharsets.UTF_8);
   }
 
   private static void walk(Utf8Matcher matcher, int length) {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -191,22 +191,27 @@ final class Utf8InputScanner implements InputScanner {
     int position = start + last;
     int work = 0;
     int workLimit = Math.max(1, (length - start) * 2);
-    while (position < length && work < workLimit) {
+    while (position < length) {
       int literalPosition = last;
       int inputPosition = position;
-      while (literalPosition >= 0
-          && bytes[offset + inputPosition] == literal[literalPosition]
-          && work++ < workLimit) {
+      while (literalPosition >= 0 && bytes[offset + inputPosition] == literal[literalPosition]) {
+        if (work >= workLimit) {
+          return -2;
+        }
+        work++;
         literalPosition--;
         inputPosition--;
       }
       if (literalPosition < 0) {
         return inputPosition + 1;
       }
+      if (work >= workLimit) {
+        return -2;
+      }
       position += shifts[bytes[offset + position] & 0xFF];
       work++;
     }
-    return position >= length ? -1 : -2;
+    return -1;
   }
 
   private int indexOfByte(byte target, int start) {

--- a/safere/src/test/java/org/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/org/safere/ExhaustiveUtils.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
@@ -148,6 +149,9 @@ final class ExhaustiveUtils {
       return 0;
     }
 
+    Utf8Coordinates utf8Coordinates = Utf8Coordinates.forText(text);
+    byte[] utf8 = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
     // Compare matches()
     tests++;
     try {
@@ -187,8 +191,7 @@ final class ExhaustiveUtils {
     try {
       java.util.regex.Matcher jdkM = jdkPat.matcher(text);
       Matcher safereM = saferePat.matcher(text);
-      byte[] bytes = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-      Utf8Matcher safereByteM = saferePat.matcher(Utf8Input.validated(bytes));
+      Utf8Matcher safereByteM = saferePat.matcher(Utf8Input.validated(utf8));
 
       boolean jdkFound = jdkM.find();
       boolean safereFound = safereM.find();
@@ -220,7 +223,7 @@ final class ExhaustiveUtils {
         int byteEnd = safereByteM.end();
         String safereByteMatch =
             String.format(
-                "[%d,%d)", byteToCharOffset(text, byteStart), byteToCharOffset(text, byteEnd));
+                "[%d,%d)", utf8Coordinates.toUtf16(byteStart), utf8Coordinates.toUtf16(byteEnd));
 
         if (!jdkMatch.equals(safereMatch)) {
           failures.add(new TestResult(regexp, text, flags, "find/pos", safereMatch, jdkMatch));
@@ -232,7 +235,8 @@ final class ExhaustiveUtils {
           int sharedGroups = Math.min(jdkM.groupCount(), safereM.groupCount());
           String jdkGroups = extractGroups(jdkM, sharedGroups);
           String safereGroups = extractGroups(safereM, sharedGroups);
-          String safereByteGroups = extractGroupsForBytes(safereByteM, sharedGroups, text);
+          String safereByteGroups =
+              extractGroupsForBytes(safereByteM, sharedGroups, utf8Coordinates);
           if (!jdkGroups.equals(safereGroups)) {
             failures.add(
                 new TestResult(regexp, text, flags, "find/groups", safereGroups, jdkGroups));
@@ -254,8 +258,7 @@ final class ExhaustiveUtils {
     try {
       java.util.regex.Matcher jdkM = jdkPat.matcher(text);
       Matcher safereM = saferePat.matcher(text);
-      byte[] bytes = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-      Utf8Matcher safereByteM = saferePat.matcher(Utf8Input.validated(bytes));
+      Utf8Matcher safereByteM = saferePat.matcher(Utf8Input.validated(utf8));
 
       List<String> jdkAll = new ArrayList<>();
       while (jdkM.find()) {
@@ -271,7 +274,7 @@ final class ExhaustiveUtils {
         int byteEnd = safereByteM.end();
         safereByteAll.add(
             String.format(
-                "[%d,%d)", byteToCharOffset(text, byteStart), byteToCharOffset(text, byteEnd)));
+                "[%d,%d)", utf8Coordinates.toUtf16(byteStart), utf8Coordinates.toUtf16(byteEnd)));
       }
 
       if (!jdkAll.equals(safereAll)) {
@@ -323,7 +326,8 @@ final class ExhaustiveUtils {
     return sb.toString();
   }
 
-  private static String extractGroupsForBytes(Utf8Matcher m, int maxGroups, String text) {
+  private static String extractGroupsForBytes(
+      Utf8Matcher m, int maxGroups, Utf8Coordinates coordinates) {
     int count = Math.min(m.groupCount(), maxGroups);
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i <= count; i++) {
@@ -332,23 +336,71 @@ final class ExhaustiveUtils {
       }
       int start = m.start(i);
       int end = m.end(i);
-      int charStart = byteToCharOffset(text, start);
-      int charEnd = byteToCharOffset(text, end);
+      int charStart = start < 0 ? -1 : coordinates.toUtf16(start);
+      int charEnd = end < 0 ? -1 : coordinates.toUtf16(end);
       sb.append(String.format("g%d=[%d,%d)", i, charStart, charEnd));
     }
     return sb.toString();
   }
 
-  private static int byteToCharOffset(String text, int byteOffset) {
-    if (byteOffset < 0) {
-      return -1;
+  /** Exact scalar-boundary mapping from relative UTF-8 offsets to UTF-16 String offsets. */
+  static final class Utf8Coordinates {
+    private final int[] utf16ByUtf8Offset;
+
+    private Utf8Coordinates(int[] utf16ByUtf8Offset) {
+      this.utf16ByUtf8Offset = utf16ByUtf8Offset;
     }
-    byte[] utf8 = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-    if (byteOffset > utf8.length) {
-      return text.length();
+
+    static Utf8Coordinates forText(String text) {
+      byte[] utf8 = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      int[] utf16ByUtf8Offset = new int[utf8.length + 1];
+      Arrays.fill(utf16ByUtf8Offset, -1);
+      int utf8Offset = 0;
+      for (int utf16Offset = 0; utf16Offset < text.length(); ) {
+        char first = text.charAt(utf16Offset);
+        if (Character.isSurrogate(first)
+            && !(Character.isHighSurrogate(first)
+                && utf16Offset + 1 < text.length()
+                && Character.isLowSurrogate(text.charAt(utf16Offset + 1)))) {
+          throw new IllegalArgumentException(
+              "String contains an unpaired surrogate at UTF-16 offset " + utf16Offset);
+        }
+        utf16ByUtf8Offset[utf8Offset] = utf16Offset;
+        int codePoint = text.codePointAt(utf16Offset);
+        utf8Offset += utf8Length(codePoint);
+        utf16Offset += Character.charCount(codePoint);
+      }
+      utf16ByUtf8Offset[utf8Offset] = text.length();
+      if (utf8Offset != utf8.length) {
+        throw new IllegalStateException("UTF-8 coordinate map length mismatch");
+      }
+      return new Utf8Coordinates(utf16ByUtf8Offset);
     }
-    String prefix = new String(utf8, 0, byteOffset, java.nio.charset.StandardCharsets.UTF_8);
-    return prefix.length();
+
+    int toUtf16(int utf8Offset) {
+      if (utf8Offset < 0 || utf8Offset >= utf16ByUtf8Offset.length) {
+        throw new IndexOutOfBoundsException("UTF-8 offset: " + utf8Offset);
+      }
+      int utf16Offset = utf16ByUtf8Offset[utf8Offset];
+      if (utf16Offset < 0) {
+        throw new IllegalArgumentException(
+            "UTF-8 offset is not a Unicode scalar boundary: " + utf8Offset);
+      }
+      return utf16Offset;
+    }
+
+    private static int utf8Length(int codePoint) {
+      if (codePoint <= 0x7f) {
+        return 1;
+      }
+      if (codePoint <= 0x7ff) {
+        return 2;
+      }
+      if (codePoint <= 0xffff) {
+        return 3;
+      }
+      return 4;
+    }
   }
 
   /**

--- a/safere/src/test/java/org/safere/ExhaustiveUtilsTest.java
+++ b/safere/src/test/java/org/safere/ExhaustiveUtilsTest.java
@@ -1,0 +1,40 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ExhaustiveUtilsTest {
+  @Test
+  void utf8CoordinatesMapOnlyUnicodeScalarBoundaries() {
+    ExhaustiveUtils.Utf8Coordinates coordinates = ExhaustiveUtils.Utf8Coordinates.forText("Aé😀Z");
+
+    assertThat(coordinates.toUtf16(0)).isEqualTo(0);
+    assertThat(coordinates.toUtf16(1)).isEqualTo(1);
+    assertThat(coordinates.toUtf16(3)).isEqualTo(2);
+    assertThat(coordinates.toUtf16(7)).isEqualTo(4);
+    assertThat(coordinates.toUtf16(8)).isEqualTo(5);
+    assertThatThrownBy(() -> coordinates.toUtf16(2))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a Unicode scalar boundary");
+    assertThatThrownBy(() -> coordinates.toUtf16(5))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a Unicode scalar boundary");
+  }
+
+  @Test
+  void utf8CoordinatesRejectUnpairedSurrogates() {
+    assertThatThrownBy(() -> ExhaustiveUtils.Utf8Coordinates.forText("a\ud800b"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unpaired surrogate");
+    assertThatThrownBy(() -> ExhaustiveUtils.Utf8Coordinates.forText("a\udc00b"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unpaired surrogate");
+  }
+}

--- a/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
+++ b/safere/src/test/java/org/safere/LinebreakGraphemeTest.java
@@ -504,6 +504,8 @@ class LinebreakGraphemeTest {
     }
 
     @Test
+    @DisabledForCrosscheck(
+        "allocation scaling must measure SafeRE directly, without crosscheck shadow bookkeeping")
     @DisplayName("unanchored multi-boundary \\X search allocation does not scale with input tail")
     void unanchoredMultiBoundarySearchDoesNotAllocatePerInputPosition() {
       AllocationTracker allocationTracker = allocationTracker();

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -12,8 +12,51 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class Utf8MatcherStateMachineTest {
+  @Test
+  void stringSearchInitializationDoesNotCorruptExistingUtf8Matcher() {
+    Pattern pattern = Pattern.compile("XXXXXX");
+    Matcher stringMatcher = pattern.matcher("..XXXXXX");
+    Utf8Matcher utf8Matcher = pattern.matcher(Utf8Input.validated("..XXXXXX".getBytes(UTF_8)));
+
+    assertThat(stringMatcher.find()).isTrue();
+    assertThat(utf8Matcher.find()).isTrue();
+    assertThat(utf8Matcher.start()).isEqualTo(2);
+    assertThat(utf8Matcher.end()).isEqualTo(8);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"X", "XX", "XXX", "XXXX", "XXXXX", "XXXXXX", "XXXXXXXX", "ééé"})
+  void unanchoredLiteralSearchMatchesStringApiAcrossOffsets(String literal) {
+    for (int prefixLength = 0; prefixLength <= 8; prefixLength++) {
+      String text = ".".repeat(prefixLength) + literal + "!";
+      byte[] bytes = text.getBytes(UTF_8);
+      int expectedStart = ".".repeat(prefixLength).getBytes(UTF_8).length;
+      int expectedEnd = expectedStart + literal.getBytes(UTF_8).length;
+
+      Pattern captureFreePattern = Pattern.compile(literal);
+      Matcher captureFreeStringMatcher = captureFreePattern.matcher(text);
+      assertThat(captureFreeStringMatcher.find())
+          .as("String prefix length %s", prefixLength)
+          .isTrue();
+      assertThat(captureFreePattern.find(Utf8Input.validated(bytes)))
+          .as("capture-free UTF-8 prefix length %s", prefixLength)
+          .isTrue();
+
+      Pattern matcherPattern = Pattern.compile(literal);
+      Matcher stringMatcher = matcherPattern.matcher(text);
+      assertThat(stringMatcher.find()).as("String matcher prefix length %s", prefixLength).isTrue();
+      Utf8Matcher matcher = matcherPattern.matcher(Utf8Input.validated(bytes));
+      assertThat(matcher.find()).as("UTF-8 prefix length %s", prefixLength).isTrue();
+      assertThat(matcher.start()).isEqualTo(expectedStart);
+      assertThat(matcher.end()).isEqualTo(expectedEnd);
+      assertThat(matcher.find()).isFalse();
+    }
+  }
+
   @Test
   void repeatedFindReportsByteRelativeGroupBounds() {
     Utf8Matcher matcher = matcher("(é)|(😀)", "xé😀y");


### PR DESCRIPTION
## Summary

- add a UTF-8 crosscheck facade that compares validated byte input call by call with SafeRE String and JDK matchers
- map UTF-16 oracle positions to relative UTF-8 byte offsets at exact Unicode scalar boundaries
- crosscheck repeated search, capture bounds, matcher state, logical windows, capture-free search, and replacement output
- add a UTF-8 shadow lane to the existing String crosscheck and route generated UTF-8 public-API tests through the facade
- keep trusted malformed UTF-8 outside semantic comparison while retaining invariant and fuzz coverage
- fix bounded Boyer-Moore-Horspool budget exhaustion so literal search falls back to KMP instead of missing the final candidate

## Verification

Passed:

- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q`
- `mvn -pl safere-fuzz -am -Dtest=Utf8InputFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- focused `Utf8CrosscheckTest`, `CrosscheckTest`, generated UTF-8 state-machine, replacement, and coordinate tests
- noninteractive review against `main` with no actionable P0-P2 findings
- `git diff --check`

Not run:

- benchmarks (this is correctness and test infrastructure work; no performance claim is made)

Fixes #568
Fixes #574
