### PR TITLE
Make C++ benchmark harness build on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,10 @@ jobs:
   benchmark-smoke-test-cpp:
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v6
@@ -130,7 +133,7 @@ jobs:
           mkdir -p safere-benchmarks/cpp/build
           cmake -S safere-benchmarks/cpp -B safere-benchmarks/cpp/build \
             -DCMAKE_BUILD_TYPE=Release -Wno-dev
-          cmake --build safere-benchmarks/cpp/build -j$(nproc)
+          cmake --build safere-benchmarks/cpp/build --parallel
 
       - name: Smoke test C++ RE2 benchmarks
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,16 @@ jobs:
             org.safere.benchmark.MemoryBenchmark
 
   benchmark-smoke-test-cpp:
+    name: ${{ matrix.job_name }}
     needs: changes
     if: needs.changes.outputs.code == 'true'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            job_name: benchmark-smoke-test-cpp
+          - os: macos-latest
+            job_name: benchmark-smoke-test-cpp (macos-latest)
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,11 @@ jobs:
             org.safere.benchmark.MemoryBenchmark
 
   benchmark-smoke-test-cpp:
-    name: ${{ matrix.job_name }}
     needs: changes
     if: needs.changes.outputs.code == 'true'
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            job_name: benchmark-smoke-test-cpp
-          - os: macos-latest
-            job_name: benchmark-smoke-test-cpp (macos-latest)
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/safere-benchmarks/cpp/CMakeLists.txt
+++ b/safere-benchmarks/cpp/CMakeLists.txt
@@ -7,6 +7,10 @@ project(re2_benchmark CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Detect optional platform-specific heap accounting support.
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(mallinfo2 "malloc.h" SAFERE_HAVE_MALLINFO2)
+
 # Fetch dependencies.
 include(FetchContent)
 
@@ -41,3 +45,6 @@ FetchContent_MakeAvailable(abseil-cpp re2 json)
 
 add_executable(re2_benchmark re2_benchmark.cc)
 target_link_libraries(re2_benchmark re2::re2 nlohmann_json::nlohmann_json)
+if(SAFERE_HAVE_MALLINFO2)
+  target_compile_definitions(re2_benchmark PRIVATE SAFERE_HAVE_MALLINFO2)
+endif()

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -7,7 +7,7 @@
 //
 // Build:
 //   cd safere-benchmarks/cpp && mkdir -p build && cd build
-//   cmake .. && cmake --build . -j$(nproc)
+//   cmake .. && cmake --build . --parallel
 //
 // Run:
 //   ./build/re2_benchmark [--data path/to/benchmark-data.json] [filter...]
@@ -22,11 +22,14 @@
 #include <cstdlib>
 #include <fstream>
 #include <functional>
-#include <malloc.h>
 #include <memory>
 #include <random>
 #include <string>
 #include <vector>
+
+#ifdef SAFERE_HAVE_MALLINFO2
+#include <malloc.h>
+#endif
 
 #include <nlohmann/json.hpp>
 #include "re2/re2.h"
@@ -1064,9 +1067,9 @@ void run_fanout_benchmarks(const json& data,
 // Memory benchmarks
 // ---------------------------------------------------------------------------
 
-// Measure the heap allocation for compiling a single RE2 pattern, using
-// mallinfo2() heap delta.  Also reports RE2's ProgramSize() (number of
-// compiled bytecode instructions).
+// Measure the heap allocation for compiling a single RE2 pattern when
+// mallinfo2() is available. Also reports RE2's ProgramSize() (number of
+// compiled bytecode instructions) on every platform.
 void run_memory_benchmarks(const json& data,
                            const std::vector<std::string>& filters) {
   const auto& compile_sec = data["compile"];
@@ -1103,14 +1106,18 @@ void run_memory_benchmarks(const json& data,
   for (const auto& pi : patterns) {
     if (!matches_filter(pi.name, filters)) continue;
 
+#ifdef SAFERE_HAVE_MALLINFO2
     // Measure heap delta around RE2 compilation using mallinfo2().
     struct mallinfo2 before = mallinfo2();
+#endif
     auto re = std::make_unique<RE2>(pi.pattern);
+#ifdef SAFERE_HAVE_MALLINFO2
     struct mallinfo2 after = mallinfo2();
 
     long heap_delta = static_cast<long>(after.uordblks) -
                       static_cast<long>(before.uordblks);
     print_memory_json(pi.name + ".heapBytes", heap_delta);
+#endif
 
     // Report RE2's program size (number of bytecode instructions).
     if (re->ok()) {


### PR DESCRIPTION
## Summary

- detect `mallinfo2()` support during CMake configuration
- preserve RE2 program-size metrics while omitting unavailable heap-delta metrics
- run the C++ benchmark smoke tests on both Ubuntu and macOS
- use CMake's portable parallel-build option in CI and the source build instructions

Fixes #597

## Verification

- configured and built `safere-benchmarks/cpp` on macOS 26.5 with Apple Clang 21
- ran `re2_benchmark --data safere-benchmarks/benchmark-data.json MemoryBenchmark`
- ran `git diff --check`

Not run:

- Linux smoke test locally; the existing Ubuntu CI matrix entry covers the `mallinfo2()` path
- full benchmark suite, because this change only affects build portability and optional memory reporting
