### PR TITLE
Bump to 0.10.0-SNAPSHOT and improve release workflow

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,21 +28,40 @@ git pull --ff-only
 ```
 
 Update release-facing documentation if needed, such as the version shown in the
-README installation snippets.
+README installation snippets. Make all release-preparation changes on a branch,
+open a ready-for-review pull request, and merge it after CI passes. Never push
+release-preparation commits directly to `main`.
+
+After the pull request is merged, return to a clean, current `main` before
+continuing:
+
+```bash
+git switch main
+git pull --ff-only
+```
 
 ### 2. Prepare the release notes
 
-Collect the complete commit messages since the previous release:
+Collect the complete commit messages and author/co-author identities since the
+previous release:
 
 ```bash
 PREVIOUS_RELEASE_TAG=$(git describe --tags --abbrev=0)
 git log --reverse --format='commit %H%n%n%B%n---' \
   "${PREVIOUS_RELEASE_TAG}..HEAD" > /tmp/safere-release-commits.txt
+git log --format='%an <%ae>%n%(trailers:key=Co-authored-by,valueonly)' \
+  "${PREVIOUS_RELEASE_TAG}..HEAD" \
+  | sed '/^$/d' | sort -fu > /tmp/safere-release-contributors.txt
 ```
 
-Review every commit in `/tmp/safere-release-commits.txt` and summarize the
-user-facing changes in `/tmp/safere-vX.Y.Z-release-notes.md`. Use the following
-structure, omitting empty sections:
+Review every commit in `/tmp/safere-release-commits.txt` and every identity in
+`/tmp/safere-release-contributors.txt`. Consolidate aliases that use different
+names or email addresses, and use linked pull requests to resolve community
+contributors to their GitHub handles.
+
+Summarize the user-facing changes in
+`/tmp/safere-vX.Y.Z-release-notes.md`. Use the following structure, omitting
+empty change sections:
 
 ```markdown
 ## Highlights
@@ -65,6 +84,11 @@ A short description of the most important release themes.
 
 - Other changes users should know about.
 
+## Contributors
+
+Thank the community contributors by GitHub handle and briefly summarize their
+areas of contribution.
+
 **Full changelog:** https://github.com/eaftan/safere/compare/PREVIOUS_TAG...vX.Y.Z
 ```
 
@@ -73,6 +97,15 @@ should be a concise, curated summary rather than a copy of the commit log. Put
 breaking changes and migration requirements first. Follow links to pull
 requests or issues when a commit message does not provide enough context to
 describe its user-visible effect accurately.
+
+Credit every human community contributor represented in the release. Do not
+describe someone as a new contributor unless the repository history confirms
+that this is their first contribution.
+
+Write each prose paragraph and Markdown list item in the release-notes file on
+one physical line, including any parenthesized list of pull request links.
+GitHub Release rendering turns source newlines into hard line breaks, so source
+wrapping makes prose and pull request lists render one fragment per line.
 
 Local verification is not repeated here because every change merged into
 `main` has already passed CI. The release workflow verifies the tagged release
@@ -117,18 +150,27 @@ gh release create vX.Y.Z \
   --notes-file /tmp/safere-vX.Y.Z-release-notes.md
 ```
 
+Inspect the rendered release page and confirm that its paragraphs, pull request
+links, contributor credits, and full changelog render correctly.
+
 ### 7. Bump to next SNAPSHOT
 
-After a successful release, bump `main` to the next development version:
+After a successful release, start from an up-to-date `main` and create a branch
+for the next development version:
 
 ```bash
+git switch main
+git pull --ff-only
+git switch -c bump-to-NEXT-SNAPSHOT
 mvn versions:set -DnewVersion=NEXT-SNAPSHOT -DgenerateBackupPoms=false
 git add -A
 git commit -m "Bump version to NEXT-SNAPSHOT"
-git push origin main
+git push -u origin bump-to-NEXT-SNAPSHOT
 ```
 
-For example, after releasing `v0.3.0`, bump to `0.4.0-SNAPSHOT`.
+Open the pull request as ready for review and merge it after CI passes. Never
+push the version bump directly to `main`. For example, after releasing
+`v0.3.0`, bump to `0.4.0-SNAPSHOT`.
 
 ## Troubleshooting
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.safere</groupId>
   <artifactId>safere-parent</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SafeRE Parent</name>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-benchmarks</artifactId>

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-crosscheck</artifactId>

--- a/safere-exhaustive/pom.xml
+++ b/safere-exhaustive/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-exhaustive</artifactId>

--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-ffm-re2</artifactId>

--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-fuzz</artifactId>

--- a/safere-unicode/pom.xml
+++ b/safere-unicode/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-unicode-generator</artifactId>

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere</artifactId>


### PR DESCRIPTION
## Summary

- bump the parent and all module parent references to `0.10.0-SNAPSHOT`
- require pull requests for release preparation and post-release version bumps
- collect commit authors and `Co-authored-by` identities for release contributor credit
- document contributor recognition and GitHub Release Markdown line-break behavior
- require inspection of the rendered GitHub Release page

## Verification

- `mvn validate --batch-mode --no-transfer-progress`
- `git diff --check main...HEAD`
- confirmed no POM retains `0.9.0-SNAPSHOT`
- exercised the documented contributor command against `v0.8.0..v0.9.0`
- confirmed `RELEASING.md` contains no direct push to `main`

The test suite was not run because this changes version metadata and release documentation only.
