### PR TITLE
Materialize shared benchmark inputs before execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release -Wno-dev
           cmake --build safere-benchmarks/cpp/build --parallel
 
+      - name: Test C++ benchmark support code
+        run: ctest --test-dir safere-benchmarks/cpp/build --output-on-failure
+
       - name: Smoke test C++ RE2 benchmarks
         run: |
           safere-benchmarks/cpp/build/re2_benchmark \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
 
       - name: Smoke test Java memory benchmarks (pattern sizes)
         run: |
-          java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
+          java -Xms256m -Xmx256m \
+            -Dsafere.benchmark.corpus="$PWD/safere-benchmarks/target/benchmark-corpus" \
+            -cp safere-benchmarks/target/benchmarks.jar \
             org.safere.benchmark.MemoryBenchmark
 
   benchmark-smoke-test-cpp:
@@ -128,6 +130,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Materialize shared benchmark inputs
+        run: ./materialize-benchmark-inputs.sh
+
       - name: Compile C++ RE2 benchmarks
         run: |
           mkdir -p safere-benchmarks/cpp/build
@@ -138,12 +150,12 @@ jobs:
       - name: Smoke test C++ RE2 benchmarks
         run: |
           safere-benchmarks/cpp/build/re2_benchmark \
-            --data safere-benchmarks/benchmark-data.json literalMatch
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
 
       - name: Smoke test C++ RE2 memory benchmarks
         run: |
           safere-benchmarks/cpp/build/re2_benchmark \
-            --data safere-benchmarks/benchmark-data.json MemoryBenchmark
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark
 
   benchmark-smoke-test-go:
     needs: changes
@@ -153,11 +165,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version: '1.21'
           cache: false
+
+      - name: Materialize shared benchmark inputs
+        run: ./materialize-benchmark-inputs.sh
 
       - name: Compile Go benchmarks
         run: cd safere-benchmarks/go && go build -o regexp_benchmark .
@@ -165,9 +187,9 @@ jobs:
       - name: Smoke test Go benchmarks
         run: |
           safere-benchmarks/go/regexp_benchmark \
-            --data safere-benchmarks/benchmark-data.json literalMatch
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
 
       - name: Smoke test Go memory benchmarks
         run: |
           safere-benchmarks/go/regexp_benchmark \
-            --data safere-benchmarks/benchmark-data.json MemoryBenchmark
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,9 +368,11 @@ per invocation and collect results incrementally:
   bandwidth, producing inaccurate results.
 - **Do not commit optimizations that do not improve benchmark results.**
   Every optimization must be validated with before/after benchmarks.
-- **All harnesses share `benchmark-data.json`.** This ensures identical
-  patterns, inputs, and parameters across Java, C++, and Go. Edit the
-  JSON file to change workloads; never hardcode values in the harness.
+- **`benchmark-data.json` is the only checked-in workload source.** Benchmark
+  scripts materialize it into a resolved manifest and exact UTF-8 input files
+  before execution. Java, C++, Go, and other harnesses read only those
+  generated artifacts. Edit the JSON file to change workloads; never hardcode
+  values or generation logic in a harness.
 
 ### Summary Statistics
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -61,8 +61,10 @@ Java used the standard project configuration: 2 forks, 2 warmup iterations of
 pass used its dedicated publication configuration and GC profiler.
 
 C++ and Go used 2 warmup and 10 measurement iterations of 2 seconds in one
-process. All harnesses read the same `benchmark-data.json`. Java results report
-99.9% confidence intervals from JMH; native harnesses use Student's
+process. Before execution, the runner scripts materialize
+`benchmark-data.json` into one resolved manifest and an exact UTF-8 input
+corpus; every harness reads only those generated artifacts. Java results
+report 99.9% confidence intervals from JMH; native harnesses use Student's
 t-distribution. A targeted Java confirmation used `--long` for SafeRE
 alternation and log parsing; it did not replace standard-run values in summary
 statistics.

--- a/README.md
+++ b/README.md
@@ -429,9 +429,14 @@ SafeRE includes a [JMH](https://github.com/openjdk/jmh) benchmark suite in the
 [FFM API](https://openjdk.org/jeps/454)), C++ RE2, and Go `regexp`.
 The suite includes focused microbenchmarks, data-driven application workloads,
 scaling/pathological cases, replacement, memory, and `PatternSet` benchmarks.
-Application workloads live in `safere-benchmarks/benchmark-data.json`, where
-each case defines its operation semantics and expected result for the Java,
-C++, and Go harnesses.
+Benchmark recipes and configuration live in
+`safere-benchmarks/benchmark-data.json`. Before a benchmark starts, its runner
+materializes that file into a resolved manifest and exact UTF-8 inputs under
+`safere-benchmarks/target/benchmark-corpus`. Java, C++, and Go consume only
+those generated artifacts instead of independently interpreting input recipes.
+See
+[`safere-benchmarks/BENCHMARK_INPUTS.md`](safere-benchmarks/BENCHMARK_INPUTS.md)
+for details.
 
 SafeRE also maintains a separate
 [OpenJDK-derived regex benchmark suite](https://github.com/eaftan/safere-openjdk-regex-benchmarks).

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -201,7 +201,9 @@ else
 fi
 
 run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \
-  java -Xms256m -Xmx256m -cp safere-benchmarks/target/benchmarks.jar \
+  java -Xms256m -Xmx256m \
+    -Dsafere.benchmark.corpus="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus" \
+    -cp safere-benchmarks/target/benchmarks.jar \
     org.safere.benchmark.MemoryBenchmark
 
 if [ "$OPENJDK_REGEX" = true ]; then

--- a/materialize-benchmark-inputs.sh
+++ b/materialize-benchmark-inputs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
+# See LICENSE file in the project root for details.
+#
+# Materialize the resolved benchmark manifest and shared UTF-8 input corpus.
+#
+# Usage:
+#   ./materialize-benchmark-inputs.sh
+#   ./materialize-benchmark-inputs.sh --no-build
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="$SCRIPT_DIR/safere-benchmarks"
+BENCHMARK_JAR="$BENCHMARK_DIR/target/benchmarks.jar"
+CORPUS_DIR="$BENCHMARK_DIR/target/benchmark-corpus"
+BUILD=true
+
+if [ "${1:-}" = "--no-build" ]; then
+  BUILD=false
+  shift
+fi
+if [ $# -ne 0 ]; then
+  echo "Usage: $0 [--no-build]" >&2
+  exit 2
+fi
+
+if [ "$BUILD" = true ]; then
+  mvn package \
+    -pl safere-benchmarks -am \
+    -DskipTests \
+    -Dpmd.skip=true \
+    -Dcheckstyle.skip=true \
+    -Dspotless.check.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dexec.skip=true \
+    -q \
+    -f "$SCRIPT_DIR/pom.xml"
+fi
+if [ ! -f "$BENCHMARK_JAR" ]; then
+  echo "ERROR: benchmark JAR not found: $BENCHMARK_JAR" >&2
+  echo "Run without --no-build to build it first." >&2
+  exit 1
+fi
+
+java -cp "$BENCHMARK_JAR" \
+  org.safere.benchmark.BenchmarkInputMaterializer "$BENCHMARK_DIR" "$CORPUS_DIR"

--- a/run-cpp-benchmarks.sh
+++ b/run-cpp-benchmarks.sh
@@ -15,7 +15,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CPP_DIR="$SCRIPT_DIR/safere-benchmarks/cpp"
 BUILD_DIR="$CPP_DIR/build"
-DATA_FILE="$SCRIPT_DIR/safere-benchmarks/benchmark-data.json"
+MANIFEST_FILE="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus/manifest.json"
+
+echo "=== Materializing shared benchmark inputs ==="
+"$SCRIPT_DIR/materialize-benchmark-inputs.sh"
 
 echo "=== Building C++ RE2 benchmarks ==="
 mkdir -p "$BUILD_DIR"
@@ -23,4 +26,4 @@ cmake -S "$CPP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -Wno-dev 2>&1 | t
 cmake --build "$BUILD_DIR" -j8 2>&1 | tail -3
 
 echo "=== Running C++ RE2 benchmarks ==="
-"$BUILD_DIR/re2_benchmark" --data "$DATA_FILE" "$@"
+"$BUILD_DIR/re2_benchmark" --manifest "$MANIFEST_FILE" "$@"

--- a/run-go-benchmarks.sh
+++ b/run-go-benchmarks.sh
@@ -14,10 +14,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GO_DIR="$SCRIPT_DIR/safere-benchmarks/go"
-DATA_FILE="$SCRIPT_DIR/safere-benchmarks/benchmark-data.json"
+MANIFEST_FILE="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus/manifest.json"
+
+echo "=== Materializing shared benchmark inputs ==="
+"$SCRIPT_DIR/materialize-benchmark-inputs.sh"
 
 echo "=== Building Go regexp benchmarks ==="
 (cd "$GO_DIR" && go build -o regexp_benchmark .)
 
 echo "=== Running Go regexp benchmarks ==="
-"$GO_DIR/regexp_benchmark" --data "$DATA_FILE" "$@"
+"$GO_DIR/regexp_benchmark" --manifest "$MANIFEST_FILE" "$@"

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -52,6 +52,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
+BENCHMARK_CORPUS="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 DEFAULT_BENCHMARK_REGEX="^(?!org\\.safere\\.benchmark\\.CrosscheckOverheadBenchmark\\.).*$"
 
@@ -146,9 +147,6 @@ else
   echo "=== Standard mode ==="
 fi
 
-# JVM args for FFM native access and native library path.
-JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR"
-
 if [ "$FASTBUILD" = true ]; then
   echo "=== Fast Building safere-benchmarks only ==="
   mvn install \
@@ -165,6 +163,12 @@ else
   echo "=== Building safere + benchmark JAR ==="
   mvn install -DskipTests -q -f "$SCRIPT_DIR/pom.xml"
 fi
+
+echo "=== Materializing shared benchmark inputs ==="
+"$SCRIPT_DIR/materialize-benchmark-inputs.sh" --no-build
+
+# JVM args for FFM native access, native library path, and the resolved corpus.
+JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR -Dsafere.benchmark.corpus=$BENCHMARK_CORPUS"
 
 # Returns true if the benchmark name matches a pathological benchmark.
 is_pathological() {

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
+BENCHMARK_CORPUS="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
 
 # Publication-quality settings: 3 forks × (3 warmup × 5s + 5 measurement × 5s).
@@ -53,11 +54,14 @@ else
   echo "=== Publication mode (for BENCHMARKS.md) ==="
 fi
 
-# JVM args for FFM native access and native library path.
-JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR"
-
 echo "=== Building safere + benchmark JAR ==="
 mvn install -DskipTests -q -f "$SCRIPT_DIR/pom.xml"
+
+echo "=== Materializing shared benchmark inputs ==="
+"$SCRIPT_DIR/materialize-benchmark-inputs.sh" --no-build
+
+# JVM args for FFM native access, native library path, and the resolved corpus.
+JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR -Dsafere.benchmark.corpus=$BENCHMARK_CORPUS"
 
 if [ $# -eq 0 ]; then
   echo "=== Running all benchmarks with GC profiling ==="

--- a/safere-benchmarks/BENCHMARK_INPUTS.md
+++ b/safere-benchmarks/BENCHMARK_INPUTS.md
@@ -1,0 +1,34 @@
+# Shared Benchmark Inputs
+
+`benchmark-data.json` is the only checked-in source for benchmark patterns,
+parameters, expected results, and deterministic input recipes.
+
+Before execution, each benchmark runner invokes the central materializer. It
+writes a resolved manifest and exact UTF-8 inputs under
+`target/benchmark-corpus/`. Java, C++, Go, and future harnesses read only those
+generated artifacts; they do not read or interpret `benchmark-data.json`.
+Java string engines decode input files as UTF-8 during benchmark setup, while
+byte-oriented engines use the bytes directly. Materialization and decoding are
+outside the timed operation.
+
+The normal runner scripts materialize automatically. To prepare the corpus
+without starting a benchmark, run from the repository root:
+
+```bash
+./materialize-benchmark-inputs.sh
+```
+
+The manifest records each input's UTF-8 byte length, UTF-16 code-unit length,
+Unicode scalar count, and SHA-256 digest, along with the resolved benchmark
+configuration. The generated directory is ignored and is replaced on every
+materialization, so there is no second checked-in representation to update.
+
+The materializer preserves the Java harness's previous generator behavior.
+Consequently, the Java workloads are unchanged. C++ and Go previously
+implemented their own random and Unicode generators, which differed in PRNG
+and size semantics; affected cross-language results collected before this
+corpus was introduced are not directly comparable with new results.
+
+Java-only diagnostic and engine-instrumentation benchmarks may still construct
+inputs locally when no other harness consumes them. Any workload shared by
+multiple engines belongs in the materialized corpus.

--- a/safere-benchmarks/cpp/CMakeLists.txt
+++ b/safere-benchmarks/cpp/CMakeLists.txt
@@ -48,3 +48,9 @@ target_link_libraries(re2_benchmark re2::re2 nlohmann_json::nlohmann_json)
 if(SAFERE_HAVE_MALLINFO2)
   target_compile_definitions(re2_benchmark PRIVATE SAFERE_HAVE_MALLINFO2)
 endif()
+
+include(CTest)
+if(BUILD_TESTING)
+  add_test(NAME benchmark_sha256_test
+           COMMAND re2_benchmark --sha256-self-test)
+endif()

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -15,9 +15,11 @@
 // Each filter is a substring match against benchmark names. If no filters
 // are given, all benchmarks are run.
 
+#include <array>
 #include <cctype>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -25,6 +27,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifdef SAFERE_HAVE_MALLINFO2
@@ -38,6 +41,128 @@ using json = nlohmann::json;
 
 json benchmark_input_manifest;
 std::filesystem::path benchmark_input_directory;
+
+std::string sha256_hex(std::string_view input) {
+  static constexpr std::array<uint32_t, 64> kRoundConstants = {
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+      0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+      0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+      0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+      0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+      0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+      0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+      0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+      0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+      0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+      0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+      0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+  std::array<uint32_t, 8> hash = {
+      0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+      0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
+  std::vector<uint8_t> message(input.begin(), input.end());
+  uint64_t bit_length = static_cast<uint64_t>(message.size()) * 8;
+  message.push_back(0x80);
+  while (message.size() % 64 != 56) {
+    message.push_back(0);
+  }
+  for (int shift = 56; shift >= 0; shift -= 8) {
+    message.push_back(static_cast<uint8_t>(bit_length >> shift));
+  }
+
+  auto rotate_right = [](uint32_t value, int count) {
+    return (value >> count) | (value << (32 - count));
+  };
+  for (size_t offset = 0; offset < message.size(); offset += 64) {
+    std::array<uint32_t, 64> words{};
+    for (size_t index = 0; index < 16; index++) {
+      size_t word_offset = offset + index * 4;
+      words[index] =
+          (static_cast<uint32_t>(message[word_offset]) << 24) |
+          (static_cast<uint32_t>(message[word_offset + 1]) << 16) |
+          (static_cast<uint32_t>(message[word_offset + 2]) << 8) |
+          static_cast<uint32_t>(message[word_offset + 3]);
+    }
+    for (size_t index = 16; index < words.size(); index++) {
+      uint32_t s0 = rotate_right(words[index - 15], 7) ^
+                    rotate_right(words[index - 15], 18) ^
+                    (words[index - 15] >> 3);
+      uint32_t s1 = rotate_right(words[index - 2], 17) ^
+                    rotate_right(words[index - 2], 19) ^
+                    (words[index - 2] >> 10);
+      words[index] =
+          words[index - 16] + s0 + words[index - 7] + s1;
+    }
+
+    uint32_t a = hash[0];
+    uint32_t b = hash[1];
+    uint32_t c = hash[2];
+    uint32_t d = hash[3];
+    uint32_t e = hash[4];
+    uint32_t f = hash[5];
+    uint32_t g = hash[6];
+    uint32_t h = hash[7];
+    for (size_t index = 0; index < words.size(); index++) {
+      uint32_t sum1 = rotate_right(e, 6) ^ rotate_right(e, 11) ^
+                      rotate_right(e, 25);
+      uint32_t choose = (e & f) ^ (~e & g);
+      uint32_t temporary1 =
+          h + sum1 + choose + kRoundConstants[index] + words[index];
+      uint32_t sum0 = rotate_right(a, 2) ^ rotate_right(a, 13) ^
+                      rotate_right(a, 22);
+      uint32_t majority = (a & b) ^ (a & c) ^ (b & c);
+      uint32_t temporary2 = sum0 + majority;
+      h = g;
+      g = f;
+      f = e;
+      e = d + temporary1;
+      d = c;
+      c = b;
+      b = a;
+      a = temporary1 + temporary2;
+    }
+    hash[0] += a;
+    hash[1] += b;
+    hash[2] += c;
+    hash[3] += d;
+    hash[4] += e;
+    hash[5] += f;
+    hash[6] += g;
+    hash[7] += h;
+  }
+
+  std::string result;
+  result.reserve(64);
+  char word[9];
+  for (uint32_t value : hash) {
+    snprintf(word, sizeof(word), "%08x", value);
+    result.append(word);
+  }
+  return result;
+}
+
+bool run_sha256_self_test() {
+  struct TestCase {
+    std::string_view input;
+    std::string_view expected;
+  };
+  static constexpr std::array<TestCase, 3> kTestCases = {{
+      {"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      {"abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+      {"The quick brown fox jumps over the lazy dog",
+       "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"},
+  }};
+  for (const TestCase& test_case : kTestCases) {
+    std::string actual = sha256_hex(test_case.input);
+    if (actual != test_case.expected) {
+      fprintf(stderr, "SHA-256 self-test failed: expected %s, found %s\n",
+              std::string(test_case.expected).c_str(), actual.c_str());
+      return false;
+    }
+  }
+  return true;
+}
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -171,6 +296,15 @@ std::string load_benchmark_input(const std::string& key) {
             "ERROR: materialized benchmark input has wrong size: %s "
             "(expected %zu, found %zu)\n",
             key.c_str(), expected_size, text.size());
+    exit(1);
+  }
+  std::string expected_sha256 = entry->at("sha256").get<std::string>();
+  std::string actual_sha256 = sha256_hex(text);
+  if (actual_sha256 != expected_sha256) {
+    fprintf(stderr,
+            "ERROR: materialized benchmark input has wrong SHA-256: %s "
+            "(expected %s, found %s)\n",
+            key.c_str(), expected_sha256.c_str(), actual_sha256.c_str());
     exit(1);
   }
   return text;
@@ -945,6 +1079,10 @@ void run_memory_benchmarks(const json& data,
 // ---------------------------------------------------------------------------
 
 int main(int argc, char* argv[]) {
+  if (argc == 2 && std::string_view(argv[1]) == "--sha256-self-test") {
+    return run_sha256_self_test() ? 0 : 1;
+  }
+
   std::string manifest_path = "../../target/benchmark-corpus/manifest.json";
   std::vector<std::string> filters;
 

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -10,7 +10,7 @@
 //   cmake .. && cmake --build . --parallel
 //
 // Run:
-//   ./build/re2_benchmark [--data path/to/benchmark-data.json] [filter...]
+//   ./build/re2_benchmark [--manifest path/to/manifest.json] [filter...]
 //
 // Each filter is a substring match against benchmark names. If no filters
 // are given, all benchmarks are run.
@@ -20,10 +20,10 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <memory>
-#include <random>
 #include <string>
 #include <vector>
 
@@ -35,6 +35,9 @@
 #include "re2/re2.h"
 
 using json = nlohmann::json;
+
+json benchmark_input_manifest;
+std::filesystem::path benchmark_input_directory;
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -127,14 +130,50 @@ void do_not_optimize(const T& val) {
 // JSON loading
 // ---------------------------------------------------------------------------
 
-json load_benchmark_data(const std::string& path) {
-  std::ifstream ifs(path);
-  if (!ifs.is_open()) {
-    fprintf(stderr, "ERROR: cannot open benchmark data file: %s\n",
-            path.c_str());
+json load_benchmark_manifest(const std::string& manifest_path_string) {
+  std::filesystem::path manifest_path = manifest_path_string;
+  benchmark_input_directory = manifest_path.parent_path();
+  std::ifstream input(manifest_path);
+  if (!input.is_open()) {
+    fprintf(stderr, "ERROR: cannot open materialized benchmark manifest: %s\n",
+            manifest_path.string().c_str());
     exit(1);
   }
-  return json::parse(ifs);
+  json manifest = json::parse(input);
+  if (manifest.at("version").get<int>() != 1) {
+    fprintf(stderr, "ERROR: unsupported benchmark input manifest version\n");
+    exit(1);
+  }
+  benchmark_input_manifest = manifest.at("inputs");
+  return manifest.at("benchmarkData");
+}
+
+std::string load_benchmark_input(const std::string& key) {
+  auto entry = benchmark_input_manifest.find(key);
+  if (entry == benchmark_input_manifest.end()) {
+    fprintf(stderr, "ERROR: unknown materialized benchmark input: %s\n",
+            key.c_str());
+    exit(1);
+  }
+  std::filesystem::path path =
+      benchmark_input_directory / entry->at("file").get<std::string>();
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) {
+    fprintf(stderr, "ERROR: cannot open materialized benchmark input: %s\n",
+            path.string().c_str());
+    exit(1);
+  }
+  std::string text((std::istreambuf_iterator<char>(input)),
+                   std::istreambuf_iterator<char>());
+  size_t expected_size = entry->at("utf8Bytes").get<size_t>();
+  if (text.size() != expected_size) {
+    fprintf(stderr,
+            "ERROR: materialized benchmark input has wrong size: %s "
+            "(expected %zu, found %zu)\n",
+            key.c_str(), expected_size, text.size());
+    exit(1);
+  }
+  return text;
 }
 
 // Convert Java-style replacement references ($N) to RE2 C++ style (\\N).
@@ -156,209 +195,6 @@ std::string convert_replacement(const std::string& repl) {
     }
   }
   return result;
-}
-
-// ---------------------------------------------------------------------------
-// Text generators (parameterized from JSON)
-// ---------------------------------------------------------------------------
-
-std::string make_random_text(int size, const std::string& alphabet,
-                             unsigned seed) {
-  std::mt19937 rng(seed);
-  std::string text(size, ' ');
-  for (int i = 0; i < size; ++i) {
-    text[i] = alphabet[rng() % alphabet.size()];
-  }
-  return text;
-}
-
-std::string make_prose(int size, const std::string& unit) {
-  std::string text;
-  text.reserve(size + unit.size());
-  while (static_cast<int>(text.size()) < size) {
-    text += unit;
-  }
-  return text;
-}
-
-std::string repeat_to_size(const std::string& unit, int size) {
-  std::string text;
-  text.reserve(size + unit.size());
-  while (static_cast<int>(text.size()) < size) {
-    text += unit;
-  }
-  text.resize(size);
-  return text;
-}
-
-std::string surround_to_size(const std::string& prefix,
-                             const std::string& unit,
-                             const std::string& suffix,
-                             int size) {
-  int body_size = size - static_cast<int>(prefix.size() + suffix.size());
-  if (body_size < 0) body_size = 0;
-  return prefix + repeat_to_size(unit, body_size) + suffix;
-}
-
-std::string suffix_match_to_size(const std::string& prefix_unit,
-                                 const std::string& match,
-                                 int size) {
-  int prefix_size = size - static_cast<int>(match.size());
-  if (prefix_size < 0) prefix_size = 0;
-  return repeat_to_size(prefix_unit, prefix_size) + match;
-}
-
-std::string generated_real_world_input(const std::string& unit, int size,
-                                       const std::string& alphabet,
-                                       int seed) {
-  if (static_cast<int>(unit.size()) >= size) {
-    return unit.substr(0, size);
-  }
-  std::string text;
-  text.reserve(size + unit.size());
-  int delimiter_index = seed;
-  while (static_cast<int>(text.size()) < size) {
-    text += unit;
-    if (static_cast<int>(text.size()) < size) {
-      text += alphabet[delimiter_index % alphabet.size()];
-      ++delimiter_index;
-    }
-  }
-  text.resize(size);
-  return text;
-}
-
-std::string generated_sparse_real_world_input(const std::string& match_unit,
-                                              const std::string& non_match_unit,
-                                              int size, int seed,
-                                              int non_match_repeats,
-                                              const std::string& alphabet) {
-  std::string text;
-  text.reserve(size + match_unit.size() + non_match_unit.size());
-  int delimiter_index = seed;
-  while (static_cast<int>(text.size()) < size) {
-    for (int i = 0; i < non_match_repeats &&
-                    static_cast<int>(text.size()) < size; ++i) {
-      text += non_match_unit;
-      if (static_cast<int>(text.size()) < size) {
-        text += alphabet[delimiter_index % alphabet.size()];
-        ++delimiter_index;
-      }
-    }
-    if (static_cast<int>(text.size()) < size) {
-      text += " ";
-      text += match_unit;
-      text += " ";
-    }
-  }
-  text.resize(size);
-  return text;
-}
-std::string generate_surround_with_spaces_input(const std::string& body, int size) {
-  if (static_cast<int>(body.size()) >= size) {
-    return body.substr(0, size);
-  }
-  int total_padding = size - static_cast<int>(body.size());
-  int leading_padding = total_padding / 2;
-  int trailing_padding = total_padding - leading_padding;
-  return std::string(leading_padding, ' ') + body + std::string(trailing_padding, ' ');
-}
-
-std::string repeat_to_length(const std::string& unit, int size) {
-  std::string text;
-  while (static_cast<int>(text.size()) < size) {
-    text += unit;
-  }
-  text.resize(size);
-  return text;
-}
-
-std::string generate_scaled_surround_with_spaces_input(
-    const std::string& body_prefix, const std::string& body_suffix,
-    const std::string& body_fill, int body_scale_percent, int size) {
-  if (body_fill.empty()) {
-    fprintf(stderr,
-            "ERROR: scaledSurroundWithSpaces requires non-empty bodyFill\n");
-    exit(1);
-  }
-  int fixed_body_length =
-      static_cast<int>(body_prefix.size() + body_suffix.size());
-  int target_body_length =
-      std::max(fixed_body_length, size * body_scale_percent / 100);
-  target_body_length = std::min(target_body_length, size);
-  int fill_length = std::max(0, target_body_length - fixed_body_length);
-  return generate_surround_with_spaces_input(
-      body_prefix + repeat_to_length(body_fill, fill_length) + body_suffix,
-      size);
-}
-
-std::string generate_real_world_input(const json& input_spec,
-                                      const std::string& match_unit,
-                                      const std::string& non_match_unit,
-                                      bool match, int size,
-                                      const std::string& alphabet, int seed) {
-  std::string unit = match ? match_unit : non_match_unit;
-  std::string kind = input_spec.value("kind", "repeat");
-  if (kind == "repeat") {
-    return generated_real_world_input(unit, size, alphabet, seed);
-  }
-  if (kind == "prefixedRepeat") {
-    std::string prefix = input_spec.at("prefix").get<std::string>();
-    if (static_cast<int>(prefix.size()) >= size) {
-      return prefix.substr(0, size);
-    }
-    int body_size = size - static_cast<int>(prefix.size());
-    return prefix + generated_real_world_input(unit, body_size, alphabet, seed);
-  }
-  if (kind == "sparseMatch") {
-    return generated_sparse_real_world_input(
-        match_unit, non_match_unit, size, seed,
-        input_spec.at("nonMatchRepeats").get<int>(),
-        input_spec.at("delimiterAlphabet").get<std::string>());
-  }
-  if (kind == "surroundWithSpaces") {
-    std::string body = input_spec.at("body").get<std::string>();
-    return generate_surround_with_spaces_input(body, size);
-  }
-  if (kind == "scaledSurroundWithSpaces") {
-    return generate_scaled_surround_with_spaces_input(
-        input_spec.at("bodyPrefix").get<std::string>(),
-        input_spec.at("bodySuffix").get<std::string>(),
-        input_spec.at("bodyFill").get<std::string>(),
-        input_spec.at("bodyScalePercent").get<int>(), size);
-  }
-  fprintf(stderr, "ERROR: invalid real-world input kind: %s\n", kind.c_str());
-  exit(1);
-}
-
-// Encode a Unicode code point as UTF-8 and append to the string.
-void append_utf8(std::string& s, int cp) {
-  if (cp < 0x80) {
-    s += static_cast<char>(cp);
-  } else if (cp < 0x800) {
-    s += static_cast<char>(0xC0 | (cp >> 6));
-    s += static_cast<char>(0x80 | (cp & 0x3F));
-  } else if (cp < 0x10000) {
-    s += static_cast<char>(0xE0 | (cp >> 12));
-    s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-    s += static_cast<char>(0x80 | (cp & 0x3F));
-  } else {
-    s += static_cast<char>(0xF0 | (cp >> 18));
-    s += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
-    s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-    s += static_cast<char>(0x80 | (cp & 0x3F));
-  }
-}
-
-std::string make_unicode_text(int size, const std::vector<int>& codepoints,
-                              unsigned seed) {
-  std::mt19937 rng(seed);
-  std::string text;
-  while (static_cast<int>(text.size()) < size) {
-    int cp = codepoints[rng() % codepoints.size()];
-    append_utf8(text, cp);
-  }
-  return text;
 }
 
 // ---------------------------------------------------------------------------
@@ -598,27 +434,17 @@ void run_real_world_regex_benchmarks(
     const json& data, const std::vector<std::string>& filters) {
   const auto& sec = data["realWorldRegex"];
   std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
-  std::string alphabet = sec["safeDelimiterAlphabet"].get<std::string>();
-  int seed = sec["seed"].get<int>();
 
   struct RealWorldCase {
     std::string name;
     std::string op;
     std::string pattern;
-    std::string match;
-    std::string non_match;
-    json match_input;
-    json non_match_input;
     RE2 re;
 
     explicit RealWorldCase(const json& item)
         : name(item.at("name").get<std::string>()),
           op(item.at("op").get<std::string>()),
           pattern(item.at("pattern").get<std::string>()),
-          match(item.at("match").get<std::string>()),
-          non_match(item.at("nonMatch").get<std::string>()),
-          match_input(item.value("matchInput", json::object())),
-          non_match_input(item.value("nonMatchInput", json::object())),
           re(pattern) {}
   };
 
@@ -644,11 +470,11 @@ void run_real_world_regex_benchmarks(
   for (const auto& case_ptr : cases) {
     const RealWorldCase& c = *case_ptr;
     for (bool match : {true, false}) {
-      const json& input_spec = match ? c.match_input : c.non_match_input;
       std::string match_label = match ? "match" : "noMatch";
       for (int size : sizes) {
-        std::string text = generate_real_world_input(
-            input_spec, c.match, c.non_match, match, size, alphabet, seed);
+        std::string text = load_benchmark_input(
+            "realWorldRegex." + c.name + "." + match_label + "." +
+            std::to_string(size));
         std::string name = "RealWorldRegexBenchmark.runBenchmark." + c.name +
                            "." + match_label + "." + std::to_string(size);
         if (!matches_filter(name, filters)) {
@@ -714,10 +540,6 @@ void run_search_scaling_benchmarks(const json& data,
                                    const std::vector<std::string>& filters) {
   const auto& sec = data["searchScaling"];
   std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
-  std::string match_suffix = sec["matchSuffix"];
-  std::string alphabet = sec["randomText"]["alphabet"];
-  unsigned seed = sec["randomText"]["seed"];
-  std::string prose_unit = sec["proseUnit"];
 
   RE2 easy(sec["patterns"]["easy"].get<std::string>());
   RE2 medium(sec["patterns"]["medium"].get<std::string>());
@@ -725,9 +547,13 @@ void run_search_scaling_benchmarks(const json& data,
   RE2 find_ing(sec["findIngPattern"].get<std::string>());
 
   for (int size : sizes) {
-    std::string random_text = make_random_text(size, alphabet, seed);
-    std::string text_with_match = random_text + match_suffix;
-    std::string prose = make_prose(size, prose_unit);
+    std::string size_string = std::to_string(size);
+    std::string random_text =
+        load_benchmark_input("searchScaling.random." + size_string);
+    std::string text_with_match =
+        load_benchmark_input("searchScaling.success." + size_string);
+    std::string prose =
+        load_benchmark_input("searchScaling.prose." + size_string);
 
     std::string suffix = "." + std::to_string(size);
 
@@ -817,31 +643,21 @@ void run_issue481_scaling_benchmarks(const json& data,
   };
 
   for (int size : sizes) {
+    std::string size_string = std::to_string(size);
     std::string split_text =
-        repeat_to_size(sec["splitW"]["unit"].get<std::string>(), size);
+        load_benchmark_input("issue481Scaling.splitW." + size_string);
     std::string block_text =
-        surround_to_size(sec["block"]["prefix"].get<std::string>(),
-                         sec["block"]["unit"].get<std::string>(),
-                         sec["block"]["suffix"].get<std::string>(), size);
+        load_benchmark_input("issue481Scaling.block." + size_string);
     std::string block_negative_text =
-        surround_to_size(sec["block"]["prefix"].get<std::string>(),
-                         sec["block"]["unit"].get<std::string>(),
-                         sec["block"]["negativeSuffix"].get<std::string>(),
-                         size);
+        load_benchmark_input("issue481Scaling.blockNegative." + size_string);
     std::string tag_text =
-        suffix_match_to_size(sec["tag"]["prefixUnit"].get<std::string>(),
-                             sec["tag"]["match"].get<std::string>(), size);
+        load_benchmark_input("issue481Scaling.tag." + size_string);
     std::string tag_negative_text =
-        suffix_match_to_size(sec["tag"]["prefixUnit"].get<std::string>(),
-                             sec["tag"]["negativeMatch"].get<std::string>(),
-                             size);
+        load_benchmark_input("issue481Scaling.tagNegative." + size_string);
     std::string scheme_text =
-        suffix_match_to_size(sec["scheme"]["prefixUnit"].get<std::string>(),
-                             sec["scheme"]["match"].get<std::string>(), size);
+        load_benchmark_input("issue481Scaling.scheme." + size_string);
     std::string scheme_negative_text =
-        suffix_match_to_size(sec["scheme"]["prefixUnit"].get<std::string>(),
-                             sec["scheme"]["negativeMatch"].get<std::string>(),
-                             size);
+        load_benchmark_input("issue481Scaling.schemeNegative." + size_string);
 
     std::string suffix = "." + std::to_string(size);
     auto run = [&](const std::string& name, const std::function<void()>& fn) {
@@ -1008,10 +824,11 @@ void run_pathological_benchmarks(const json& data,
       data["pathological"]["nValues"].get<std::vector<int>>();
 
   for (int n : ns) {
-    std::string regex;
-    for (int i = 0; i < n; ++i) regex += "a?";
-    for (int i = 0; i < n; ++i) regex += "a";
-    std::string text(n, 'a');
+    std::string n_string = std::to_string(n);
+    std::string regex =
+        load_benchmark_input("pathological.pattern." + n_string);
+    std::string text =
+        load_benchmark_input("pathological.text." + n_string);
 
     std::string name =
         "PathologicalBenchmark.pathological." + std::to_string(n);
@@ -1032,18 +849,12 @@ void run_fanout_benchmarks(const json& data,
   RE2 fanout(sec["unicodeFanout"]["pattern"].get<std::string>());
   RE2 nested(sec["nestedQuantifier"]["pattern"].get<std::string>());
 
-  std::vector<int> codepoints =
-      sec["unicodeFanout"]["codePoints"].get<std::vector<int>>();
-  unsigned unicode_seed = sec["unicodeFanout"]["seed"];
-
-  std::string nested_alphabet = sec["nestedQuantifier"]["alphabet"];
-  unsigned nested_seed = sec["nestedQuantifier"]["seed"];
-
   for (int size : sizes) {
+    std::string size_string = std::to_string(size);
     std::string unicode_text =
-        make_unicode_text(size, codepoints, unicode_seed);
+        load_benchmark_input("fanout.unicode." + size_string);
     std::string ascii_text =
-        make_random_text(size, nested_alphabet, nested_seed);
+        load_benchmark_input("fanout.ascii." + size_string);
 
     std::string suffix = "." + std::to_string(size);
 
@@ -1134,19 +945,19 @@ void run_memory_benchmarks(const json& data,
 // ---------------------------------------------------------------------------
 
 int main(int argc, char* argv[]) {
-  std::string data_path = "../../benchmark-data.json";
+  std::string manifest_path = "../../target/benchmark-corpus/manifest.json";
   std::vector<std::string> filters;
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
-    if (arg == "--data" && i + 1 < argc) {
-      data_path = argv[++i];
+    if (arg == "--manifest" && i + 1 < argc) {
+      manifest_path = argv[++i];
     } else {
       filters.push_back(arg);
     }
   }
 
-  json data = load_benchmark_data(data_path);
+  json data = load_benchmark_manifest(manifest_path);
 
   run_regex_benchmarks(data, filters);
   run_application_benchmarks(data, filters);

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -11,23 +11,23 @@
 //
 // Run:
 //
-//	./regexp_benchmark [--data path/to/benchmark-data.json] [filter...]
+//	./regexp_benchmark [--manifest path/to/manifest.json] [filter...]
 //
 // Each filter is a substring match against benchmark names. If no filters
 // are given, all benchmarks are run.
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"math"
-	"math/rand"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 // ---------------------------------------------------------------------------
@@ -127,18 +127,66 @@ var sink any
 // JSON loading
 // ---------------------------------------------------------------------------
 
-func loadBenchmarkData(path string) map[string]any {
+type materializedInput struct {
+	File      string `json:"file"`
+	UTF8Bytes int    `json:"utf8Bytes"`
+	SHA256    string `json:"sha256"`
+}
+
+var benchmarkInputDirectory string
+var benchmarkInputs map[string]materializedInput
+
+func loadBenchmarkManifest(manifestPath string) map[string]any {
+	benchmarkInputDirectory = filepath.Dir(manifestPath)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: cannot open benchmark input manifest: %v\n", err)
+		os.Exit(1)
+	}
+	var manifest struct {
+		Version       int                          `json:"version"`
+		BenchmarkData map[string]any               `json:"benchmarkData"`
+		Inputs        map[string]materializedInput `json:"inputs"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: invalid benchmark input manifest: %v\n", err)
+		os.Exit(1)
+	}
+	if manifest.Version != 1 {
+		fmt.Fprintf(os.Stderr, "ERROR: unsupported benchmark input manifest version: %d\n",
+			manifest.Version)
+		os.Exit(1)
+	}
+	benchmarkInputs = manifest.Inputs
+	return manifest.BenchmarkData
+}
+
+func loadBenchmarkInput(key string) string {
+	entry, ok := benchmarkInputs[key]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "ERROR: unknown materialized benchmark input: %s\n", key)
+		os.Exit(1)
+	}
+	path := filepath.Join(benchmarkInputDirectory, entry.File)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: cannot open benchmark data file: %s\n", path)
+		fmt.Fprintf(os.Stderr, "ERROR: cannot open materialized benchmark input %s: %v\n", key, err)
 		os.Exit(1)
 	}
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: invalid JSON in %s: %v\n", path, err)
+	if len(data) != entry.UTF8Bytes {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: materialized benchmark input %s has size %d, expected %d\n",
+			key, len(data), entry.UTF8Bytes)
 		os.Exit(1)
 	}
-	return result
+	actualHash := fmt.Sprintf("%x", sha256.Sum256(data))
+	if actualHash != entry.SHA256 {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: materialized benchmark input %s has SHA-256 %s, expected %s\n",
+			key, actualHash, entry.SHA256)
+		os.Exit(1)
+	}
+	return string(data)
 }
 
 // get navigates a dot-separated path in the JSON structure.
@@ -199,186 +247,6 @@ func getStringSlice(data any, path string) []string {
 		}
 	}
 	return result
-}
-
-// ---------------------------------------------------------------------------
-// Text generators
-// ---------------------------------------------------------------------------
-
-func makeRandomText(size int, alphabet string, seed int64) string {
-	rng := rand.New(rand.NewSource(seed))
-	buf := make([]byte, size)
-	for i := range buf {
-		buf[i] = alphabet[rng.Intn(len(alphabet))]
-	}
-	return string(buf)
-}
-
-func makeProse(size int, unit string) string {
-	var b strings.Builder
-	b.Grow(size + len(unit))
-	for b.Len() < size {
-		b.WriteString(unit)
-	}
-	return b.String()
-}
-
-func repeatToSize(unit string, size int) string {
-	var b strings.Builder
-	b.Grow(size + len(unit))
-	for b.Len() < size {
-		b.WriteString(unit)
-	}
-	return b.String()[:size]
-}
-
-func surroundToSize(prefix string, unit string, suffix string, size int) string {
-	bodySize := size - len(prefix) - len(suffix)
-	if bodySize < 0 {
-		bodySize = 0
-	}
-	return prefix + repeatToSize(unit, bodySize) + suffix
-}
-
-func suffixMatchToSize(prefixUnit string, match string, size int) string {
-	prefixSize := size - len(match)
-	if prefixSize < 0 {
-		prefixSize = 0
-	}
-	return repeatToSize(prefixUnit, prefixSize) + match
-}
-
-func generatedRealWorldInput(unit string, size int, alphabet string, seed int) string {
-	if len(unit) >= size {
-		return unit[:size]
-	}
-	var b strings.Builder
-	b.Grow(size + len(unit))
-	delimiterIndex := seed
-	for b.Len() < size {
-		b.WriteString(unit)
-		if b.Len() < size {
-			b.WriteByte(alphabet[delimiterIndex%len(alphabet)])
-			delimiterIndex++
-		}
-	}
-	return b.String()[:size]
-}
-
-func generatedSparseRealWorldInput(
-	matchUnit string, nonMatchUnit string, size int, seed int, nonMatchRepeats int,
-	alphabet string,
-) string {
-	var b strings.Builder
-	b.Grow(size + len(matchUnit) + len(nonMatchUnit))
-	delimiterIndex := seed
-	for b.Len() < size {
-		for i := 0; i < nonMatchRepeats && b.Len() < size; i++ {
-			b.WriteString(nonMatchUnit)
-			if b.Len() < size {
-				b.WriteByte(alphabet[delimiterIndex%len(alphabet)])
-				delimiterIndex++
-			}
-		}
-		if b.Len() < size {
-			b.WriteByte(' ')
-			b.WriteString(matchUnit)
-			b.WriteByte(' ')
-		}
-	}
-	return b.String()[:size]
-}
-
-func generateRealWorldInput(
-	inputSpec map[string]any, matchUnit string, nonMatchUnit string, match bool, size int,
-	alphabet string, seed int,
-) string {
-	unit := nonMatchUnit
-	if match {
-		unit = matchUnit
-	}
-	kind := "repeat"
-	if rawKind, ok := inputSpec["kind"]; ok {
-		kind = rawKind.(string)
-	}
-	switch kind {
-	case "repeat":
-		return generatedRealWorldInput(unit, size, alphabet, seed)
-	case "prefixedRepeat":
-		prefix := getString(inputSpec, "prefix")
-		if len(prefix) >= size {
-			return prefix[:size]
-		}
-		bodySize := size - len(prefix)
-		return prefix + generatedRealWorldInput(unit, bodySize, alphabet, seed)
-	case "sparseMatch":
-		return generatedSparseRealWorldInput(
-			matchUnit, nonMatchUnit, size, seed, getInt(inputSpec, "nonMatchRepeats"),
-			getString(inputSpec, "delimiterAlphabet"))
-	case "surroundWithSpaces":
-		body := getString(inputSpec, "body")
-		return generateSurroundWithSpacesInput(body, size)
-	case "scaledSurroundWithSpaces":
-		return generateScaledSurroundWithSpacesInput(
-			getString(inputSpec, "bodyPrefix"),
-			getString(inputSpec, "bodySuffix"),
-			getString(inputSpec, "bodyFill"),
-			getInt(inputSpec, "bodyScalePercent"),
-			size)
-	default:
-		fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex input kind: %s\n", kind)
-		os.Exit(1)
-	}
-	panic("unreachable")
-}
-
-func generateSurroundWithSpacesInput(body string, size int) string {
-	if len(body) >= size {
-		return body[:size]
-	}
-	totalPadding := size - len(body)
-	leadingPadding := totalPadding / 2
-	trailingPadding := totalPadding - leadingPadding
-	return strings.Repeat(" ", leadingPadding) + body + strings.Repeat(" ", trailingPadding)
-}
-
-func generateScaledSurroundWithSpacesInput(
-	bodyPrefix string, bodySuffix string, bodyFill string, bodyScalePercent int, size int,
-) string {
-	if bodyFill == "" {
-		fmt.Fprintln(os.Stderr, "ERROR: scaledSurroundWithSpaces requires non-empty bodyFill")
-		os.Exit(1)
-	}
-	fixedBodyLength := len(bodyPrefix) + len(bodySuffix)
-	targetBodyLength := size * bodyScalePercent / 100
-	if targetBodyLength < fixedBodyLength {
-		targetBodyLength = fixedBodyLength
-	}
-	if targetBodyLength > size {
-		targetBodyLength = size
-	}
-	fillLength := targetBodyLength - fixedBodyLength
-	if fillLength < 0 {
-		fillLength = 0
-	}
-	body := bodyPrefix + repeatToSize(bodyFill, fillLength) + bodySuffix
-	return generateSurroundWithSpacesInput(body, size)
-}
-
-func appendUTF8(b *strings.Builder, cp int) {
-	var buf [4]byte
-	n := utf8.EncodeRune(buf[:], rune(cp))
-	b.Write(buf[:n])
-}
-
-func makeUnicodeText(size int, codepoints []int, seed int64) string {
-	rng := rand.New(rand.NewSource(seed))
-	var b strings.Builder
-	for b.Len() < size {
-		cp := codepoints[rng.Intn(len(codepoints))]
-		appendUTF8(&b, cp)
-	}
-	return b.String()
 }
 
 // ---------------------------------------------------------------------------
@@ -572,19 +440,11 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 		os.Exit(1)
 	}
 	sizes := getIntSlice(sec, "textSizes")
-	alphabet := getString(sec, "safeDelimiterAlphabet")
-	seed := getInt(sec, "seed")
-
 	type realWorldCase struct {
-		name          string
-		op            string
-		pattern       string
-		match         string
-		nonMatch      string
-		matchInput    map[string]any
-		nonMatchInput map[string]any
-		re            *regexp.Regexp
-		fullRe        *regexp.Regexp
+		name   string
+		op     string
+		re     *regexp.Regexp
+		fullRe *regexp.Regexp
 	}
 
 	rawCases, ok := sec["cases"].([]any)
@@ -605,17 +465,10 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 			os.Exit(1)
 		}
 		pattern := getString(item, "pattern")
-		matchInput, _ := item["matchInput"].(map[string]any)
-		nonMatchInput, _ := item["nonMatchInput"].(map[string]any)
 		c := realWorldCase{
-			name:          getString(item, "name"),
-			op:            op,
-			pattern:       pattern,
-			match:         getString(item, "match"),
-			nonMatch:      getString(item, "nonMatch"),
-			matchInput:    matchInput,
-			nonMatchInput: nonMatchInput,
-			re:            regexp.MustCompile(pattern),
+			name: getString(item, "name"),
+			op:   op,
+			re:   regexp.MustCompile(pattern),
 		}
 		if op == "matches" {
 			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
@@ -631,12 +484,8 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 				matchLabel = "match"
 			}
 			for _, size := range sizes {
-				inputSpec := c.nonMatchInput
-				if match {
-					inputSpec = c.matchInput
-				}
-				text := generateRealWorldInput(
-					inputSpec, c.match, c.nonMatch, match, size, alphabet, seed)
+				text := loadBenchmarkInput(fmt.Sprintf(
+					"realWorldRegex.%s.%s.%d", c.name, matchLabel, size))
 				name := fmt.Sprintf(
 					"RealWorldRegexBenchmark.runBenchmark.%s.%s.%d",
 					c.name, matchLabel, size)
@@ -695,22 +544,15 @@ func runSearchScalingBenchmarks(data map[string]any, filters []string) {
 	sec := data["searchScaling"].(map[string]any)
 
 	sizes := getIntSlice(sec, "textSizes")
-	matchSuffix := getString(sec, "matchSuffix")
-	alphabet := getString(sec, "randomText.alphabet")
-	// Interpret \n in alphabet
-	alphabet = strings.ReplaceAll(alphabet, `\n`, "\n")
-	seed := int64(getInt(sec, "randomText.seed"))
-	proseUnit := getString(sec, "proseUnit")
-
 	easy := regexp.MustCompile(getString(sec, "patterns.easy"))
 	medium := regexp.MustCompile(getString(sec, "patterns.medium"))
 	hard := regexp.MustCompile(getString(sec, "patterns.hard"))
 	findIng := regexp.MustCompile(getString(sec, "findIngPattern"))
 
 	for _, size := range sizes {
-		randomText := makeRandomText(size, alphabet, seed)
-		textWithMatch := randomText + matchSuffix
-		proseText := makeProse(size, proseUnit)
+		randomText := loadBenchmarkInput(fmt.Sprintf("searchScaling.random.%d", size))
+		textWithMatch := loadBenchmarkInput(fmt.Sprintf("searchScaling.success.%d", size))
+		proseText := loadBenchmarkInput(fmt.Sprintf("searchScaling.prose.%d", size))
 
 		suffix := fmt.Sprintf(".%d", size)
 
@@ -768,33 +610,16 @@ func runIssue481ScalingBenchmarks(data map[string]any, filters []string) {
 	}
 
 	for _, size := range sizes {
-		splitText := repeatToSize(getString(sec, "splitW.unit"), size)
-		blockText := surroundToSize(
-			getString(sec, "block.prefix"),
-			getString(sec, "block.unit"),
-			getString(sec, "block.suffix"),
-			size)
-		blockNegativeText := surroundToSize(
-			getString(sec, "block.prefix"),
-			getString(sec, "block.unit"),
-			getString(sec, "block.negativeSuffix"),
-			size)
-		tagText := suffixMatchToSize(
-			getString(sec, "tag.prefixUnit"),
-			getString(sec, "tag.match"),
-			size)
-		tagNegativeText := suffixMatchToSize(
-			getString(sec, "tag.prefixUnit"),
-			getString(sec, "tag.negativeMatch"),
-			size)
-		schemeText := suffixMatchToSize(
-			getString(sec, "scheme.prefixUnit"),
-			getString(sec, "scheme.match"),
-			size)
-		schemeNegativeText := suffixMatchToSize(
-			getString(sec, "scheme.prefixUnit"),
-			getString(sec, "scheme.negativeMatch"),
-			size)
+		splitText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.splitW.%d", size))
+		blockText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.block.%d", size))
+		blockNegativeText := loadBenchmarkInput(
+			fmt.Sprintf("issue481Scaling.blockNegative.%d", size))
+		tagText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.tag.%d", size))
+		tagNegativeText := loadBenchmarkInput(
+			fmt.Sprintf("issue481Scaling.tagNegative.%d", size))
+		schemeText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.scheme.%d", size))
+		schemeNegativeText := loadBenchmarkInput(
+			fmt.Sprintf("issue481Scaling.schemeNegative.%d", size))
 
 		suffix := fmt.Sprintf(".%d", size)
 		run := func(name string, fn func()) {
@@ -949,8 +774,8 @@ func runPathologicalBenchmarks(data map[string]any, filters []string) {
 	ns := getIntSlice(data, "pathological.nValues")
 
 	for _, n := range ns {
-		pattern := strings.Repeat("a?", n) + strings.Repeat("a", n)
-		text := strings.Repeat("a", n)
+		pattern := loadBenchmarkInput(fmt.Sprintf("pathological.pattern.%d", n))
+		text := loadBenchmarkInput(fmt.Sprintf("pathological.text.%d", n))
 
 		name := fmt.Sprintf("PathologicalBenchmark.pathological.%d", n)
 		if matchesFilter(name, filters) {
@@ -969,15 +794,9 @@ func runFanoutBenchmarks(data map[string]any, filters []string) {
 	fanout := regexp.MustCompile(getString(sec, "unicodeFanout.pattern"))
 	nested := regexp.MustCompile(getString(sec, "nestedQuantifier.pattern"))
 
-	codepoints := getIntSlice(sec, "unicodeFanout.codePoints")
-	unicodeSeed := int64(getInt(sec, "unicodeFanout.seed"))
-
-	nestedAlphabet := getString(sec, "nestedQuantifier.alphabet")
-	nestedSeed := int64(getInt(sec, "nestedQuantifier.seed"))
-
 	for _, size := range sizes {
-		unicodeText := makeUnicodeText(size, codepoints, unicodeSeed)
-		asciiText := makeRandomText(size, nestedAlphabet, nestedSeed)
+		unicodeText := loadBenchmarkInput(fmt.Sprintf("fanout.unicode.%d", size))
+		asciiText := loadBenchmarkInput(fmt.Sprintf("fanout.ascii.%d", size))
 
 		suffix := fmt.Sprintf(".%d", size)
 
@@ -1083,20 +902,20 @@ func runMemoryBenchmarks(data map[string]any, filters []string) {
 // ---------------------------------------------------------------------------
 
 func main() {
-	dataPath := "../../benchmark-data.json"
+	manifestPath := "../../target/benchmark-corpus/manifest.json"
 	var filters []string
 
 	args := os.Args[1:]
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--data" && i+1 < len(args) {
-			dataPath = args[i+1]
+		if args[i] == "--manifest" && i+1 < len(args) {
+			manifestPath = args[i+1]
 			i++
 		} else {
 			filters = append(filters, args[i])
 		}
 	}
 
-	data := loadBenchmarkData(dataPath)
+	data := loadBenchmarkManifest(manifestPath)
 
 	runRegexBenchmarks(data, filters)
 	runApplicationBenchmarks(data, filters)

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -58,6 +58,18 @@
       <version>${jmh.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -125,14 +137,10 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Skip surefire — benchmarks have no unit tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -61,14 +61,6 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>${project.basedir}</directory>
-        <includes>
-          <include>benchmark-data.json</include>
-        </includes>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -9,32 +9,54 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Loads benchmark data (patterns, texts, parameters) from the shared {@code benchmark-data.json}
- * file. This is the single source of truth for benchmark inputs, shared between Java and C++
- * harnesses.
+ * Loads resolved benchmark configuration and exact generated inputs from the materialized corpus.
  */
 public final class BenchmarkData {
 
+  private static final String CORPUS_PROPERTY = "safere.benchmark.corpus";
   private static final BenchmarkData INSTANCE = new BenchmarkData();
 
+  private final Path corpusDirectory;
   private final JsonObject root;
+  private final JsonObject materializedInputs;
+  private final Map<String, byte[]> inputBytes = new ConcurrentHashMap<>();
+  private final Map<String, String> inputStrings = new ConcurrentHashMap<>();
 
   private BenchmarkData() {
-    try (InputStream is = BenchmarkData.class.getResourceAsStream("/benchmark-data.json");
-        InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
-      root = new Gson().fromJson(reader, JsonObject.class);
+    String configuredCorpus = System.getProperty(CORPUS_PROPERTY);
+    if (configuredCorpus == null || configuredCorpus.isBlank()) {
+      throw new IllegalArgumentException(
+          "Missing -D"
+              + CORPUS_PROPERTY
+              + "=<directory>; run benchmarks through the project scripts");
+    }
+    corpusDirectory = Path.of(configuredCorpus);
+    Path manifestPath = corpusDirectory.resolve("manifest.json");
+    try (Reader reader = Files.newBufferedReader(manifestPath, StandardCharsets.UTF_8)) {
+      JsonObject manifest = new Gson().fromJson(reader, JsonObject.class);
+      if (manifest.get("version").getAsInt() != 1) {
+        throw new IllegalArgumentException(
+            "Unsupported benchmark input manifest version: " + manifest.get("version"));
+      }
+      root = manifest.getAsJsonObject("benchmarkData");
+      materializedInputs = manifest.getAsJsonObject("inputs");
     } catch (Exception e) {
-      throw new RuntimeException("Failed to load benchmark-data.json", e);
+      throw new RuntimeException("Failed to load materialized benchmark data: " + manifestPath, e);
     }
   }
 
@@ -105,6 +127,27 @@ public final class BenchmarkData {
     return result;
   }
 
+  /**
+   * Returns one materialized benchmark input decoded from its canonical UTF-8 bytes.
+   *
+   * @param key logical input key from the materialized manifest
+   * @return immutable decoded input
+   */
+  public String getInputString(String key) {
+    return inputStrings.computeIfAbsent(
+        key, ignored -> new String(loadInputBytes(key), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Returns a copy of one canonical materialized UTF-8 benchmark input.
+   *
+   * @param key logical input key from the materialized manifest
+   * @return copy of the materialized bytes
+   */
+  public byte[] getInputBytes(String key) {
+    return loadInputBytes(key).clone();
+  }
+
   /** Returns application benchmark cases in JSON order, keyed by case name. */
   public Map<String, ApplicationCase> getApplicationCases() {
     JsonArray arr = root.getAsJsonArray("application");
@@ -130,5 +173,55 @@ public final class BenchmarkData {
       }
     }
     return Collections.unmodifiableMap(cases);
+  }
+
+  private byte[] loadInputBytes(String key) {
+    return inputBytes.computeIfAbsent(key, this::readAndVerifyInput);
+  }
+
+  private byte[] readAndVerifyInput(String key) {
+    JsonObject entry = materializedInputs.getAsJsonObject(key);
+    if (entry == null) {
+      throw new IllegalArgumentException("Unknown materialized benchmark input: " + key);
+    }
+    String relativePath = entry.get("file").getAsString();
+    Path inputPath = corpusDirectory.resolve(relativePath);
+    try {
+      byte[] bytes = Files.readAllBytes(inputPath);
+      int expectedLength = entry.get("utf8Bytes").getAsInt();
+      if (bytes.length != expectedLength) {
+        throw new IllegalArgumentException(
+            "Materialized benchmark input has wrong length: "
+                + key
+                + " expected "
+                + expectedLength
+                + " but was "
+                + bytes.length);
+      }
+      String expectedHash = entry.get("sha256").getAsString();
+      String actualHash = sha256(bytes);
+      if (!expectedHash.equals(actualHash)) {
+        throw new IllegalArgumentException(
+            "Materialized benchmark input has wrong SHA-256: "
+                + key
+                + " expected "
+                + expectedHash
+                + " but was "
+                + actualHash);
+      }
+      return bytes;
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(
+          "Failed to load materialized benchmark input: " + key + " (" + inputPath + ")",
+          exception);
+    }
+  }
+
+  private static String sha256(byte[] bytes) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    } catch (NoSuchAlgorithmException exception) {
+      throw new AssertionError("SHA-256 must be available", exception);
+    }
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -346,9 +346,12 @@ public final class BenchmarkInputMaterializer {
     return " ".repeat(leading) + body + " ".repeat(padding - leading);
   }
 
-  private static String repeatToSize(String unit, int size) {
+  static String repeatToSize(String unit, int size) {
     if (size == 0) {
       return "";
+    }
+    if (unit.isEmpty()) {
+      throw new IllegalArgumentException("Repeat unit must not be empty when size is positive");
     }
     StringBuilder result = new StringBuilder(size + unit.length());
     while (result.length() < size) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -1,0 +1,493 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+
+/**
+ * Materializes resolved benchmark configuration and deterministic UTF-8 input files.
+ *
+ * <p>The compact recipes in {@code benchmark-data.json} remain the human-editable source of truth.
+ * Benchmark engines consume only the resulting byte-identical corpus.
+ */
+public final class BenchmarkInputMaterializer {
+  private static final Gson GSON =
+      new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+  private static final String MANIFEST_FILE = "manifest.json";
+
+  private final JsonObject data;
+  private final String benchmarkDataSha256;
+  private final Map<String, byte[]> inputs = new LinkedHashMap<>();
+
+  private BenchmarkInputMaterializer(JsonObject data, String benchmarkDataSha256) {
+    this.data = data;
+    this.benchmarkDataSha256 = benchmarkDataSha256;
+  }
+
+  /**
+   * Generates the resolved benchmark manifest and materialized input corpus.
+   *
+   * @param args {@code [safere-benchmarks-directory] [output-directory]}
+   * @throws Exception if materialization fails
+   */
+  public static void main(String[] args) throws Exception {
+    if (args.length > 2) {
+      throw new IllegalArgumentException(
+          "Usage: BenchmarkInputMaterializer "
+              + "[safere-benchmarks-directory] [output-directory]");
+    }
+    Path benchmarkDirectory = Path.of("safere-benchmarks");
+    if (args.length >= 1) {
+      benchmarkDirectory = Path.of(args[0]);
+    }
+    Path outputDirectory = benchmarkDirectory.resolve("target/benchmark-corpus");
+    if (args.length == 2) {
+      outputDirectory = Path.of(args[1]);
+    }
+
+    byte[] benchmarkDataBytes =
+        Files.readAllBytes(benchmarkDirectory.resolve("benchmark-data.json"));
+    JsonObject data =
+        GSON.fromJson(new String(benchmarkDataBytes, StandardCharsets.UTF_8), JsonObject.class);
+
+    BenchmarkInputMaterializer materializer =
+        new BenchmarkInputMaterializer(data, sha256(benchmarkDataBytes));
+    materializer.generate();
+    materializer.write(outputDirectory);
+  }
+
+  private void generate() {
+    generateUtf8Matching();
+    generateSearchScaling();
+    generateIssue481Scaling();
+    generateIssue488ReplaceAll();
+    generateRealWorldRegex();
+    generateScrubber();
+    generatePathological();
+    generateFanout();
+    add("memory.dfaCacheText", "contact user.name+tag@example.co.uk for info".repeat(200));
+  }
+
+  private void generateUtf8Matching() {
+    String prefix = "utf8Matching.literalScan.";
+    String alphabet = string(prefix + "alphabet");
+    int size = integer(prefix + "textSize");
+    Random random = new Random(integer(prefix + "seed"));
+    StringBuilder text = new StringBuilder(size);
+    for (int index = 0; index < size; index++) {
+      text.append(alphabet.charAt(random.nextInt(alphabet.length())));
+    }
+    add("utf8Matching.literalScan.text", text.toString());
+
+    prefix = "utf8Matching.requiredClassNonmatch.";
+    add(
+        "utf8Matching.requiredClassNonmatch.text",
+        repeatToSize(string(prefix + "unit"), integer(prefix + "textSize")));
+
+    for (int textSize : integers("utf8Matching.hardFailure.textSizes")) {
+      add(
+          "utf8Matching.hardFailure." + textSize,
+          repeatToSize(string("utf8Matching.hardFailure.unit"), textSize));
+    }
+  }
+
+  private void generateSearchScaling() {
+    String alphabet = string("searchScaling.randomText.alphabet");
+    int seed = integer("searchScaling.randomText.seed");
+    String matchSuffix = string("searchScaling.matchSuffix");
+    String proseUnit = string("searchScaling.proseUnit");
+    for (int textSize : integers("searchScaling.textSizes")) {
+      Random random = new Random(seed);
+      char[] characters = new char[textSize];
+      for (int index = 0; index < textSize; index++) {
+        characters[index] = alphabet.charAt(random.nextInt(alphabet.length()));
+      }
+      String randomText = new String(characters);
+      add("searchScaling.random." + textSize, randomText);
+      add("searchScaling.success." + textSize, randomText + matchSuffix);
+
+      StringBuilder prose = new StringBuilder(textSize + proseUnit.length());
+      while (prose.length() < textSize) {
+        prose.append(proseUnit);
+      }
+      add("searchScaling.prose." + textSize, prose.toString());
+    }
+  }
+
+  private void generateIssue481Scaling() {
+    for (int textSize : integers("issue481Scaling.textSizes")) {
+      add(
+          "issue481Scaling.splitW." + textSize,
+          repeatToSize(string("issue481Scaling.splitW.unit"), textSize));
+      add(
+          "issue481Scaling.block." + textSize,
+          surroundToSize(
+              string("issue481Scaling.block.prefix"),
+              string("issue481Scaling.block.unit"),
+              string("issue481Scaling.block.suffix"),
+              textSize));
+      add(
+          "issue481Scaling.blockNegative." + textSize,
+          surroundToSize(
+              string("issue481Scaling.block.prefix"),
+              string("issue481Scaling.block.unit"),
+              string("issue481Scaling.block.negativeSuffix"),
+              textSize));
+      add(
+          "issue481Scaling.tag." + textSize,
+          suffixMatchToSize(
+              string("issue481Scaling.tag.prefixUnit"),
+              string("issue481Scaling.tag.match"),
+              textSize));
+      add(
+          "issue481Scaling.tagNegative." + textSize,
+          suffixMatchToSize(
+              string("issue481Scaling.tag.prefixUnit"),
+              string("issue481Scaling.tag.negativeMatch"),
+              textSize));
+      add(
+          "issue481Scaling.scheme." + textSize,
+          suffixMatchToSize(
+              string("issue481Scaling.scheme.prefixUnit"),
+              string("issue481Scaling.scheme.match"),
+              textSize));
+      add(
+          "issue481Scaling.schemeNegative." + textSize,
+          suffixMatchToSize(
+              string("issue481Scaling.scheme.prefixUnit"),
+              string("issue481Scaling.scheme.negativeMatch"),
+              textSize));
+    }
+  }
+
+  private void generateIssue488ReplaceAll() {
+    for (int textSize : integers("issue488ReplaceAll.textSizes")) {
+      add(
+          "issue488ReplaceAll.lazyAlt." + textSize,
+          lazyAltInput(
+              string("issue488ReplaceAll.lazyAlt.prefixUnit"),
+              string("issue488ReplaceAll.lazyAlt.match"),
+              string("issue488ReplaceAll.lazyAlt.suffixUnit"),
+              textSize));
+      add(
+          "issue488ReplaceAll.altCapture." + textSize,
+          altCaptureInput(
+              string("issue488ReplaceAll.altCapture.hitUnit"),
+              string("issue488ReplaceAll.altCapture.missUnit"),
+              integer("issue488ReplaceAll.altCapture.hitInterval"),
+              textSize));
+    }
+  }
+
+  private void generateRealWorldRegex() {
+    JsonObject section = object("realWorldRegex");
+    int[] textSizes = integers("realWorldRegex.textSizes");
+    String alphabet = string("realWorldRegex.safeDelimiterAlphabet");
+    int seed = integer("realWorldRegex.seed");
+    for (JsonElement element : section.getAsJsonArray("cases")) {
+      RealWorldRegexCase benchmarkCase = RealWorldRegexCase.fromJson(element.getAsJsonObject());
+      for (boolean match : new boolean[] {true, false}) {
+        String label = match ? "match" : "noMatch";
+        RealWorldRegexCase.InputSpec inputSpec =
+            match ? benchmarkCase.matchInput : benchmarkCase.nonMatchInput;
+        for (int textSize : textSizes) {
+          add(
+              "realWorldRegex." + benchmarkCase.name + "." + label + "." + textSize,
+              realWorldInput(benchmarkCase, inputSpec, match, textSize, alphabet, seed));
+        }
+      }
+    }
+  }
+
+  private void generateScrubber() {
+    int repeatCount = integer("scrubber.repeatCount");
+    add("scrubber.withoutDirectives", string("scrubber.baseWithoutDirectives").repeat(repeatCount));
+    add("scrubber.withDirectives", string("scrubber.baseWithDirectives").repeat(repeatCount));
+  }
+
+  private void generatePathological() {
+    for (int n : integers("pathological.nValues")) {
+      add("pathological.pattern." + n, "a?".repeat(n) + "a".repeat(n));
+      add("pathological.text." + n, "a".repeat(n));
+    }
+  }
+
+  private void generateFanout() {
+    int[] codePoints = integers("fanout.unicodeFanout.codePoints");
+    int unicodeSeed = integer("fanout.unicodeFanout.seed");
+    String alphabet = string("fanout.nestedQuantifier.alphabet");
+    int asciiSeed = integer("fanout.nestedQuantifier.seed");
+    for (int textSize : integers("fanout.textSizes")) {
+      Random unicodeRandom = new Random(unicodeSeed);
+      StringBuilder unicodeText = new StringBuilder();
+      while (unicodeText.length() < textSize) {
+        unicodeText.appendCodePoint(codePoints[unicodeRandom.nextInt(codePoints.length)]);
+      }
+      add("fanout.unicode." + textSize, unicodeText.toString());
+
+      Random asciiRandom = new Random(asciiSeed);
+      char[] asciiText = new char[textSize];
+      for (int index = 0; index < textSize; index++) {
+        asciiText[index] = alphabet.charAt(asciiRandom.nextInt(alphabet.length()));
+      }
+      add("fanout.ascii." + textSize, new String(asciiText));
+    }
+  }
+
+  private String realWorldInput(
+      RealWorldRegexCase benchmarkCase,
+      RealWorldRegexCase.InputSpec inputSpec,
+      boolean match,
+      int size,
+      String alphabet,
+      int seed) {
+    String template = match ? benchmarkCase.match : benchmarkCase.nonMatch;
+    return switch (inputSpec.kind) {
+      case "repeat" -> repeatedInput(template, size, alphabet, seed);
+      case "prefixedRepeat" -> prefixedInput(inputSpec.prefix, template, size, alphabet, seed);
+      case "sparseMatch" ->
+          sparseInput(
+              benchmarkCase.match,
+              benchmarkCase.nonMatch,
+              size,
+              seed,
+              inputSpec.nonMatchRepeats,
+              inputSpec.delimiterAlphabet);
+      case "surroundWithSpaces" -> surroundWithSpaces(inputSpec.body, size);
+      case "scaledSurroundWithSpaces" ->
+          scaledSurroundWithSpaces(
+              inputSpec.bodyPrefix,
+              inputSpec.bodySuffix,
+              inputSpec.bodyFill,
+              inputSpec.bodyScalePercent,
+              size);
+      default ->
+          throw new IllegalArgumentException("Unknown real-world input kind: " + inputSpec.kind);
+    };
+  }
+
+  private static String repeatedInput(String template, int size, String alphabet, int seed) {
+    if (template.length() >= size) {
+      return template.substring(0, size);
+    }
+    StringBuilder result = new StringBuilder(size);
+    int delimiterIndex = seed;
+    while (result.length() < size) {
+      result.append(template);
+      if (result.length() < size) {
+        result.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
+        delimiterIndex++;
+      }
+    }
+    return result.substring(0, size);
+  }
+
+  private static String prefixedInput(
+      String prefix, String template, int size, String alphabet, int seed) {
+    if (prefix.length() >= size) {
+      return prefix.substring(0, size);
+    }
+    return prefix + repeatedInput(template, size - prefix.length(), alphabet, seed);
+  }
+
+  private static String sparseInput(
+      String match, String nonMatch, int size, int seed, int nonMatchRepeats, String alphabet) {
+    StringBuilder result = new StringBuilder(size);
+    int delimiterIndex = seed;
+    while (result.length() < size) {
+      for (int index = 0; index < nonMatchRepeats && result.length() < size; index++) {
+        result.append(nonMatch);
+        if (result.length() < size) {
+          result.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
+          delimiterIndex++;
+        }
+      }
+      if (result.length() < size) {
+        result.append(' ').append(match).append(' ');
+      }
+    }
+    return result.substring(0, size);
+  }
+
+  private static String scaledSurroundWithSpaces(
+      String bodyPrefix, String bodySuffix, String bodyFill, int scalePercent, int size) {
+    int fixedLength = bodyPrefix.length() + bodySuffix.length();
+    int targetLength = Math.max(fixedLength, size * scalePercent / 100);
+    targetLength = Math.min(targetLength, size);
+    String body =
+        bodyPrefix + repeatToSize(bodyFill, Math.max(0, targetLength - fixedLength)) + bodySuffix;
+    return surroundWithSpaces(body, size);
+  }
+
+  private static String surroundWithSpaces(String body, int size) {
+    if (body.length() >= size) {
+      return body.substring(0, size);
+    }
+    int padding = size - body.length();
+    int leading = padding / 2;
+    return " ".repeat(leading) + body + " ".repeat(padding - leading);
+  }
+
+  private static String repeatToSize(String unit, int size) {
+    if (size == 0) {
+      return "";
+    }
+    StringBuilder result = new StringBuilder(size + unit.length());
+    while (result.length() < size) {
+      result.append(unit);
+    }
+    return result.substring(0, size);
+  }
+
+  private static String surroundToSize(String prefix, String unit, String suffix, int size) {
+    int bodySize = Math.max(0, size - prefix.length() - suffix.length());
+    return prefix + repeatToSize(unit, bodySize) + suffix;
+  }
+
+  private static String suffixMatchToSize(String prefixUnit, String match, int size) {
+    return repeatToSize(prefixUnit, Math.max(0, size - match.length())) + match;
+  }
+
+  private static String lazyAltInput(String prefixUnit, String match, String suffixUnit, int size) {
+    StringBuilder result = new StringBuilder(size + match.length() + prefixUnit.length());
+    int halfSize = size / 2;
+    while (result.length() < halfSize) {
+      result.append(prefixUnit);
+    }
+    result.append(match);
+    while (result.length() < size) {
+      result.append(suffixUnit);
+    }
+    return result.substring(0, size);
+  }
+
+  private static String altCaptureInput(
+      String hitUnit, String missUnit, int hitInterval, int size) {
+    StringBuilder result = new StringBuilder(size + Math.max(hitUnit.length(), missUnit.length()));
+    int counter = 0;
+    while (result.length() < size) {
+      result.append(counter % hitInterval == 0 ? hitUnit : missUnit);
+      counter++;
+    }
+    return result.substring(0, size);
+  }
+
+  private void add(String key, String value) {
+    byte[] previous = inputs.put(key, value.getBytes(StandardCharsets.UTF_8));
+    if (previous != null) {
+      throw new IllegalArgumentException("Duplicate materialized input key: " + key);
+    }
+  }
+
+  private void write(Path corpusDirectory) throws IOException {
+    if (Files.exists(corpusDirectory)) {
+      try (Stream<Path> paths = Files.walk(corpusDirectory)) {
+        for (Path path : paths.sorted((left, right) -> right.compareTo(left)).toList()) {
+          if (!path.equals(corpusDirectory)) {
+            Files.delete(path);
+          }
+        }
+      }
+    }
+    Files.createDirectories(corpusDirectory);
+
+    JsonObject manifest = manifest();
+    for (Map.Entry<String, byte[]> input : inputs.entrySet()) {
+      String relativePath =
+          manifest
+              .getAsJsonObject("inputs")
+              .getAsJsonObject(input.getKey())
+              .get("file")
+              .getAsString();
+      Path output = corpusDirectory.resolve(relativePath);
+      Files.createDirectories(output.getParent());
+      Files.write(output, input.getValue());
+    }
+    Files.writeString(
+        corpusDirectory.resolve(MANIFEST_FILE),
+        GSON.toJson(manifest) + System.lineSeparator(),
+        StandardCharsets.UTF_8);
+    System.out.printf("Materialized %d benchmark inputs in %s%n", inputs.size(), corpusDirectory);
+  }
+
+  private JsonObject manifest() {
+    JsonObject manifest = new JsonObject();
+    manifest.addProperty("version", 1);
+    manifest.addProperty(
+        "description", "Resolved benchmark configuration and generated UTF-8 inputs.");
+    manifest.addProperty("benchmarkDataSha256", benchmarkDataSha256);
+    manifest.add("benchmarkData", data.deepCopy());
+    JsonObject entries = new JsonObject();
+    for (Map.Entry<String, byte[]> input : inputs.entrySet()) {
+      byte[] bytes = input.getValue();
+      String text = new String(bytes, StandardCharsets.UTF_8);
+      JsonObject entry = new JsonObject();
+      entry.addProperty("file", input.getKey().replace('.', '/') + ".txt");
+      entry.addProperty("utf8Bytes", bytes.length);
+      entry.addProperty("utf16CodeUnits", text.length());
+      entry.addProperty("unicodeScalars", text.codePointCount(0, text.length()));
+      entry.addProperty("sha256", sha256(bytes));
+      entries.add(input.getKey(), entry);
+    }
+    manifest.add("inputs", entries);
+    return manifest;
+  }
+
+  private static String sha256(byte[] bytes) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    } catch (NoSuchAlgorithmException exception) {
+      throw new AssertionError("SHA-256 must be available", exception);
+    }
+  }
+
+  private JsonObject object(String path) {
+    return element(path).getAsJsonObject();
+  }
+
+  private String string(String path) {
+    return element(path).getAsString();
+  }
+
+  private int integer(String path) {
+    return element(path).getAsInt();
+  }
+
+  private int[] integers(String path) {
+    JsonArray array = element(path).getAsJsonArray();
+    int[] values = new int[array.size()];
+    for (int index = 0; index < array.size(); index++) {
+      values[index] = array.get(index).getAsInt();
+    }
+    return values;
+  }
+
+  private JsonElement element(String path) {
+    JsonElement current = data;
+    for (String part : path.split("\\.")) {
+      current = current.getAsJsonObject().get(part);
+      if (current == null) {
+        throw new IllegalArgumentException("No benchmark data at path: " + path);
+      }
+    }
+    return current;
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/FanoutBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/FanoutBenchmark.java
@@ -5,7 +5,6 @@
 
 package org.safere.benchmark;
 
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -58,11 +57,6 @@ public class FanoutBenchmark {
     BenchmarkData data = BenchmarkData.get();
     fanoutPattern = data.getString("fanout.unicodeFanout.pattern");
     nestedPattern = data.getString("fanout.nestedQuantifier.pattern");
-    int[] codePoints = data.getIntArray("fanout.unicodeFanout.codePoints");
-    int unicodeSeed = data.getInt("fanout.unicodeFanout.seed");
-    String nestedAlphabet = data.getString("fanout.nestedQuantifier.alphabet");
-    int nestedSeed = data.getInt("fanout.nestedQuantifier.seed");
-
     safeFanout = org.safere.Pattern.compile(fanoutPattern);
     jdkFanout = java.util.regex.Pattern.compile(fanoutPattern);
 
@@ -75,21 +69,8 @@ public class FanoutBenchmark {
     re2ffmFanout = org.safere.re2ffm.RE2FfmPattern.compile(fanoutPattern);
     re2ffmNested = org.safere.re2ffm.RE2FfmPattern.compile(nestedPattern);
 
-    // Generate Unicode text (mix of CJK, Latin Extended, Cyrillic, Hiragana).
-    Random rng = new Random(unicodeSeed);
-    StringBuilder sb = new StringBuilder();
-    while (sb.length() < textSize) {
-      sb.appendCodePoint(codePoints[rng.nextInt(codePoints.length)]);
-    }
-    unicodeText = sb.toString();
-
-    // Generate ASCII text for nested quantifier test.
-    rng = new Random(nestedSeed);
-    char[] chars = new char[textSize];
-    for (int i = 0; i < textSize; i++) {
-      chars[i] = nestedAlphabet.charAt(rng.nextInt(nestedAlphabet.length()));
-    }
-    asciiText = new String(chars);
+    unicodeText = data.getInputString("fanout.unicode." + textSize);
+    asciiText = data.getInputString("fanout.ascii." + textSize);
   }
 
   // ===== Unicode fanout: find in Unicode text =====

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/Issue481ScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/Issue481ScalingBenchmark.java
@@ -61,39 +61,13 @@ public class Issue481ScalingBenchmark {
     String tagPattern = data.getString("issue481Scaling.tag.pattern");
     String schemePattern = data.getString("issue481Scaling.scheme.pattern");
 
-    splitText = repeatToSize(data.getString("issue481Scaling.splitW.unit"), textSize);
-    blockText =
-        surroundToSize(
-            data.getString("issue481Scaling.block.prefix"),
-            data.getString("issue481Scaling.block.unit"),
-            data.getString("issue481Scaling.block.suffix"),
-            textSize);
-    blockNegativeText =
-        surroundToSize(
-            data.getString("issue481Scaling.block.prefix"),
-            data.getString("issue481Scaling.block.unit"),
-            data.getString("issue481Scaling.block.negativeSuffix"),
-            textSize);
-    tagText =
-        suffixMatchToSize(
-            data.getString("issue481Scaling.tag.prefixUnit"),
-            data.getString("issue481Scaling.tag.match"),
-            textSize);
-    tagNegativeText =
-        suffixMatchToSize(
-            data.getString("issue481Scaling.tag.prefixUnit"),
-            data.getString("issue481Scaling.tag.negativeMatch"),
-            textSize);
-    schemeText =
-        suffixMatchToSize(
-            data.getString("issue481Scaling.scheme.prefixUnit"),
-            data.getString("issue481Scaling.scheme.match"),
-            textSize);
-    schemeNegativeText =
-        suffixMatchToSize(
-            data.getString("issue481Scaling.scheme.prefixUnit"),
-            data.getString("issue481Scaling.scheme.negativeMatch"),
-            textSize);
+    splitText = data.getInputString("issue481Scaling.splitW." + textSize);
+    blockText = data.getInputString("issue481Scaling.block." + textSize);
+    blockNegativeText = data.getInputString("issue481Scaling.blockNegative." + textSize);
+    tagText = data.getInputString("issue481Scaling.tag." + textSize);
+    tagNegativeText = data.getInputString("issue481Scaling.tagNegative." + textSize);
+    schemeText = data.getInputString("issue481Scaling.scheme." + textSize);
+    schemeNegativeText = data.getInputString("issue481Scaling.schemeNegative." + textSize);
 
     safereSplitW = org.safere.Pattern.compile(splitPattern);
     safereBlock = org.safere.Pattern.compile(blockPattern);
@@ -278,24 +252,6 @@ public class Issue481ScalingBenchmark {
   @Benchmark
   public boolean schemeFindNegative_re2ffm() {
     return re2ffmScheme.matcher(schemeNegativeText).find();
-  }
-
-  private static String repeatToSize(String unit, int size) {
-    StringBuilder sb = new StringBuilder(size + unit.length());
-    while (sb.length() < size) {
-      sb.append(unit);
-    }
-    return sb.substring(0, size);
-  }
-
-  private static String surroundToSize(String prefix, String unit, String suffix, int size) {
-    int targetBodySize = Math.max(0, size - prefix.length() - suffix.length());
-    return prefix + repeatToSize(unit, targetBodySize) + suffix;
-  }
-
-  private static String suffixMatchToSize(String prefixUnit, String match, int size) {
-    int targetPrefixSize = Math.max(0, size - match.length());
-    return repeatToSize(prefixUnit, targetPrefixSize) + match;
   }
 
   private static int splitLengthSum(String[] parts) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/Issue488ReplaceAllBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/Issue488ReplaceAllBenchmark.java
@@ -47,21 +47,11 @@ public class Issue488ReplaceAllBenchmark {
 
     String lazyAltPattern = data.getString("issue488ReplaceAll.lazyAlt.pattern");
     lazyAltReplacement = data.getString("issue488ReplaceAll.lazyAlt.replacement");
-    lazyAltInput =
-        generateLazyAltInput(
-            data.getString("issue488ReplaceAll.lazyAlt.prefixUnit"),
-            data.getString("issue488ReplaceAll.lazyAlt.match"),
-            data.getString("issue488ReplaceAll.lazyAlt.suffixUnit"),
-            textSize);
+    lazyAltInput = data.getInputString("issue488ReplaceAll.lazyAlt." + textSize);
 
     String altCapturePattern = data.getString("issue488ReplaceAll.altCapture.pattern");
     altCaptureReplacement = data.getString("issue488ReplaceAll.altCapture.replacement");
-    altCaptureInput =
-        generateAltCaptureInput(
-            data.getString("issue488ReplaceAll.altCapture.hitUnit"),
-            data.getString("issue488ReplaceAll.altCapture.missUnit"),
-            data.getInt("issue488ReplaceAll.altCapture.hitInterval"),
-            textSize);
+    altCaptureInput = data.getInputString("issue488ReplaceAll.altCapture." + textSize);
 
     safereLazyAlt = org.safere.Pattern.compile(lazyAltPattern);
     safereAltCapture = org.safere.Pattern.compile(altCapturePattern);
@@ -114,30 +104,5 @@ public class Issue488ReplaceAllBenchmark {
   @Benchmark
   public String altCapture_re2ffm() {
     return re2ffmAltCapture.matcher(altCaptureInput).replaceAll(altCaptureReplacement);
-  }
-
-  private static String generateLazyAltInput(
-      String prefixUnit, String match, String suffixUnit, int size) {
-    StringBuilder sb = new StringBuilder(size + match.length() + prefixUnit.length());
-    int halfSize = size / 2;
-    while (sb.length() < halfSize) {
-      sb.append(prefixUnit);
-    }
-    sb.append(match);
-    while (sb.length() < size) {
-      sb.append(suffixUnit);
-    }
-    return sb.substring(0, size);
-  }
-
-  private static String generateAltCaptureInput(
-      String hitUnit, String missUnit, int hitInterval, int size) {
-    StringBuilder sb = new StringBuilder(size + Math.max(hitUnit.length(), missUnit.length()));
-    int counter = 0;
-    while (sb.length() < size) {
-      sb.append(counter % hitInterval == 0 ? hitUnit : missUnit);
-      counter++;
-    }
-    return sb.substring(0, size);
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
@@ -91,7 +91,7 @@ public final class MemoryBenchmark {
     System.out.println("─".repeat(32));
 
     // Build a large text to exercise DFA cache creation across many character classes.
-    String largeText = getSampleText(data, "complex").repeat(200);
+    String largeText = data.getInputString("memory.dfaCacheText");
 
     for (String name : patternNames) {
       String pattern = data.getString("compile." + name + ".pattern");
@@ -188,17 +188,5 @@ public final class MemoryBenchmark {
 
     Arrays.sort(results);
     return results[TRIALS / 2]; // median
-  }
-
-  /** Returns a sample text appropriate for the given compile pattern name. */
-  private static String getSampleText(BenchmarkData data, String patternName) {
-    return switch (patternName) {
-      case "simple" -> "hello world hello world hello";
-      case "medium" -> "2025-12-25T10:30:00 and 2024-01-15T08:00:00";
-      case "complex" -> "contact user.name+tag@example.co.uk for info";
-      case "alternation" ->
-          "the garply went to the baz and met a quux and fred and xyzzy and plugh";
-      default -> "the quick brown fox jumps over the lazy dog";
-    };
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryScalingBenchmark.java
@@ -5,7 +5,6 @@
 
 package org.safere.benchmark;
 
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -54,9 +53,6 @@ public class MemoryScalingBenchmark {
 
     String easyPattern = data.getString("searchScaling.patterns.easy");
     String mediumPattern = data.getString("searchScaling.patterns.medium");
-    String alphabet = data.getString("searchScaling.randomText.alphabet").replace("\\n", "\n");
-    int seed = data.getInt("searchScaling.randomText.seed");
-
     safeEasy = org.safere.Pattern.compile(easyPattern);
     jdkEasy = java.util.regex.Pattern.compile(easyPattern);
     re2jEasy = com.google.re2j.Pattern.compile(easyPattern);
@@ -65,7 +61,7 @@ public class MemoryScalingBenchmark {
     jdkMedium = java.util.regex.Pattern.compile(mediumPattern);
     re2jMedium = com.google.re2j.Pattern.compile(mediumPattern);
 
-    randomText = makeRandomText(textSize, alphabet, seed);
+    randomText = data.getInputString("searchScaling.random." + textSize);
   }
 
   // ===== Easy pattern (allocation scaling with text size) =====
@@ -100,14 +96,5 @@ public class MemoryScalingBenchmark {
   @Benchmark
   public boolean searchMedium_re2j() {
     return re2jMedium.matcher(randomText).find();
-  }
-
-  private static String makeRandomText(int size, String alphabet, int seed) {
-    Random rng = new Random(seed);
-    char[] buf = new char[size];
-    for (int i = 0; i < size; i++) {
-      buf[i] = alphabet.charAt(rng.nextInt(alphabet.length()));
-    }
-    return new String(buf);
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalBenchmark.java
@@ -47,11 +47,12 @@ public class PathologicalBenchmark {
 
   @Setup
   public void setup() {
-    String regex = "a?".repeat(n) + "a".repeat(n);
+    BenchmarkData data = BenchmarkData.get();
+    String regex = data.getInputString("pathological.pattern." + n);
     safePattern = org.safere.Pattern.compile(regex);
     re2jPattern = com.google.re2j.Pattern.compile(regex);
     re2ffmPattern = org.safere.re2ffm.RE2FfmPattern.compile(regex);
-    text = "a".repeat(n);
+    text = data.getInputString("pathological.text." + n);
   }
 
   /** SafeRE: should be linear in n. */

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalComparisonBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PathologicalComparisonBenchmark.java
@@ -35,12 +35,13 @@ public class PathologicalComparisonBenchmark {
 
   @Setup
   public void setup() {
-    String regex = "a?".repeat(n) + "a".repeat(n);
+    BenchmarkData data = BenchmarkData.get();
+    String regex = data.getInputString("pathological.pattern." + n);
     safePattern = org.safere.Pattern.compile(regex);
     jdkPattern = java.util.regex.Pattern.compile(regex);
     re2jPattern = com.google.re2j.Pattern.compile(regex);
     re2ffmPattern = org.safere.re2ffm.RE2FfmPattern.compile(regex);
-    text = "a".repeat(n);
+    text = data.getInputString("pathological.text." + n);
   }
 
   @Benchmark

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RealWorldRegexBenchmark.java
@@ -176,133 +176,14 @@ public class RealWorldRegexBenchmark {
                   "Unknown real-world regex benchmark op: " + regexCase.op);
         };
 
-    RealWorldRegexCase.InputSpec inputSpec = match ? regexCase.matchInput : regexCase.nonMatchInput;
-    String alphabet = data.getString("realWorldRegex.safeDelimiterAlphabet");
-    int seed = data.getInt("realWorldRegex.seed");
-    testInput = generateInput(regexCase, inputSpec, match, inputSize, alphabet, seed);
+    String matchLabel = match ? "match" : "noMatch";
+    testInput =
+        data.getInputString("realWorldRegex." + patternName + "." + matchLabel + "." + inputSize);
   }
 
   @TearDown
   public void tearDown() throws Exception {
     regexEngine.close();
-  }
-
-  private String generateInput(String template, int size, String alphabet, int seed) {
-    if (template.length() >= size) {
-      return template.substring(0, size);
-    }
-    StringBuilder sb = new StringBuilder(size);
-    int delimiterIndex = seed;
-    while (sb.length() < size) {
-      sb.append(template);
-      if (sb.length() < size) {
-        sb.append(alphabet.charAt(Math.floorMod(delimiterIndex, alphabet.length())));
-        delimiterIndex++;
-      }
-    }
-    return sb.substring(0, size);
-  }
-
-  private String generateInput(
-      RealWorldRegexCase regexCase,
-      RealWorldRegexCase.InputSpec inputSpec,
-      boolean match,
-      int size,
-      String alphabet,
-      int seed) {
-    String template = match ? regexCase.match : regexCase.nonMatch;
-    return switch (inputSpec.kind) {
-      case "repeat" -> generateInput(template, size, alphabet, seed);
-      case "prefixedRepeat" ->
-          generatePrefixedInput(inputSpec.prefix, template, size, alphabet, seed);
-      case "sparseMatch" ->
-          generateSparseInput(
-              regexCase.match,
-              regexCase.nonMatch,
-              size,
-              seed,
-              inputSpec.nonMatchRepeats,
-              inputSpec.delimiterAlphabet);
-      case "surroundWithSpaces" -> generateSurroundWithSpacesInput(inputSpec.body, size);
-      case "scaledSurroundWithSpaces" ->
-          generateScaledSurroundWithSpacesInput(
-              inputSpec.bodyPrefix,
-              inputSpec.bodySuffix,
-              inputSpec.bodyFill,
-              inputSpec.bodyScalePercent,
-              size);
-      default ->
-          throw new IllegalArgumentException("Unknown real-world input kind: " + inputSpec.kind);
-    };
-  }
-
-  private String generateScaledSurroundWithSpacesInput(
-      String bodyPrefix, String bodySuffix, String bodyFill, int bodyScalePercent, int size) {
-    if (bodyFill.isEmpty()) {
-      throw new IllegalArgumentException("scaledSurroundWithSpaces requires non-empty bodyFill");
-    }
-    int fixedBodyLength = bodyPrefix.length() + bodySuffix.length();
-    int targetBodyLength = Math.max(fixedBodyLength, size * bodyScalePercent / 100);
-    targetBodyLength = Math.min(targetBodyLength, size);
-    int fillLength = Math.max(0, targetBodyLength - fixedBodyLength);
-    String body = bodyPrefix + repeatToLength(bodyFill, fillLength) + bodySuffix;
-    return generateSurroundWithSpacesInput(body, size);
-  }
-
-  private String repeatToLength(String unit, int size) {
-    if (size == 0) {
-      return "";
-    }
-    StringBuilder sb = new StringBuilder(size);
-    while (sb.length() < size) {
-      sb.append(unit);
-    }
-    return sb.substring(0, size);
-  }
-
-  private String generateSurroundWithSpacesInput(String body, int size) {
-    if (body.length() >= size) {
-      return body.substring(0, size);
-    }
-    int totalPadding = size - body.length();
-    int leadingPadding = totalPadding / 2;
-    int trailingPadding = totalPadding - leadingPadding;
-    return " ".repeat(leadingPadding) + body + " ".repeat(trailingPadding);
-  }
-
-  private String generatePrefixedInput(
-      String prefix, String template, int size, String alphabet, int seed) {
-    if (prefix.length() >= size) {
-      return prefix.substring(0, size);
-    }
-    return prefix + generateInput(template, size - prefix.length(), alphabet, seed);
-  }
-
-  private String generateSparseInput(
-      String matchPart,
-      String nonMatchPart,
-      int size,
-      int seed,
-      int nonMatchRepeats,
-      String delimiterAlphabet) {
-    StringBuilder sb = new StringBuilder(size);
-    int delimiterIndex = seed;
-    while (sb.length() < size) {
-      for (int i = 0; i < nonMatchRepeats && sb.length() < size; i++) {
-        sb.append(nonMatchPart);
-        if (sb.length() < size) {
-          sb.append(
-              delimiterAlphabet.charAt(Math.floorMod(delimiterIndex, delimiterAlphabet.length())));
-          delimiterIndex++;
-        }
-      }
-      if (sb.length() < size) {
-        sb.append(" ");
-        sb.append(matchPart);
-        sb.append(" ");
-      }
-    }
-    return sb.substring(0, size);
   }
 
   @Benchmark

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ScrubberBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ScrubberBenchmark.java
@@ -43,12 +43,11 @@ public class ScrubberBenchmark {
   @Setup
   public void setup() {
     BenchmarkData data = BenchmarkData.get();
-    int repeatCount = data.getInt("scrubber.repeatCount");
     String linePattern = data.getString("scrubber.linePattern");
     String blockPattern = data.getString("scrubber.blockPattern");
 
-    inputWithoutDirectives = data.getString("scrubber.baseWithoutDirectives").repeat(repeatCount);
-    inputWithDirectives = data.getString("scrubber.baseWithDirectives").repeat(repeatCount);
+    inputWithoutDirectives = data.getInputString("scrubber.withoutDirectives");
+    inputWithDirectives = data.getInputString("scrubber.withDirectives");
 
     safeLineStrip = org.safere.Pattern.compile(linePattern, org.safere.Pattern.COMMENTS);
     safeBlockStrip = org.safere.Pattern.compile(blockPattern, org.safere.Pattern.COMMENTS);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SearchScalingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SearchScalingBenchmark.java
@@ -5,7 +5,6 @@
 
 package org.safere.benchmark;
 
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -72,9 +71,7 @@ public class SearchScalingBenchmark {
   private String easyPattern;
   private String mediumPattern;
   private String hardPattern;
-  private String matchSuffix;
   private String findIngPattern;
-  private String proseUnit;
 
   @Setup
   public void setup() {
@@ -82,22 +79,9 @@ public class SearchScalingBenchmark {
     easyPattern = data.getString("searchScaling.patterns.easy");
     mediumPattern = data.getString("searchScaling.patterns.medium");
     hardPattern = data.getString("searchScaling.patterns.hard");
-    matchSuffix = data.getString("searchScaling.matchSuffix");
     findIngPattern = data.getString("searchScaling.findIngPattern");
-    proseUnit = data.getString("searchScaling.proseUnit");
-
-    int seed = data.getInt("searchScaling.randomText.seed");
-    String alphabet = data.getString("searchScaling.randomText.alphabet");
-    alphabet = alphabet.replace("\\n", "\n");
-
-    // Generate random lowercase + digits + space text (no uppercase).
-    Random rng = new Random(seed);
-    char[] chars = new char[textSize];
-    for (int i = 0; i < textSize; i++) {
-      chars[i] = alphabet.charAt(rng.nextInt(alphabet.length()));
-    }
-    randomText = new String(chars);
-    textWithMatch = randomText + matchSuffix;
+    randomText = data.getInputString("searchScaling.random." + textSize);
+    textWithMatch = data.getInputString("searchScaling.success." + textSize);
 
     // Compile search patterns.
     safeEasy = org.safere.Pattern.compile(easyPattern);
@@ -107,12 +91,7 @@ public class SearchScalingBenchmark {
     safeHard = org.safere.Pattern.compile(hardPattern);
     jdkHard = java.util.regex.Pattern.compile(hardPattern);
 
-    // Build scaled prose by repeating the unit to reach textSize.
-    StringBuilder sb = new StringBuilder(textSize + proseUnit.length());
-    while (sb.length() < textSize) {
-      sb.append(proseUnit);
-    }
-    scaledProse = sb.toString();
+    scaledProse = data.getInputString("searchScaling.prose." + textSize);
     safeFindIng = org.safere.Pattern.compile(findIngPattern);
     jdkFindIng = java.util.regex.Pattern.compile(findIngPattern);
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/Utf8MatchingBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/Utf8MatchingBenchmark.java
@@ -133,19 +133,13 @@ public class Utf8MatchingBenchmark extends ByteMatchingBenchmark {
     public void setup() {
       BenchmarkData data = BenchmarkData.get();
       String prefix = "utf8Matching.literalScan.";
-      String alphabet = data.getString(prefix + "alphabet");
-      int size = data.getInt(prefix + "textSize");
-      java.util.Random random = new java.util.Random(data.getInt(prefix + "seed"));
-      StringBuilder text = new StringBuilder(size);
-      for (int index = 0; index < size; index++) {
-        text.append(alphabet.charAt(random.nextInt(alphabet.length())));
-      }
+      String text = data.getInputString("utf8Matching.literalScan.text");
       String literal = data.getString(prefix + "patterns." + name);
       if (text.indexOf(literal) >= 0) {
         throw new IllegalStateException("literal " + literal + " must be absent from the input");
       }
       pattern = org.safere.Pattern.compile(literal);
-      input = org.safere.Utf8Input.trusted(text.toString().getBytes(StandardCharsets.UTF_8));
+      input = org.safere.Utf8Input.trusted(data.getInputBytes("utf8Matching.literalScan.text"));
     }
   }
 
@@ -254,9 +248,7 @@ public class Utf8MatchingBenchmark extends ByteMatchingBenchmark {
     public void setup() {
       BenchmarkData data = BenchmarkData.get();
       pattern = org.safere.Pattern.compile(data.getString("utf8Matching.hardFailure.pattern"));
-      String unit = data.getString("utf8Matching.hardFailure.unit");
-      String text = unit.repeat((size + unit.length() - 1) / unit.length()).substring(0, size);
-      input = org.safere.Utf8Input.trusted(text.getBytes(StandardCharsets.UTF_8));
+      input = org.safere.Utf8Input.trusted(data.getInputBytes("utf8Matching.hardFailure." + size));
     }
   }
 
@@ -272,10 +264,10 @@ public class Utf8MatchingBenchmark extends ByteMatchingBenchmark {
       BenchmarkData data = BenchmarkData.get();
       String prefix = "utf8Matching.requiredClassNonmatch.";
       pattern = org.safere.Pattern.compile(data.getString(prefix + "pattern"));
-      String unit = data.getString(prefix + "unit");
-      int size = data.getInt(prefix + "textSize");
-      text = unit.repeat((size + unit.length() - 1) / unit.length()).substring(0, size);
-      input = org.safere.Utf8Input.trusted(text.getBytes(StandardCharsets.UTF_8));
+      text = data.getInputString("utf8Matching.requiredClassNonmatch.text");
+      input =
+          org.safere.Utf8Input.trusted(
+              data.getInputBytes("utf8Matching.requiredClassNonmatch.text"));
     }
   }
 

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -1,0 +1,26 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BenchmarkInputMaterializerTest {
+
+  @Test
+  void emptyRepeatUnitIsRejectedWhenOutputIsRequired() {
+    assertThatThrownBy(() -> BenchmarkInputMaterializer.repeatToSize("", 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Repeat unit must not be empty when size is positive");
+  }
+
+  @Test
+  void emptyRepeatUnitCanProduceEmptyOutput() {
+    assertThat(BenchmarkInputMaterializer.repeatToSize("", 0)).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

- make `safere-benchmarks/benchmark-data.json` the only checked-in benchmark
  workload source
- materialize one resolved manifest and 232 exact UTF-8 inputs under
  `safere-benchmarks/target/benchmark-corpus` before benchmark execution
- migrate the Java, C++ RE2, and Go harnesses to consume only the generated
  artifacts, removing their duplicated input generators
- record input byte length, UTF-16 length, Unicode scalar count, SHA-256, and
  the source JSON SHA-256 in the generated manifest
- validate input digests in Java, C++, and Go before benchmarking
- update benchmark runners, collection scripts, CI, tests, and documentation
  for the materialization workflow

The centralized materializer preserves the previous Java generator semantics.
C++ and Go previously used different PRNG and size semantics, so affected
cross-language generated workloads begin a new comparable result series with
this change.

## Verification

- `mvn -pl safere-benchmarks spotless:check -q`
- `mvn -pl safere-benchmarks test -DskipTests=false --batch-mode --no-transfer-progress`
  - 2 tests run, 0 failures, 0 errors, 0 skipped
- shell syntax checks for all changed benchmark scripts
- clean `./materialize-benchmark-inputs.sh`
  - generated 232 inputs plus the resolved manifest
  - verified the manifest source hash against `benchmark-data.json`
  - verified the JMH JAR contains neither `benchmark-data.json` nor generated
    input resources
- `go test ./...` in `safere-benchmarks/go`
- C++ configure, build, and support-code tests:
  - `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -Wno-dev`
  - `cmake --build build -j4`
  - `ctest --test-dir build --output-on-failure`
- verified that C++ accepts the generated corpus and rejects a same-length
  input whose contents do not match the manifest SHA-256
- Java materialized-input smoke:
  - `./run-java-benchmarks.sh --smoke --fastbuild '^org\.safere\.benchmark\.SearchScalingBenchmark\.searchEasyFail_safere$'`
- C++ RE2 materialized-input runtime check for
  `SearchScalingBenchmark.searchEasyFail.1048576`
- Go `regexp` materialized-input runtime check for
  `SearchScalingBenchmark.searchEasyFail.1048576`
- final `codex exec review --base main` pass reported no correctness findings

The full benchmark collection and full SafeRE test suite were not run because
this change is limited to benchmark data preparation and harness setup.
