### PR TITLE
Accelerate searches using required pattern content

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1303,10 +1303,15 @@ public final class Matcher implements MatchResult {
       return applyFailedMatchResult();
     }
 
+    boolean hasAcceleratedSearchPath =
+        (parentPattern.prefix() != null)
+            || (prog.anchorEnd()
+                && scanner.length() >= MIN_REVERSE_FIRST_LEN
+                && canUseReverseDfa());
     String requiredLiteral = parentPattern.requiredLiteral();
     if (options.literalFastPaths()
         && requiredLiteral != null
-        && parentPattern.prefix() == null
+        && !hasAcceleratedSearchPath
         && (text != null || scanner instanceof Utf8InputScanner)) {
       int idx =
           scanner instanceof Utf8InputScanner utf8Scanner
@@ -1315,18 +1320,13 @@ public final class Matcher implements MatchResult {
                   parentPattern.requiredLiteralFailure(),
                   parentPattern.requiredLiteralShifts(),
                   searchFrom)
-              : text.indexOf(requiredLiteral, searchFrom);
+              : indexOfRequiredLiteral(requiredLiteral);
       if (idx < 0) {
         return applyFailedMatchResult();
       }
     }
 
     int[] requiredRanges = parentPattern.requiredMatchClassRanges();
-    boolean hasAcceleratedSearchPath =
-        (parentPattern.prefix() != null)
-            || (prog.anchorEnd()
-                && scanner.length() >= MIN_REVERSE_FIRST_LEN
-                && canUseReverseDfa());
     if (options.charClassMatchFastPaths()
         && requiredRanges != null
         && !hasAcceleratedSearchPath
@@ -1737,6 +1737,13 @@ public final class Matcher implements MatchResult {
     } else {
       return applyDeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false);
     }
+  }
+
+  private int indexOfRequiredLiteral(String requiredLiteral) {
+    if (WorkCounterConfig.ENABLED) {
+      WorkCounter.record(Math.max(0, text.length() - searchFrom));
+    }
+    return text.indexOf(requiredLiteral, searchFrom);
   }
 
   private boolean findKeywordAlternation(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1303,6 +1303,24 @@ public final class Matcher implements MatchResult {
       return applyFailedMatchResult();
     }
 
+    String requiredLiteral = parentPattern.requiredLiteral();
+    if (options.literalFastPaths()
+        && requiredLiteral != null
+        && parentPattern.prefix() == null
+        && (text != null || scanner instanceof Utf8InputScanner)) {
+      int idx =
+          scanner instanceof Utf8InputScanner utf8Scanner
+              ? utf8Scanner.indexOf(
+                  parentPattern.requiredLiteralUtf8(),
+                  parentPattern.requiredLiteralFailure(),
+                  parentPattern.requiredLiteralShifts(),
+                  searchFrom)
+              : text.indexOf(requiredLiteral, searchFrom);
+      if (idx < 0) {
+        return applyFailedMatchResult();
+      }
+    }
+
     int[] requiredRanges = parentPattern.requiredMatchClassRanges();
     boolean hasAcceleratedSearchPath =
         (parentPattern.prefix() != null)

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -148,15 +148,26 @@ public final class Pattern implements Serializable {
   private final transient long singleCharClassBitmap1;
 
   /**
-   * Precomputed character class data for a mandatory character class in a full-match pattern.
-   * Non-null when {@code matches()} can reject by scanning for an absent required code point before
-   * invoking the full engine cascade. This is intentionally a negative-only accelerator: if the
-   * class is present, normal matching still determines the result.
+   * Precomputed character class data for a mandatory character class. Non-null when matching can
+   * reject by scanning for an absent required code point before invoking the full engine cascade.
+   * This is intentionally a negative-only accelerator: if the class is present, normal matching
+   * still determines the result.
    */
   private final transient int[] requiredMatchClassRanges;
 
   private final transient long requiredMatchClassBitmap0;
   private final transient long requiredMatchClassBitmap1;
+
+  /**
+   * A case-sensitive literal substring that every match must contain. This is a negative-only
+   * accelerator: an absent literal rejects the search, while a present literal still goes through
+   * the normal engine to determine match boundaries and captures.
+   */
+  private final transient String requiredLiteral;
+
+  private final transient byte[] requiredLiteralUtf8;
+  private final transient int[] requiredLiteralFailure;
+  private final transient int[] requiredLiteralShifts;
 
   /**
    * Lazily computed OnePass analysis results. Holds the OnePass automaton (if eligible) and derived
@@ -250,6 +261,7 @@ public final class Pattern implements Serializable {
       int[] requiredMatchClassRanges,
       long requiredMatchClassBitmap0,
       long requiredMatchClassBitmap1,
+      String requiredLiteral,
       EnginePathOptions enginePathOptions) {
     this.pattern = pattern;
     this.flags = flags;
@@ -312,6 +324,15 @@ public final class Pattern implements Serializable {
     this.requiredMatchClassRanges = requiredMatchClassRanges;
     this.requiredMatchClassBitmap0 = requiredMatchClassBitmap0;
     this.requiredMatchClassBitmap1 = requiredMatchClassBitmap1;
+    this.requiredLiteral = requiredLiteral;
+    this.requiredLiteralUtf8 =
+        requiredLiteral == null
+            ? null
+            : requiredLiteral.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    this.requiredLiteralFailure =
+        requiredLiteralUtf8 == null ? null : literalFailure(requiredLiteralUtf8);
+    this.requiredLiteralShifts =
+        requiredLiteralUtf8 == null ? null : literalShifts(requiredLiteralUtf8);
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
     onePassAnalysis();
@@ -384,7 +405,9 @@ public final class Pattern implements Serializable {
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
-    CharClassScanInfo requiredMatchClass = extractRequiredMatchClass(metadataAst);
+    CharClassScanInfo requiredMatchClass =
+        extractRequiredMatchClass(metadataAst, prefix == null && ccPrefixAscii == null);
+    String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -414,6 +437,7 @@ public final class Pattern implements Serializable {
         requiredMatchClass != null ? requiredMatchClass.ranges : null,
         requiredMatchClass != null ? requiredMatchClass.bitmap0 : 0,
         requiredMatchClass != null ? requiredMatchClass.bitmap1 : 0,
+        requiredLiteral,
         enginePathOptions);
   }
 
@@ -504,6 +528,13 @@ public final class Pattern implements Serializable {
     int length = scanner.length();
     if (literalMatchUtf8 != null && !prefixFoldCase) {
       return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
+    }
+    if (enginePathOptions.literalFastPaths()
+        && requiredLiteralUtf8 != null
+        && prefixUtf8 == null
+        && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
+            < 0) {
+      return false;
     }
     if (enginePathOptions.charClassMatchFastPaths()
         && requiredMatchClassRanges != null
@@ -1048,10 +1079,7 @@ public final class Pattern implements Serializable {
     return singleCharClassBitmap1;
   }
 
-  /**
-   * Returns precomputed ranges for a required character class in {@code matches()}, or {@code
-   * null}.
-   */
+  /** Returns precomputed ranges for a required character class, or {@code null}. */
   int[] requiredMatchClassRanges() {
     return requiredMatchClassRanges;
   }
@@ -1064,6 +1092,22 @@ public final class Pattern implements Serializable {
   /** ASCII bitmap (code points 64–127) for the required-character-class fast path. */
   long requiredMatchClassBitmap1() {
     return requiredMatchClassBitmap1;
+  }
+
+  String requiredLiteral() {
+    return requiredLiteral;
+  }
+
+  byte[] requiredLiteralUtf8() {
+    return requiredLiteralUtf8;
+  }
+
+  int[] requiredLiteralFailure() {
+    return requiredLiteralFailure;
+  }
+
+  int[] requiredLiteralShifts() {
+    return requiredLiteralShifts;
   }
 
   /**
@@ -2178,35 +2222,37 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Detects a mandatory character class in a full-match pattern, such as {@code .*\\s+.*}. The
-   * resulting class is only used to reject inputs that contain no matching code point; positive
-   * results still go through the normal engine to preserve full regex semantics.
+   * Detects a mandatory character class, such as the whitespace in {@code .*\\s+.*}. The resulting
+   * class is only used to reject inputs that contain no matching code point; positive results still
+   * go through the normal engine to preserve full regex semantics.
+   *
+   * <p>Alternation is inspected only when no start-character accelerator was found. For a leading
+   * alternation, its union is already represented more precisely by that accelerator; constructing
+   * the same union again would add compile-time work without improving searches.
    */
-  private static CharClassScanInfo extractRequiredMatchClass(Regexp re) {
-    if (hasUserCaptures(re)) {
+  private static CharClassScanInfo extractRequiredMatchClass(
+      Regexp re, boolean inspectAlternation) {
+    Regexp node = unwrapRequiredNode(re);
+    if (node == null) {
       return null;
     }
-    Regexp node = re;
-    if (node.op == RegexpOp.CAPTURE && node.cap == 0) {
-      node = node.sub();
-    }
     if (node.op != RegexpOp.CONCAT || node.subs == null) {
-      CharClass cc = requiredCharClass(node);
-      return cc != null ? buildCharClassScanInfo(cc) : null;
+      CharClass required = requiredCharClass(node, inspectAlternation);
+      return required != null ? buildCharClassScanInfo(required) : null;
     }
     for (Regexp sub : node.subs) {
-      CharClass cc = requiredCharClass(sub);
-      if (cc != null) {
-        return buildCharClassScanInfo(cc);
+      CharClass required = requiredCharClass(sub, inspectAlternation);
+      if (required != null) {
+        return buildCharClassScanInfo(required);
       }
     }
     return null;
   }
 
-  private static CharClass requiredCharClass(Regexp re) {
-    Regexp node = re;
-    if (node.op == RegexpOp.NON_CAPTURE) {
-      node = node.sub();
+  private static CharClass requiredCharClass(Regexp re, boolean inspectAlternation) {
+    Regexp node = unwrapRequiredNode(re);
+    if (node == null) {
+      return null;
     }
     if (node.op == RegexpOp.LITERAL) {
       return literalCharClass(node.rune, node.flags);
@@ -2217,13 +2263,101 @@ public final class Pattern implements Serializable {
     if (node.op == RegexpOp.CHAR_CLASS && node.charClass != null) {
       return node.charClass.isEmpty() ? null : node.charClass;
     }
-    if ((node.op == RegexpOp.PLUS || (node.op == RegexpOp.REPEAT && node.min > 0))
-        && node.sub().op == RegexpOp.CHAR_CLASS
-        && node.sub().charClass != null
-        && !node.sub().charClass.isEmpty()) {
-      return node.sub().charClass;
+    if (inspectAlternation
+        && node.op == RegexpOp.ALTERNATE
+        && node.subs != null
+        && !node.subs.isEmpty()) {
+      CharClassBuilder union = new CharClassBuilder();
+      for (Regexp branch : node.subs) {
+        CharClass branchClass = requiredAtomicCharClass(branch);
+        if (branchClass == null) {
+          return null;
+        }
+        union.addCharClass(branchClass);
+      }
+      CharClass result = union.build();
+      return result.isEmpty() ? null : result;
     }
     return null;
+  }
+
+  private static CharClass requiredAtomicCharClass(Regexp re) {
+    Regexp node = unwrapRequiredNode(re);
+    if (node == null) {
+      return null;
+    }
+    if (node.op == RegexpOp.LITERAL) {
+      return literalCharClass(node.rune, node.flags);
+    }
+    if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
+      return literalCharClass(node.runes[0], node.flags);
+    }
+    if (node.op == RegexpOp.CHAR_CLASS && node.charClass != null && !node.charClass.isEmpty()) {
+      return node.charClass;
+    }
+    return null;
+  }
+
+  private static Regexp unwrapRequiredNode(Regexp re) {
+    Regexp node = re;
+    while (true) {
+      if (node.op == RegexpOp.CAPTURE
+          || node.op == RegexpOp.NON_CAPTURE
+          || node.op == RegexpOp.PLUS) {
+        node = node.sub();
+        continue;
+      }
+      if (node.op == RegexpOp.REPEAT) {
+        if (node.min == 0) {
+          return null;
+        }
+        node = node.sub();
+        continue;
+      }
+      return node;
+    }
+  }
+
+  /**
+   * Finds the longest case-sensitive literal substring that every match must contain.
+   *
+   * <p>The worklist descends only through operators whose children are mandatory: concatenation,
+   * transparent groups, and repetitions with a positive minimum. It deliberately stops at
+   * alternation and optional repetition, so the result can only reject inputs that cannot match.
+   */
+  private static String extractRequiredLiteral(Regexp re) {
+    String longest = null;
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.addLast(re);
+    while (!pending.isEmpty()) {
+      Regexp node = pending.removeLast();
+      switch (node.op) {
+        case CAPTURE, NON_CAPTURE, PLUS -> pending.addLast(node.sub());
+        case REPEAT -> {
+          if (node.min > 0) {
+            pending.addLast(node.sub());
+          }
+        }
+        case CONCAT -> {
+          if (node.subs != null) {
+            for (Regexp sub : node.subs) {
+              pending.addLast(sub);
+            }
+          }
+        }
+        case LITERAL_STRING -> {
+          if ((node.flags & ParseFlags.FOLD_CASE) == 0
+              && node.runes != null
+              && node.runes.length >= 2
+              && (longest == null
+                  || node.runes.length > longest.codePointCount(0, longest.length()))) {
+            longest = new String(node.runes, 0, node.runes.length);
+          }
+        }
+        default -> {}
+      }
+    }
+    return longest;
   }
 
   private static CharClass literalCharClass(int cp, int flags) {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for package-private {@link Pattern} metadata. */
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
@@ -171,6 +172,58 @@ class PatternInternalTest {
     assertThat(p.requiredMatchClassRanges()).isNotNull();
   }
 
+  @ParameterizedTest
+  @CsvSource({
+    "'.*(x|y).*',             xy, az",
+    "'.*(?:m|n).*',           mn, xz",
+    "'.*([0-2]|[7-9]).*',     08, 56",
+    "'.*((?:α|β))+.*',        αβ, γδ",
+    "'.*(?:ab|cd).*',         ac, bd"
+  })
+  void mandatoryAlternativesRecordTheirRequiredCharacterUnion(
+      String regex, String members, String nonMembers) {
+    Pattern p = Pattern.compile(regex);
+
+    assertThat(p.requiredMatchClassRanges()).isNotNull();
+    members
+        .codePoints()
+        .forEach(codePoint -> assertThat(requiredClassContains(p, codePoint)).isTrue());
+    nonMembers
+        .codePoints()
+        .forEach(codePoint -> assertThat(requiredClassContains(p, codePoint)).isFalse());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {".*(x|).*", ".*(?:x|y)?.*", ".*(?:x|y){0,3}.*", ".*(?:x|y|.*).*"})
+  void nullableAlternativesDoNotRecordRequiredCharacterClasses(String regex) {
+    assertThat(Pattern.compile(regex).requiredMatchClassRanges()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'.*coolfunctionname.*',       coolfunctionname",
+    "'.*(needle).*',               needle",
+    "'(?:ab)+.*',                  ab",
+    "'.*short.*much-longer.*',     much-longer",
+    "'.*前置.*かなり長い必要語.*', かなり長い必要語"
+  })
+  void mandatoryCaseSensitiveLiteralsAreRecorded(String regex, String expected) {
+    assertThat(Pattern.compile(regex).requiredLiteral()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        ".*(?:needle)?.*",
+        "(?i).*needle.*",
+        ".*(?:needle|thread).*",
+        ".*(?:needle){0,2}.*",
+        "needle.*"
+      })
+  void optionalCaseInsensitiveAndAlreadyPrefixedLiteralsAreNotRecorded(String regex) {
+    assertThat(Pattern.compile(regex).requiredLiteral()).isNull();
+  }
+
   @Test
   void boundaryPrefixedLiteralRecordsRequiredClass() {
     Pattern p = Pattern.compile("\\b{g}z");
@@ -183,6 +236,14 @@ class PatternInternalTest {
     Pattern p = Pattern.compile(".*");
 
     assertThat(p.requiredMatchClassRanges()).isNull();
+  }
+
+  private static boolean requiredClassContains(Pattern pattern, int codePoint) {
+    return InputScanner.classContains(
+        pattern.requiredMatchClassRanges(),
+        pattern.requiredMatchClassBitmap0(),
+        pattern.requiredMatchClassBitmap1(),
+        codePoint);
   }
 
   @ParameterizedTest(name = "compile(\"{0}\").numGroups() == {1}")

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -7,8 +7,10 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.IntPredicate;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -17,39 +19,46 @@ import org.junit.jupiter.api.Test;
 class SearchScalingRegressionTest {
 
   @Test
-  void testReverseDfaSuffixScanScalingFailsInConstantTime() {
+  void reverseDfaSuffixFailureIsConstantWorkForStringInput() {
     Pattern pattern = Pattern.compile("[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$");
+    assertReverseDfaSuffixFailureIsConstantWork(size -> pattern.matcher("a".repeat(size)).find());
+  }
 
-    // Generate failing text (all lowercase) of two different sizes
-    String text2000 = "a".repeat(2000);
-    String text10000 = "a".repeat(10000);
+  @Test
+  void reverseDfaSuffixFailureIsConstantWorkForUtf8Input() {
+    Pattern pattern = Pattern.compile("[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$");
+    assertReverseDfaSuffixFailureIsConstantWork(
+        size -> pattern.matcher(Utf8Input.trusted("a".repeat(size).getBytes(UTF_8))).find());
+  }
 
-    // Measure work done using WorkCounter
+  private static void assertReverseDfaSuffixFailureIsConstantWork(IntPredicate find) {
     long work2000 =
         WorkCounter.countForTesting(
             () -> {
-              boolean matched = pattern.matcher(text2000).find();
+              boolean matched = find.test(2_000);
               assertThat(matched).isFalse();
             });
 
     long work10000 =
         WorkCounter.countForTesting(
             () -> {
-              boolean matched = pattern.matcher(text10000).find();
+              boolean matched = find.test(10_000);
               assertThat(matched).isFalse();
             });
 
-    // If the containsRequiredMatchClass pre-filter loop runs, it would scan the entire string,
-    // resulting in at least 2,000 and 10,000 operations respectively.
+    // If a required-content prefilter runs first, it scans the entire input, resulting in at least
+    // 2,000 and 10,000 operations respectively.
     //
     // Under reverse DFA suffix acceleration, it rejects after inspecting only a few characters
     // from the end of the text, executing in constant time independent of text size.
     assertThat(work2000)
         .as("Short text failing scan should run in constant-time reverse DFA setup")
+        .isPositive()
         .isLessThan(200);
 
     assertThat(work10000)
         .as("Long text failing scan should also run in constant-time reverse DFA setup")
+        .isPositive()
         .isLessThan(200);
 
     // Assert that scaling is sub-linear (effectively constant)

--- a/safere/src/test/java/org/safere/Utf8ReplacementTest.java
+++ b/safere/src/test/java/org/safere/Utf8ReplacementTest.java
@@ -193,6 +193,28 @@ class Utf8ReplacementTest {
   }
 
   @Test
+  void requiredCapturedClassPrefilterPreservesReplacementResults() {
+    assertThat(replace(".*(x|y).*", "aaaaaaaa", "X")).isEqualTo("aaaaaaaa");
+    assertThat(replace(".*(x|y).*", "aaaayaaa", "[$1]")).isEqualTo("[y]");
+    assertThat(replace(".*(cat|dog).*", "birds only", "X")).isEqualTo("birds only");
+    assertThat(replace(".*(cat|dog).*", "a dog appears", "[$1]")).isEqualTo("[dog]");
+    assertThat(replace(".*(α|β).*", "γδ", "X")).isEqualTo("γδ");
+    assertThat(replace(".*(α|β).*", "γβδ", "[$1]")).isEqualTo("[β]");
+  }
+
+  @Test
+  void requiredLiteralPrefilterPreservesReplacementResults() {
+    assertThat(replace(".*coolfunctionname.*", "cool-function-name", "X"))
+        .isEqualTo("cool-function-name");
+    assertThat(replace(".*coolfunctionname.*", "before coolfunctionname after", "X"))
+        .isEqualTo("X");
+    assertThat(replace(".*mandatory-token.*", "mandatory token", "X")).isEqualTo("mandatory token");
+    assertThat(replace(".*mandatory-token.*", "before mandatory-token after", "X")).isEqualTo("X");
+    assertThat(replace(".*必要語.*", "これは不要です", "X")).isEqualTo("これは不要です");
+    assertThat(replace(".*必要語.*", "これは必要語です", "X")).isEqualTo("X");
+  }
+
+  @Test
   @DisplayName("array and buffer sink dispatch preserve chunk boundaries and caller position")
   void sinkDispatchPreservesChunksAndBufferPosition() {
     CollectingSink sink = new CollectingSink();


### PR DESCRIPTION
## Summary

This change accelerates searches and replacements when a pattern contains content that every
successful match must contain:

- derive a conservative required character set through captures, mandatory repetition, and
  alternation;
- derive the longest case-sensitive literal contained by every match through mandatory AST
  constructs;
- precompute the UTF-8 literal-search tables at pattern compilation time; and
- use both facts only as negative prefilters. A missing character or literal can reject the
  search, while a positive result still goes through the normal matching engine for boundaries,
  captures, and replacement semantics.

The analysis is pattern-independent and stops at optional or otherwise non-mandatory constructs.
Alternation-derived character sets are omitted when an existing prefix accelerator already
represents that information. The optimization therefore preserves SafeRE semantics and the
linear-time guarantee without introducing Trino- or benchmark-specific cases.

Fixes #573.

## Performance

These are Trino's `BenchmarkRegexpFunctions` replacement benchmarks. Times are nanoseconds per
operation; lower is better. `.*x.*` is the existing control workload. The other two pattern
families are the regressions investigated in #573.

| Pattern | Input bytes | SafeRE on `399b7a7` | SafeRE on this PR | SafeRE speedup | vs. Joni | vs. RE2/J |
|---|---:|---:|---:|---:|---:|---:|
| `.*x.*` | 1,024 | 498 | 493 | 1.01x (flat) | 1.47x faster | 6.06x faster |
| `.*x.*` | 32,768 | 15,016 | 15,064 | 1.00x (flat) | 1.44x faster | 6.23x faster |
| `.*(x\|y).*` | 1,024 | 1,353 | 498 | 2.72x faster | 1.69x faster | 5.89x faster |
| `.*(x\|y).*` | 32,768 | 42,240 | 14,909 | 2.83x faster | 1.70x faster | 6.30x faster |
| `.*coolfunctionname.*` | 1,024 | 1,369 | 265 | 5.17x faster | 1.29x faster | 11.25x faster |
| `.*coolfunctionname.*` | 32,768 | 41,945 | 7,622 | 5.50x faster | 1.44x faster | 12.32x faster |

Across the four optimized cases, the geometric mean of the per-case speed ratios is:

- 3.85x faster than SafeRE on `399b7a7`;
- 1.52x faster than Joni; and
- 8.47x faster than Trino's RE2/J fork.

Benchmark provenance:

- SafeRE baseline: `399b7a7d96f5582ace990dd41629a244dbdc3f6f`
- SafeRE optimized: `195a25f22907c0b5d55ad4b00bfbb8d800c0d4df`
- Trino validation branch: `94a6dfabb4192a7763d25765c7924228b7fc8f73`
- Configuration: 2 forks, 3 one-second warmups, and 5 one-second measurements

The focused `CompileBenchmark` comparison at `e9120b9` showed no statistically clear compilation
regression; the point estimates were between 0.8% and 3.1% slower and their confidence intervals
overlapped the baseline results. The CI follow-up changes matcher dispatch and work accounting, not
pattern compilation.

## Trino validation

The complete Trino `BenchmarkRegexpFunctions` matrix was run with the benchmarked SafeRE revision.
This is Trino's only regex benchmark class, and the matrix covers five pattern families, two input
sizes, matching and replacement, and all three engines. The cases were run sequentially with 2
forks, 3 one-second warmups, and 5 one-second measurements. Lower values are better.

| Workload group | SafeRE compared with RE2/J | SafeRE compared with Joni |
|---|---:|---:|
| Matching | **2.46x faster** | **2.92x faster** |
| Replacement | **4.04x faster** | **1.60x faster** |
| Across all benchmark cases | **3.15x faster** | **2.16x faster** |

Each comparison is the geometric mean of the per-benchmark speed ratios, giving every pattern and
input-size combination equal weight.

Full results, in nanoseconds per operation:

| Operation | Pattern | Bytes | SafeRE | RE2/J | Joni |
|---|---|---:|---:|---:|---:|
| Match | `.*x.*` | 1,024 | **46.9** | 317.4 | 570.5 |
| Match | `.*(x\|y).*` | 1,024 | **114.5** | 318.6 | 696.3 |
| Match | `longdotstar` | 1,024 | **244.5** | 439.4 | 256.3 |
| Match | `phone` | 1,024 | **477.3** | 1,084.2 | 1,363.3 |
| Match | `literal` | 1,024 | 451.9 | **437.3** | 463.5 |
| Match | `.*x.*` | 32,768 | **1,269** | 9,281 | 17,600 |
| Match | `.*(x\|y).*` | 32,768 | **3,535** | 9,812 | 21,198 |
| Match | `longdotstar` | 32,768 | 7,676 | 20,605 | **7,002** |
| Match | `phone` | 32,768 | **478.8** | 937.6 | 1,357.2 |
| Match | `literal` | 32,768 | 15,219 | 15,285 | **13,937** |
| Replace | `.*x.*` | 1,024 | **493.5** | 2,991 | 727.6 |
| Replace | `.*(x\|y).*` | 1,024 | **498.2** | 2,936 | 842.7 |
| Replace | `longdotstar` | 1,024 | **264.9** | 2,980 | 341.7 |
| Replace | `phone` | 1,024 | **1,638** | 2,993 | 4,465 |
| Replace | `literal` | 1,024 | 489.3 | **463.6** | 564.2 |
| Replace | `.*x.*` | 32,768 | **15,064** | 93,866 | 21,754 |
| Replace | `.*(x\|y).*` | 32,768 | **14,909** | 93,884 | 25,409 |
| Replace | `longdotstar` | 32,768 | **7,622** | 93,902 | 10,972 |
| Replace | `phone` | 32,768 | **57,544** | 133,967 | 146,453 |
| Replace | `literal` | 32,768 | **15,126** | 22,209 | 18,138 |

Benchmark provenance:

- SafeRE: `195a25f22907c0b5d55ad4b00bfbb8d800c0d4df`
- Trino: `94a6dfabb4192a7763d25765c7924228b7fc8f73`
- Runtime: OpenJDK 25.0.2

## Testing

- `mvn clean test -pl safere -q`
- `mvn clean test -pl safere -Pwork-counters -Dtest.parallelism=4 --batch-mode --no-transfer-progress`
- `mvn -pl safere install -DskipTests -q`
- `./mvnw -pl core/trino-main -Dtest=TestSafeReRegexpFunctions,TestRe2jRegexpFunctions,TestFeaturesConfig,TestTypeCoercion,TestConnectorExpressionTranslator test -q`
- independent review/fix loop against `main` (no P0-P2 findings)

The complete Trino test suite and the broad SafeRE benchmark matrix were not run. The focused
Trino tests above cover the regex functions plus adjacent configuration, type-coercion, and planner
paths.
