### PR TITLE
Integrate external OpenJDK regex benchmarks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,12 @@ Benchmark classes have no `@Fork`, `@Warmup`, or `@Measurement` annotations
 
 # Longer confirmation run for close, surprising, or important comparisons
 ./run-java-benchmarks.sh --long '^org\.safere\.benchmark\.RegexBenchmark\.'
+
+# Separately licensed OpenJDK-derived suite (requires an external checkout)
+./run-openjdk-regex-benchmarks.sh
+
+# Full collection; includes the external OpenJDK-derived suite by default
+./collect-benchmark-results.sh
 ```
 
 Arguments after the mode flag are passed directly to JMH as benchmark regex
@@ -345,10 +351,18 @@ per invocation and collect results incrementally:
 - **Pathological benchmarks always use `-f 0`.** The script handles this
   automatically — PathologicalBenchmark and PathologicalComparisonBenchmark
   run without forking because the JDK engine can hang on large inputs.
-- **Default benchmark collection is Java-only.** `./collect-benchmark-results.sh`
-  collects SafeRE, JDK, RE2/J, and RE2-FFM results by default. Use
-  `./collect-benchmark-results.sh --cross-language` only when broader C++ RE2
-  and Go `regexp` context is explicitly needed.
+- **Default benchmark collection includes both Java suites.**
+  `./collect-benchmark-results.sh` collects SafeRE, JDK, RE2/J, and RE2-FFM
+  results from SafeRE's suite, then SafeRE/JDK results from the external
+  OpenJDK-derived suite. Use `./collect-benchmark-results.sh --cross-language`
+  only when broader C++ RE2 and Go `regexp` context is explicitly needed.
+- **OpenJDK-derived benchmarks stay external.** Their GPL-2.0-only repository
+  must be checked out separately and must not be vendored or added to SafeRE's
+  Maven modules. The collection script runs them as a separate result set
+  against the current SafeRE snapshot. A request to run "our benchmarks" or the
+  "full benchmarks" includes this external suite unless the user explicitly
+  narrows the requested scope. Use it when broad matching, search, compilation,
+  or rejection changes could affect its workloads.
 - **NEVER run benchmarks in parallel.** All benchmark runs must run
   sequentially, one at a time. Parallel runs compete for CPU, cache, and memory
   bandwidth, producing inaccurate results.
@@ -389,6 +403,13 @@ and inconsistent under inversion.
 `BENCHMARKS.md` must be self-contained for checked-in benchmark claims. Raw
 outputs may remain local, but do not make an ignored or machine-local artifact
 the only place where a reported result or supporting table can be inspected.
+
+When updating `BENCHMARKS.md`, update the external OpenJDK-derived benchmark
+section from the same collection. Keep its results and aggregates separate from
+SafeRE's native suite, and record the SafeRE commit, external benchmark
+repository commit, pinned OpenJDK source commit, SafeRE version, and JDK
+version. Do not leave the previous external results in place after publishing a
+new full collection.
 
 ### Writing About Benchmark Results
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -72,6 +72,45 @@ RE2-FFM also pays UTF-16-to-UTF-8 conversion and native-call costs. Native
 results therefore provide ecosystem context, not a controlled language-runtime
 comparison.
 
+## External OpenJDK-derived benchmark suite
+
+The separately maintained
+[SafeRE OpenJDK regex benchmarks](https://github.com/eaftan/safere-openjdk-regex-benchmarks)
+compare SafeRE and `java.util.regex` on compatible workloads adapted from
+OpenJDK's regex microbenchmarks.
+
+The benchmark source remains outside this repository because it is
+GPL-2.0-only. SafeRE's collection tooling can build the current SafeRE snapshot
+and invoke the external checkout during the default collection. Its raw results
+remain separate from the summaries below because the workload set and JMH
+schedules differ.
+
+The initial external run compared SafeRE 0.9.0 with JDK 26.0.1 across 35 paired
+configurations. Ratios are SafeRE time / JDK time, and every row has equal
+weight within its reported geometric mean.
+
+| Workload family | Pairs | Geomean SafeRE/JDK | Interpretation |
+|---|---:|---:|---|
+| Exponential | 24 | 0.0838 | 11.93× faster |
+| FindPattern | 4 | 0.4182 | 2.39× faster |
+| PatternBench compatible subset | 4 | 1.5832 | 1.58× slower |
+| Trim compatible subset | 3 | 0.0011 | 934.82× faster |
+| All rows, equally weighted | 35 | 0.0970 | 10.31× faster |
+
+The overall result is materially influenced by adversarial no-match cases where
+the JDK does quadratic work, especially `Trim.simpleFind` at size 4096. The
+suite also identifies compilation as a clear weakness: SafeRE was 69.77×
+slower for the character-pattern compile-only workload and 25.64× slower when
+compiling and matching. The
+[complete external report](https://github.com/eaftan/safere-openjdk-regex-benchmarks/blob/main/RESULTS.md)
+contains every paired result and the full reproduction record.
+
+That run used benchmark repository commit
+`781c780ef4e83b5a8424813e5b7fb71ffcbb5013`, OpenJDK source commit
+`2d1c83340d0e3d24a52963c77464f6fa796da5e7`, and JDK 26.0.1. It started at
+`2026-07-26T22:32:29Z`, completed in 32 minutes 26 seconds, and preserved each
+upstream benchmark class's JMH schedule.
+
 ## Summary statistics
 
 Ratios are SafeRE time / competitor time; values below 1 mean SafeRE is faster.

--- a/README.md
+++ b/README.md
@@ -433,6 +433,12 @@ Application workloads live in `safere-benchmarks/benchmark-data.json`, where
 each case defines its operation semantics and expected result for the Java,
 C++, and Go harnesses.
 
+SafeRE also maintains a separate
+[OpenJDK-derived regex benchmark suite](https://github.com/eaftan/safere-openjdk-regex-benchmarks).
+It compares SafeRE and `java.util.regex` on compatible workloads adapted from
+OpenJDK's regex microbenchmarks. That suite is GPL-2.0-only, so its source is
+not vendored here or included in the `safere-benchmarks` Maven module.
+
 ### Benchmark Collection
 
 To collect a full set of benchmark data for updating
@@ -443,9 +449,19 @@ root:
 ./collect-benchmark-results.sh
 ```
 
-The default collection is Java-only: SafeRE, `java.util.regex`, RE2/J, and
-RE2-FFM. These are the normal engineering comparisons because they run in the
-same JVM environment.
+The default collection includes SafeRE's Java suite—SafeRE,
+`java.util.regex`, RE2/J, and RE2-FFM—and the external OpenJDK-derived
+SafeRE/JDK suite. Clone the external repository beside SafeRE before the first
+collection:
+
+```bash
+git clone https://github.com/eaftan/safere-openjdk-regex-benchmarks.git \
+  ../safere-openjdk-regex-benchmarks
+```
+
+These are the normal engineering comparisons because the engines run in the
+same JVM environment. Use `--openjdk-regex-repo PATH` when the external
+checkout is elsewhere.
 
 Use the longer Java mode when confirming close, surprising, or especially
 important comparisons:
@@ -470,9 +486,20 @@ To verify the collection pipeline without doing a full run:
 The script runs benchmark batches sequentially, captures raw output, and
 generates markdown tables.
 
+The collection script installs the SafeRE version from the current checkout,
+builds the external suite against that exact version, and runs both engines.
+Use `--skip-openjdk-regex` only for a deliberately incomplete local collection,
+such as when the separate checkout is unavailable. A comprehensive
+cross-runtime collection uses `--cross-language`; the OpenJDK-derived suite
+remains included by default.
+
+The OpenJDK-derived results remain a separate result set: they are not folded
+into `merged-tables.md` because the external workloads and their upstream JMH
+schedules differ from SafeRE's native suite.
+
 By default, results are written to a timestamped directory under
 `benchmark-results/`, and `benchmark-results/latest` is updated to point to
-the newest run. 
+the newest run.
 
 When the run finishes, hand off the result directory to the agent that will
 update `BENCHMARKS.md`:
@@ -497,6 +524,13 @@ cpp-results.jsonl
 go-results.jsonl
 ```
 
+Default runs also include:
+
+```text
+openjdk-regex-output.txt
+openjdk-regex-results.json
+```
+
 ### Targeted Benchmark Runs
 
 Always use the wrapper scripts — they run `mvn install` first to ensure
@@ -518,6 +552,18 @@ development iteration or focused investigation; use
 
 Arguments to the Java wrapper scripts are passed directly to JMH as benchmark
 regex filters.
+
+Run a targeted workload from the external OpenJDK-derived suite with:
+
+```bash
+./run-openjdk-regex-benchmarks.sh \
+  'org.safere.bench.openjdk.FindPatternComparison.*'
+```
+
+The wrapper defaults to a sibling `safere-openjdk-regex-benchmarks` checkout.
+Use `--repo PATH` or `SAFERE_OPENJDK_REGEX_BENCHMARKS_REPO` to select another
+location. Standard runs preserve the JMH schedules defined by the external
+suite; `--smoke` provides a short compile-and-execute check.
 
 `CrosscheckOverheadBenchmark` is excluded from the no-argument Java benchmark
 run. It measures overhead in the `safere-crosscheck` facade and should be run

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -8,12 +8,14 @@
 #   ./collect-benchmark-results.sh
 #   ./collect-benchmark-results.sh --long
 #   ./collect-benchmark-results.sh --cross-language
+#   ./collect-benchmark-results.sh --skip-openjdk-regex
 #   ./collect-benchmark-results.sh --smoke
 #   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 #
 # The script intentionally does not run the test suite. It runs benchmark
 # batches sequentially, captures raw output, and generates markdown tables.
-# By default it collects Java/JMH results only. Use --cross-language to also
+# By default it collects the Java/JMH results and the separately licensed
+# OpenJDK-derived suite from an external checkout. Use --cross-language to also
 # collect C++ RE2 and Go regexp results.
 
 set -euo pipefail
@@ -23,6 +25,8 @@ DEFAULT_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 OUTPUT_DIR="$SCRIPT_DIR/benchmark-results/$DEFAULT_RUN_ID"
 MODE="standard"
 CROSS_LANGUAGE=false
+OPENJDK_REGEX=true
+OPENJDK_REGEX_REPO=""
 
 usage() {
   cat <<EOF
@@ -30,6 +34,7 @@ Usage:
   ./collect-benchmark-results.sh
   ./collect-benchmark-results.sh --long
   ./collect-benchmark-results.sh --cross-language
+  ./collect-benchmark-results.sh --skip-openjdk-regex
   ./collect-benchmark-results.sh --smoke
   ./collect-benchmark-results.sh --output-dir benchmark-results/my-run
 
@@ -38,6 +43,10 @@ Collects benchmark outputs for updating BENCHMARKS.md.
 Options:
   --long            Use the longer Java confirmation mode.
   --cross-language  Also run C++ RE2 and Go regexp benchmark harnesses.
+  --openjdk-regex-repo PATH
+                    Select the external OpenJDK-derived suite checkout.
+  --skip-openjdk-regex
+                    Omit that external suite; the run is not a full collection.
   --smoke           Run one small benchmark through the collection pipeline.
 EOF
 }
@@ -50,6 +59,19 @@ while [ $# -gt 0 ]; do
       ;;
     --cross-language)
       CROSS_LANGUAGE=true
+      shift
+      ;;
+    --openjdk-regex-repo)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --openjdk-regex-repo requires a path" >&2
+        exit 2
+      fi
+      OPENJDK_REGEX=true
+      OPENJDK_REGEX_REPO="$2"
+      shift 2
+      ;;
+    --skip-openjdk-regex)
+      OPENJDK_REGEX=false
       shift
       ;;
     --smoke)
@@ -112,6 +134,7 @@ cd "$SCRIPT_DIR"
 log "Writing benchmark outputs to $OUTPUT_DIR"
 log "Mode: $MODE"
 log "Cross-language: $CROSS_LANGUAGE"
+log "OpenJDK regex suite: $OPENJDK_REGEX"
 
 JAVA_MODE_ARGS=()
 if [ "$MODE" = "long" ]; then
@@ -180,6 +203,27 @@ fi
 run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \
   java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
     org.safere.benchmark.MemoryBenchmark
+
+if [ "$OPENJDK_REGEX" = true ]; then
+  OPENJDK_REGEX_ARGS=()
+  if [ -n "$OPENJDK_REGEX_REPO" ]; then
+    OPENJDK_REGEX_ARGS+=(--repo "$OPENJDK_REGEX_REPO")
+  fi
+  if [ "$MODE" = "smoke" ]; then
+    OPENJDK_REGEX_ARGS+=(
+      --smoke
+      'org.safere.bench.openjdk.FindPatternComparison.*'
+    )
+  fi
+  OPENJDK_REGEX_ARGS+=(
+    --
+    -rf json
+    -rff "$OUTPUT_DIR/openjdk-regex-results.json"
+  )
+
+  run_and_capture "$OUTPUT_DIR/openjdk-regex-output.txt" \
+    ./run-openjdk-regex-benchmarks.sh "${OPENJDK_REGEX_ARGS[@]}"
+fi
 
 COMPARE_ENGINES="safere,jdk,re2j,re2_ffm"
 COMPARE_ARGS=(
@@ -258,5 +302,12 @@ if [ "$CROSS_LANGUAGE" = true ]; then
   cat <<EOF
   cpp-results.jsonl
   go-results.jsonl
+EOF
+fi
+
+if [ "$OPENJDK_REGEX" = true ]; then
+  cat <<EOF
+  openjdk-regex-output.txt
+  openjdk-regex-results.json
 EOF
 fi

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -180,19 +180,39 @@ run_benchmark() {
   if is_pathological "$bench"; then
     opts="$PATHOLOGICAL_JMH_OPTS"
   fi
-  echo "=== Running $bench ($opts ${JMH_EXTRA_ARGS[*]}) ==="
-  java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "${JMH_EXTRA_ARGS[@]}" "$bench"
+  if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
+    echo "=== Running $bench ($opts ${JMH_EXTRA_ARGS[*]}) ==="
+    java \
+      $JVM_ARGS \
+      -jar "$BENCHMARK_JAR" \
+      -jvmArgs "$JVM_ARGS" \
+      $opts \
+      "${JMH_EXTRA_ARGS[@]}" \
+      "$bench"
+  else
+    echo "=== Running $bench ($opts) ==="
+    java $JVM_ARGS -jar "$BENCHMARK_JAR" -jvmArgs "$JVM_ARGS" $opts "$bench"
+  fi
 }
 
 if [ ${#BENCHMARKS[@]} -eq 0 ]; then
   echo "=== Running standard benchmarks ($DEFAULT_BENCHMARK_REGEX) ==="
-  java \
-    $JVM_ARGS \
-    -jar "$BENCHMARK_JAR" \
-    -jvmArgs "$JVM_ARGS" \
-    $JMH_OPTS \
-    "${JMH_EXTRA_ARGS[@]}" \
-    "$DEFAULT_BENCHMARK_REGEX"
+  if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
+    java \
+      $JVM_ARGS \
+      -jar "$BENCHMARK_JAR" \
+      -jvmArgs "$JVM_ARGS" \
+      $JMH_OPTS \
+      "${JMH_EXTRA_ARGS[@]}" \
+      "$DEFAULT_BENCHMARK_REGEX"
+  else
+    java \
+      $JVM_ARGS \
+      -jar "$BENCHMARK_JAR" \
+      -jvmArgs "$JVM_ARGS" \
+      $JMH_OPTS \
+      "$DEFAULT_BENCHMARK_REGEX"
+  fi
 else
   for bench in "${BENCHMARKS[@]}"; do
     run_benchmark "$bench"

--- a/run-openjdk-regex-benchmarks.sh
+++ b/run-openjdk-regex-benchmarks.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
+# See LICENSE file in the project root for details.
+#
+# Run the separately licensed OpenJDK-derived regex benchmark suite against the
+# current SafeRE checkout. The external suite is intentionally not vendored or
+# included as a module of this repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_EXTERNAL_REPO="$SCRIPT_DIR/../safere-openjdk-regex-benchmarks"
+EXTERNAL_REPO="${SAFERE_OPENJDK_REGEX_BENCHMARKS_REPO:-$DEFAULT_EXTERNAL_REPO}"
+MODE="standard"
+BENCHMARKS=()
+JMH_ARGS=()
+
+usage() {
+  cat <<EOF
+Usage:
+  ./run-openjdk-regex-benchmarks.sh [--repo PATH] [--smoke] [JmhBenchmarkRegex ...] [-- JmhArg ...]
+
+Runs the GPL-2.0-only OpenJDK-derived benchmark suite from a separate checkout
+against the SafeRE version in this checkout.
+
+Options:
+  --repo PATH  External benchmark checkout. Defaults to:
+               $DEFAULT_EXTERNAL_REPO
+  --smoke      Override the upstream JMH schedules with a minimal validation run.
+
+The SAFERE_OPENJDK_REGEX_BENCHMARKS_REPO environment variable provides another
+way to set the external checkout path.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --repo requires a path" >&2
+        exit 2
+      fi
+      EXTERNAL_REPO="$2"
+      shift 2
+      ;;
+    --smoke)
+      MODE="smoke"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      JMH_ARGS=("$@")
+      set --
+      ;;
+    --*)
+      echo "ERROR: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      BENCHMARKS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ! -d "$EXTERNAL_REPO" ]]; then
+  cat >&2 <<EOF
+ERROR: external benchmark checkout not found: $EXTERNAL_REPO
+
+Clone https://github.com/eaftan/safere-openjdk-regex-benchmarks outside this
+repository, or select an existing checkout with --repo PATH.
+EOF
+  exit 1
+fi
+
+EXTERNAL_REPO="$(cd "$EXTERNAL_REPO" && pwd)"
+EXTERNAL_POM="$EXTERNAL_REPO/pom.xml"
+EXTERNAL_JAR="$EXTERNAL_REPO/target/benchmarks.jar"
+
+if [[ ! -f "$EXTERNAL_POM" || ! -f "$EXTERNAL_REPO/LICENSE" ]]; then
+  echo "ERROR: not a safere-openjdk-regex-benchmarks checkout: $EXTERNAL_REPO" >&2
+  exit 1
+fi
+
+if [[ ${#BENCHMARKS[@]} -eq 0 ]]; then
+  BENCHMARKS=('org.safere.bench.openjdk.*')
+fi
+
+SAFERE_VERSION="$(
+  mvn help:evaluate \
+    -Dexpression=project.version \
+    -q \
+    -DforceStdout \
+    -f "$SCRIPT_DIR/pom.xml"
+)"
+SAFERE_COMMIT="$(git -C "$SCRIPT_DIR" rev-parse HEAD)"
+EXTERNAL_COMMIT="$(git -C "$EXTERNAL_REPO" rev-parse HEAD)"
+
+echo "=== SafeRE OpenJDK regex benchmarks ==="
+echo "SafeRE checkout: $SCRIPT_DIR"
+echo "SafeRE commit: $SAFERE_COMMIT"
+echo "SafeRE version: $SAFERE_VERSION"
+echo "External checkout: $EXTERNAL_REPO"
+echo "External commit: $EXTERNAL_COMMIT"
+echo "Mode: $MODE"
+
+if [[ -n "$(git -C "$SCRIPT_DIR" status --short)" ]]; then
+  echo "WARNING: SafeRE checkout has uncommitted changes" >&2
+fi
+if [[ -n "$(git -C "$EXTERNAL_REPO" status --short)" ]]; then
+  echo "WARNING: external benchmark checkout has uncommitted changes" >&2
+fi
+
+echo "=== Installing current SafeRE artifact ==="
+mvn install \
+  -pl safere \
+  -am \
+  -DskipTests \
+  -Dpmd.skip=true \
+  -Dcheckstyle.skip=true \
+  -Dspotless.check.skip=true \
+  -Dmaven.javadoc.skip=true \
+  -Dexec.skip=true \
+  -q \
+  -f "$SCRIPT_DIR/pom.xml"
+
+echo "=== Building external benchmark JAR ==="
+mvn package \
+  --quiet \
+  --batch-mode \
+  --no-transfer-progress \
+  -Dsafere.version="$SAFERE_VERSION" \
+  -f "$EXTERNAL_POM"
+
+JMH_OPTS=()
+if [[ "$MODE" = "smoke" ]]; then
+  JMH_OPTS=(-f 1 -wi 1 -i 1 -w 100ms -r 100ms)
+fi
+
+echo "=== Running external benchmark suite ==="
+java \
+  -jar "$EXTERNAL_JAR" \
+  "${JMH_OPTS[@]}" \
+  "${JMH_ARGS[@]}" \
+  "${BENCHMARKS[@]}"


### PR DESCRIPTION
## Summary

- make the separately licensed OpenJDK-derived regex suite part of SafeRE's
  default full benchmark collection
- add a wrapper that installs the current SafeRE snapshot, builds the external
  checkout against that exact version, records both repository commits, and
  runs its SafeRE/JDK comparisons
- keep the GPL-2.0-only source outside SafeRE's repository and Maven modules
- preserve the external results as a separate raw JMH result set rather than
  mixing workloads with SafeRE's native aggregate tables
- add the initial 35-pair OpenJDK-derived results, methodology, caveats, and
  provenance to `BENCHMARKS.md`
- define in `AGENTS.md` that requests to run "our benchmarks" or the "full
  benchmarks" include the external suite
- fix empty JMH argument-array handling on the Bash version shipped with macOS

## Verification

- `bash -n run-java-benchmarks.sh run-openjdk-regex-benchmarks.sh collect-benchmark-results.sh`
- `./run-openjdk-regex-benchmarks.sh --smoke 'org.safere.bench.openjdk.FindPatternComparison.*'`
- complete collection smoke pipeline with the external checkout:

  ```text
  ./collect-benchmark-results.sh \
    --smoke \
    --openjdk-regex-repo ../safere-openjdk-regex-benchmarks \
    --output-dir /tmp/safere-benchmark-collection-smoke
  ```

The collection produced all eight paired external smoke rows, structured JSON,
the complete external console log, and the existing SafeRE merged table.

The 32-minute full external suite was not rerun for this orchestration and
documentation change. `BENCHMARKS.md` incorporates the previously completed,
committed SafeRE 0.9.0/JDK 26.0.1 run and links its complete reproduction
record.

Fixes #595
