### PR TITLE
Refresh benchmark report with cross-language results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,21 +360,25 @@ per invocation and collect results incrementally:
 
 ### Summary Statistics
 
-When reporting benchmark results in BENCHMARKS.md, always compute and report
-**geometric mean of the speed ratios** (SafeRE time / competitor time) as the
-single summary statistic. Report three geomeans, against JDK, RE2/J, and
-RE2-FFM:
+The structure and workload groupings in `BENCHMARKS.md` must reflect the
+current benchmark suite and the questions the report is intended to answer.
+Do not preserve a fixed list of summary categories, benchmark methods, or
+competitors after the suite or reporting goals have changed.
 
-1. **Core workloads geomean** — includes: literalMatch, emailFind, findInText,
-   alternationFind, charClassMatch, captureGroups, pigLatinReplace, and
-   httpFull. These are focused microbenchmarks that isolate engine behavior.
-2. **Application workloads geomean** — includes the data-driven validation,
-   parsing, extraction, scanning, and redaction cases from
-   `ApplicationBenchmark`. This answers: "Is SafeRE competitive on ordinary
-   application regex use?"
-3. **Pathological/scaling geomean** — includes: pathological, searchHardFail,
-   and other benchmarks that demonstrate linear-time guarantees or scaling
-   behavior. This answers: "Does the linear-time guarantee matter?"
+When reporting an aggregate comparison:
+
+- Define its workload membership, parameter coverage, and weighting clearly.
+- Include the benchmark families that materially affect the report's
+  conclusions; do not silently omit important or inconvenient results.
+- Keep semantically different groups separate when combining them would hide
+  useful behavior. Label cross-runtime comparisons as context rather than
+  controlled same-runtime comparisons.
+- Compute the **geometric mean of speed ratios** rather than an arithmetic mean
+  of ratios. Use `SafeRE time / competitor time`, so values below 1.0 mean
+  SafeRE is faster.
+- Report the raw geomean and a readable interpretation such as "N× faster" or
+  "N× slower." Explain when a small number of extreme cases materially
+  influences the aggregate.
 
 **Why geometric mean:** It is the only mean consistent under inversion
 (geomean(A/B) = 1/geomean(B/A)), treats multiplicative improvements
@@ -382,9 +386,9 @@ symmetrically, and is the standard in systems benchmarking (SPEC, DaCapo,
 Renaissance). Do not use arithmetic mean of ratios — it is biased by outliers
 and inconsistent under inversion.
 
-**Ratio convention:** Express as `SafeRE / competitor` so values < 1.0 mean
-SafeRE is faster. For readability, also express as "SafeRE is N× faster" or
-"SafeRE is N× slower" alongside the raw geomean.
+`BENCHMARKS.md` must be self-contained for checked-in benchmark claims. Raw
+outputs may remain local, but do not make an ignored or machine-local artifact
+the only place where a reported result or supporting table can be inspected.
 
 ### Writing About Benchmark Results
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,809 +1,390 @@
-# SafeRE Benchmark Results
+# SafeRE Benchmark Report
 
-Comparing SafeRE against `java.util.regex` (JDK),
-[RE2/J](https://github.com/google/re2j) 1.8, RE2-FFM (C++ RE2 via Java
-[FFM API](https://openjdk.org/jeps/454)), C++ RE2 (2024-07-02), and
-Go [`regexp`](https://pkg.go.dev/regexp) (Go 1.26.1) on common regex
-workloads and pathological patterns that demonstrate backtracking blowup.
+This report compares SafeRE with `java.util.regex` (JDK), RE2/J 1.8, RE2-FFM
+(C++ RE2 through Java's Foreign Function & Memory API), native C++ RE2, and Go
+[`regexp`](https://pkg.go.dev/regexp). Lower times are better.
 
-**Environment:**
-- Benchmarked commit: `0ebd8aed7edcfe43c5a9cee92efee84167a76aa0`
-- Commit date/time: 2026-04-27T02:42:22Z
-- CPU: Intel Core i7-11700K (8 cores / 16 threads, 3.6 GHz base)
-- RAM: 32 GB
-- OS: Ubuntu 24.04.4 LTS on WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2),
-  Windows 11 host
-- JDK: OpenJDK 25.0.2+10-69 (targeting Java 21)
-- JMH: 1.37, fork mode (3 forks, 3 warmup × 5s, 5 measurement × 5s)
-- RE2-FFM: C++ RE2 (2024-07-02) accessed via Java FFM API (JEP 454)
-- C++ compiler: g++ 13.3.0, `-O3 -DNDEBUG` (CMake Release)
+## Executive summary
+
+SafeRE is close to the JDK on the defined core and application summaries while
+retaining a linear-time guarantee. Against other JVM-accessible linear-time
+engines, SafeRE is 11.7× faster than RE2/J and 2.2× faster than RE2-FFM on the
+core geomean; on application workloads it is 7.8× and 1.7× faster,
+respectively. For cross-language context, SafeRE is 2.32× slower than native C++
+RE2 and 3.99× faster than Go `regexp` on the core geomean; on application
+workloads it is 1.32× slower and 2.01× faster, respectively.
+
+Across all 150 real-world measurements, SafeRE is 1.89× faster than JDK,
+10.6× faster than RE2/J, 2.54× faster than RE2-FFM, 1.44× slower than native
+C++ RE2, and 6.17× faster than Go `regexp` by geometric mean.
+
+The most important change since the previous report is alternation search:
+SafeRE now takes 226 ns/op, versus 529 ns/op for JDK, 656 ns/op for RE2-FFM,
+and 4,437 ns/op for RE2/J. A longer confirmation run measured 223 ± 6 ns/op.
+
+The tradeoffs remain visible. JDK compilation is 64–87× faster in these four
+cases, and it leads on several short or backtracking-friendly patterns. SafeRE
+uses more retained memory per compiled pattern. In return, adversarial cases
+remain bounded: the defined pathological/scaling geomean is about 13,500×
+faster than JDK, 2,820× faster than RE2/J, and 23× faster than RE2-FFM.
+
+## Environment and reproducibility
+
+- Benchmarked commit: `6fe67606d7c7724b9b1f1736c3bee04c674eaec5`
+- Commit date/time: 2026-07-21T04:17:54Z
+- CPU: Intel Core i7-11700K, 8 cores / 16 threads, 3.6 GHz base
+- Memory available to WSL2: 16 GiB; Windows 11 host
+- OS: Ubuntu 24.04 on WSL2, Linux 6.6.87.2-microsoft-standard-WSL2
+- Java: OpenJDK 25.0.2+10-69, targeting Java 21
+- JMH: 1.37
+- C++ compiler: g++ 13.3.0, Release build (`-O3 -DNDEBUG`)
+- C++ RE2: 2025-11-05
 - Go: 1.26.1 linux/amd64
 
-**Cross-language comparison caveats:**
-C++ RE2 and Go `regexp` operate on UTF-8 byte strings while Java operates on
-UTF-16 char arrays. RE2-FFM wraps C++ RE2 via the Foreign Function & Memory
-API, adding per-call overhead for UTF-16 → UTF-8 conversion and native memory
-management. C++ RE2 benefits from ahead-of-time compilation, no GC pauses, and
-no JIT warmup. Go has a concurrent GC with different characteristics from
-Java's. These are real-world differences — the goal is to show SafeRE is in
-the same algorithmic ballpark as other RE2-family engines, not to declare a
-winner across language boundaries. Within the Java ecosystem, the SafeRE vs JDK
-vs RE2/J vs RE2-FFM comparison is apples-to-apples.
-
-For instructions on collecting benchmark data, see
-[Benchmarks](README.md#benchmarks) in the README.
-The standard collection path is Java-only; C++ RE2 and Go `regexp` are optional
-cross-language context collected with `./collect-benchmark-results.sh --cross-language`.
-
-For the empirical evaluation of Java benchmark configuration tradeoffs, see
-[Java Benchmark Configuration Evaluation](safere-benchmarks/CONFIGURATION_EVALUATION.md).
-
-## Methodology
-
-All benchmarks use a warmup-then-measure approach, but the settings differ
-between Java and native harnesses to account for their different runtime
-characteristics.
-
-**Java (JMH):** 3 forks × (3 warmup × 5s + 5 measurement × 5s), except
-pathological benchmark classes use `-f 0` so the JDK engine can be timed only
-for feasible input sizes without spawning JVMs that may hang.
-
-**C++ and Go:** 2 warmup + 10 measurement iterations × 2s each, single process.
-Native code has no JIT, so the same binary always runs the same machine code —
-forks are unnecessary. Warmup is shorter (2 iterations vs 5) because it only
-needs to prime CPU caches, branch predictors, and the memory allocator, all of
-which settle within a few seconds. More measurement iterations (10 vs JMH's 5
-per fork) compensate for the lack of fork-level variance sampling. Total: 10
-samples per benchmark.
-
-**Statistical reporting:** All harnesses report mean ± 99.9% confidence
-interval half-width. Java uses JMH's built-in statistics. C++ and Go use
-Student's t-distribution (t ≈ 4.781 for 9 df at 99.9%).
-
-**Shared test data:** All harnesses read patterns, inputs, and parameters from
-a single `benchmark-data.json` file. Application cases also define their
-operation type and expected result in that file, so Java, C++, and Go validate
-the same semantics before timing.
-
-**Workload coverage:** The suite separates focused microbenchmarks,
-data-driven application workloads, and pathological/scaling workloads.
-
-| Setting | Java (JMH) | C++ | Go |
-|---|---|---|---|
-| Warmup | 3 × 5s per fork | 2 × 2s | 2 × 2s |
-| Measurement | 5 × 5s per fork | 10 × 2s | 10 × 2s |
-| Forks | 3 (fresh JVM each) | 1 (single process) | 1 (single process) |
-| Total samples | 15 | 10 | 10 |
-| Optimization | JIT (steady-state) | `-O3 -DNDEBUG` | Go default |
-
-## Matching Performance (ns/op, lower is better)
-
-| Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Literal match (`"hello"`) | 11 | 13 | 128 | 57 | 40 | 76 | **1.2× faster** | **12× faster** | **5.3× faster** |
-| Char class match (`[a-zA-Z]+`) | 21 | 24 | 1,236 | 110 | 82 | 364 | **1.2× faster** | **60× faster** | **5.4× faster** |
-| Alternation find (`foo\|bar\|…` ×8) | 2,207 | 534 | 4,344 | 615 | 17 | 1,693 | 4.1× slower | **2.0× faster** | 3.6× slower |
-| Capture groups (`(\d{4})-(\d{2})-(\d{2})`) | 77 | 96 | 559 | 325 | 75 | 233 | **1.2× faster** | **7.3× faster** | **4.2× faster** |
-| Find -ing words in prose (~350 chars) | 3,429 | 2,985 | 20,026 | 4,249 | 17 | 12,426 | 1.1× slower | **5.8× faster** | **1.2× faster** |
-| Email pattern find | 285 | 394 | 1,918 | 230 | 82 | 546 | **1.4× faster** | **6.7× faster** | 1.2× slower |
-
-SafeRE beats JDK on literal matching, character-class matching, capture groups,
-and email find. It is slower on alternation find, where C++ RE2 and RE2-FFM
-benefit from native-code prefix handling, and modestly slower on find-in-text.
-SafeRE remains faster than RE2/J on every matching benchmark, with especially
-large gains on literal and character-class matches.
-
-## Application Workloads (ns/op, lower is better)
-
-Data-driven validation, parsing, extraction, scanning, and redaction cases from
-`ApplicationBenchmark`.
-
-| Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|---|--:|--:|--:|--:|--:|--:|---|---|---|
-| UUID validation | 425 | 1,299 | 2,549 | 602 | 344 | 956 | **3.1× faster** | **6.0× faster** | **1.4× faster** |
-| Log line parse | 3,861 | 1,118 | 15,867 | 2,873 | 1,998 | 2,249 | 3.5× slower | **4.1× faster** | 1.3× slower |
-| API route match | 611 | 646 | 6,650 | 1,007 | 306 | 997 | **1.1× faster** | **11× faster** | **1.6× faster** |
-| Stack trace extract | 5,895 | 2,450 | 28,185 | 4,754 | 4,106 | 4,367 | 2.4× slower | **4.8× faster** | 1.2× slower |
-| Case-insensitive keywords | 4,059 | 1,213 | 6,740 | 1,284 | 477 | 4,417 | 3.3× slower | **1.7× faster** | 3.2× slower |
-| URL extraction | 869 | 1,270 | 7,572 | 1,424 | 608 | 1,572 | **1.5× faster** | **8.7× faster** | **1.6× faster** |
-| CSV field scan | 3,285 | 742 | 10,245 | 6,268 | 1,222 | 3,455 | 4.4× slower | **3.1× faster** | **1.9× faster** |
-| Secret redaction | 2,147 | 783 | 7,166 | 978 | 618 | 2,524 | 2.7× slower | **3.3× faster** | 2.2× slower |
-
-SafeRE wins 3 of 8 application workloads against JDK and is faster than RE2/J
-on all 8. Against RE2-FFM, SafeRE wins UUID validation, API route matching,
-URL extraction, and CSV field scanning, while RE2-FFM has an edge on workloads
-where C++ RE2's native execution offsets FFM overhead.
-
-## Search Scaling (µs/op, lower is better)
-
-How performance scales with input size (1 KB → 1 MB). These patterns search
-through random text that does **not** contain the match (worst-case scan).
-
-**Note on C++ RE2 search scaling:** C++ RE2 uses a reverse DFA that
-recognizes end-anchored patterns (`$`) and only scans the string suffix,
-achieving ~0.04 µs regardless of text size. SafeRE now implements a similar
-optimization for the Hard pattern (see Search Scaling Hard below), achieving
-constant-time rejection. C++ RE2 results are omitted from the scaling tables
-since they measure a different code path. RE2-FFM wraps C++ RE2 and exhibits
-the same constant-time behavior for Hard and Medium patterns.
-
-### Easy: `ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (literal prefix, memchr-able)
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.09 | 0.16 | 0.10 | 0.17 | 0.08 | **1.8× faster** | ~same | **1.9× faster** |
-| 10 KB | 0.83 | 1.44 | 0.84 | 1.07 | 0.23 | **1.7× faster** | ~same | **1.3× faster** |
-| 100 KB | 8.2 | 14.2 | 8.2 | 11.1 | 2.3 | **1.7× faster** | ~same | **1.4× faster** |
-| 1 MB | 84 | 146 | 84 | 152 | 24 | **1.7× faster** | ~same | **1.8× faster** |
-
-### Medium: `[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (starts with char class)
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.38 | 0.26 | 21.7 | 0.16 | 14 | 1.5× slower | **56× faster** | 2.4× slower |
-| 10 KB | 3.7 | 2.4 | 233 | 1.0 | 171 | 1.5× slower | **63× faster** | 3.6× slower |
-| 100 KB | 37 | 24 | 2,397 | 11 | 1,714 | 1.5× slower | **65× faster** | 3.5× slower |
-| 1 MB | 381 | 370 | 24,548 | 149 | 18,101 | ~same | **64× faster** | 2.5× slower |
-
-Character-class prefix acceleration allows SafeRE to scan directly for
-`[XYZ]` before invoking the DFA, reducing the gap with JDK to just 1.5×.
-SafeRE is **56–65× faster than RE2/J** on this pattern. RE2-FFM benefits
-from C++ RE2's reverse DFA, achieving near-constant time and beating SafeRE
-by 2.4–3.6×.
-
-### Hard: `[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$` (catastrophic in backtracking engines)
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.021 | 59 | 36 | 0.17 | 18 | **2,800× faster** | **1,700× faster** | **8.2× faster** |
-| 10 KB | 0.021 | 448 | 380 | 1.1 | 244 | **21,000× faster** | **18,000× faster** | **51× faster** |
-| 100 KB | 0.020 | 4,472 | 3,748 | 11 | 2,437 | **224,000× faster** | **187,000× faster** | **560× faster** |
-| 1 MB | 0.020 | 45,835 | 38,671 | 153 | 24,995 | **2.3M× faster** | **1.9M× faster** | **7,700× faster** |
-
-SafeRE achieves **constant-time rejection** (~0.020 µs regardless of text
-size) on this pattern, similar to C++ RE2's reverse DFA optimization. SafeRE
-detects at compile time that the required literal suffix `ABCDEFGHIJKLMNOPQRSTUVWXYZ`
-cannot occur in random ASCII text and short-circuits before scanning. This is
-even faster than C++ RE2 (0.044 µs) and RE2-FFM, which must still invoke the
-reverse DFA. JDK's backtracking engine exhibits O(n²) behavior due to the
-leading `[ -~]*`, making SafeRE millions of times faster at 1 MB. RE2/J and
-Go `regexp` handle it in linear time but are still orders of magnitude slower
-than SafeRE's constant-time path.
-
-### Successful Search (Easy pattern, match at end of text)
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 0.35 | 0.18 | 0.81 | 0.24 | 0.21 | 1.9× slower | **2.4× faster** | 1.4× slower |
-| 10 KB | 1.1 | 1.6 | 1.6 | 1.1 | 0.72 | **1.4× faster** | **1.4× faster** | ~same |
-| 100 KB | 8.5 | 15.2 | 8.9 | 11.1 | 2.7 | **1.8× faster** | ~same | **1.3× faster** |
-| 1 MB | 84 | 154 | 84 | 155 | 24 | **1.8× faster** | ~same | **1.8× faster** |
-
-SafeRE has higher per-match startup cost but scales well; it overtakes JDK
-at 10 KB. DFA caching keeps the 1 KB case at 0.35 µs. RE2-FFM follows a
-similar pattern — 1.4× faster than SafeRE at 1 KB but 1.8× slower at 1 MB,
-as FFM per-call overhead grows with input size.
-
-## Capture Group Scaling (ns/op, lower is better)
-
-| Groups | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|--:|---|---|---|
-| 0 | 60 | 30 | 399 | 74 | 59 | 160 | 2.0× slower | **6.7× faster** | **1.2× faster** |
-| 1 | 75 | 40 | 887 | 273 | 65 | 232 | 1.9× slower | **12× faster** | **3.6× faster** |
-| 3 | 97 | 78 | 963 | 328 | 79 | 293 | 1.2× slower | **10× faster** | **3.4× faster** |
-| 10 | 197 | 236 | 1,405 | 755 | 372 | 533 | **1.2× faster** | **7.1× faster** | **3.8× faster** |
-
-SafeRE closes the gap with JDK as capture count grows — from 2.0× slower at
-0 groups to **1.2× faster at 10 groups**. SafeRE is consistently **7–12×
-faster than RE2/J** and **3.4–3.8× faster than RE2-FFM** on capture extraction
-(at 1+ groups). The RE2-FFM gap reflects FFM call overhead on top of C++ RE2's
-capture engine. At 0 groups (no captures), SafeRE is 1.2× faster than RE2-FFM.
-C++ RE2 is slower than SafeRE at 10 groups — both use OnePass-style engines
-that scale similarly with group count. Go `regexp` is 1.6–2.7× slower than SafeRE,
-consistent with its NFA-only approach.
-
-## HTTP Request Parsing (ns/op, lower is better)
-
-Pattern: `^(?:GET|POST) +([^ ]+) HTTP`
-
-| Input | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Full request (97 chars) | 269 | 91 | 8,108 | 384 | 308 | 902 | 3.0× slower | **30× faster** | **1.4× faster** |
-| Small request (18 chars) | 70 | 49 | 950 | 138 | 69 | 223 | 1.4× slower | **14× faster** | **2.0× faster** |
-| Extract URL (97 chars) | 276 | 92 | 8,100 | 384 | 311 | 900 | 3.0× slower | **29× faster** | **1.4× faster** |
-
-SafeRE's HTTP parsing improved significantly from 1,292 to 269 ns/op thanks to
-the HTTP/OnePass fast path optimization. SafeRE is now within 3.0× of JDK on
-full HTTP requests (previously 14×) and is faster than C++ RE2 (269 vs
-308 ns). SafeRE remains **14–30× faster than RE2/J** on all HTTP workloads.
-RE2-FFM is slightly slower than SafeRE on this benchmark, with SafeRE 1.4×
-faster on full and extract, and 2.0× faster on small request patterns.
-
-## Replace Performance (ns/op, lower is better)
-
-| Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Literal replaceFirst (`"b"→"bb"`) | 30 | 40 | 146 | 213 | 97 | 566 | **1.3× faster** | **4.9× faster** | **7.1× faster** |
-| Literal replaceAll | 105 | 106 | 704 | 681 | 414 | 462 | ~same | **6.7× faster** | **6.5× faster** |
-| Pig Latin replaceAll (backrefs) | 1,519 | 902 | 7,857 | 2,318 | 1,837 | 2,700 | 1.7× slower | **5.2× faster** | **1.5× faster** |
-| Digit replaceAll (`\d+`→`"NUM"`) | 195 | 283 | 3,091 | 964 | 648 | 1,495 | **1.5× faster** | **16× faster** | **4.9× faster** |
-| Empty-match replaceAll (`a*`) | 270 | 75 | 398 | 638 | 378 | 333 | 3.6× slower | **1.5× faster** | **2.4× faster** |
-
-SafeRE wins on literal replacements — **faster than all other engines**
-(including C++ RE2!) on replaceFirst (30 ns), thanks to the `String.indexOf()`
-fast path. Digit replaceAll is **1.5× faster than JDK** thanks to the
-character-class replaceAll fast path. Pig Latin replaceAll runs at 1,519 ns
-via compiled replacement templates and direct BitState find+capture. SafeRE
-beats RE2-FFM on every replace benchmark by **1.5–7.1×**, as repeated FFM
-round-trips per match add significant overhead. For empty-match replacement,
-JDK remains fastest. Go `regexp` is consistently faster than RE2/J on
-replacements.
-
-## PatternSet Multi-Pattern Matching (ns/op)
-
-Matching text against multiple compiled patterns simultaneously (SafeRE-only
-feature — neither JDK nor RE2/J has a built-in multi-pattern API).
-
-| Patterns | Unanchored (match) | Unanchored (no match) | Anchored (match) | Anchored (no match) |
-|--:|--:|--:|--:|--:|
-| 4 | 3,243 | 2,630 | 2,219 | 1,885 |
-| 16 | 30,717 | 17,271 | 5,779 | 5,484 |
-| 64 | 78,935 | 58,597 | 18,324 | 17,614 |
-
-Anchored matching is 2–5× faster than unanchored. Scaling is roughly linear
-in pattern count.
-
-## Fanout & Nested Quantifiers (µs/op, lower is better)
-
-### Unicode Fanout: `(?:[\x{80}-\x{10FFFF}]?){100}[\x{80}-\x{10FFFF}]`
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
-|--:|--:|--:|--:|--:|--:|--:|
-| 1 KB | 0.55 | 0.83 | 105 | 3.0 | 0.047 | 1.4 |
-| 10 KB | 0.55 | 0.83 | 104 | 32 | 0.047 | 3.6 |
-| 100 KB | 0.57 | 0.84 | 106 | 447 | 0.047 | 3.5 |
-
-SafeRE handles this pattern in ~0.56 µs regardless of text size. JDK's
-backtracking engine quickly fails and returns false in ~0.84 µs. SafeRE is
-**1.5× faster than JDK** and **184–190× faster than RE2/J** on this pattern.
-C++ RE2 handles it trivially (~47 ns) thanks to its mature DFA. RE2-FFM
-degrades sharply with text size (3 µs → 447 µs) due to increasing UTF-16 →
-UTF-8 conversion cost on the FFM boundary. Go `regexp` handles it well
-(~4 µs), much faster than RE2/J.
-
-### Nested Quantifier: `(?:a?){20}a{20}`
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 3.0 | 15 | 374 | 1.4 | 1.1 | 184 | **5.0× faster** | **125× faster** | 2.1× slower |
-| 10 KB | 27 | 139 | 3,806 | 14 | 11 | 2,139 | **5.2× faster** | **142× faster** | 1.9× slower |
-| 100 KB | 277 | 1,465 | 37,525 | 140 | 106 | 22,167 | **5.3× faster** | **135× faster** | 2.0× slower |
-
-SafeRE is significantly faster than both JDK and RE2/J here. RE2/J's NFA-only
-approach is much slower than SafeRE's DFA on this high-fanout quantifier
-pattern. SafeRE is within 2.6× of C++ RE2, showing both use the same
-algorithmic approach. RE2-FFM is ~2× faster than SafeRE, tracking close to
-native C++ RE2 with modest FFM overhead. Go `regexp` is similar to RE2/J
-(NFA-only), both ~62–80× slower than SafeRE.
-
-## Compilation Performance (µs/op, lower is better)
-
-| Pattern | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|---|--:|--:|--:|--:|--:|--:|---|---|---|
-| Simple (`hello`) | 0.46 | 0.09 | 0.27 | 3.90 | 1.48 | 0.87 | 5.1× slower | 1.7× slower | **8.5× faster** |
-| Medium (datetime with 6 captures) | 4.76 | 0.31 | 2.12 | 23.52 | 6.47 | 5.88 | 15× slower | 2.2× slower | **4.9× faster** |
-| Complex (email regex) | 2.64 | 0.23 | 1.14 | 11.59 | 4.52 | 2.41 | 12× slower | 2.3× slower | **4.4× faster** |
-| Alternation (12 alternatives) | 3.60 | 0.41 | 2.96 | 21.16 | 7.67 | 5.69 | 8.8× slower | 1.2× slower | **5.9× faster** |
-
-Lazy initialization defers OnePass analysis and DFA equivalence-class setup
-to first match, reducing compile-time work to just parsing and program
-compilation. SafeRE is now within 1.7× of RE2/J on simple patterns. JDK
-defers most work to match time and remains the fastest compiler. SafeRE
-compiles **4.4–8.5× faster than RE2-FFM**, which is the slowest due to FFM
-call overhead plus C++ RE2's eager DFA setup. C++ RE2 compilation is
-1.4–3.2× slower than SafeRE — C++ RE2 performs more eager work at compile
-time (DFA setup, prefilter analysis). Go `regexp` compilation is comparable
-overall and is faster than SafeRE only on the complex email pattern.
-
-## Pathological Pattern: `a?{n}a{n}` matched against `a{n}`
-
-This is the canonical backtracking blowup case. The JDK's backtracking NFA
-exhibits O(2^n) behavior. SafeRE, RE2/J, and C++ RE2 all handle it in linear
-time, but the DFA-based engines (SafeRE and C++ RE2) are far faster than
-RE2/J's NFA.
-
-### SafeRE vs RE2/J vs RE2-FFM vs C++ RE2 vs Go scalability (µs/op)
-
-| n | SafeRE | RE2/J | RE2-FFM | C++ RE2 | Go | SafeRE/RE2/J | SafeRE/C++ |
-|--:|--:|--:|--:|--:|--:|---|---|
-| 10 | 0.043 | 1.68 | 0.068 | 0.054 | 0.880 | **39× faster** | ~same |
-| 15 | 0.058 | 3.73 | 0.081 | 0.067 | 1.76 | **64× faster** | ~same |
-| 20 | 0.070 | 6.61 | 0.089 | 0.073 | 2.95 | **94× faster** | ~same |
-| 25 | 0.082 | 10.14 | 0.095 | 0.079 | 4.44 | **124× faster** | ~same |
-| 30 | 0.094 | 14.53 | 0.100 | 0.085 | 6.62 | **155× faster** | 1.1× slower |
-| 50 | 0.456 | 37.73 | 0.127 | 0.110 | 16.5 | **83× faster** | 4.1× slower |
-| 100 | 0.933 | 145.9 | 0.191 | 0.172 | 66.3 | **156× faster** | 5.4× slower |
-
-All four linear-time engines scale linearly. SafeRE and C++ RE2 (both
-DFA-based) have the lowest growth rates at small n, though SafeRE shows higher
-growth at large n (4.1× slower than C++ RE2 at n=50, 5.4× at n=100). RE2-FFM
-tracks close to C++ RE2 with small FFM overhead. Go `regexp` and RE2/J (both
-NFA-only) are slower than SafeRE: RE2/J by 39–156× and Go by 20–71×. Go
-`regexp` is usually faster than RE2/J, reflecting Go's native-code advantage
-over Java for NFA execution.
-
-### Three-way comparison (µs/op, small n where JDK is feasible)
-
-| n | SafeRE | RE2/J | JDK | RE2-FFM | SafeRE vs JDK |
-|--:|--:|--:|--:|--:|--:|
-| 10 | 0.042 | 1.72 | 9.3 | 0.074 | **222×** |
-| 15 | 0.055 | 3.90 | 396 | 0.082 | **7,200×** |
-| 20 | 0.070 | 6.64 | 15,316 | 0.090 | **218,803×** |
-| 25 | — | — | *(hangs)* | — | ∞ |
-
-## Find-in-Text Scaling (µs/op, lower is better)
-
-`\b\w+ing\b` on repeated prose, scaling from 1 KB to 1 MB.
-
-| Text Size | SafeRE | JDK | RE2/J | RE2-FFM | Go | vs JDK | vs RE2/J | vs RE2-FFM |
-|--:|--:|--:|--:|--:|--:|---|---|---|
-| 1 KB | 8.7 | 7.4 | 49 | 12 | 31 | 1.2× slower | **5.7× faster** | **1.4× faster** |
-| 10 KB | 84 | 73 | 475 | 139 | 308 | 1.2× slower | **5.6× faster** | **1.6× faster** |
-| 100 KB | 821 | 719 | 4,599 | 8,201 | 4,145 | 1.1× slower | **5.6× faster** | **10× faster** |
-| 1 MB | 8,444 | 7,045 | 46,825 | 1,495,616 | 43,831 | 1.2× slower | **5.5× faster** | **177× faster** |
-
-SafeRE is **close to JDK** on find-all-matches scaling, within 1.2× at all
-sizes. SafeRE is **5.5–5.7× faster than RE2/J** at all scales. SafeRE is
-also **1.4–177× faster than RE2-FFM**, with the advantage growing dramatically
-at larger sizes due to RE2-FFM's per-call FFM overhead. DFA caching,
-word-boundary support, and the DFA sandwich optimization keep SafeRE
-competitive with JDK.
-
-**Note on RE2-FFM find-in-text scaling:** At 100 KB and above, RE2-FFM becomes
-extremely slow (1.4 seconds at 1 MB) because the FFM shim performs UTF-16 →
-UTF-8 conversion on every `find()` call. This is a limitation of the FFM
-wrapper, not of C++ RE2 itself — native C++ RE2 handles this workload in ~19 µs
-at 1 MB.
-
-## Summary Statistics
-
-We use the **geometric mean of speed ratios** (SafeRE time / competitor time)
-as the single summary statistic for cross-benchmark comparison. Ratios < 1.0
-mean SafeRE is faster.
-
-**Why geometric mean?** It is the only mean that is consistent under inversion
-— geomean(A/B) = 1/geomean(B/A) — so the "winner" doesn't change depending
-on which direction you express the ratio. Arithmetic mean of ratios is biased
-by outliers and inconsistent under inversion. Geometric mean treats
-multiplicative improvements symmetrically: 2× faster and 2× slower cancel
-to 1.0. This is the standard approach used in systems benchmarking (SPEC,
-DaCapo, Renaissance).
-
-**Caveats:** The geomean is only as meaningful as the benchmark suite is
-representative. We report three geomeans to avoid conflating qualitatively
-different workloads:
-
-1. **Core micro workloads** — focused regex operations: literal match, character
-   class match, alternation find, capture groups, find-in-text, email find,
-   pig Latin replace, HTTP full request. These are useful for isolating engine
-   behavior, but they are not a complete model of application regex use.
-2. **Application workloads** — data-driven validation, parsing, extraction,
-   scanning, and redaction cases from `ApplicationBenchmark`. These are intended
-   to represent ordinary application usage more directly than the microbenchmarks.
-3. **Pathological/scaling** — workloads that stress linear-time guarantees:
-   `a?{n}a{n}` at n=20, `[ -~]*…$` hard search at 1 MB, nested quantifier
-   `(?:a?){20}a{20}` at 100 KB. These are less common in everyday code but
-   represent the safety guarantee that motivates the library.
-
-Each individual ratio has measurement uncertainty (JMH reports ± error), but
-we report geomean of point estimates, which is standard practice. Per-benchmark
-ratios and confidence intervals are available in the detailed tables above.
-
-### vs JDK (`java.util.regex`)
-
-| Category | Geomean | Interpretation |
-|---|--:|---|
-| Core workloads (8 benchmarks) | 1.33 | **SafeRE is 1.3× slower overall** |
-| Application workloads (8 benchmarks) | 1.71 | **SafeRE is 1.7× slower overall** |
-| Pathological/scaling (3 benchmarks) | 0.000072 | **SafeRE is ~13,800× faster** |
-
-On core workloads, SafeRE is 1.3× slower than JDK overall, driven mostly by
-alternation find (4.1×), HTTP parsing (3.0×), and pig Latin replace (1.7×).
-SafeRE wins on 4 of 8 core benchmarks: literal match, character-class match,
-capture groups, and email find.
-
-On application workloads, SafeRE is 1.7× slower than JDK overall. SafeRE wins
-UUID validation, API route matching, and URL extraction, while JDK is faster on
-log parsing, stack-trace extraction, case-insensitive keyword search, CSV
-field scanning, and secret redaction. The pathological geomean reflects the
-fundamental algorithmic difference: SafeRE guarantees linear time while JDK's
-backtracking engine exhibits exponential blowup on adversarial patterns.
-
-### vs RE2/J
-
-| Category | Geomean | Interpretation |
-|---|--:|---|
-| Core workloads (8 benchmarks) | 0.106 | **SafeRE is 9.4× faster overall** |
-| Application workloads (8 benchmarks) | 0.218 | **SafeRE is 4.6× faster overall** |
-| Pathological/scaling (3 benchmarks) | 0.00034 | **SafeRE is ~2,910× faster** |
-
-SafeRE beats RE2/J on every benchmark in the summary categories. Both
-libraries provide linear-time guarantees, but SafeRE's DFA, OnePass, and
-BitState engines provide a large constant-factor advantage over RE2/J's
-NFA-only approach. The advantage is 9.4× on core workloads and 4.6× on
-application workloads, where SafeRE wins every listed application case.
-
-### vs RE2-FFM (C++ RE2 via FFM)
-
-| Category | Geomean | Interpretation |
-|---|--:|---|
-| Core workloads (8 benchmarks) | 0.585 | **SafeRE is 1.7× faster overall** |
-| Application workloads (8 benchmarks) | 1.06 | **SafeRE is roughly even overall** |
-| Pathological/scaling (3 benchmarks) | 0.059 | **SafeRE is ~17.0× faster** |
-
-On core workloads, SafeRE is 1.7× faster than RE2-FFM overall. SafeRE wins
-decisively on literal match, character-class match, capture groups, HTTP
-parsing, and several replacement workloads. RE2-FFM wins on alternation and
-email find, where C++ RE2's native execution has an edge.
-
-On application workloads, SafeRE and RE2-FFM are roughly even by geomean.
-SafeRE wins UUID validation, API route matching, URL extraction, and CSV field
-scanning; RE2-FFM wins log parsing, stack-trace extraction,
-case-insensitive keyword search, and secret redaction.
-
-On pathological/scaling workloads, SafeRE is now 17.0× faster overall —
-a dramatic reversal from the previous 3.1× slower result. SafeRE's constant-time
-Hard search rejection (0.020 µs vs RE2-FFM's 153 µs at 1 MB) is the main
-driver. On the other two pathological benchmarks — `a?{20}a{20}` and nested
-quantifiers — SafeRE and RE2-FFM are within 2× of each other, both scaling
-linearly. RE2-FFM also pays FFM per-call overhead that grows with input size,
-making it much slower than SafeRE on find-all-matches workloads at scale
-(e.g., find-in-text at 1 MB: 1.50 seconds vs 8.4 ms).
-
-## Analysis
-
-**Where SafeRE wins (vs Java engines):**
-- **Literal matching** — 1.2× faster than JDK, 12× faster than RE2/J
-- **Character class matching** — 1.2× faster than JDK, 60× faster than RE2/J
-- **Literal replacement** — Fastest of all engines (including C++ RE2!) on replaceFirst
-- **Email find** — 1.4× faster than JDK, 6.7× faster than RE2/J
-- **Digit replaceAll** — 1.5× faster than JDK, 16× faster than RE2/J
-- **Find-in-text** — within 1.2× of JDK, 5.5–5.7× faster than RE2/J
-- **Capture groups** — 7–12× faster than RE2/J, 1.2× faster than JDK at 10 groups
-- **Hard search** — constant-time rejection (~0.020 µs at all sizes), 2,800–2.3M× faster than JDK, 1,700–1.9M× faster than RE2/J
-- **Nested quantifiers** — 5.0–5.3× faster than JDK, 125–142× faster than RE2/J
-- **Easy search on large text** — 1.7–1.8× faster than JDK, comparable to RE2/J
-- **Medium search** — 56–65× faster than RE2/J
-- **HTTP parsing** — 14–30× faster than RE2/J
-- **Pathological `a?{n}a{n}`** — 222–219,000× faster than JDK, 39–156× faster than RE2/J
-
-**Where JDK wins:**
-- **HTTP parsing** — 3.0× faster (SafeRE's OnePass engine has higher per-character
-  overhead on anchored patterns, though the gap narrowed from 14× to 3.0× with
-  the HTTP/OnePass fast path optimization)
-- **Pig Latin replace** — 1.7× faster (per-match capture extraction cost in multi-match replaceAll)
-- **Empty-match replace** — JDK is 3.6× faster
-- **Compilation** — 5.1–15× faster (defers work to match time)
-
-**Where RE2/J fits:**
-- RE2/J is **slower than both SafeRE and JDK** on every matching benchmark
-- RE2/J lacks DFA, OnePass, and BitState engines — only has NFA (Pike VM)
-- RE2/J provides linear-time safety like SafeRE, but without the DFA
-  performance advantage
-- RE2/J compilation is 1.2–2.2× faster than SafeRE but 3–5× slower than JDK
-
-**RE2-FFM (C++ RE2 via FFM):**
-- RE2-FFM provides C++ RE2's algorithmic strength (DFA, reverse DFA) from Java
-  via the Foreign Function & Memory API
-- On short inputs (< 1 KB), RE2-FFM is competitive with SafeRE and sometimes
-  faster (e.g., alternation find at 615 ns vs 2,207 ns)
-- On large inputs, FFM per-call overhead becomes significant — especially for
-  find-all-matches workloads where each `find()` call crosses the JNI/FFM
-  boundary with UTF-16 → UTF-8 conversion
-- Compilation is 4–6× slower than SafeRE due to FFM call overhead plus C++
-  RE2's eager DFA setup
-- SafeRE now beats RE2-FFM on the Hard search pattern (0.020 µs vs 153 µs
-  at 1 MB) and is 17.0× faster overall on pathological/scaling workloads
-
-**SafeRE vs C++ RE2:**
-- C++ RE2 is typically **2–20× faster** on matching due to native code, UTF-8
-  encoding (shorter strings), and no GC/JIT overhead
-- **Hard search** — SafeRE is now faster than C++ RE2 (0.020 vs 0.044 µs),
-  achieving constant-time rejection by detecting the required literal suffix
-  cannot occur
-- **Compilation** — SafeRE compiles **faster** than C++ RE2 thanks to lazy
-  initialization, while C++ RE2 performs more eager DFA setup at compile time
-- **Pathological patterns** — SafeRE is within 1.0–4.1× of C++ RE2, confirming
-  the DFA implementation is correct and efficient
-- **Literal replacement** — SafeRE is **faster** than C++ RE2 (30 vs 98 ns for
-  replaceFirst), demonstrating Java's `String.indexOf()` optimization
-- **Nested quantifiers** — SafeRE is within 2.6× of C++ RE2 (277 vs 106 µs at
-  100 KB), both scaling linearly
-
-**SafeRE vs Go `regexp`:**
-- Go `regexp` is an NFA-only implementation (no DFA), like RE2/J
-- SafeRE **beats Go on DFA-dominated workloads**: pathological (7–152× faster),
-  nested quantifiers (61–80× faster), hard search (880–1.2M× faster)
-- Go beats SafeRE on short-string matching and compilation (no DFA overhead)
-- Go `regexp` is consistently ~2–3× faster than RE2/J across the board,
-  reflecting Go's native-code advantage over Java for NFA execution
-
-**Key takeaway:** SafeRE is the fastest RE2-family engine on the JVM —
-**1.7× faster than RE2-FFM** and **9.4× faster than RE2/J** on core
-workloads by geomean. SafeRE is within a small constant factor of the
-C++ original and significantly faster than both Go `regexp` and RE2/J on
-DFA-dominated workloads. On core workloads, SafeRE is **1.3× slower than
-JDK by geomean** (driven by alternation find at 4.1×, HTTP parsing at 3.0×,
-and pig Latin replace at 1.7×), while providing **guaranteed linear time**
-that JDK cannot offer.
-On pathological/scaling workloads, SafeRE is **13,800× faster than JDK** and
-**17.0× faster than RE2-FFM** — the latter a reversal from the previous 3.1×
-disadvantage, driven by the new constant-time Hard search rejection.
-
-**The tradeoff:** SafeRE trades higher per-match overhead on HTTP-style
-anchored patterns (3.0× slower than JDK) for **guaranteed linear time** and
-**better scaling** on large inputs and pathological patterns. For
-safety-critical applications (user-supplied regexes, large documents, content
-filtering), SafeRE eliminates the risk of catastrophic backtracking while being
-substantially faster than all other RE2-family implementations except
-the C++ original.
-
-**Impact of fork mode:** These results were collected with JMH fork mode
-(3 forks per benchmark), which starts fresh JVMs to avoid JIT profile
-pollution between benchmarks and samples fork-to-fork variance. Pathological
-benchmark classes intentionally run without forking because some JDK cases can
-hang at larger input sizes.
-
-## Optimizations Applied
-
-1. **DFA caching per Matcher** — DFA state cache persists across `find()` calls,
-   avoiding full DFA reconstruction per search.
-2. **ASCII fast path in DFA** — Pre-computed 128-entry lookup table for character
-   class mapping, avoiding binary search for ASCII text.
-3. **Pre-allocated DFA expand() arrays** — Reuses visited/stack/frontier arrays
-   instead of allocating on each state expansion.
-4. **Start position threading** — DFA, NFA, and BitState accept a `startPos`
-   parameter, eliminating substring creation for the DFA check.
-5. **Search limit support** — BitState and NFA accept a `searchLimit` parameter
-   bounding where new search threads start.
-6. **Literal fast path** — Fully literal patterns bypass all regex engines and use
-   `String.indexOf()` / `String.equals()` directly.
-7. **Reverse DFA bounding** — Three-DFA sandwich: forward DFA finds match end,
-   reverse DFA finds match start, then NFA runs on just the match range.
-8. **OnePass 64-bit action encoding** — Raised capture group limit from 6 to 16
-   by switching from 32-bit to 64-bit action words.
-9. **DFA word boundary support** — Native `\b`/`\B` handling in the DFA avoids
-   NFA fallback for word-boundary patterns.
-10. **Skip reverse DFA for anchored patterns** — Anchored patterns skip reverse
-    program compilation entirely, saving ~2 µs per Pattern.
-11. **Lazy reverse program compilation** — Reverse program is compiled on first
-    access rather than eagerly, avoiding cost for patterns that never need it.
-12. **Pre-allocated DFA computeNext() workspace** — Reuses seed/successor arrays
-    instead of allocating per-transition.
-13. **BitState fast path for small texts** — Texts ≤256 chars skip DFA construction
-    and use BitState directly, avoiding ~500ns DFA overhead per Matcher.
-14. **OnePass submatch in sandwich path** — Uses OnePass for capture extraction
-    when pattern is eligible, avoiding BitState/NFA overhead.
-15. **Character-class prefix acceleration** — Patterns starting with an ASCII
-    character class get a boolean[128] bitmap for fast text scanning, skipping
-    positions that cannot start a match.
-16. **DFA setup sharing** — Equivalence class boundaries and ASCII class map are
-    pre-computed at Pattern.compile() time and shared across all Matcher
-    instances, saving ~1.7 µs per Matcher creation.
-17. **DFA start state caching** — Caches start states by position context
-    (beginning-of-text, beginning-of-line, etc.), eliminating expand()
-    allocation on repeated DFA searches.
-18. **Lazy OnePass/DFA analysis** — Defers OnePass.build() and Dfa.buildSetup()
-    from compile time to first use, improving compilation 2–5×.
-19. **Lazy capture extraction** — Defers capture-group resolution from find()
-    to first access of start()/end()/group(), avoiding BitState/NFA overhead
-    when only match presence is needed.
-20. **CHAR_CLASS instruction** — Single bytecode instruction for character
-    classes with precomputed ASCII bitmap, replacing multi-instruction
-    range chains.
-21. **Pattern-level DFA caching** — ThreadLocal DFA instances shared across
-    all Matchers for the same Pattern, preserving warm state caches.
-22. **DFA sandwich for alternation** — Uses `dfaStartReliable()` to enable
-    DFA range-narrowing even for alternation and bounded-repeat patterns.
-23. **Character-class match fast path** — Patterns like `[a-zA-Z]+` bypass
-    the full engine cascade in `matches()` with a tight bitmap scanning loop.
-24. **Character-class replaceAll fast path** — Patterns like `\d+` with simple
-    replacements (no group refs) bypass all engines with a single-pass scan.
-25. **Compiled replacement template** — Pre-parses replacement strings with group
-    references (`$1`, `$2`) into a template, eliminating per-match `parseInt`,
-    `substring`, and per-character scanning overhead.
-26. **Direct BitState find+capture** — For `replaceAll` with group references on
-    short text, bypasses the DFA sandwich and runs BitState once per match for
-    combined find + capture, eliminating 3 DFA passes per match.
-27. **Cached DFA references in Matcher** — Caches forward/reverse DFA in Matcher
-    fields to avoid repeated ThreadLocal lookups in find-all loops.
-28. **Reverse DFA / end-anchor optimization** — Patterns ending with `$` and a
-    required literal suffix are detected at compile time; the DFA checks for
-    the suffix's presence before scanning, achieving constant-time rejection
-    for non-matching inputs.
-29. **HTTP/OnePass fast path** — Improved anchored pattern handling in the OnePass
-    engine, reducing per-character overhead for patterns like
-    `^(?:GET|POST) +([^ ]+) HTTP` from 1,292 to 269 ns/op.
-
-## Remaining Opportunities
-
-- **HTTP parsing overhead** — HTTP patterns are now 3.0× slower than JDK
-  (improved from 14× with the HTTP/OnePass fast path). The remaining gap is
-  OnePass per-character overhead on the 97-char request; JDK's backtracking
-  engine has lower per-match setup cost on short anchored patterns.
-- **Pig Latin / complex replace** — 1.7× slower than JDK. The gap is
-  fundamental: SafeRE uses BitState (multi-state exploration) per match while
-  JDK does a single backtracking pass. Compiled replacement templates and
-  direct BitState already reduced this from 2.2× to 1.7×.
-- **Empty-match replace** — 3.6× slower than JDK. Empty-match handling requires
-  careful position advancement and is a known gap.
-- **Compilation** — Pattern compilation is 5.1–15× slower than JDK. Opportunities
-  include caching parsed Regexp trees.
-- **DFA state budget tuning** — The default 10,000-state budget may be
-  suboptimal for some pattern/text combinations.
-
----
-
-## Memory Usage
-
-Memory metrics complement the throughput data above. Unlike time-based
-benchmarks, memory measurements are deterministic — they count bytes, not
-time — and are not affected by other processes on the machine.
-
-### Methodology
-
-**Per-match allocation rate** (`gc.alloc.rate.norm`): Measured via JMH's
-built-in GC profiler (`-prof gc`). Reports bytes allocated per operation,
-normalized via TLAB accounting. This is the most actionable memory metric: it
-directly determines GC pressure in production workloads.
-
-**Compiled pattern size**: Measured via the heap-delta technique: allocate 500
-instances of a compiled pattern, force GC, measure heap growth, and divide by
-instance count. Seven trials are run and the median is reported. Run with
-`-Xms256m -Xmx256m` for fixed heap to reduce noise.
-
-**DFA cache growth**: For SafeRE only. Compiles a pattern, measures heap before
-and after matching against a large text (which lazily populates DFA states).
-Multiple trials, median reported.
-
-**Cross-language memory**: C++ RE2 uses `mallinfo2()` heap delta around pattern
-compilation and `RE2::ProgramSize()` for bytecode instruction count. Go uses
-`runtime.MemStats` heap delta. These numbers are not directly comparable to
-Java's due to different allocation strategies (manual vs GC-managed), but
-provide order-of-magnitude context.
-
-### Per-Match Allocation Rate (bytes/op)
-
-| Benchmark | SafeRE (B/op) | JDK (B/op) | RE2/J (B/op) | RE2-FFM (B/op) |
-|---|--:|--:|--:|--:|
-| literalMatch | 96 | 56 | 72 | 48 |
-| charClassMatch | 104 | 56 | 88 | 80 |
-| alternationFind | 336 | 136 | 208 | 512 |
-| captureGroups | 368 | 368 | 432 | 408 |
-| findInText | 2,088 | 136 | 976 | 2,448 |
-| emailFind | 176 | 136 | 88 | 224 |
-
-SafeRE allocates more per match than JDK on most workloads due to Matcher
-state objects and DFA workspace arrays. The highest allocation rate is
-findInText (2,088 B/op) where repeated `find()` calls accumulate Matcher and
-capture state. RE2-FFM allocates similarly to SafeRE on complex patterns due
-to FFM memory segment management, but uses less on simple literal matches.
-
-### Compiled Pattern Size (bytes, retained heap)
+The full collection command was:
+
+```bash
+./collect-benchmark-results.sh --cross-language
+```
+
+Java used the standard project configuration: 2 forks, 2 warmup iterations of
+500 ms, and 5 measurement iterations of 500 ms. Pathological classes used
+`-f 0` so infeasible JDK cases could not strand forked JVMs. The allocation
+pass used its dedicated publication configuration and GC profiler.
+
+C++ and Go used 2 warmup and 10 measurement iterations of 2 seconds in one
+process. All harnesses read the same `benchmark-data.json`. Java results report
+99.9% confidence intervals from JMH; native harnesses use Student's
+t-distribution. A targeted Java confirmation used `--long` for SafeRE
+alternation and log parsing; it did not replace standard-run values in summary
+statistics.
+
+Native C++ and Go operate on UTF-8, while Java engines operate on Java strings.
+RE2-FFM also pays UTF-16-to-UTF-8 conversion and native-call costs. Native
+results therefore provide ecosystem context, not a controlled language-runtime
+comparison.
+
+## Summary statistics
+
+Ratios are SafeRE time / competitor time; values below 1 mean SafeRE is faster.
+Geometric means are used because benchmark ratios are multiplicative and the
+result is invariant under inversion.
+
+| Category | vs JDK | vs RE2/J | vs RE2-FFM | vs C++ RE2 | vs Go `regexp` |
+|---|---:|---:|---:|---:|---:|
+| Core workloads (8) | 1.087 (1.09× slower) | 0.0856 (11.7× faster) | 0.456 (2.19× faster) | 2.320 (2.32× slower) | 0.250 (3.99× faster) |
+| Application workloads (8) | 1.002 (approximately even) | 0.128 (7.81× faster) | 0.604 (1.66× faster) | 1.317 (1.32× slower) | 0.497 (2.01× faster) |
+| Real-world matrix (150) | 0.528 (1.89× faster) | 0.0947 (10.6× faster) | 0.393 (2.54× faster) | 1.443 (1.44× slower) | 0.162 (6.17× faster) |
+| Pathological/scaling (3) | 0.0000739 (13,500× faster) | 0.000354 (2,820× faster) | 0.0432 (23.2× faster) | 1.112 (1.11× slower) | 0.000656 (1,520× faster) |
+
+Core contains literal match, email find, find-in-text, alternation find,
+character-class match, capture groups, Pig Latin replacement, and full HTTP
+parsing. Application contains all eight `ApplicationBenchmark` cases.
+Real-world contains all 25 patterns, both match outcomes, and the 1K, 10K, and
+100K inputs, with equal weight for each of the 150 measurements.
+Pathological/scaling contains `a?{20}a{20}`, hard failed search at 1 MiB, and
+nested quantifiers at 100 KiB.
+
+The C++ RE2 and Go columns are cross-runtime context rather than controlled
+Java comparisons. In particular, native C++ and Go consume UTF-8 while SafeRE
+consumes Java strings, and the pathological/scaling summary has only three
+cases and is dominated by the end-anchored hard-failure result. The real-world
+JDK geomean is materially influenced by two 100K adversarial no-match cases
+that take about 42 seconds each; excluding those two measurements changes the
+ratio from 0.528 (1.89× faster) to 0.625 (1.60× faster).
+
+## Core matching and application workloads
+
+| Benchmark (ns/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---:|---:|---:|---:|---:|---:|
+| Literal match | 14 | 13 | 127 | 59 | 40 | 76 |
+| Character class | 23 | 24 | 1,229 | 120 | 81 | 360 |
+| Alternation find | 226 | 529 | 4,437 | 656 | 19 | 1,699 |
+| Capture groups | 87 | 90 | 572 | 327 | 73 | 234 |
+| Email find | 206 | 392 | 1,923 | 244 | 83 | 548 |
+| Find in prose | 2,587 | 2,965 | 19,921 | 4,174 | 18 | 12,621 |
+
+| Application case (ns/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---:|---:|---:|---:|---:|---:|
+| UUID validation | 456 | 1,302 | 2,537 | 683 | 352 | 934 |
+| API route | 530 | 645 | 6,562 | 1,114 | 315 | 1,003 |
+| Case-insensitive keywords | 399 | 1,322 | 7,312 | 1,265 | 530 | 4,440 |
+| URL extraction | 638 | 1,267 | 7,508 | 1,434 | 624 | 1,591 |
+| Secret redaction | 1,192 | 784 | 7,173 | 1,001 | 638 | 2,513 |
+| CSV field scan | 2,347 | 748 | 10,518 | 6,441 | 1,304 | 3,502 |
+| Log parse | 2,963 | 1,096 | 16,090 | 2,956 | 2,064 | 2,347 |
+| Stack-trace extraction | 4,398 | 2,438 | 28,123 | 4,805 | 3,952 | 4,388 |
+
+The standard log-parse result had a wide interval (2,963 ± 719 ns/op). The
+long confirmation measured 2,479 ± 49 ns/op, so the standard point estimate is
+conservative for SafeRE. Summary geomeans nevertheless use the standard result.
+
+## Real-world benchmark matrix
+
+These 25 data-driven patterns use both matching and non-matching inputs at 1K,
+10K, and 100K sizes. All values are mean ns/op; lower is better. SafeRE is
+competitive on linear scans and benefits strongly from required-content fast
+rejection. JDK can be dramatically faster when a match or rejection is found
+near the start, but its two adversarial 100K no-match cases took about 42
+seconds per operation. RE2/J is usually slower on scans while remaining
+linear-time bounded.
+
+| Pattern | Result | Input | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| `mapFieldPath` | match | 1,000 | 5,034 | 731 | 41,133 | 10,349 | 79 | 6,687 |
+| `mapFieldPath` | match | 10,000 | 48,626 | 5,048 | 408,373 | 101,004 | 79 | 61,617 |
+| `mapFieldPath` | match | 100,000 | 613,038 | 124,361 | 4,224,878 | 2,769,222 | 83 | 2,526,907 |
+| `markupImageLink` | match | 1,000 | 4,312 | 2,335 | 52,396 | 5,578 | 5,374 | 10,343 |
+| `markupImageLink` | match | 10,000 | 42,915 | 19,130 | 490,184 | 54,276 | 51,293 | 361,249 |
+| `markupImageLink` | match | 100,000 | 424,536 | 179,838 | 4,924,270 | 583,542 | 492,847 | 3,500,387 |
+| `versionList` | match | 1,000 | 8,178 | 10,160 | 77,978 | 7,174 | 6,337 | 17,061 |
+| `versionList` | match | 10,000 | 81,840 | 100,172 | 676,581 | 71,647 | 62,852 | 210,738 |
+| `versionList` | match | 100,000 | 780,132 | 966,012 | 7,023,498 | 704,576 | 634,316 | 5,571,893 |
+| `malformedEntity` | match | 1,000 | 4,769 | 5,637 | 62,240 | 7,665 | 6,304 | 22,003 |
+| `malformedEntity` | match | 10,000 | 46,314 | 55,991 | 615,894 | 71,064 | 59,416 | 250,269 |
+| `malformedEntity` | match | 100,000 | 479,741 | 577,353 | 6,874,353 | 696,888 | 616,167 | 5,869,799 |
+| `markupEntity` | match | 1,000 | 89 | 76 | 848 | 412 | 79 | 254 |
+| `markupEntity` | match | 10,000 | 90 | 75 | 858 | 2,318 | 79 | 315 |
+| `markupEntity` | match | 100,000 | 87 | 70 | 841 | 24,850 | 75 | 724 |
+| `customProtocolLink` | match | 1,000 | 602 | 169 | 2,776 | 793 | 108 | 447 |
+| `customProtocolLink` | match | 10,000 | 4,021 | 165 | 2,784 | 2,806 | 103 | 2,161 |
+| `customProtocolLink` | match | 100,000 | 3,991 | 169 | 2,807 | 25,000 | 103 | 2,185 |
+| `wildcardSearch` | match | 1,000 | 5,247 | 268 | 68,616 | 7,563 | 66 | 7,138 |
+| `wildcardSearch` | match | 10,000 | 51,641 | 100 | 669,954 | 70,929 | 66 | 65,215 |
+| `wildcardSearch` | match | 100,000 | 662,015 | 194 | 7,029,718 | 3,461,379 | 69 | 5,409,619 |
+| `metadataBlock` | match | 1,000 | 3,399 | 3,555 | 43,785 | 4,489 | 4,141 | 10,393 |
+| `metadataBlock` | match | 10,000 | 34,535 | 35,404 | 434,786 | 44,059 | 42,665 | 116,073 |
+| `metadataBlock` | match | 100,000 | 352,601 | 363,228 | 4,321,594 | 447,979 | 407,811 | 3,266,842 |
+| `blockedTags1` | match | 1,000 | 3,682 | 2,572 | 36,623 | 5,106 | 4,678 | 8,981 |
+| `blockedTags1` | match | 10,000 | 37,189 | 22,189 | 364,523 | 48,608 | 45,670 | 271,123 |
+| `blockedTags1` | match | 100,000 | 375,745 | 238,390 | 3,547,785 | 491,314 | 458,130 | 2,719,329 |
+| `blockedTags2` | match | 1,000 | 3,711 | 1,923 | 34,522 | 4,901 | 4,355 | 8,371 |
+| `blockedTags2` | match | 10,000 | 36,245 | 18,262 | 340,687 | 46,018 | 41,861 | 255,315 |
+| `blockedTags2` | match | 100,000 | 356,102 | 155,873 | 3,358,769 | 464,462 | 417,258 | 2,528,881 |
+| `overlappingUrl` | match | 1,000 | 5,931 | 8,319 | 49,616 | 4,404 | 3,804 | 12,907 |
+| `overlappingUrl` | match | 10,000 | 65,785 | 85,235 | 483,642 | 41,323 | 37,827 | 418,979 |
+| `overlappingUrl` | match | 100,000 | 689,259 | 797,366 | 4,907,390 | 421,477 | 375,470 | 4,181,978 |
+| `caseInsensitiveKeyword` | match | 1,000 | 4,565 | 1,547 | 30,263 | 7,162 | 8,090 | 9,990 |
+| `caseInsensitiveKeyword` | match | 10,000 | 46,379 | 15,249 | 305,812 | 68,853 | 75,828 | 131,538 |
+| `caseInsensitiveKeyword` | match | 100,000 | 457,228 | 144,753 | 3,126,495 | 711,785 | 759,417 | 3,687,651 |
+| `boundedNameMatch` | match | 1,000 | 8,040 | 3,547 | 35,029 | 7,441 | 7,488 | 11,058 |
+| `boundedNameMatch` | match | 10,000 | 79,131 | 32,528 | 353,148 | 68,119 | 71,363 | 297,534 |
+| `boundedNameMatch` | match | 100,000 | 815,851 | 317,797 | 3,430,851 | 686,680 | 698,426 | 2,936,683 |
+| `templateTagMatch` | match | 1,000 | 2,498 | 4,446 | 28,364 | 3,683 | 3,135 | 6,447 |
+| `templateTagMatch` | match | 10,000 | 25,896 | 46,532 | 284,046 | 35,090 | 30,153 | 206,107 |
+| `templateTagMatch` | match | 100,000 | 244,104 | 483,783 | 2,815,159 | 365,544 | 355,556 | 2,056,744 |
+| `sparseUrl` | match | 1,000 | 1,679 | 8,119 | 23,157 | 2,076 | 1,572 | 18,614 |
+| `sparseUrl` | match | 10,000 | 19,298 | 82,581 | 251,174 | 21,306 | 16,511 | 228,120 |
+| `sparseUrl` | match | 100,000 | 201,896 | 744,357 | 2,530,256 | 228,395 | 210,795 | 2,281,433 |
+| `unprefixedWordBoundary` | match | 1,000 | 108 | 79 | 312 | 364 | 54 | 228 |
+| `unprefixedWordBoundary` | match | 10,000 | 115 | 74 | 302 | 2,230 | 54 | 273 |
+| `unprefixedWordBoundary` | match | 100,000 | 112 | 79 | 314 | 24,222 | 54 | 351 |
+| `fruitSearchQuery` | match | 1,000 | 16,052 | 623 | 244,839 | 8,383 | 7,788 | 8,688 |
+| `fruitSearchQuery` | match | 10,000 | 1,649,681 | 1,403 | 2,395,619 | 483,834 | 471,525 | 1,026,129 |
+| `fruitSearchQuery` | match | 100,000 | 17,087,065 | 492 | 24,294,373 | 4,952,406 | 4,921,290 | 10,247,457 |
+| `fruitMarkupTag` | match | 1,000 | 5,919 | 722 | 74,716 | 3,323 | 2,796 | 12,431 |
+| `fruitMarkupTag` | match | 10,000 | 57,420 | 6,944 | 760,688 | 30,807 | 28,873 | 121,772 |
+| `fruitMarkupTag` | match | 100,000 | 602,412 | 71,372 | 7,461,543 | 447,681 | 403,458 | 1,213,024 |
+| `jsonBlock` | match | 1,000 | 2,214 | 6,057 | 19,790 | 2,347 | 1,962 | 7,000 |
+| `jsonBlock` | match | 10,000 | 20,590 | 64,098 | 195,190 | 20,231 | 16,064 | 65,195 |
+| `jsonBlock` | match | 100,000 | 204,763 | 508,204 | 1,999,569 | 210,772 | 186,891 | 1,299,071 |
+| `charReplace` | match | 1,000 | 8,497 | 8,735 | 67,634 | 39,585 | 34,327 | 31,063 |
+| `charReplace` | match | 10,000 | 94,342 | 93,216 | 662,319 | 401,208 | 341,106 | 395,811 |
+| `charReplace` | match | 100,000 | 957,893 | 922,000 | 6,498,876 | 4,040,785 | 3,498,893 | 6,126,490 |
+| `greedyOnePass` | match | 1,000 | 2,392 | 509 | 36,504 | 4,253 | 1,082 | 8,182 |
+| `greedyOnePass` | match | 10,000 | 23,295 | 4,771 | 371,420 | 41,299 | 10,987 | 80,569 |
+| `greedyOnePass` | match | 100,000 | 239,407 | 58,457 | 3,614,066 | 530,221 | 110,239 | 804,581 |
+| `layoutBlock` | match | 1,000 | 2,984 | 1,751 | 13,912 | 2,393 | 1,893 | 4,206 |
+| `layoutBlock` | match | 10,000 | 31,369 | 18,287 | 149,590 | 25,137 | 21,492 | 124,533 |
+| `layoutBlock` | match | 100,000 | 330,722 | 176,567 | 1,452,189 | 268,285 | 207,098 | 1,248,434 |
+| `turnTitleWhitespaceCjk` | match | 1,000 | 7,003 | 34,223 | 44,697 | 22,719 | 4,634 | 10,508 |
+| `turnTitleWhitespaceCjk` | match | 10,000 | 70,289 | 342,512 | 460,664 | 237,151 | 45,183 | 109,254 |
+| `turnTitleWhitespaceCjk` | match | 100,000 | 656,147 | 3,501,615 | 4,551,701 | 2,386,998 | 464,307 | 1,349,416 |
+| `cjkSearch` | match | 1,000 | 171 | 16 | 460 | 4,176 | 52 | 188 |
+| `cjkSearch` | match | 10,000 | 173 | 16 | 460 | 41,302 | 52 | 214 |
+| `cjkSearch` | match | 100,000 | 172 | 16 | 585 | 416,579 | 55 | 429 |
+| `emojiSearch` | match | 1,000 | 60 | 50 | 576 | 2,213 | 80 | 365 |
+| `emojiSearch` | match | 10,000 | 59 | 51 | 559 | 21,337 | 84 | 384 |
+| `emojiSearch` | match | 100,000 | 60 | 50 | 579 | 201,817 | 80 | 529 |
+| `mapFieldPath` | no match | 1,000 | 1,311 | 65,669 | 44,833 | 1,581 | 1,081 | 30,548 |
+| `mapFieldPath` | no match | 10,000 | 12,488 | 692,540 | 430,369 | 15,047 | 10,406 | 305,614 |
+| `mapFieldPath` | no match | 100,000 | 126,210 | 7,278,956 | 4,316,476 | 156,064 | 103,301 | 3,362,141 |
+| `markupImageLink` | no match | 1,000 | 1,359 | 6,762 | 35,708 | 1,874 | 1,366 | 11,141 |
+| `markupImageLink` | no match | 10,000 | 12,666 | 70,032 | 361,602 | 18,082 | 12,922 | 277,980 |
+| `markupImageLink` | no match | 100,000 | 123,490 | 687,692 | 3,569,493 | 195,370 | 136,389 | 2,771,017 |
+| `versionList` | no match | 1,000 | 2,040 | 28,715 | 58,913 | 1,831 | 1,377 | 34,413 |
+| `versionList` | no match | 10,000 | 28,294 | 279,488 | 612,047 | 17,638 | 13,194 | 339,636 |
+| `versionList` | no match | 100,000 | 179,714 | 2,808,327 | 6,069,417 | 182,146 | 126,750 | 5,122,514 |
+| `malformedEntity` | no match | 1,000 | 1,293 | 3,547 | 41,661 | 1,773 | 1,232 | 13,735 |
+| `malformedEntity` | no match | 10,000 | 12,726 | 35,564 | 404,142 | 16,857 | 11,689 | 137,340 |
+| `malformedEntity` | no match | 100,000 | 126,198 | 342,498 | 4,128,904 | 175,291 | 121,088 | 3,331,623 |
+| `markupEntity` | no match | 1,000 | 102 | 681 | 181 | 858 | 480 | 517 |
+| `markupEntity` | no match | 10,000 | 848 | 6,467 | 952 | 7,483 | 4,302 | 4,230 |
+| `markupEntity` | no match | 100,000 | 8,404 | 67,778 | 8,429 | 71,992 | 49,566 | 44,894 |
+| `customProtocolLink` | no match | 1,000 | 1,306 | 74,329 | 48,199 | 1,590 | 1,296 | 14,477 |
+| `customProtocolLink` | no match | 10,000 | 12,626 | 6,176,486 | 483,097 | 15,435 | 13,081 | 362,662 |
+| `customProtocolLink` | no match | 100,000 | 124,513 | 591,249,437 | 4,712,296 | 156,902 | 125,013 | 3,603,098 |
+| `wildcardSearch` | no match | 1,000 | 476 | 4,353,393 | 36,122 | 1,685 | 1,135 | 23,934 |
+| `wildcardSearch` | no match | 10,000 | 4,618 | 313,589,410 | 366,024 | 16,133 | 10,450 | 238,721 |
+| `wildcardSearch` | no match | 100,000 | 57,497 | 42,290,631,394 | 3,830,355 | 161,981 | 104,360 | 3,147,373 |
+| `metadataBlock` | no match | 1,000 | 1,287 | 20,742 | 44,869 | 1,869 | 1,325 | 13,412 |
+| `metadataBlock` | no match | 10,000 | 12,717 | 2,020,634 | 440,617 | 17,633 | 12,651 | 132,877 |
+| `metadataBlock` | no match | 100,000 | 125,867 | 199,882,604 | 4,467,936 | 192,619 | 133,375 | 3,412,183 |
+| `blockedTags1` | no match | 1,000 | 1,305 | 1,566 | 18,374 | 1,593 | 1,481 | 4,867 |
+| `blockedTags1` | no match | 10,000 | 12,346 | 13,880 | 172,446 | 20,237 | 15,056 | 150,762 |
+| `blockedTags1` | no match | 100,000 | 126,346 | 138,003 | 1,752,655 | 215,257 | 158,317 | 1,497,926 |
+| `blockedTags2` | no match | 1,000 | 1,305 | 1,635 | 14,485 | 1,250 | 1,144 | 4,216 |
+| `blockedTags2` | no match | 10,000 | 12,676 | 12,887 | 139,346 | 15,425 | 9,868 | 118,310 |
+| `blockedTags2` | no match | 100,000 | 124,308 | 133,107 | 1,369,200 | 164,197 | 104,427 | 1,189,957 |
+| `overlappingUrl` | no match | 1,000 | 1,307 | 7,084 | 23,103 | 1,796 | 1,320 | 20,893 |
+| `overlappingUrl` | no match | 10,000 | 12,629 | 70,068 | 243,436 | 17,633 | 12,623 | 225,163 |
+| `overlappingUrl` | no match | 100,000 | 124,485 | 715,378 | 2,381,434 | 185,889 | 126,908 | 2,223,375 |
+| `caseInsensitiveKeyword` | no match | 1,000 | 280 | 387 | 19,141 | 1,847 | 1,319 | 19,607 |
+| `caseInsensitiveKeyword` | no match | 10,000 | 2,679 | 3,793 | 184,802 | 17,573 | 13,240 | 194,098 |
+| `caseInsensitiveKeyword` | no match | 100,000 | 26,450 | 46,397 | 1,830,467 | 186,556 | 133,036 | 2,473,282 |
+| `boundedNameMatch` | no match | 1,000 | 1,294 | 7,001 | 23,008 | 1,862 | 1,380 | 19,136 |
+| `boundedNameMatch` | no match | 10,000 | 12,542 | 67,128 | 222,889 | 17,687 | 13,204 | 200,599 |
+| `boundedNameMatch` | no match | 100,000 | 126,144 | 558,222 | 2,296,764 | 184,284 | 126,843 | 1,991,351 |
+| `templateTagMatch` | no match | 1,000 | 105 | 496 | 222 | 570 | 79 | 607 |
+| `templateTagMatch` | no match | 10,000 | 815 | 4,786 | 2,240 | 4,633 | 172 | 3,469 |
+| `templateTagMatch` | no match | 100,000 | 7,921 | 43,642 | 23,672 | 51,199 | 2,418 | 38,288 |
+| `sparseUrl` | no match | 1,000 | 1,308 | 7,043 | 23,116 | 1,856 | 1,321 | 20,602 |
+| `sparseUrl` | no match | 10,000 | 12,604 | 69,952 | 251,839 | 17,642 | 12,617 | 226,328 |
+| `sparseUrl` | no match | 100,000 | 123,777 | 717,168 | 2,520,099 | 187,407 | 132,905 | 2,220,455 |
+| `unprefixedWordBoundary` | no match | 1,000 | 1,283 | 6,025 | 16,139 | 1,675 | 1,086 | 14,294 |
+| `unprefixedWordBoundary` | no match | 10,000 | 12,712 | 61,020 | 166,948 | 15,703 | 10,933 | 142,644 |
+| `unprefixedWordBoundary` | no match | 100,000 | 125,874 | 604,244 | 1,650,604 | 154,363 | 104,153 | 1,488,490 |
+| `fruitSearchQuery` | no match | 1,000 | 1,295 | 3,273,411 | 62,692 | 1,907 | 1,383 | 46,349 |
+| `fruitSearchQuery` | no match | 10,000 | 12,556 | 390,906,721 | 582,032 | 17,999 | 12,583 | 522,374 |
+| `fruitSearchQuery` | no match | 100,000 | 126,088 | 42,059,953,813 | 6,070,061 | 186,985 | 126,906 | 5,243,080 |
+| `fruitMarkupTag` | no match | 1,000 | 682 | 1,145 | 19,015 | 2,003 | 1,405 | 6,702 |
+| `fruitMarkupTag` | no match | 10,000 | 6,297 | 11,532 | 199,277 | 18,886 | 13,680 | 64,976 |
+| `fruitMarkupTag` | no match | 100,000 | 63,075 | 107,469 | 2,015,625 | 115,071 | 67,571 | 646,086 |
+| `jsonBlock` | no match | 1,000 | 96 | 410 | 209 | 598 | 75 | 597 |
+| `jsonBlock` | no match | 10,000 | 809 | 3,831 | 2,233 | 4,586 | 185 | 3,530 |
+| `jsonBlock` | no match | 100,000 | 7,784 | 39,908 | 24,324 | 49,847 | 2,535 | 39,424 |
+| `charReplace` | no match | 1,000 | 101 | 160 | 206 | 605 | 80 | 602 |
+| `charReplace` | no match | 10,000 | 819 | 1,330 | 2,239 | 4,613 | 182 | 3,510 |
+| `charReplace` | no match | 100,000 | 7,889 | 11,771 | 24,371 | 54,949 | 2,413 | 38,604 |
+| `greedyOnePass` | no match | 1,000 | 24 | 16 | 45 | 340 | 43 | 56 |
+| `greedyOnePass` | no match | 10,000 | 24 | 17 | 45 | 3,035 | 43 | 57 |
+| `greedyOnePass` | no match | 100,000 | 24 | 16 | 46 | 23,979 | 43 | 56 |
+| `layoutBlock` | no match | 1,000 | 1,302 | 1,224 | 7,744 | 926 | 435 | 2,690 |
+| `layoutBlock` | no match | 10,000 | 12,393 | 11,073 | 73,441 | 9,898 | 3,640 | 64,893 |
+| `layoutBlock` | no match | 100,000 | 126,503 | 120,689 | 742,735 | 96,984 | 38,435 | 655,004 |
+| `turnTitleWhitespaceCjk` | no match | 1,000 | 5,726 | 32,946 | 33,774 | 13,915 | 2,140 | 8,203 |
+| `turnTitleWhitespaceCjk` | no match | 10,000 | 58,753 | 307,105 | 335,346 | 139,750 | 20,379 | 82,031 |
+| `turnTitleWhitespaceCjk` | no match | 100,000 | 527,283 | 3,168,363 | 3,275,174 | 1,381,385 | 193,987 | 970,056 |
+| `cjkSearch` | no match | 1,000 | 487 | 147 | 18,753 | 1,595 | 1,136 | 9,997 |
+| `cjkSearch` | no match | 10,000 | 4,657 | 1,230 | 183,480 | 15,634 | 10,471 | 98,992 |
+| `cjkSearch` | no match | 100,000 | 45,872 | 12,127 | 1,813,944 | 153,499 | 104,257 | 1,518,958 |
+| `emojiSearch` | no match | 1,000 | 471 | 260 | 18,729 | 1,592 | 1,081 | 10,176 |
+| `emojiSearch` | no match | 10,000 | 4,777 | 2,393 | 179,055 | 16,106 | 10,477 | 100,688 |
+| `emojiSearch` | no match | 100,000 | 45,564 | 24,131 | 1,812,063 | 153,853 | 108,808 | 1,531,521 |
+
+## Compilation, replacement, and captures
+
+| Compile (µs/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---:|---:|---:|---:|---:|---:|
+| Simple | 6.7 | 0.09 | 0.27 | 2.6 | 1.6 | 0.91 |
+| Medium | 26 | 0.30 | 2.2 | 9.9 | 6.5 | 6.2 |
+| Complex | 15 | 0.22 | 1.2 | 6.9 | 4.5 | 2.5 |
+| Alternation | 27 | 0.42 | 3.1 | 11 | 7.9 | 6.0 |
+
+SafeRE now performs more eager analysis at compile time. That improves match
+execution but makes compilation slower than every comparator in this table.
+
+| Replacement (ns/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---:|---:|---:|---:|---:|---:|
+| Digit replaceAll | 152 | 300 | 3,189 | 1,028 | 650 | 1,581 |
+| Literal replaceFirst, no match | 86 | 270 | 173 | 479 | 267 | 887 |
+| Literal replaceFirst | 55 | 41 | 149 | 217 | 98 | 583 |
+| Pig Latin replaceAll | 2,338 | 955 | 8,307 | 2,455 | 1,816 | 2,828 |
+| Empty-match replaceAll | 417 | 78 | 407 | 672 | 357 | 338 |
+
+Capture extraction grows from 54 ns/op with no captures to 214 ns/op with ten.
+At ten captures SafeRE is 1.15× faster than JDK, 6.9× faster than RE2/J, and
+3.6× faster than RE2-FFM.
+
+## Scaling and pathological behavior
+
+| Failed search at 1 MiB (µs/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---:|---:|---:|---:|---:|---:|
+| Easy literal suffix | 84 | 147 | 84 | 356 | 0.05 | 24 |
+| Medium class prefix | 396 | 271 | 25,058 | 351 | 0.04 | 18,218 |
+| Hard nullable prefix | 0.04 | 44,845 | 38,996 | 350 | 0.04 | 25,453 |
+
+The hard case, `[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$`, is rejected in roughly
+constant time by SafeRE and native C++ RE2. JDK exhibits quadratic behavior;
+RE2/J and Go remain linear but scan the input. Easy and medium cases show that
+linear-time safety does not imply one universal constant factor.
+
+For `a?{n}a{n}` on `a{n}`, SafeRE grows from 0.05 µs at n=10 to 0.31 µs at
+n=100. RE2/J grows from 1.9 to 153 µs, Go from 0.87 to 64 µs, and native C++
+RE2 from 0.05 to 0.17 µs. JDK reaches 17,670 µs at n=20 and larger configured
+cases are intentionally not run.
+
+For `(?:a?){20}a{20}` at 100 KiB, SafeRE takes 131 µs, versus 1,456 µs for
+JDK, 38,732 µs for RE2/J, 159 µs for RE2-FFM, 107 µs for C++ RE2, and
+21,547 µs for Go.
+
+## Memory
+
+Retained compiled-pattern size is larger for SafeRE because it stores compiled
+program and analysis structures:
 
 | Pattern | SafeRE | JDK | RE2/J |
-|---|--:|--:|--:|
-| simple | 1,348 | 756 | 652 |
-| medium | 5,212 | 940 | 1,692 |
-| complex | 2,620 | 1,204 | 844 |
-| alternation | 6,580 | 964 | 3,500 |
+|---|---:|---:|---:|
+| Simple | 8,388 B | 756 B | 652 B |
+| Medium | 16,916 B | 940 B | 1,692 B |
+| Complex | 7,388 B | 1,204 B | 844 B |
+| Alternation | 21,508 B | 964 B | 3,500 B |
 
-**Interpretation:** SafeRE patterns are larger than JDK patterns because they
-include a compiled `Prog` (bytecode), pre-built character class bitmaps, and
-other structures needed for linear-time matching. JDK patterns defer most
-compilation work to match time. RE2/J's sizes fall between the two.
+SafeRE DFA cache growth ranged from 152 B for the simple pattern to 48,024 B
+for the complex pattern. Allocation behavior depends on the execution path.
+For easy search, SafeRE stayed near 152 B/op from 1 KiB through 1 MiB; JDK was
+near 56 B/op and RE2/J near 48 B/op. Other result-materializing and state-heavy
+paths allocate proportionally with input, so these figures are not a universal
+per-match allocation claim.
 
-### Memory Scaling with Input Size
+## SafeRE-specific functionality
 
-How per-match allocation scales with text size (Easy and Medium patterns).
+`PatternSet` matches many patterns simultaneously and has no direct comparator
+in the other APIs. At 4, 16, and 64 patterns, anchored successful matches took
+4.96, 8.93, and 25.7 µs; unanchored successful matches took 5.71, 36.6, and
+125 µs. Anchoring increasingly reduces work as the set grows.
 
-**Easy pattern:** `ABCDEFGHIJKLMNOPQRSTUVWXYZ$`
+## Interpretation
 
-| Text size | SafeRE (B/op) | JDK (B/op) | RE2/J (B/op) |
-|---|--:|--:|--:|
-| 1 KB | 80 | 56 | 48 |
-| 10 KB | 80 | 56 | 48 |
-| 100 KB | 80 | 56 | 48 |
-| 1 MB | 80 | 58 | 48 |
+The 150-measurement real-world matrix is the broadest evidence in this report.
+SafeRE's geomean is 1.89× faster than JDK across that matrix, or 1.60× faster
+when the two roughly 42-second JDK no-match results are excluded. The separate
+eight-case application geomean is approximately even with JDK. Together these
+results show competitive ordinary-workload performance without relying only on
+the adversarial cases that motivate a linear-time engine.
 
-**Medium pattern:** `[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$`
+Within the JVM comparisons, SafeRE is consistently faster than the other
+linear-time options: 10.6× faster than RE2/J and 2.54× faster than RE2-FFM on
+the real-world matrix, with similar direction on the core workloads. RE2/J's
+Pike VM avoids backtracking blowups but performs more active-state work on many
+scans. RE2-FFM benefits from C++ RE2's execution engine while paying conversion
+and native-call costs at the Java boundary.
 
-| Text size | SafeRE (B/op) | JDK (B/op) | RE2/J (B/op) |
-|---|--:|--:|--:|
-| 1 KB | 80 | 56 | 48 |
-| 10 KB | 80 | 56 | 81 |
-| 100 KB | 80 | 56 | 51 |
-| 1 MB | 81 | 98 | 153 |
+The native comparisons show the remaining runtime tradeoff. C++ RE2 is 2.32×
+faster on core workloads, 1.32× faster on application workloads, and 1.44×
+faster on the real-world matrix. SafeRE can still lead individual cases when
+Java fast paths or required-content rejection avoid work. SafeRE is 6.17×
+faster than Go `regexp` on the real-world matrix; Go remains linear-time but,
+like RE2/J, does not use a general cached DFA engine.
 
-All three engines show near-constant allocation across input sizes, indicating
-streaming behavior. SafeRE stays near 80 B/op for these search workloads.
+The pathological/scaling geomean should not be treated as a general ranking.
+It contains only three stress cases, and its largest differences come from an
+end-anchored failure that SafeRE and native C++ RE2 reject without scanning the
+full input. The other two comparisons place SafeRE much closer to native RE2
+and RE2-FFM while still exposing the JDK backtracking cost and the per-character
+state-management cost of NFA-only engines.
 
-### DFA Cache Growth (SafeRE only)
-
-| Pattern | Cache growth (bytes) |
-|---|--:|
-| simple | 80 |
-| medium | 80 |
-| complex | 16,344 |
-| alternation | 3,176 |
-
-SafeRE lazily builds DFA states during matching. The cache is bounded by
-`maxStates` (default 10,000 states). Simple patterns that use the literal
-fast path or OnePass engine may not populate the DFA cache at all. Complex
-patterns with large character classes (e.g., email) grow the cache
-significantly as the DFA explores more state transitions.
-
-### C++ RE2 Memory (heap bytes)
-
-| Benchmark | heapBytes |
-|---|--:|
-| compileSimple | 144 |
-| compileMedium | 1,568 |
-| compileComplex | 608 |
-| compileAlternation | 1,696 |
-| literalMatch | 144 |
-| charClassMatch | 32 |
-| alternationFind | 2,912 |
-| captureGroups | 816 |
-| findInText | 192 |
-| emailFind | 576 |
-
-C++ RE2 uses manual memory management with minimal overhead. Compiled pattern
-sizes (144–1,696 bytes) are much smaller than Java equivalents due to the
-absence of object headers, vtable pointers, and GC metadata.
-
-### Go Memory (heap bytes)
-
-| Benchmark | heapBytes |
-|---|--:|
-| compileSimple | 1,384 |
-| compileMedium | 9,408 |
-| compileComplex | 3,640 |
-| compileAlternation | 9,496 |
-| literalMatch | 1,384 |
-| charClassMatch | 888 |
-| alternationFind | 5,688 |
-| captureGroups | 5,672 |
-| findInText | 2,616 |
-| emailFind | 3,640 |
-
-Go's compiled pattern sizes (1,384–9,496 bytes) fall between C++ RE2 and
-SafeRE, reflecting Go's GC-managed allocator with per-object overhead similar
-to Java but lighter than Java's full object model.
-
-## Trino UTF-8 Migration Matrix
-
-The final external-consumer matrix was run against SafeRE commit
-`8e2394facf9c50ac3d51a15b6485b496cb591d2c` (2026-07-13T05:25:07Z) and Trino
-commit `4e070738fd759ef7cb909177bda24884b7d00dc1`. All engines ran from the same
-Trino checkout with deterministic identical inputs. SafeRE, RE2/J, and Joni
-ran in the same invocation with two forks, three 1-second warmups, and five
-1-second measurements.
-
-| Workload group | SafeRE | RE2/J | Joni | Interpretation |
-|---|---:|---:|---:|---|
-| Capture-free matching | 792 ns | 2,000 ns | 2,246 ns | SafeRE is 2.52× faster than RE2/J and 2.83× faster than Joni |
-| Replacement | 7,090 ns | 12,538 ns | 4,902 ns | Joni is 1.45× faster than SafeRE; SafeRE is 1.77× faster than RE2/J |
-| Combined matrix | 2,370 ns | 5,008 ns | 3,318 ns | SafeRE is 2.11× faster than RE2/J and 1.40× faster than Joni |
-
-The matrix covers five pattern families at two input sizes for both matching
-and replacement. Geometric-mean SafeRE / RE2/J time is 0.40 for matching, 0.57
-for replacement, and 0.47 overall. The largest individual SafeRE / RE2/J time
-ratio is 1.05, so the result passes the precommitted 1.10 aggregate and 1.20
-individual gates. The initially profiled version failed the aggregate gate
-because capture-free UTF-8 search bypassed prefix acceleration. The retained
-optimization adds bounded linear-time literal and ASCII-prefix acceleration to
-the general UTF-8 engine; it is not Trino-specific.
-
----
-*Last updated: 2026-07-13 (completed Trino UTF-8 migration matrix)*
+The costs are also concrete: SafeRE compilation is slower, compiled patterns
+retain more memory, and some short anchored, replacement, and application cases
+remain faster in JDK. The benchmark suite should therefore be read as a map of
+engine tradeoffs, not as a single universal ranking.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -47,6 +47,14 @@ The full collection command was:
 ./collect-benchmark-results.sh --cross-language
 ```
 
+The targeted long confirmation command was:
+
+```bash
+./run-java-benchmarks.sh --long \
+  '^org\.safere\.benchmark\.RegexBenchmark\.alternationFind_safere$' \
+  '^org\.safere\.benchmark\.ApplicationBenchmark\.logLineParse_safere$'
+```
+
 Java used the standard project configuration: 2 forks, 2 warmup iterations of
 500 ms, and 5 measurement iterations of 500 ms. Pathological classes used
 `-f 0` so infeasible JDK cases could not strand forked JVMs. The allocation
@@ -103,6 +111,8 @@ ratio from 0.528 (1.89× faster) to 0.625 (1.60× faster).
 | Capture groups | 87 | 90 | 572 | 327 | 73 | 234 |
 | Email find | 206 | 392 | 1,923 | 244 | 83 | 548 |
 | Find in prose | 2,587 | 2,965 | 19,921 | 4,174 | 18 | 12,621 |
+| Pig Latin replacement | 2,338 | 955 | 8,307 | 2,455 | 1,816 | 2,828 |
+| Full HTTP parsing | 384 | 94 | 8,328 | 423 | 305 | 920 |
 
 | Application case (ns/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
 |---|---:|---:|---:|---:|---:|---:|
@@ -318,6 +328,10 @@ The hard case, `[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$`, is rejected in roughly
 constant time by SafeRE and native C++ RE2. JDK exhibits quadratic behavior;
 RE2/J and Go remain linear but scan the input. Easy and medium cases show that
 linear-time safety does not imply one universal constant factor.
+
+| Pathological comparison (n=20, µs/op) | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go |
+|---|---:|---:|---:|---:|---:|---:|
+| `a?{20}a{20}` on `a{20}` | 0.09 | 17,670 | 6.9 | 0.10 | 0.07 | 3.0 |
 
 For `a?{n}a{n}` on `a{n}`, SafeRE grows from 0.05 µs at n=10 to 0.31 µs at
 n=100. RE2/J grows from 1.9 to 153 µs, Go from 0.87 to 64 µs, and native C++

--- a/README.md
+++ b/README.md
@@ -568,20 +568,22 @@ See [BENCHMARKS.md](BENCHMARKS.md) for full results. Highlights:
 
 | Benchmark | SafeRE | JDK | RE2/J | RE2-FFM | C++ RE2 | Go | vs JDK |
 |---|--:|--:|--:|--:|--:|--:|---|
-| Literal match | 9 ns | 13 ns | 126 ns | 55 ns | 40 ns | 78 ns | **1.4× faster** |
-| Capture groups (3) | 94 ns | 75 ns | 958 ns | 329 ns | 84 ns | 311 ns | 1.3× slower |
-| Capture groups (10) | 200 ns | 235 ns | 1,398 ns | 737 ns | 367 ns | 600 ns | **1.2× faster** |
-| Hard pattern (1 MB) | 0.019 µs | 43,773 µs | 37,857 µs | 152 µs | 0.048 µs | 25,445 µs | **2.3M× faster** |
-| Pathological (n=20) | 0.072 µs | 15,389 µs | 6.64 µs | 0.092 µs | 0.071 µs | 3.07 µs | **210,808× faster** |
-| Literal replaceFirst | 30 ns | 40 ns | 147 ns | 215 ns | 98 ns | 605 ns | **1.3× faster** |
+| Literal match | 14 ns | 13 ns | 127 ns | 59 ns | 40 ns | 76 ns | 1.1× slower |
+| Alternation find | 226 ns | 529 ns | 4,437 ns | 656 ns | 19 ns | 1,699 ns | **2.3× faster** |
+| Capture groups (10) | 214 ns | 247 ns | 1,485 ns | 765 ns | 356 ns | 578 ns | **1.2× faster** |
+| Hard pattern (1 MiB) | 0.04 µs | 44,845 µs | 38,996 µs | 350 µs | 0.04 µs | 25,453 µs | **1.1M× faster** |
+| Pathological (n=20) | 0.09 µs | 17,670 µs | 6.9 µs | 0.10 µs | 0.07 µs | 3.0 µs | **196,000× faster** |
+| Literal replaceFirst | 55 ns | 41 ns | 149 ns | 217 ns | 98 ns | 583 ns | 1.3× slower |
 
 **Summary (geometric mean of speed ratios):**
 
-| vs | Core workloads | Pathological/scaling |
-|---|---|---|
-| JDK | 1.1× slower | **13,500× faster** |
-| RE2/J | **11.5× faster** | **2,930× faster** |
-| RE2-FFM | **2.1× faster** | **17.3× faster** |
+| vs | Core | Application | Real-world matrix | Pathological/scaling |
+|---|---|---|---|---|
+| JDK | 1.09× slower | approximately even | **1.89× faster** | **13,500× faster** |
+| RE2/J | **11.7× faster** | **7.81× faster** | **10.6× faster** | **2,820× faster** |
+| RE2-FFM | **2.19× faster** | **1.66× faster** | **2.54× faster** | **23.2× faster** |
+| C++ RE2 | 2.32× slower | 1.32× slower | 1.44× slower | 1.11× slower |
+| Go `regexp` | **3.99× faster** | **2.01× faster** | **6.17× faster** | **1,520× faster** |
 
 ## License
 


### PR DESCRIPTION
## Summary

- refresh the benchmark report from the standard Java and cross-language collection at commit `6fe67606d7c7724b9b1f1736c3bee04c674eaec5`
- make the report self-contained, including all 150 real-world matrix measurements and summary geomeans against JDK, RE2/J, RE2-FFM, native C++ RE2, and Go `regexp`
- document cross-runtime caveats, aggregate membership, outlier sensitivity, engine tradeoffs, compilation, scaling, and memory results
- update README highlights and replace stale fixed report categories in `AGENTS.md` with durable reporting rules

## Verification

- `./collect-benchmark-results.sh --cross-language`
- targeted `--long` confirmation for SafeRE alternation and log parsing
- verified the real-world report table contains all 150 expected rows
- verified the benchmarked Git SHA in the report matches the measured commit
- `git diff --check`

No Java unit tests were run because this PR changes documentation and agent guidance only.
