### PR TITLE
Accelerate greedy whole-input keyword searches

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1798,6 +1798,9 @@ public final class Matcher implements MatchResult {
 
   private boolean findKeywordAlternation(
       Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
+    if (keywordAlternation.greedyWholeInput) {
+      return findGreedyWholeInputKeywordAlternation(keywordAlternation, startPos, ncap);
+    }
     for (int i = Math.max(0, startPos); i < text.length(); i++) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
@@ -1809,7 +1812,7 @@ public final class Matcher implements MatchResult {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();
           if (end <= text.length()
-              && text.regionMatches(true, i, keyword, 0, keyword.length())
+              && regionMatchesAsciiIgnoreCase(text, i, keyword, 0, keyword.length())
               && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
             int[] keywordGroups = new int[2 * ncap];
             Arrays.fill(keywordGroups, -1);
@@ -1826,6 +1829,39 @@ public final class Matcher implements MatchResult {
       }
       int cp = text.codePointAt(i);
       i += Character.charCount(cp) - 1;
+    }
+    return applyFailedMatchResult();
+  }
+
+  private boolean findGreedyWholeInputKeywordAlternation(
+      Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
+    int matchStart = Math.max(0, startPos);
+    for (int i = text.length() - 1; i >= matchStart; i--) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      char ch = text.charAt(i);
+      if (ch < 128
+          && keywordAlternation.firstAscii[asciiLower(ch)]
+          && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
+        for (String keyword : keywordAlternation.keywords) {
+          int end = i + keyword.length();
+          if (end <= text.length()
+              && regionMatchesAsciiIgnoreCase(text, i, keyword, 0, keyword.length())
+              && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
+            int[] keywordGroups = new int[2 * ncap];
+            Arrays.fill(keywordGroups, -1);
+            keywordGroups[0] = matchStart;
+            keywordGroups[1] = text.length();
+            if (keywordAlternation.captureGroup > 0) {
+              int group = keywordAlternation.captureGroup;
+              keywordGroups[2 * group] = i;
+              keywordGroups[2 * group + 1] = end;
+            }
+            return applyFullMatchResult(keywordGroups);
+          }
+        }
+      }
     }
     return applyFailedMatchResult();
   }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1686,19 +1686,25 @@ public final class Pattern implements Serializable {
     }
   }
 
-  /** Fast-path data for {@code (?i)\b(keyword|...)\b}. */
+  /** Fast-path data for {@code (?i)\b(keyword|...)\b} and its greedy whole-input form. */
   static final class KeywordAlternation {
     final String[] keywords;
     final boolean[] firstAscii;
     final int captureGroup;
     final boolean unicodeWordBoundary;
+    final boolean greedyWholeInput;
 
     KeywordAlternation(
-        String[] keywords, boolean[] firstAscii, int captureGroup, boolean unicodeWordBoundary) {
+        String[] keywords,
+        boolean[] firstAscii,
+        int captureGroup,
+        boolean unicodeWordBoundary,
+        boolean greedyWholeInput) {
       this.keywords = keywords;
       this.firstAscii = firstAscii;
       this.captureGroup = captureGroup;
       this.unicodeWordBoundary = unicodeWordBoundary;
+      this.greedyWholeInput = greedyWholeInput;
     }
   }
 
@@ -1899,12 +1905,22 @@ public final class Pattern implements Serializable {
     }
 
     Regexp node = unwrapImplicitCapture(re);
-    if (node == null || node.op != RegexpOp.CONCAT || node.nsub() != 3) {
+    if (node == null || node.op != RegexpOp.CONCAT) {
       return null;
     }
-    Regexp before = unwrapImplicitCapture(node.subs.get(0));
-    Regexp middle = unwrapImplicitCapture(node.subs.get(1));
-    Regexp after = unwrapImplicitCapture(node.subs.get(2));
+    boolean greedyWholeInput = false;
+    int coreOffset = 0;
+    if (node.nsub() == 5
+        && isGreedyAnyCharStar(node.subs.getFirst())
+        && isGreedyAnyCharStar(node.subs.getLast())) {
+      greedyWholeInput = true;
+      coreOffset = 1;
+    } else if (node.nsub() != 3) {
+      return null;
+    }
+    Regexp before = unwrapImplicitCapture(node.subs.get(coreOffset));
+    Regexp middle = unwrapImplicitCapture(node.subs.get(coreOffset + 1));
+    Regexp after = unwrapImplicitCapture(node.subs.get(coreOffset + 2));
     if (before == null
         || before.op != RegexpOp.WORD_BOUNDARY
         || after == null
@@ -1939,7 +1955,16 @@ public final class Pattern implements Serializable {
     }
 
     boolean unicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
-    return new KeywordAlternation(keywords, firstAscii, captureGroup, unicodeWordBoundary);
+    return new KeywordAlternation(
+        keywords, firstAscii, captureGroup, unicodeWordBoundary, greedyWholeInput);
+  }
+
+  private static boolean isGreedyAnyCharStar(Regexp re) {
+    Regexp node = unwrapImplicitCapture(re);
+    return node != null
+        && node.op == RegexpOp.STAR
+        && !node.nonGreedy()
+        && node.sub().op == RegexpOp.ANY_CHAR;
   }
 
   private static boolean hasOtherUserCaptures(Regexp re, int allowedCapture) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -568,6 +568,37 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("keyword alternation keeps default case folding ASCII-only")
+    void keywordAlternationKeepsDefaultCaseFoldingAsciiOnly() {
+      assertAllFindsMatchJdk("(?i)\\b(ak|as)\\b", "a\u212Ax ask");
+      assertAllFindsMatchJdk("(?is).*\\b(ak|as)\\b.*", "a\u212Ax ask");
+    }
+
+    @Test
+    @DisplayName("greedy whole-input keyword alternation preserves rightmost capture")
+    void greedyWholeInputKeywordAlternationPreservesRightmostCapture() {
+      assertAllFindsMatchJdk(
+          "(?is).*\\b(you|your)\\b.*",
+          "You spoke first.\nThen your example referred to YOU at the end.");
+    }
+
+    @Test
+    @DisplayName("greedy whole-input keyword alternation honors explicit find start")
+    void greedyWholeInputKeywordAlternationHonorsExplicitFindStart() {
+      String regex = "(?is).*\\b(you|your)\\b.*";
+      String input = "ignore YOU, then keep your answer";
+      Matcher safere = Pattern.compile(regex).matcher(input);
+      java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(regex).matcher(input);
+
+      assertThat(safere.find(12)).isEqualTo(jdk.find(12));
+      assertThat(safere.start()).isEqualTo(jdk.start());
+      assertThat(safere.end()).isEqualTo(jdk.end());
+      assertThat(safere.group(1)).isEqualTo(jdk.group(1));
+      assertThat(safere.start(1)).isEqualTo(jdk.start(1));
+      assertThat(safere.end(1)).isEqualTo(jdk.end(1));
+    }
+
+    @Test
     @DisplayName("find() start acceleration matches JDK for comma-or-line-start CSV fields")
     void findStartAccelerationForCsvFields() {
       assertAllFindsMatchJdk(

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -71,6 +71,14 @@ class PatternInternalTest {
   }
 
   @Test
+  void greedyDotAllWrappersPreserveKeywordAlternationAccelerator() {
+    Pattern p = Pattern.compile("(?is).*\\b(you|your)\\b.*");
+
+    assertThat(p.keywordAlternation()).isNotNull();
+    assertThat(p.keywordAlternation().greedyWholeInput).isTrue();
+  }
+
+  @Test
   void caseInsensitiveAsciiLiteralPreservesLiteralAccelerators() {
     Pattern p = Pattern.compile("(?i)needle");
 


### PR DESCRIPTION
## Summary

- recognize greedy whole-input wrappers around word-bounded ASCII
  case-insensitive keyword alternatives
- resolve the rightmost capture with one backward scan
- preserve ASCII-only default case-insensitive behavior
- add regression coverage for matching, captures, and pattern recognition

This PR is stacked on the capture-extraction optimization.

## Benchmark impact

Before: `e398d25`  
After: `657d4d3`

Standard Java benchmark configuration (`2` forks, `2 x 500 ms` warmup,
`5 x 500 ms` measurement), lower is better:

| `wildcardSearch` matching input | Before (ns/op) | After (ns/op) | Impact |
|---:|---:|---:|---:|
| 1,000 chars | 5,393.788 | 49.679 | 108.6x faster |
| 10,000 chars | 51,823.032 | 34.024 | 1,523x faster |
| 100,000 chars | 663,077.818 | 45.028 | 14,726x faster |

The successful-match path becomes independent of the long prefix because the
greedy wrapper can select the rightmost bounded keyword directly. A standard
100,000-character non-match remains linear at 51,693 ns/op.

## Verification

- `mvn -pl safere -Dtest=MatcherTest,PatternInternalTest test -q`
- focused before/after `RealWorldRegexBenchmark` runs via
  `./run-java-benchmarks.sh`
- full test suite was not rerun while preparing this PR; GitHub CI will provide
  full project verification

Part of #584

Fixes #585
