### PR TITLE
Accelerate long-input literal search with a SWAR candidate filter

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -51,6 +51,16 @@
   },
 
   "utf8Matching": {
+    "literalScan": {
+      "seed": 20260721,
+      "textSize": 32768,
+      "alphabet": "abcdefghijklmnopqrstuvwxyz",
+      "patterns": {
+        "fourByte": "qjxv",
+        "shortWord": "literal",
+        "longWord": "coolfunctionname"
+      }
+    },
     "captureFreeFind": {
       "asciiEarly": { "pattern": "ERROR", "text": "ERROR request completed" },
       "asciiLate": { "pattern": "ERROR", "text": "request completed with ERROR" },

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/Utf8MatchingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/Utf8MatchingBenchmark.java
@@ -111,6 +111,44 @@ public class Utf8MatchingBenchmark extends ByteMatchingBenchmark {
     return state.pattern.matcher(state.text).find();
   }
 
+  /** Measures a full literal scan over a large input where the literal is absent. */
+  @Benchmark
+  public boolean literalScan(LiteralScanState state) {
+    return state.pattern.find(state.input);
+  }
+
+  @State(Scope.Thread)
+  public static class LiteralScanState {
+    @Param({"fourByte", "shortWord", "longWord"})
+    public String name;
+
+    private org.safere.Pattern pattern;
+    private org.safere.Utf8Input input;
+
+    /**
+     * Builds a frozen pseudo-random single-byte-alphabet input that does not contain the literal,
+     * so every invocation scans the whole input.
+     */
+    @Setup
+    public void setup() {
+      BenchmarkData data = BenchmarkData.get();
+      String prefix = "utf8Matching.literalScan.";
+      String alphabet = data.getString(prefix + "alphabet");
+      int size = data.getInt(prefix + "textSize");
+      java.util.Random random = new java.util.Random(data.getInt(prefix + "seed"));
+      StringBuilder text = new StringBuilder(size);
+      for (int index = 0; index < size; index++) {
+        text.append(alphabet.charAt(random.nextInt(alphabet.length())));
+      }
+      String literal = data.getString(prefix + "patterns." + name);
+      if (text.indexOf(literal) >= 0) {
+        throw new IllegalStateException("literal " + literal + " must be absent from the input");
+      }
+      pattern = org.safere.Pattern.compile(literal);
+      input = org.safere.Utf8Input.trusted(text.toString().getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
   @State(Scope.Thread)
   public static class CaptureFreeState {
     @Param({

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -15,6 +15,16 @@ final class Utf8InputScanner implements InputScanner {
   private static final int REPLACEMENT_CHARACTER = 0xFFFD;
   private static final long BYTE_ONES = 0x0101_0101_0101_0101L;
   private static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
+
+  /**
+   * Input sizes at which the SWAR candidate filter overtakes the skip loop. The filter always
+   * advances eight positions per step, while the skip loop can advance as far as the literal
+   * length, so the filter needs an input large enough to outweigh that per-step advantage. Both
+   * bounds were measured; see {@link #indexOfFiltered}.
+   */
+  private static final int MIN_FILTER_LENGTH = 64;
+
+  private static final int FILTER_LENGTH_FACTOR = 40;
   private static final VarHandle LONG_VIEW = byteArrayViewVarHandle(long[].class, nativeOrder());
 
   private final byte[] bytes;
@@ -132,15 +142,37 @@ final class Utf8InputScanner implements InputScanner {
     if (literal.length == 0) {
       return start;
     }
-    if (literal.length == 1 && !WorkCounterConfig.ENABLED) {
-      return indexOfByte(literal[0], start);
-    }
-    if (!WorkCounterConfig.ENABLED && shifts != null) {
-      int result = boundedBoyerMooreHorspool(literal, shifts, start);
-      if (result >= -1) {
-        return result;
+    if (!WorkCounterConfig.ENABLED) {
+      if (literal.length == 1) {
+        return indexOfByte(literal[0], start);
+      }
+      if (shifts != null) {
+        // Both searches beat the linear scan, but they win over different ranges. The skip loop
+        // reaches the end of a short input in a handful of steps, while the candidate filter has
+        // to pay for its wider setup and finish with a scalar tail. Once the input is long enough
+        // for the filter's eight-positions-per-step throughput to dominate that fixed cost, it
+        // wins by a growing margin. The crossover scales with the literal length, since a longer
+        // literal lets the skip loop advance further per step.
+        int result =
+            remaining(start) >= Math.max(MIN_FILTER_LENGTH, literal.length * FILTER_LENGTH_FACTOR)
+                ? indexOfFiltered(literal, failure, start)
+                : boundedBoyerMooreHorspool(literal, shifts, start);
+        // A match index or a trusted -1; only the -2 "work budget exhausted" sentinel falls
+        // through to the linear-time scan below.
+        if (result >= -1) {
+          return result;
+        }
       }
     }
+    return indexOfLinear(literal, failure, start);
+  }
+
+  private int remaining(int start) {
+    return length - start;
+  }
+
+  /** Knuth-Morris-Pratt scan, linear in the input length regardless of the literal. */
+  private int indexOfLinear(byte[] literal, int[] failure, int start) {
     int matched = 0;
     for (int position = start; position < length; position++) {
       if (WorkCounterConfig.ENABLED) {
@@ -186,11 +218,18 @@ final class Utf8InputScanner implements InputScanner {
     return indexOfBytePair((byte) first, (byte) second, start);
   }
 
+  /**
+   * Boyer-Moore-Horspool with a bad-character skip table, used for inputs too short to amortize the
+   * candidate filter's setup.
+   *
+   * @return the index of the first match, {@code -1} if the literal is absent, or {@code -2} if the
+   *     work budget was exhausted before either could be established
+   */
   private int boundedBoyerMooreHorspool(byte[] literal, int[] shifts, int start) {
     int last = literal.length - 1;
     int position = start + last;
     int work = 0;
-    int workLimit = Math.max(1, (length - start) * 2);
+    int workLimit = Math.max(1, remaining(start) * 2);
     while (position < length) {
       int literalPosition = last;
       int inputPosition = position;
@@ -212,6 +251,81 @@ final class Utf8InputScanner implements InputScanner {
       work++;
     }
     return -1;
+  }
+
+  /**
+   * Searches for a multi-byte {@code literal} by locating candidate positions with a SWAR filter on
+   * the literal's first and last bytes, then verifying each candidate in full.
+   *
+   * <p>Two words are loaded per step, one aligned with the literal's first byte and one with its
+   * last byte. XOR-ing each against the corresponding broadcast byte turns matching positions into
+   * zero bytes, so the standard zero-byte test identifies positions where both the first and last
+   * byte agree. Requiring both bytes makes candidates far rarer than a single-byte filter would.
+   *
+   * <p>This examines eight positions per step with no data-dependent branching. A skip loop such as
+   * Boyer-Moore-Horspool can advance further per step, but each of its steps is a serialized load,
+   * table lookup, and add, which costs more than the wider branch-free step here.
+   *
+   * <p>The zero-byte test never misses a matching position, but it can flag a position that does
+   * not match, so every candidate is verified against the whole literal rather than trusting the
+   * filter for the first and last byte.
+   *
+   * <p>Verification is O(literal length) per candidate, so an adversarial input can drive this to
+   * O(input length * literal length). A work budget bounds that: on exhaustion this returns {@code
+   * -2} and the caller falls back to linear-time KMP.
+   *
+   * @return the index of the first match, {@code -1} if the literal is absent, or {@code -2} if the
+   *     work budget was exhausted before either could be established
+   */
+  private int indexOfFiltered(byte[] literal, int[] failure, int start) {
+    int last = literal.length - 1;
+    long repeatedFirst = (literal[0] & 0xFFL) * BYTE_ONES;
+    long repeatedLast = (literal[last] & 0xFFL) * BYTE_ONES;
+    int wordEnd = length - last - Long.BYTES;
+    int work = 0;
+    int workLimit = Math.max(1, (length - start) * 2);
+    int position = start;
+    while (position <= wordEnd) {
+      long firstDifference = (long) LONG_VIEW.get(bytes, offset + position) ^ repeatedFirst;
+      long lastDifference = (long) LONG_VIEW.get(bytes, offset + position + last) ^ repeatedLast;
+      long candidates =
+          (firstDifference - BYTE_ONES)
+              & ~firstDifference
+              & (lastDifference - BYTE_ONES)
+              & ~lastDifference
+              & BYTE_HIGH_BITS;
+      if (candidates != 0) {
+        // Scanning the eight positions in address order keeps this independent of byte order and
+        // returns the leftmost match within the word.
+        for (int index = 0; index < Long.BYTES; index++) {
+          int candidate = position + index;
+          if (bytes[offset + candidate] == literal[0]) {
+            if (matchesAt(literal, candidate)) {
+              return candidate;
+            }
+            work += literal.length;
+          }
+        }
+        work += Long.BYTES;
+      }
+      position += Long.BYTES;
+      work++;
+      if (work >= workLimit) {
+        return -2;
+      }
+    }
+    // Fewer than literal.length + Long.BYTES positions remain. Finishing with the linear scan
+    // keeps the tail linear rather than comparing the whole literal at each remaining position.
+    return indexOfLinear(literal, failure, position);
+  }
+
+  private boolean matchesAt(byte[] literal, int position) {
+    for (int index = 0; index < literal.length; index++) {
+      if (bytes[offset + position + index] != literal[index]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private int indexOfByte(byte target, int start) {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -154,7 +154,7 @@ final class Utf8InputScanner implements InputScanner {
         // wins by a growing margin. The crossover scales with the literal length, since a longer
         // literal lets the skip loop advance further per step.
         int result =
-            remaining(start) >= Math.max(MIN_FILTER_LENGTH, literal.length * FILTER_LENGTH_FACTOR)
+            remaining(start) >= filterThreshold(literal.length)
                 ? indexOfFiltered(literal, failure, start)
                 : boundedBoyerMooreHorspool(literal, shifts, start);
         // A match index or a trusted -1; only the -2 "work budget exhausted" sentinel falls
@@ -169,6 +169,18 @@ final class Utf8InputScanner implements InputScanner {
 
   private int remaining(int start) {
     return length - start;
+  }
+
+  static long filterThreshold(int literalLength) {
+    return Math.max(MIN_FILTER_LENGTH, (long) literalLength * FILTER_LENGTH_FACTOR);
+  }
+
+  static long workLimit(int remaining) {
+    return Math.max(1L, (long) remaining * 2);
+  }
+
+  static long addCandidateWork(long work, int candidateCount, int literalLength) {
+    return work + (long) candidateCount * literalLength + Long.BYTES;
   }
 
   /** Knuth-Morris-Pratt scan, linear in the input length regardless of the literal. */
@@ -228,8 +240,8 @@ final class Utf8InputScanner implements InputScanner {
   private int boundedBoyerMooreHorspool(byte[] literal, int[] shifts, int start) {
     int last = literal.length - 1;
     int position = start + last;
-    int work = 0;
-    int workLimit = Math.max(1, remaining(start) * 2);
+    long work = 0;
+    long workLimit = workLimit(remaining(start));
     while (position < length) {
       int literalPosition = last;
       int inputPosition = position;
@@ -282,8 +294,8 @@ final class Utf8InputScanner implements InputScanner {
     long repeatedFirst = (literal[0] & 0xFFL) * BYTE_ONES;
     long repeatedLast = (literal[last] & 0xFFL) * BYTE_ONES;
     int wordEnd = length - last - Long.BYTES;
-    int work = 0;
-    int workLimit = Math.max(1, (length - start) * 2);
+    long work = 0;
+    long workLimit = workLimit(remaining(start));
     int position = start;
     while (position <= wordEnd) {
       long firstDifference = (long) LONG_VIEW.get(bytes, offset + position) ^ repeatedFirst;
@@ -297,16 +309,17 @@ final class Utf8InputScanner implements InputScanner {
       if (candidates != 0) {
         // Scanning the eight positions in address order keeps this independent of byte order and
         // returns the leftmost match within the word.
+        int candidateCount = 0;
         for (int index = 0; index < Long.BYTES; index++) {
           int candidate = position + index;
           if (bytes[offset + candidate] == literal[0]) {
             if (matchesAt(literal, candidate)) {
               return candidate;
             }
-            work += literal.length;
+            candidateCount++;
           }
         }
-        work += Long.BYTES;
+        work = addCandidateWork(work, candidateCount, literal.length);
       }
       position += Long.BYTES;
       work++;

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -149,6 +149,125 @@ class Utf8InputScannerTest {
     }
   }
 
+  /**
+   * Smallest input that selects the SWAR candidate filter over the skip loop, mirroring {@code
+   * Utf8InputScanner.MIN_FILTER_LENGTH} and {@code FILTER_LENGTH_FACTOR}. Tests run each scenario
+   * both below and above this bound so that both search paths are covered.
+   */
+  private static int filterThreshold(int literalLength) {
+    return Math.max(64, literalLength * 40);
+  }
+
+  @Test
+  void multiByteLiteralSearchCoversEveryWindowAlignmentAndPosition() {
+    // The candidate filter reads eight positions at a time and hands the remainder to a linear
+    // tail, so every combination of window alignment and match position must agree.
+    for (String literal : List.of("zy", "zqy", "zabcdefy", "zabcdefghijy")) {
+      byte[] needle = literal.getBytes(UTF_8);
+      for (int window : new int[] {40, filterThreshold(needle.length) + 40}) {
+        for (int offset = 0; offset < Long.BYTES * 2; offset++) {
+          for (int expected = 0; expected <= window - needle.length; expected++) {
+            byte[] storage = new byte[offset + window + Long.BYTES];
+            Arrays.fill(storage, (byte) 'a');
+            System.arraycopy(needle, 0, storage, offset + expected, needle.length);
+            Utf8InputScanner scanner = new Utf8InputScanner(storage, offset, window);
+
+            assertThat(scanner.indexOf(needle, literalFailure(needle), literalShifts(needle)))
+                .as(
+                    "literal %s, window %s, offset %s, position %s",
+                    literal, window, offset, expected)
+                .isEqualTo(expected);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void multiByteLiteralSearchFindsMatchesFromEveryStartPosition() {
+    byte[] needle = "cab".getBytes(UTF_8);
+    int[] failure = literalFailure(needle);
+    int[] shifts = literalShifts(needle);
+    // Long enough that early start positions select the filter and late ones fall back to the
+    // skip loop as the remaining input shrinks past the threshold.
+    for (int repeats : new int[] {11, filterThreshold(needle.length)}) {
+      byte[] haystack = "abc".repeat(repeats).getBytes(UTF_8);
+      String text = new String(haystack, UTF_8);
+      Utf8InputScanner scanner = new Utf8InputScanner(haystack);
+
+      for (int start = 0; start <= haystack.length; start++) {
+        assertThat(scanner.indexOf(needle, failure, shifts, start))
+            .as("repeats %s, start %s", repeats, start)
+            .isEqualTo(text.indexOf("cab", start));
+      }
+    }
+  }
+
+  @Test
+  void multiByteLiteralSearchAgreesWithStringIndexOfOnDenseCandidateInput() {
+    // A tiny alphabet makes nearly every position pass the first/last byte filter, which is the
+    // input shape that exhausts the work budget and falls back to the linear-time scan. Texts run
+    // well past the filter threshold so the budget is actually reachable.
+    Random random = new Random(0x5AFE_5EAL);
+    for (int trial = 0; trial < 20_000; trial++) {
+      int alphabet = 1 + random.nextInt(3);
+      String text = randomFromAlphabet(random, random.nextInt(1200), alphabet);
+      String literal = randomFromAlphabet(random, 2 + random.nextInt(10), alphabet);
+      byte[] needle = literal.getBytes(UTF_8);
+      Utf8InputScanner scanner = new Utf8InputScanner(text.getBytes(UTF_8));
+      int start = text.isEmpty() ? 0 : random.nextInt(text.length());
+
+      assertThat(scanner.indexOf(needle, literalFailure(needle), literalShifts(needle), start))
+          .as("%s in %s from %s", literal, text, start)
+          .isEqualTo(text.indexOf(literal, start));
+    }
+  }
+
+  @Test
+  void multiByteLiteralSearchHandlesMatchesAtTheVeryEndOfTheInput() {
+    for (int length = 2; length <= 20; length++) {
+      StringBuilder literal = new StringBuilder();
+      for (int index = 0; index < length; index++) {
+        literal.append((char) ('a' + (index % 5)));
+      }
+      byte[] needle = literal.toString().getBytes(UTF_8);
+      // Prefix lengths straddle the threshold so the match lands in the filter's tail as well as
+      // in the skip loop.
+      for (int prefix :
+          new int[] {0, 19, filterThreshold(needle.length), filterThreshold(needle.length) + 7}) {
+        String text = "z".repeat(prefix) + literal;
+        Utf8InputScanner scanner = new Utf8InputScanner(text.getBytes(UTF_8));
+
+        assertThat(scanner.indexOf(needle, literalFailure(needle), literalShifts(needle)))
+            .as("length %s, prefix %s", length, prefix)
+            .isEqualTo(prefix);
+      }
+    }
+  }
+
+  @Test
+  void multiByteLiteralSearchAgreesWithStringIndexOfOnNonAsciiLiterals() {
+    List<String> literals = List.of("é", "café", "日本語", "😀x", "aé😀");
+    List<String> texts =
+        List.of("", "café", "le café est chaud", "日本語のテキスト", "😀😀x", "aé😀aé😀", "z".repeat(50));
+    for (String literal : literals) {
+      byte[] needle = literal.getBytes(UTF_8);
+      int[] failure = literalFailure(needle);
+      int[] shifts = literalShifts(needle);
+      for (String text : texts) {
+        // Padding pushes the same case past the threshold so both paths see non-ASCII literals.
+        for (String padded :
+            List.of(text, "\u00e9\u65e5".repeat(filterThreshold(needle.length)) + text)) {
+          byte[] haystack = padded.getBytes(UTF_8);
+
+          assertThat(new Utf8InputScanner(haystack).indexOf(needle, failure, shifts))
+              .as("%s in %s", literal, padded)
+              .isEqualTo(naiveIndexOf(haystack, needle, 0));
+        }
+      }
+    }
+  }
+
   @Test
   void emptySingleByteAndFourByteWindowsStayBounded() {
     Utf8InputScanner empty = new Utf8InputScanner(new byte[] {'x'}, 1, 0);
@@ -233,6 +352,56 @@ class Utf8InputScannerTest {
       assertThat(jdkError).as("JDK accepted %s", Arrays.toString(bytes)).isNotEqualTo(-1);
       assertThat(e).hasMessageContaining("byte " + jdkError);
     }
+  }
+
+  /** Builds the KMP failure function, mirroring what {@code Pattern} precomputes per literal. */
+  private static int[] literalFailure(byte[] literal) {
+    int[] failure = new int[literal.length];
+    int matched = 0;
+    for (int index = 1; index < literal.length; index++) {
+      while (matched > 0 && literal[index] != literal[matched]) {
+        matched = failure[matched - 1];
+      }
+      if (literal[index] == literal[matched]) {
+        matched++;
+      }
+      failure[index] = matched;
+    }
+    return failure;
+  }
+
+  /** Builds the bad-character skip table, mirroring what {@code Pattern} precomputes. */
+  private static int[] literalShifts(byte[] literal) {
+    if (literal.length < 2) {
+      return null;
+    }
+    int[] shifts = new int[256];
+    Arrays.fill(shifts, literal.length);
+    for (int index = 0; index < literal.length - 1; index++) {
+      shifts[literal[index] & 0xFF] = literal.length - index - 1;
+    }
+    return shifts;
+  }
+
+  private static int naiveIndexOf(byte[] haystack, byte[] needle, int start) {
+    outer:
+    for (int position = start; position + needle.length <= haystack.length; position++) {
+      for (int index = 0; index < needle.length; index++) {
+        if (haystack[position + index] != needle[index]) {
+          continue outer;
+        }
+      }
+      return position;
+    }
+    return -1;
+  }
+
+  private static String randomFromAlphabet(Random random, int length, int alphabet) {
+    StringBuilder result = new StringBuilder(length);
+    for (int index = 0; index < length; index++) {
+      result.append((char) ('a' + random.nextInt(alphabet)));
+    }
+    return result.toString();
   }
 
   private static String randomAscii(Random random, int length) {

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -159,6 +159,18 @@ class Utf8InputScannerTest {
   }
 
   @Test
+  void literalSearchSizeArithmeticDoesNotOverflowForLargeArrays() {
+    assertThat(Utf8InputScanner.filterThreshold(Integer.MAX_VALUE)).isEqualTo(85_899_345_880L);
+    assertThat(Utf8InputScanner.workLimit(Integer.MAX_VALUE)).isEqualTo(4_294_967_294L);
+  }
+
+  @Test
+  void candidateVerificationWorkDoesNotWrapPastIntegerMaximum() {
+    assertThat(Utf8InputScanner.addCandidateWork(2_100_000_000L, 8, 20_000_000))
+        .isEqualTo(2_260_000_008L);
+  }
+
+  @Test
   void multiByteLiteralSearchCoversEveryWindowAlignmentAndPosition() {
     // The candidate filter reads eight positions at a time and hands the remainder to a linear
     // tail, so every combination of window alignment and match position must agree.


### PR DESCRIPTION
Accelerates multi-byte literal search over UTF-8 input with a SWAR candidate
filter, keeping Boyer-Moore-Horspool for short inputs.

Fixes #579

## The reported diagnosis was not the cause

The issue attributes the problem to a scalar 1-byte-per-step KMP loop. That is
not what runs. Instrumenting `boundedBoyerMooreHorspool` on the exact repro
input shows the skip loop is engaged, completes, and never falls back to KMP:

| literal | outer iterations | avg advance | work used | work limit | fell back? |
|---|---|---|---|---|---|
| `literal` | 5,301 | 6.18 B/step | 5,502 | 65,536 | no |
| `coolfunctionname` | 2,645 | 12.39 B/step | 2,767 | 65,536 | no |

The cost is per step, not per byte: ~3.6 ns per iteration, because each step is
a serialized load, bad-character table lookup, and add. There is no
instruction-level parallelism to exploit, and a wider scan — not a smarter skip
— is what helps.

## Change

Locate candidates with a SWAR filter on the literal's first *and* last byte,
then verify each candidate in full. Two words are loaded per step and XOR-ed
against the broadcast bytes, so the standard zero-byte test identifies
positions where both bytes agree. This examines eight positions per step with
no data-dependent branching.

Requiring both bytes rather than the first alone is what keeps this cheap: on
random `[a-z]` it drops the candidate rate from 1/26 to 1/676, so verification
cost stays negligible.

Two correctness points:

- **The zero-byte test has false positives.** Exhaustive check over every
  (lane, value, filler) combination: 7 false-positive lanes, 0 false negatives.
  It is therefore sound as a filter, but a set lane bit cannot be read as "first
  and last byte matched" — every candidate is verified against the whole
  literal, including those two bytes.
- **The linear-time guarantee is preserved.** Verification is O(literal length)
  per candidate, so an adversarial input (haystack `aaaa…`, literal `abbbbbba`)
  can drive this quadratic. The existing work budget and its `-2` sentinel are
  retained: the budget is exhausted and the search falls back to linear-time
  KMP. Verified that this path fires and still returns correct results.

**Boyer-Moore-Horspool is kept for short inputs.** Measurement across literal
lengths shows the two algorithms win over different ranges — the skip loop
finishes a short input in a handful of steps, while the filter must amortize
its wider setup and a linear tail. The crossover scales with the literal
length, since a longer literal lets the skip loop advance further per step, so
the filter is selected at `max(64, 40 * literal length)` remaining bytes.

## Benchmarks

`run-java-benchmarks.sh` standard mode (2 forks, 2×500ms warmup, 5×500ms
measurement), JDK 25 Temurin, macOS aarch64. Baseline is `main` plus the new
benchmark, so both sides measure identical workloads. Times ns/op; ratio is
after/before, so lower is faster.

**Noise floor first.** 17 rows in this suite cannot be affected by this change
— they use `String.indexOf` or the JDK engine and never enter
`Utf8InputScanner`. Their spread bounds what is resolvable:

| control row | before | after | ratio |
|---|---|---|---|
| captureFreeDecode [multibyteEarly] | 27.6 | 44.5 | 1.61x |
| captureFreeDecode [multibyteLate] | 31.4 | 47.3 | 1.51x |
| captureFreeDecode [asciiNoMatch] | 21.8 | 26.9 | 1.23x |

Median control deviation 3%, maximum 61%. Nothing below ~1.2x in this run is
meaningful.

**New `literalScan` benchmark** — 32KB of random `[a-z]`, literal absent, so
every invocation is a full scan. This is the issue's scenario, which the
existing suite did not cover (its literal cases are ~20-byte texts that never
enter the vectorized loop):

| literal | before | after | speedup |
|---|---|---|---|
| `qjxv` (4 B) | 31,990 | 5,177 | **6.2x** |
| `literal` (7 B) | 19,082 | 5,189 | **3.7x** |
| `coolfunctionname` (16 B) | 9,480 | 4,231 | **2.2x** |

Long-mode confirmation of the same three: 4,144 ± 51, 4,045 ± 27, 4,450 ±
1,351. For reference, the issue measured `Slice.indexOf` at ~5,000 ns and
`String.indexOf` at ~6,500 ns for `literal`.

**Scaling** (`hardFailure`, required literal absent):

| size | before | after | ratio |
|---|---|---|---|
| 10,240 | 867 | 667 | 0.77x |
| 102,400 | 8,564 | 6,639 | 0.78x |
| 1,048,576 | 85,181 | 57,608 | **0.68x** |
| 1,024 | 59.9 | 72.2 | 1.20x — see below |

All other UTF-8-path rows fall between 0.87x and 1.04x, inside the noise floor.

## Open questions for review

Two things I could not settle on this hardware, both worth a look before merge:

1. **`hardFailure[1024]` measures ~1.2x slower.** Long mode gives 69.8 ± 1.9 vs
   59.9 ± 1.5, which looks real. But with the filter disabled entirely it
   measures 61.6, matching baseline — and at that size the threshold should
   already be routing this pattern's 26-byte literal to the skip loop, i.e. the
   same path as "disabled". Either I have misread which literal this pattern
   extracts, or it is noise. I am not claiming it is resolved.
2. **`FILTER_LENGTH_FACTOR = 40` is fitted to these measurements.** The shape is
   principled — the filter always advances 8 bytes per step while the skip loop
   can advance up to the literal length — but the constant itself is soft and
   deserves a re-run on a quiet machine.

## Verification

Ran:

- Full `safere` test suite (`mvn -pl safere test`): 14,828 tests. Green on two
  runs; a third had one failure in
  `ParserTest$CharacterClasses#manyPlainCharacterClassesParseWithLinearScaling`,
  a wall-clock ratio test in the parser that passes 3/3 in isolation and does
  not touch this code path. Consistent with the machine noise documented above.
- `Utf8MatchingBenchmark` before/after, plus long-mode confirmation of
  `hardFailure` and `literalScan`.
- Mutation check that the new tests actually cover the filter: introducing an
  off-by-one in the word step fails 3 of them. This mattered — the threshold
  means small-input tests exercise only the skip loop, so the new tests run each
  scenario both below and above it.

Not run: crosscheck, exhaustive, and fuzz modules; benchmark suites other than
`Utf8MatchingBenchmark`.

## Note on the shared benchmark script

`run-java-benchmarks.sh` fails on macOS with `JMH_EXTRA_ARGS[*]: unbound
variable`. Its shebang is `#!/bin/bash`, which is bash 3.2 on macOS, where
expanding an empty array under `set -u` is an error. These runs used Homebrew's
bash 5.3. Not fixed here as it is unrelated; happy to file it separately.
