### PR TITLE
Improve replacement fast paths

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2727,9 +2727,8 @@ public final class Matcher implements MatchResult {
     }
     StringBuilder sb = new StringBuilder(text.length());
     ReplacementSegment[] compiledTemplate = template.get();
-    boolean needsCaptures = templateNeedsCaptures(compiledTemplate);
     do {
-      if (needsCaptures || !groupZeroResolved) {
+      if (!groupZeroResolved) {
         resolveCaptures();
       }
       sb.append(text, appendPos, groups[0]);
@@ -2769,9 +2768,11 @@ public final class Matcher implements MatchResult {
   private String charClassReplaceFastPath(LazyTemplate template, int limit) {
     if (!enginePathOptions().charClassReplacementFastPath()
         || parentPattern.charClassMatchRanges() == null
-        || parentPattern.charClassMatchAllowEmpty()
         || parentPattern.hasLazyQuantifiers()) {
       return null;
+    }
+    if (parentPattern.charClassMatchAllowEmpty()) {
+      return nullableCharClassReplaceFastPath(template, limit);
     }
     String repText = null;
 
@@ -2825,6 +2826,7 @@ public final class Matcher implements MatchResult {
         }
         if (compiledTemplate.length != 1
             || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
+          clearCurrentResult();
           return null;
         }
         applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
@@ -2856,6 +2858,66 @@ public final class Matcher implements MatchResult {
     }
 
     return sb.toString();
+  }
+
+  private String nullableCharClassReplaceFastPath(LazyTemplate template, int limit) {
+    int[] ranges = parentPattern.charClassMatchRanges();
+    long b0 = parentPattern.charClassMatchBitmap0();
+    long b1 = parentPattern.charClassMatchBitmap1();
+    int textLen = text.length();
+    int firstMatchEnd = 0;
+    while (firstMatchEnd < textLen) {
+      int cp = text.codePointAt(firstMatchEnd);
+      if (!charClassContains(ranges, b0, b1, cp)) {
+        break;
+      }
+      firstMatchEnd += Character.charCount(cp);
+    }
+
+    applyFullMatchResult(new int[] {0, firstMatchEnd});
+    ReplacementSegment[] compiledTemplate = template.get();
+    if (compiledTemplate.length != 1
+        || !(compiledTemplate[0] instanceof ReplacementSegment.Literal literalSeg)) {
+      clearCurrentResult();
+      return null;
+    }
+    String replacement = literalSeg.text();
+    if (limit == 1) {
+      StringBuilder result = new StringBuilder(textLen + replacement.length());
+      result.append(replacement);
+      result.append(text, firstMatchEnd, textLen);
+      appendPos = firstMatchEnd;
+      return result.toString();
+    }
+
+    StringBuilder result = new StringBuilder(textLen + replacement.length());
+    int pos = 0;
+    while (pos < textLen) {
+      int runEnd = pos;
+      while (runEnd < textLen) {
+        int cp = text.codePointAt(runEnd);
+        if (!charClassContains(ranges, b0, b1, cp)) {
+          break;
+        }
+        runEnd += Character.charCount(cp);
+      }
+      result.append(replacement);
+      if (runEnd > pos) {
+        pos = runEnd;
+      } else {
+        // Matcher.find() advances a terminal empty match by one UTF-16 position, matching the JDK
+        // Matcher contract even when that position lies between surrogate halves.
+        result.append(text.charAt(pos));
+        pos++;
+      }
+    }
+    result.append(replacement);
+
+    appendPos = textLen;
+    searchFrom = regionEnd + 1;
+    applyFailedMatchResult();
+    findExhaustedAfterTerminalEmptyMatch = true;
+    return result.toString();
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2204,18 +2204,20 @@ public final class Pattern implements Serializable {
 
     Regexp inner = node.sub();
 
-    // The quantified element must be a character class.
-    if (inner.op != RegexpOp.CHAR_CLASS || inner.charClass == null) {
-      return null;
-    }
-
     // Reject if the original pattern has user capture groups — the fast path only produces
     // group 0, so it can't provide group(1) etc.
     if (hasUserCaptures(re)) {
       return null;
     }
 
-    CharClass cc = inner.charClass;
+    CharClass cc;
+    if (inner.op == RegexpOp.CHAR_CLASS && inner.charClass != null) {
+      cc = inner.charClass;
+    } else if (inner.op == RegexpOp.LITERAL) {
+      cc = literalCharClass(inner.rune, inner.flags);
+    } else {
+      return null;
+    }
     if (cc.isEmpty()) {
       return null;
     }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1249,6 +1249,29 @@ class MatcherTest {
           .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceFirst("X"));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"", "abc", "aa", "baab", "💰a💰"})
+    @DisplayName("nullable repeated character-class replacement matches JDK across input shapes")
+    void nullableRepeatedCharacterClassReplacementMatchesJdk(String input) {
+      String regex = "a*";
+
+      assertThat(Pattern.compile(regex).matcher(input).replaceAll("xyz"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceAll("xyz"));
+      assertThat(Pattern.compile(regex).matcher(input).replaceFirst("xyz"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceFirst("xyz"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[a-z]+", "[a-z]*"})
+    @DisplayName("character-class replacement fallback retains the first match")
+    void characterClassReplacementFallbackRetainsFirstMatch(String regex) {
+      String input = "abc def";
+      String replacement = "[$0]";
+
+      assertThat(Pattern.compile(regex).matcher(input).replaceAll(replacement))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceAll(replacement));
+    }
+
     @Test
     @DisplayName("replaceAll() with nullable alternation matches JDK replacement sequence")
     void replaceAllNullableAlternationMatchesJdkReplacementSequence() {
@@ -1357,6 +1380,21 @@ class MatcherTest {
       assertThat(m.start()).isEqualTo(0);
       assertThat(m.end()).isEqualTo(3);
       assertThat(m.group()).isEqualTo("123");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$", "\\"})
+    @DisabledForCrosscheck(
+        "generated wrapper cannot advance both delegates after the first delegate throws")
+    @DisplayName("nullable char-class fast path records first match before throwing")
+    void nullableCharClassMalformedReplacementRecordsFirstMatch(String replacement) {
+      Matcher matcher = Pattern.compile("a*").matcher("abc");
+
+      assertThatThrownBy(() -> matcher.replaceAll(replacement))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThat(matcher.start()).isEqualTo(0);
+      assertThat(matcher.end()).isEqualTo(1);
+      assertThat(matcher.group()).isEqualTo("a");
     }
 
     @Test
@@ -1640,6 +1678,7 @@ class MatcherTest {
       Matcher m = p.matcher("b");
       String result = m.replaceAll("x");
       assertThat(result).isEqualTo("xbx");
+      assertThat(m.find()).isFalse();
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1250,10 +1250,25 @@ class MatcherTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "abc", "aa", "baab", "💰a💰"})
+    @ValueSource(strings = {"", "abc", "aa", "baab"})
     @DisplayName("nullable repeated character-class replacement matches JDK across input shapes")
     void nullableRepeatedCharacterClassReplacementMatchesJdk(String input) {
       String regex = "a*";
+
+      assertThat(Pattern.compile(regex).matcher(input).replaceAll("xyz"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceAll("xyz"));
+      assertThat(Pattern.compile(regex).matcher(input).replaceFirst("xyz"))
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceFirst("xyz"));
+    }
+
+    @Test
+    @DisabledForCrosscheck(
+        "String empty-match progression may split surrogate pairs; the UTF-8 API advances by code"
+            + " point")
+    @DisplayName("nullable character-class replacement matches JDK UTF-16 progression")
+    void nullableCharacterClassReplacementMatchesJdkUtf16Progression() {
+      String regex = "a*";
+      String input = "💰a💰";
 
       assertThat(Pattern.compile(regex).matcher(input).replaceAll("xyz"))
           .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(input).replaceAll("xyz"));

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -79,6 +79,15 @@ class PatternInternalTest {
   }
 
   @Test
+  void replacementGroupConsumptionRecordsCaptureDemand() {
+    Pattern pattern = Pattern.compile("(qu|[b-df-hj-np-tv-z]*)([a-z]+)");
+
+    pattern.matcher("the quick brown fox").replaceAll("$2$1ay");
+
+    assertThat(pattern.innerCapturesObserved()).isTrue();
+  }
+
+  @Test
   void caseInsensitiveAsciiLiteralPreservesLiteralAccelerators() {
     Pattern p = Pattern.compile("(?i)needle");
 


### PR DESCRIPTION
## Summary

- record replacement-template capture demand before deferred resolution
- directly replace nullable repeated character classes with literal templates
- preserve fallback behavior and terminal-empty matcher state
- add regression coverage for optimized and fallback replacement semantics

This optimization is independent and is based directly on `main`.

## Benchmark impact

These measurements were collected before rebasing the unchanged optimization
onto `main`; only this optimization differs between the measured revisions:

Before: `657d4d3`  
After: `26c98bd`

Standard Java benchmark configuration (`2` forks, `2 x 500 ms` warmup,
`5 x 500 ms` measurement), lower is better:

| Benchmark | Before (ns/op) | After (ns/op) | Impact |
|---|---:|---:|---:|
| `emptyReplaceAll_safere` | 427.602 | 59.228 | 7.22x faster |
| `pigLatinReplaceAll_safere` | 2,397.451 | 1,996.987 | 1.20x faster |
| `manualReplaceAll_safere` | 1,985.852 | 1,985.271 | neutral |

The unchanged manual implementation is a control and shows no material
movement.

## Verification

- `mvn -pl safere -Dtest=MatcherTest,PatternInternalTest test -q`
- focused before/after replacement benchmarks via
  `./run-java-benchmarks.sh`
- full test suite was not rerun while preparing this PR; GitHub CI will provide
  full project verification

Part of #584

Fixes #586
