### PR TITLE
Initialize regex engines lazily

### DIFF
--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -96,8 +96,8 @@ public final class Pattern implements Serializable {
   private final String pattern;
   private final int flags;
   private final transient Prog prog;
-  private final transient Prog flatProg;
-  private final transient Prog flatDfaProg;
+  private transient volatile Prog flatProg;
+  private transient volatile Prog flatDfaProg;
   private final transient Regexp ast;
 
   private final transient Map<String, Integer> namedGroups;
@@ -273,27 +273,6 @@ public final class Pattern implements Serializable {
     this.pattern = pattern;
     this.flags = flags;
     this.prog = prog;
-    if (enginePathOptions.dfa()) {
-      this.flatProg = new Prog(prog);
-      this.flatProg.flatten();
-      this.flatProg.freeze();
-      if (prog.numLoopRegs() > 0) {
-        Prog dfaProg = Compiler.compileForDfa(ast);
-        if (dfaProg != null) {
-          this.flatDfaProg = new Prog(dfaProg);
-          this.flatDfaProg.flatten();
-          this.flatDfaProg.freeze();
-        } else {
-          this.flatDfaProg = this.flatProg;
-        }
-      } else {
-        this.flatDfaProg = this.flatProg;
-      }
-    } else {
-      this.flatProg = null;
-      this.flatDfaProg = null;
-    }
-
     this.ast = ast;
     this.namedGroups = namedGroups;
     this.prefix = prefix;
@@ -340,13 +319,6 @@ public final class Pattern implements Serializable {
         requiredLiteralUtf8 == null ? null : literalFailure(requiredLiteralUtf8);
     this.requiredLiteralShifts =
         requiredLiteralUtf8 == null ? null : literalShifts(requiredLiteralUtf8);
-
-    // Eagerly compute analysis and setup to avoid latency spikes on first use.
-    onePassAnalysis();
-    forwardDfaSetup();
-    if (!prog.anchorStart()) {
-      flatReverseDfaProg();
-    }
   }
 
   /**
@@ -863,17 +835,40 @@ public final class Pattern implements Serializable {
    * from warm DFA transitions.
    */
   Prog flatProg() {
-    return flatProg;
+    Prog fp = flatProg;
+    if (fp == null && enginePathOptions.dfa()) {
+      fp = new Prog(prog);
+      fp.flatten();
+      fp.freeze();
+      flatProg = fp;
+    }
+    return fp;
   }
 
   Prog flatDfaProg() {
-    return flatDfaProg;
+    Prog fp = flatDfaProg;
+    if (fp == null && enginePathOptions.dfa()) {
+      if (prog.numLoopRegs() > 0) {
+        Prog dfaProg = Compiler.compileForDfa(ast);
+        if (dfaProg != null) {
+          fp = new Prog(dfaProg);
+          fp.flatten();
+          fp.freeze();
+        } else {
+          fp = flatProg();
+        }
+      } else {
+        fp = flatProg();
+      }
+      flatDfaProg = fp;
+    }
+    return fp;
   }
 
   Dfa forwardFirstMatchDfa() {
     Dfa dfa = cachedForwardFirstMatchDfa.get();
     if (dfa == null) {
-      dfa = new Dfa(flatDfaProg, MAX_DFA_STATES, forwardDfaSetup(), false);
+      dfa = new Dfa(flatDfaProg(), MAX_DFA_STATES, forwardDfaSetup(), false);
       cachedForwardFirstMatchDfa.set(dfa);
     }
     return dfa;
@@ -882,7 +877,7 @@ public final class Pattern implements Serializable {
   Dfa forwardLongestMatchDfa() {
     Dfa dfa = cachedForwardLongestMatchDfa.get();
     if (dfa == null) {
-      dfa = new Dfa(flatDfaProg, MAX_DFA_STATES, forwardDfaSetup(), true);
+      dfa = new Dfa(flatDfaProg(), MAX_DFA_STATES, forwardDfaSetup(), true);
       cachedForwardLongestMatchDfa.set(dfa);
     }
     return dfa;
@@ -1186,7 +1181,8 @@ public final class Pattern implements Serializable {
   Dfa.Setup forwardDfaSetup() {
     Dfa.Setup setup = forwardDfaSetup;
     if (setup == null) {
-      setup = Dfa.buildSetup(flatProg != null ? flatProg : prog);
+      Prog dfaProg = flatDfaProg();
+      setup = Dfa.buildSetup(dfaProg != null ? dfaProg : prog);
       forwardDfaSetup = setup;
     }
     return setup;

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -19,6 +19,26 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PatternInternalTest {
 
   @Test
+  void engineAnalysesRemainLazyUntilRequested() throws ReflectiveOperationException {
+    Pattern pattern = Pattern.compile("(foo|bar)+");
+
+    assertThat(field(pattern, "flatProg")).isNull();
+    assertThat(field(pattern, "flatDfaProg")).isNull();
+    assertThat(field(pattern, "onePassAnalysis")).isNull();
+    assertThat(field(pattern, "forwardDfaSetup")).isNull();
+    assertThat(field(pattern, "reverseProg")).isNull();
+    assertThat(field(pattern, "flatReverseProg")).isNull();
+    assertThat(field(pattern, "flatReverseDfaProg")).isNull();
+    assertThat(field(pattern, "reverseDfaSetup")).isNull();
+
+    assertThat(pattern.matcher("foo bar").find()).isTrue();
+    assertThat(field(pattern, "flatProg")).isNotNull();
+    assertThat(field(pattern, "flatDfaProg")).isNotNull();
+    assertThat(field(pattern, "onePassAnalysis")).isNotNull();
+    assertThat(field(pattern, "forwardDfaSetup")).isNotNull();
+  }
+
+  @Test
   void testOnePassEligibility() {
     Pattern p1 =
         Pattern.compile(
@@ -85,6 +105,12 @@ class PatternInternalTest {
     pattern.matcher("the quick brown fox").replaceAll("$2$1ay");
 
     assertThat(pattern.innerCapturesObserved()).isTrue();
+  }
+
+  private static Object field(Pattern pattern, String name) throws ReflectiveOperationException {
+    var field = Pattern.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(pattern);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- defer OnePass analysis, flattened forward and reverse programs, and DFA setup
  until first use
- retain shared volatile publication and per-pattern engine caches
- add regression coverage for lazy initialization

This PR is stacked on the replacement optimization.

## Benchmark impact

Before: `26c98bd`  
After: `5f9b40e`

Standard Java benchmark configuration (`2` forks, `2 x 500 ms` warmup,
`5 x 500 ms` measurement), lower is better:

| Compile benchmark | Before (us/op) | After (us/op) | Impact |
|---|---:|---:|---:|
| simple | 6.327 | 0.779 | 8.12x faster |
| alternation | 26.954 | 5.307 | 5.08x faster |
| complex | 14.395 | 4.593 | 3.13x faster |
| medium | 25.332 | 8.544 | 2.96x faster |

The retained-heap harness also shows lower freshly compiled pattern size:

| Pattern | Before (bytes) | After (bytes) | Reduction |
|---|---:|---:|---:|
| simple | 8,396 | 3,580 | 57% |
| medium | 16,924 | 5,260 | 69% |
| complex | 7,396 | 2,716 | 63% |
| alternation | 21,516 | 6,748 | 69% |

## Verification

- `mvn -pl safere -Dtest=PatternInternalTest test -q`
- focused compile, retained-memory, and match-throughput benchmarks
- `--long` confirmation of the post-change compile results
- full test suite was not rerun while preparing this PR; GitHub CI will provide
  full project verification

Part of #584
