### PR TITLE
Optimize repeated capture extraction

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -74,6 +74,13 @@ public final class Matcher implements MatchResult {
    */
   private static final int MAX_LAZY_FALLBACK_SUBMATCHES = 3;
 
+  /**
+   * Maximum input length for adapting match operations to observed inner-capture demand. On small
+   * inputs BitState can produce the boolean result and all capture bounds in one bounded pass;
+   * larger inputs retain the DFA's scanning advantage.
+   */
+  private static final int CAPTURE_DEMAND_TEXT_LIMIT = 512;
+
   private Pattern parentPattern;
   private CharSequence inputSequence;
   private String text;
@@ -305,6 +312,22 @@ public final class Matcher implements MatchResult {
 
   private EnginePathOptions enginePathOptions() {
     return parentPattern.enginePathOptions();
+  }
+
+  private void recordInnerCaptureDemand() {
+    if (!eagerFallbackCaptures) {
+      parentPattern.recordInnerCaptureAccess();
+      eagerFallbackCaptures = true;
+    }
+  }
+
+  private boolean shouldPreferCaptureEngine(Prog prog, InputScanner scanner) {
+    return parentPattern.innerCapturesObserved()
+        && scanner.length() <= CAPTURE_DEMAND_TEXT_LIMIT
+        && enginePathOptions().bitState()
+        && !fullTextRegionContext
+        && !prog.hasGraphemeSemantics()
+        && BitState.maxTextSize(prog) >= scanner.length();
   }
 
   /** Returns the Pattern's thread-local cached forward DFA, caching it for reuse. */
@@ -622,6 +645,9 @@ public final class Matcher implements MatchResult {
    */
   private void applyReplacementTemplate(StringBuilder sb, ReplacementSegment[] template) {
     if (templateNeedsCaptures(template)) {
+      if (!capturesResolved) {
+        recordInnerCaptureDemand();
+      }
       resolveCaptures();
     }
     for (ReplacementSegment seg : template) {
@@ -750,8 +776,11 @@ public final class Matcher implements MatchResult {
     }
 
     InputScanner scanner = activeScanner();
+    boolean preferCaptureEngine = shouldPreferCaptureEngine(prog, scanner);
     // Medium path: use DFA to check if a full match exists.
-    if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
+    if (!preferCaptureEngine
+        && enginePathOptions().dfa()
+        && dfaSupportsProgram(parentPattern.flatDfaProg())) {
       Dfa.SearchResult dfaResult = dfa(true).doSearch(scanner, true, true);
       if (dfaResult != null && !dfaResult.matched()) {
         return applyFailedMatchResult();
@@ -1441,6 +1470,27 @@ public final class Matcher implements MatchResult {
     // for anchored matching, trying deterministic anchored matches at successive positions can
     // miss the leftmost start when a greedy leading repetition overlaps a later required literal.
     // The DFA/BitState/NFA pipeline below preserves leftmost find() semantics and remains linear.
+
+    // Once callers have demonstrated that they consume inner captures, use the capture-aware
+    // engine directly for bounded small inputs. This avoids finding group 0 with the DFA and then
+    // replaying the same range through BitState on every successful find().
+    if (shouldPreferCaptureEngine(prog, scanner)) {
+      int[] result =
+          searchWithBitStateOrNfa(
+              prog,
+              scanner,
+              effectiveStart,
+              scanner.length(),
+              scanner.length(),
+              scanner.length(),
+              false,
+              false,
+              false,
+              prog.numCaptures(),
+              false,
+              this.groups);
+      return applyFullMatchResult(result);
+    }
 
     // Reverse-first optimization for end-anchored patterns: for patterns ending with $ or \z
     // that are NOT anchored at the start, run the reverse DFA from the end of the text first.
@@ -2219,7 +2269,11 @@ public final class Matcher implements MatchResult {
     checkGroup(group);
     if (group != 0 || !groupZeroResolved) {
       if (group != 0) {
-        eagerFallbackCaptures = true;
+        if (!capturesResolved) {
+          recordInnerCaptureDemand();
+        } else {
+          eagerFallbackCaptures = true;
+        }
       }
       resolveCaptures();
     }
@@ -2254,7 +2308,11 @@ public final class Matcher implements MatchResult {
     checkGroup(group);
     if (group != 0 || !groupZeroResolved) {
       if (group != 0) {
-        eagerFallbackCaptures = true;
+        if (!capturesResolved) {
+          recordInnerCaptureDemand();
+        } else {
+          eagerFallbackCaptures = true;
+        }
       }
       resolveCaptures();
     }
@@ -3034,7 +3092,11 @@ public final class Matcher implements MatchResult {
    *     operation failed
    */
   public MatchResult toMatchResult() {
-    eagerFallbackCaptures = true;
+    if (parentPattern.numGroups() > 0 && !capturesResolved) {
+      recordInnerCaptureDemand();
+    } else {
+      eagerFallbackCaptures = true;
+    }
     if (hasMatch) {
       resolveCaptures();
     }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -177,6 +177,13 @@ public final class Pattern implements Serializable {
   private transient volatile OnePassAnalysis onePassAnalysis;
 
   /**
+   * Whether a matcher created from this pattern has requested an inner capture. This adaptive
+   * signal lets later small-input match operations avoid a redundant DFA pass when capture
+   * extraction is demonstrably part of the workload.
+   */
+  private transient volatile boolean innerCapturesObserved;
+
+  /**
    * Lazily computed DFA equivalence-class setup for the forward program. Shared across all Matcher
    * instances. Computed on first access to avoid paying the boundary-scan cost at compile time.
    */
@@ -811,6 +818,16 @@ public final class Pattern implements Serializable {
 
   EnginePathOptions enginePathOptions() {
     return enginePathOptions;
+  }
+
+  boolean innerCapturesObserved() {
+    return innerCapturesObserved;
+  }
+
+  void recordInnerCaptureAccess() {
+    if (!innerCapturesObserved) {
+      innerCapturesObserved = true;
+    }
   }
 
   /** Returns the thread-local cached BitState, or null if none has been cached yet. */

--- a/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
+++ b/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
@@ -92,6 +92,70 @@ class MatcherDeferredCaptureStateTest {
   }
 
   @Test
+  @DisplayName("inner capture demand makes later small full matches capture eagerly")
+  void innerCaptureDemandMakesLaterSmallFullMatchesCaptureEagerly()
+      throws ReflectiveOperationException {
+    Pattern pattern = Pattern.compile("^a\\s+-\\s+(.+)$");
+    Matcher first = pattern.matcher("a - value");
+
+    assertThat(first.matches()).isTrue();
+    assertThat(booleanField(first, "capturesResolved")).isFalse();
+    assertThat(first.group(1)).isEqualTo("value");
+
+    Matcher second = pattern.matcher("a - another");
+    assertThat(second.matches()).isTrue();
+    assertThat(booleanField(second, "capturesResolved")).isTrue();
+    assertThat(second.group(1)).isEqualTo("another");
+  }
+
+  @Test
+  @DisplayName("group zero access keeps later full matches on deferred captures")
+  void groupZeroAccessKeepsLaterFullMatchesOnDeferredCaptures()
+      throws ReflectiveOperationException {
+    Pattern pattern = Pattern.compile("^a\\s+-\\s+(.+)$");
+    Matcher first = pattern.matcher("a - value");
+
+    assertThat(first.matches()).isTrue();
+    assertThat(first.group()).isEqualTo("a - value");
+
+    Matcher second = pattern.matcher("a - another");
+    assertThat(second.matches()).isTrue();
+    assertThat(booleanField(second, "capturesResolved")).isFalse();
+  }
+
+  @Test
+  @DisplayName("inner capture demand makes later small finds capture eagerly")
+  void innerCaptureDemandMakesLaterSmallFindsCaptureEagerly() throws ReflectiveOperationException {
+    Pattern pattern = Pattern.compile("a\\s+(.+)");
+    Matcher first = pattern.matcher("prefix a value");
+
+    assertThat(first.find()).isTrue();
+    assertThat(booleanField(first, "capturesResolved")).isFalse();
+    assertThat(first.group(1)).isEqualTo("value");
+
+    Matcher second = pattern.matcher("prefix a another");
+    assertThat(second.find()).isTrue();
+    assertThat(booleanField(second, "capturesResolved")).isTrue();
+    assertThat(second.group(1)).isEqualTo("another");
+  }
+
+  @Test
+  @DisplayName("capture-demand adaptation remains bounded to small inputs")
+  void captureDemandAdaptationRemainsBoundedToSmallInputs() throws ReflectiveOperationException {
+    Pattern pattern = Pattern.compile("a\\s+(.+)");
+    Matcher first = pattern.matcher("a first");
+
+    assertThat(first.find()).isTrue();
+    assertThat(first.group(1)).isEqualTo("first");
+
+    String capturedText = "x".repeat(600);
+    Matcher second = pattern.matcher("prefix a " + capturedText);
+    assertThat(second.find()).isTrue();
+    assertThat(booleanField(second, "capturesResolved")).isFalse();
+    assertThat(second.group(1)).isEqualTo(capturedText);
+  }
+
+  @Test
   @DisplayName("anchoring bounds change resolves stale deferred captures before clearing markers")
   void anchoringBoundsChangeResolvesStaleDeferredCapturesBeforeClearingMarkers()
       throws ReflectiveOperationException {


### PR DESCRIPTION
## Summary

- remember when callers consume inner captures
- prefer capture-aware BitState directly for bounded small inputs after that demand is observed
- retain the DFA path for group-zero-only and larger-input workloads
- add regression coverage for the adaptive matcher state

This is the first PR in the issue #584 optimization stack.

## Benchmark impact

Before: `6eda1b9`  
After: `e398d25`

Standard Java benchmark configuration (`2` forks, `2 x 500 ms` warmup,
`5 x 500 ms` measurement), lower is better:

| Benchmark | Before (ns/op) | After (ns/op) | Impact |
|---|---:|---:|---:|
| `ApplicationBenchmark.logLineParse_safere` | 3,489.821 | 1,881.919 | 1.85x faster |
| `ApplicationBenchmark.stackTraceExtract_safere` | 4,529.965 | 2,990.428 | 1.51x faster |
| `ApplicationBenchmark.csvFieldScan_safere` | 2,463.666 | 2,491.547 | statistically neutral |
| `RegexBenchmark.captureGroups_safere` | 94.161 | 91.615 | statistically neutral |

The improvement is concentrated in repeated successful operations that consume
inner captures; standalone capture microbenchmarks remain neutral.

## Verification

- `mvn -pl safere -Dtest=MatcherDeferredCaptureStateTest test -q`
- focused before/after application and capture benchmarks via
  `./run-java-benchmarks.sh`
- full test suite was not rerun while preparing this PR; GitHub CI will provide
  full project verification

Part of #584
