### PR TITLE
Preserve Boyer-Moore-Horspool throughput with explicit batching

### DIFF
--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -15,6 +15,7 @@ final class Utf8InputScanner implements InputScanner {
   private static final int REPLACEMENT_CHARACTER = 0xFFFD;
   private static final long BYTE_ONES = 0x0101_0101_0101_0101L;
   private static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
+  private static final int BOYER_MOORE_HORSPOOL_BATCH_SIZE = 2;
 
   /**
    * Input sizes at which the SWAR candidate filter overtakes the skip loop. The filter always
@@ -243,24 +244,29 @@ final class Utf8InputScanner implements InputScanner {
     long work = 0;
     long workLimit = workLimit(remaining(start));
     while (position < length) {
-      int literalPosition = last;
-      int inputPosition = position;
-      while (literalPosition >= 0 && bytes[offset + inputPosition] == literal[literalPosition]) {
+      // Keep two dependent skip steps under one outer backedge. C2 otherwise leaves this loop
+      // scalar when it is compiled alongside the candidate-filter path, adding a backedge and
+      // safepoint poll to every skip.
+      for (int step = 0; step < BOYER_MOORE_HORSPOOL_BATCH_SIZE && position < length; step++) {
+        int literalPosition = last;
+        int inputPosition = position;
+        while (literalPosition >= 0 && bytes[offset + inputPosition] == literal[literalPosition]) {
+          if (work >= workLimit) {
+            return -2;
+          }
+          work++;
+          literalPosition--;
+          inputPosition--;
+        }
+        if (literalPosition < 0) {
+          return inputPosition + 1;
+        }
         if (work >= workLimit) {
           return -2;
         }
+        position += shifts[bytes[offset + position] & 0xFF];
         work++;
-        literalPosition--;
-        inputPosition--;
       }
-      if (literalPosition < 0) {
-        return inputPosition + 1;
-      }
-      if (work >= workLimit) {
-        return -2;
-      }
-      position += shifts[bytes[offset + position] & 0xFF];
-      work++;
     }
     return -1;
   }


### PR DESCRIPTION
Stacked on #580.

Refs #579

## Summary

PR #580 adds a SWAR candidate filter while retaining Boyer-Moore-Horspool
(BMH) for shorter inputs. The resulting `hardFailure[1024]` regression was
first observed on macOS ARM64 and reproduced on Linux x86-64, even though that
input correctly selects BMH and never executes the filter.

On x86-64, `perfasm` shows that the additional filter path changes HotSpot
C2's compilation of the existing BMH loop: C2 stops unrolling the loop. This
explains the same behavior and filter-disabled ablation reported on ARM64 in
PR #580.

Batch two BMH skip steps explicitly beneath one outer loop backedge. This
preserves the original search and work-budget semantics while no longer relying
on C2 to choose the same unrolling optimization.

## Diagnosis

The required literal in `hardFailure` is `ABCDEFGHIJKLMNOPQRSTUVWXYZ`, or 26
bytes. Its filter threshold is 1,040 bytes, so the 1,024-byte case correctly
uses BMH.

On x86-64, `perfasm` showed:

- `main`: C2 processes two BMH iterations per outer backedge.
- PR #580: C2 leaves the loop scalar, adding a backedge and safepoint poll to
  every skip.
- Disabling loop unrolling on `main` reproduces the regression: 123.87 ns/op
  versus 125.36 ns/op on PR #580.

Hardware counters also showed more instructions per operation and a higher
branch-miss rate, with negligible cache and TLB misses.

## Benchmark

The regression reproduces on both tested architectures:

| Platform | Baseline | PR #580 | Filter-disabled ablation |
|---|---:|---:|---:|
| macOS ARM64 | 59.9 ± 1.5 | 69.8 ± 1.9 | 61.6 |
| Linux x86-64 | 101.71 ± 2.23 | 125.42 ± 3.33 | 101.75 ± 2.22 |

Times are ns/op; lower is better.

After explicit batching on Linux x86-64:

| `hardFailure[1024]` | Time (ns/op) |
|---|---:|
| PR #580 before this change | 125.42 ± 3.33 |
| After explicit batching | 101.10 ± 2.17 |
| `main` reference | 101.71 ± 2.23 |

This reduces time by approximately 19% and restores performance to the `main`
baseline on x86-64. A post-change ARM64 benchmark would still be useful, but
the source-level batching directly removes reliance on platform-specific C2
unrolling.

The SWAR workloads remain healthy:

| Literal | PR #580 before | After |
|---|---:|---:|
| `qjxv` | 6,044.92 ± 77.47 | 5,795.97 ± 106.66 |
| `literal` | 6,022.80 ± 33.12 | 5,836.72 ± 55.93 |
| `coolfunctionname` | 6,027.19 ± 164.67 | 5,675.56 ± 304.81 |

Times are ns/op; lower is better.

## Verification

Ran:

- `mvn -pl safere -Dtest=Utf8InputScannerTest test -q`
- `mvn -pl safere test -q`
- Long-mode `hardFailure[1024]`
- Long-mode all `literalScan` variants
- `perf` hardware-counter profiling
- JMH `perfasm` inspection with JDK 25-compatible hsdis
- Review-fix loop against PR #580 commit
  `b5f6cd09fa7e2923a6ed873f1110d6c4ebd5c57f`; no findings

Not run: crosscheck, standalone exhaustive, or fuzz modules.
