### PR TITLE
Make benchmark input materialization recipe-driven

### DIFF
--- a/safere-benchmarks/BENCHMARK_INPUTS.md
+++ b/safere-benchmarks/BENCHMARK_INPUTS.md
@@ -27,12 +27,11 @@ Unicode scalar count, and SHA-256 digest, along with the resolved benchmark
 configuration. The generated directory is ignored and is replaced on every
 materialization, so there is no second checked-in representation to update.
 
-The materializer preserves the Java harness's previous generator behavior.
-Consequently, the Java workloads are unchanged. C++ and Go previously
+Every benchmark input is an explicit declaration in `benchmark-data.json`.
+The materializer evaluates only the schema's bounded, generic recipe kinds; it
+contains no workload-family dispatch or hidden input defaults. These
+declarations preserve the Java harness's previous generator behavior, so the
+Java workloads are unchanged. C++ and Go previously
 implemented their own random and Unicode generators, which differed in PRNG
 and size semantics; affected cross-language results collected before this
 corpus was introduced are not directly comparable with new results.
-
-Java-only diagnostic and engine-instrumentation benchmarks may still construct
-inputs locally when no other harness consumes them. Any workload shared by
-multiple engines belongs in the materialized corpus.

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -84,6 +84,9 @@ classes, scripts, or workload-family code. Version 1 defines:
 | `literal` | Exact text |
 | `repeat` | Repeat text a fixed count |
 | `repeatToLength` | Repeat and truncate to a target UTF-16 length |
+| `repeatAtLeastLength` | Repeat through the first unit boundary at or beyond a minimum length |
+| `delimitedRepeatToLength` | Repeat text with a deterministic delimiter sequence and truncate |
+| `appendInput` | Append a suffix to another declared materialized input |
 | `randomChars` | Seeded selection from a UTF-16 alphabet |
 | `randomCodePoints` | Seeded selection from declared Unicode code points |
 | `surroundToLength` | Prefix, repeated body, and suffix at a target length |
@@ -97,8 +100,9 @@ classes, scripts, or workload-family code. Version 1 defines:
 | `optionalRequiredRepeatPattern` | Pathological optional/required literal pattern |
 
 Recipe fields are fixed for each kind. A new shape requires one generic recipe
-kind and validation, not a family-specific branch. Materialization and exact
-recipe semantics are implemented by #609.
+kind and validation, not a family-specific branch. The central materializer
+evaluates these recipes and rejects unknown dependencies and dependency
+cycles.
 
 ## Workload requirements
 

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1,4 +1,1521 @@
 {
+  "schemaVersion": 1,
+  "inputs": [
+    {
+      "id": "crossEngine.RegexBenchmark.literalMatch.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "hello"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.charClassMatch.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "TheQuickBrownFoxJumpsOverTheLazyDog"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.alternationFind.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "the garply went to the baz and met a quux"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.captureGroups.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "2025-12-25"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.findInText.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "The morning sun was shining brightly, casting long shadows across the rolling hills. Birds were singing their melodious songs while children were playing in the sprawling gardens. A gentle breeze was blowing through the swaying trees, carrying the scent of blooming flowers. People were walking along the winding paths, enjoying the refreshing air and the stunning views of the surrounding countryside. Everything was moving in perfect harmony."
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.emailFind.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "contact user.name+tag@example.co.uk for info"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.0",
+      "recipe": {
+        "kind": "literal",
+        "text": "550e8400-e29b-41d4-a716-446655440000"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.1",
+      "recipe": {
+        "kind": "literal",
+        "text": "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.2",
+      "recipe": {
+        "kind": "literal",
+        "text": "not-a-uuid"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.3",
+      "recipe": {
+        "kind": "literal",
+        "text": "550e8400e29b41d4a716446655440000"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.4",
+      "recipe": {
+        "kind": "literal",
+        "text": "ffffffff-ffff-5fff-bfff-ffffffffffff"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.5",
+      "recipe": {
+        "kind": "literal",
+        "text": "12345678-1234-7234-9234-123456789abc"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.logLineParse.input.0",
+      "recipe": {
+        "kind": "literal",
+        "text": "2026-03-31T14:22:08Z INFO api.gateway - request completed status=200 latency=38ms"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.logLineParse.input.1",
+      "recipe": {
+        "kind": "literal",
+        "text": "2026-03-31T14:22:09Z WARN db.pool - connection wait exceeded threshold=100ms"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.logLineParse.input.2",
+      "recipe": {
+        "kind": "literal",
+        "text": "2026-03-31T14:22:10Z ERROR worker-7 - job failed id=abc123 retry=2"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.logLineParse.input.3",
+      "recipe": {
+        "kind": "literal",
+        "text": "debug line without structured prefix"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.logLineParse.input.4",
+      "recipe": {
+        "kind": "literal",
+        "text": "2026-03-31 14:22:11 INFO api.gateway - malformed timestamp"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.apiRouteMatch.input.0",
+      "recipe": {
+        "kind": "literal",
+        "text": "/api/v1/users/12345"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.apiRouteMatch.input.1",
+      "recipe": {
+        "kind": "literal",
+        "text": "/api/v2/orders/ord_9f3a?include=items"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.apiRouteMatch.input.2",
+      "recipe": {
+        "kind": "literal",
+        "text": "/api/v3/inventory/sku-7788"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.apiRouteMatch.input.3",
+      "recipe": {
+        "kind": "literal",
+        "text": "/assets/app.js"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.apiRouteMatch.input.4",
+      "recipe": {
+        "kind": "literal",
+        "text": "/api/v1/users/"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.apiRouteMatch.input.5",
+      "recipe": {
+        "kind": "literal",
+        "text": "/api/latest/users/12345"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.stackTraceExtract.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "java.lang.IllegalStateException: failed to process request\n\tat org.example.api.Handler.handle(Handler.java:87)\n\tat org.example.api.Router.dispatch(Router.java:142)\n\tat org.example.Main.main(Main.java:25)\nCaused by: java.io.IOException: timeout\n\tat org.example.net.Client.read(Client.java:203)"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.caseInsensitiveKeywords.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "INFO startup complete\nWarning cache miss ratio high\nrequest failed after TIMEOUT waiting for backend\nERROR circuit breaker opened\nhealth check passed"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.urlExtraction.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "Docs: https://example.com/docs/v1/index.html?lang=en and callback http://localhost:8080/api/callback?id=42; mirror at https://cdn.example.org/assets/app.js"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.csvFieldScan.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "id,name,email,status,created_at\n42,\"Ada Lovelace\",ada@example.com,active,2026-03-31T14:22:08Z\n43,\"Grace Hopper\",grace@example.com,pending,2026-04-01T09:15:00Z"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ApplicationBenchmark.secretRedaction.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "user=service password=hunter2 token=abc123XYZ path=/api secret=prod-key-9 debug=true"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.HttpBenchmark.httpFull.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "GET /asdfhjasdhfasdlfhasdflkjasdfkljasdhflaskdjhflkajsdhflkajshfklasjdhfklasjdhfklashdflka HTTP/1.1"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.HttpBenchmark.httpSmall.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "GET /abc HTTP/1.1"
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8Matching.literalScan.text",
+      "recipe": {
+        "kind": "randomChars",
+        "alphabet": "abcdefghijklmnopqrstuvwxyz",
+        "length": 32768,
+        "seed": 20260721
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8Matching.requiredClassNonmatch.text",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "This is a sentence containing only English characters. ",
+        "length": 10000
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8Matching.hardFailure.{size}",
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "ordinary ASCII text without the required suffix ",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "searchScaling.random.{size}",
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "randomChars",
+        "alphabet": "abcdefghijklmnopqrstuvwxyz0123456789 \n",
+        "length": "{size}",
+        "seed": 42
+      },
+      "shared": true
+    },
+    {
+      "id": "searchScaling.success.{size}",
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "appendInput",
+        "input": "searchScaling.random.{size}",
+        "suffix": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      },
+      "shared": true
+    },
+    {
+      "id": "searchScaling.prose.{size}",
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatAtLeastLength",
+        "unit": "The morning sun was shining brightly casting long shadows across the rolling hills Birds were singing their melodious songs while children were playing in the sprawling gardens A gentle breeze was blowing through the swaying trees carrying the scent of blooming flowers People were walking along the winding paths enjoying the refreshing air and the stunning views ",
+        "minimumLength": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.splitW.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "This is a generic sentence containing words that will be used to test splitting routines. ",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.block.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "This is a <block>",
+        "unit": "content bytes here... blah blah blah ",
+        "suffix": "</block> transcript.",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.blockNegative.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "This is a <block>",
+        "unit": "content bytes here... blah blah blah ",
+        "suffix": " transcript without a closing block tag.",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.tag.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "plain text before the tagged value ",
+        "suffix": "Hello <<tag type=\"typeA\" value=\"valA\">>!",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.tagNegative.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "plain text before the tagged value ",
+        "suffix": "Hello <<notag type=\"typeA\" value=\"valA\">>!",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.scheme.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "ordinary prose without a custom scheme link ",
+        "suffix": "Check [this link](customScheme://<id_1>) or [another](customScheme://id_2).",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue481Scaling.schemeNegative.{size}",
+      "axes": {
+        "size": [
+          128,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "ordinary prose without a custom scheme link ",
+        "suffix": "Check [this link](https://example.test/id_1) or [another](otherScheme://id_2).",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue488ReplaceAll.lazyAlt.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "lazyAlternationToLength",
+        "prefixUnit": "Some prefix text preceding the render block element. ",
+        "match": "\n<block>\nrenderElement(id=\"el-42\", width=100, height=200, label=\"hello world\")\n</block>\n",
+        "suffixUnit": "Some suffix text following the render block element. ",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "issue488ReplaceAll.altCapture.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "periodicAlternationToLength",
+        "hitUnit": "This is some sample prose text that contains a tag marker #!customTag and more text here. ",
+        "missUnit": "This is some sample prose text that contains a tag marker #customTag and more text here. ",
+        "hitInterval": 5,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.mapFieldPath.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "config.overrides[some_value]",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.mapFieldPath.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "config.overrides",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.markupImageLink.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<<!image(src=\"http://image.png\")>>",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.markupImageLink.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<<!image",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.versionList.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "[1.2.3, 4.5.6]",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.versionList.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "[1.2.3,",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.malformedEntity.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<entity id=\"123\">",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.malformedEntity.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<ent id=\"123\">",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.markupEntity.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<<!entity(id=\"123\")>>",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.markupEntity.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<<entity(id=\"123\")",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.customProtocolLink.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "[Click here](customProtocol://<doc_1>)",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.customProtocolLink.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "[Click here](http://google.com)",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.wildcardSearch.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "What can I do for you today?",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.wildcardSearch.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "What is the capital of France?",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.metadataBlock.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<meta_start>Thinking process: analyzing query...<meta_end>",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.metadataBlock.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<meta_start>Thinking process: analyzing query...",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.blockedTags1.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "```code_block\n# tags_identified: shopping\n```",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.blockedTags1.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "```code_block\n# tags: shopping\n```",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.blockedTags2.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<container>\n# topic_identified: sports\n</container>",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.blockedTags2.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<container>\n# topic: sports\n</container>",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.overlappingUrl.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "https://www.example.com/search?q=testing&hl=en",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.overlappingUrl.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "some-random-domain-name",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.caseInsensitiveKeyword.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "KEYWORD_TO_FIND",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.caseInsensitiveKeyword.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "other_random_words",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.boundedNameMatch.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "first name value",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.boundedNameMatch.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "first name other_value",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.templateTagMatch.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<template name>content to match</template",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.templateTagMatch.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "plain text without template tag",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.sparseUrl.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "sparseMatchToLength",
+        "match": "https://www.example.com/search?q=testing&hl=en",
+        "nonMatch": "some-random-domain-name",
+        "nonMatchRepeats": 20,
+        "delimiterAlphabet": "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.sparseUrl.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "some-random-domain-name",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.unprefixedWordBoundary.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "prefixedRepeatToLength",
+        "prefix": "12345 ",
+        "value": "hello",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.unprefixedWordBoundary.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "12345",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.fruitSearchQuery.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "Here are the apples to show for banana in this session.",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.fruitSearchQuery.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "Orange lemon melon peach pear plum.",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.fruitMarkupTag.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "centerInSpaces",
+        "body": "<Banana>",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.fruitMarkupTag.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "centerInSpaces",
+        "body": "<Orange>",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.jsonBlock.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "scaledCenterInSpaces",
+        "bodyPrefix": "{ \"key\": \"value\", \"padding\": \"",
+        "bodySuffix": "\" }",
+        "bodyFill": "a",
+        "bodyScalePercent": 5,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.jsonBlock.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "some non-matching string containing no braces",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.charReplace.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "a",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.charReplace.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "b",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.greedyOnePass.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "abcdefghijklmnopqrstuvwxyz",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.greedyOnePass.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "\nabcdefghijklmnopqrstuvwxyz",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.layoutBlock.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "sparseMatchToLength",
+        "match": "<block>\n  # category_defined: alpha, beta\n  entry: apple\n  entry: banana\n</block>\n",
+        "nonMatch": "<block>\n  # comment but not defined tag\n  entry: orange\n</block>\n",
+        "nonMatchRepeats": 5,
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.layoutBlock.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "<block>\n  # comment but not defined tag\n  entry: orange\n</block>\n",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.turnTitleWhitespaceCjk.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.turnTitleWhitespaceCjk.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.cjkSearch.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "这是一个中文测试句子",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.cjkSearch.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "This is a sentence containing only English characters.",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.emojiSearch.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "Today is a beautiful day 😇 with warm sunshine.",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.emojiSearch.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "Today is a beautiful day with warm sunshine.",
+        "delimiterAlphabet": " ",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "scrubber.withoutDirectives",
+      "recipe": {
+        "kind": "repeat",
+        "value": "public class Foo {\n  // Some comment\n  public void bar() {\n    System.out.println(\"Hello, world!\");\n  }\n}\n",
+        "count": 500
+      },
+      "shared": true
+    },
+    {
+      "id": "scrubber.withDirectives",
+      "recipe": {
+        "kind": "repeat",
+        "value": "public class Foo {\n  // SCRUB:strip_line\n  public void bar() {\n    // SCRUB:begin_strip\n    System.out.println(\"Secret code\");\n    // SCRUB:end_strip\n  }\n}\n",
+        "count": 500
+      },
+      "shared": true
+    },
+    {
+      "id": "pathological.pattern.{size}",
+      "axes": {
+        "size": [
+          10,
+          15,
+          20,
+          25,
+          30,
+          50,
+          100
+        ]
+      },
+      "recipe": {
+        "kind": "optionalRequiredRepeatPattern",
+        "literal": "a",
+        "count": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "pathological.text.{size}",
+      "axes": {
+        "size": [
+          10,
+          15,
+          20,
+          25,
+          30,
+          50,
+          100
+        ]
+      },
+      "recipe": {
+        "kind": "repeat",
+        "value": "a",
+        "count": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "fanout.unicode.{size}",
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400
+        ]
+      },
+      "recipe": {
+        "kind": "randomCodePoints",
+        "codePoints": [
+          19968,
+          19969,
+          19970,
+          233,
+          241,
+          252,
+          1040,
+          1041,
+          1042,
+          12354,
+          12356,
+          12358
+        ],
+        "minimumCodeUnits": "{size}",
+        "seed": 42
+      },
+      "shared": true
+    },
+    {
+      "id": "fanout.ascii.{size}",
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400
+        ]
+      },
+      "recipe": {
+        "kind": "randomChars",
+        "alphabet": "abcdefghijklmnopqrstuvwxyz",
+        "length": "{size}",
+        "seed": 42
+      },
+      "shared": true
+    },
+    {
+      "id": "memory.dfaCacheText",
+      "recipe": {
+        "kind": "repeat",
+        "value": "contact user.name+tag@example.co.uk for info",
+        "count": 200
+      },
+      "shared": true
+    }
+  ],
   "regex": {
     "literalMatch": {
       "id": "RegexBenchmark.literalMatch",
@@ -38,7 +1555,6 @@
       "op": "find"
     }
   },
-
   "matcherApi": {
     "lookingAt": {
       "pattern": "[A-Za-z]+:\\s+\\d+",
@@ -55,7 +1571,6 @@
       "text": "item1 item22 item333"
     }
   },
-
   "utf8Matching": {
     "literalScan": {
       "seed": 20260721,
@@ -68,12 +1583,30 @@
       }
     },
     "captureFreeFind": {
-      "asciiEarly": { "pattern": "ERROR", "text": "ERROR request completed" },
-      "asciiLate": { "pattern": "ERROR", "text": "request completed with ERROR" },
-      "asciiNoMatch": { "pattern": "ERROR", "text": "request completed normally" },
-      "multibyteEarly": { "pattern": "错误", "text": "错误：请求失败" },
-      "multibyteLate": { "pattern": "错误", "text": "请求处理结束：错误" },
-      "multibyteNoMatch": { "pattern": "错误", "text": "请求处理成功" }
+      "asciiEarly": {
+        "pattern": "ERROR",
+        "text": "ERROR request completed"
+      },
+      "asciiLate": {
+        "pattern": "ERROR",
+        "text": "request completed with ERROR"
+      },
+      "asciiNoMatch": {
+        "pattern": "ERROR",
+        "text": "request completed normally"
+      },
+      "multibyteEarly": {
+        "pattern": "错误",
+        "text": "错误：请求失败"
+      },
+      "multibyteLate": {
+        "pattern": "错误",
+        "text": "请求处理结束：错误"
+      },
+      "multibyteNoMatch": {
+        "pattern": "错误",
+        "text": "请求处理成功"
+      }
     },
     "requiredClassNonmatch": {
       "pattern": "[一-龥]{3,}",
@@ -81,8 +1614,14 @@
       "textSize": 10000
     },
     "repeatedFind": {
-      "ascii": { "pattern": "[A-Za-z]+", "text": "one two three four five" },
-      "multibyte": { "pattern": "\\p{L}+", "text": "one café 東京 naïve" }
+      "ascii": {
+        "pattern": "[A-Za-z]+",
+        "text": "one two three four five"
+      },
+      "multibyte": {
+        "pattern": "\\p{L}+",
+        "text": "one café 東京 naïve"
+      }
     },
     "captureBounds": {
       "numbered": {
@@ -93,11 +1632,21 @@
         "pattern": "(?<key>[A-Za-z]+)=(?<value>[^&]+)",
         "text": "city=東京&name=Renée"
       },
-      "nonparticipating": { "pattern": "(cat)|(dog)", "text": "dog" }
+      "nonparticipating": {
+        "pattern": "(cat)|(dog)",
+        "text": "dog"
+      }
     },
-    "emptyMatchIteration": { "pattern": "", "text": "a💰有" },
+    "emptyMatchIteration": {
+      "pattern": "",
+      "text": "a💰有"
+    },
     "replacement": {
-      "literal": { "pattern": "错误", "text": "错误 then 错误", "replacement": "OK" },
+      "literal": {
+        "pattern": "错误",
+        "text": "错误 then 错误",
+        "replacement": "OK"
+      },
       "numbered": {
         "pattern": "([A-Za-z]+)=([^&]+)",
         "text": "city=東京&name=Renée",
@@ -118,18 +1667,32 @@
     "hardFailure": {
       "pattern": "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$",
       "unit": "ordinary ASCII text without the required suffix ",
-      "textSizes": [1024, 10240, 102400, 1048576]
+      "textSizes": [
+        1024,
+        10240,
+        102400,
+        1048576
+      ]
     },
-    "constructionModes": ["trusted", "validated"]
+    "constructionModes": [
+      "trusted",
+      "validated"
+    ]
   },
-
   "compile": {
-    "simple": { "pattern": "hello" },
-    "medium": { "pattern": "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})" },
-    "complex": { "pattern": "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}" },
-    "alternation": { "pattern": "foo|bar|baz|qux|quux|corge|grault|garply|waldo|fred|plugh|xyzzy" }
+    "simple": {
+      "pattern": "hello"
+    },
+    "medium": {
+      "pattern": "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})"
+    },
+    "complex": {
+      "pattern": "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+    },
+    "alternation": {
+      "pattern": "foo|bar|baz|qux|quux|corge|grault|garply|waldo|fred|plugh|xyzzy"
+    }
   },
-
   "searchScaling": {
     "workloadIds": {
       "easyFail": "SearchScalingBenchmark.searchEasyFail",
@@ -145,16 +1708,26 @@
     },
     "matchSuffix": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     "findIngPattern": "\\b\\w+ing\\b",
-    "textSizes": [1024, 10240, 102400, 1048576],
+    "textSizes": [
+      1024,
+      10240,
+      102400,
+      1048576
+    ],
     "randomText": {
       "alphabet": "abcdefghijklmnopqrstuvwxyz0123456789 \n",
       "seed": 42
     },
     "proseUnit": "The morning sun was shining brightly casting long shadows across the rolling hills Birds were singing their melodious songs while children were playing in the sprawling gardens A gentle breeze was blowing through the swaying trees carrying the scent of blooming flowers People were walking along the winding paths enjoying the refreshing air and the stunning views "
   },
-
   "issue481Scaling": {
-    "textSizes": [128, 1024, 10240, 102400, 1048576],
+    "textSizes": [
+      128,
+      1024,
+      10240,
+      102400,
+      1048576
+    ],
     "splitW": {
       "pattern": "\\W+",
       "unit": "This is a generic sentence containing words that will be used to test splitting routines. "
@@ -179,9 +1752,12 @@
       "negativeMatch": "Check [this link](https://example.test/id_1) or [another](otherScheme://id_2)."
     }
   },
-
   "issue488ReplaceAll": {
-    "textSizes": [1000, 10000, 100000],
+    "textSizes": [
+      1000,
+      10000,
+      100000
+    ],
     "lazyAlt": {
       "pattern": "(?i)(?s)\\s*\\n*(?:<block>|\\[block\\])\\s*\\n?renderElement\\(.*?\\)\\s*\\n?(?:</block>|\\[/block\\])",
       "replacement": "",
@@ -197,7 +1773,6 @@
       "hitInterval": 5
     }
   },
-
   "captureScaling": {
     "capture0": {
       "pattern": "[0-9]+-[0-9]+-[0-9]+",
@@ -220,7 +1795,6 @@
       "groups": 10
     }
   },
-
   "http": {
     "workloadIds": {
       "full": "HttpBenchmark.httpFull",
@@ -231,7 +1805,6 @@
     "fullRequest": "GET /asdfhjasdhfasdlfhasdflkjasdfkljasdhflaskdjhflkajsdhflkajshfklasjdhfklasjdhfklashdflka HTTP/1.1",
     "smallRequest": "GET /abc HTTP/1.1"
   },
-
   "replace": {
     "literalReplaceFirst": {
       "pattern": "b",
@@ -270,7 +1843,6 @@
       "op": "replaceAll"
     }
   },
-
   "scrubber": {
     "repeatCount": 500,
     "linePattern": "[^\\n]*\\bSCRUB:strip_line\\b[^\\n]*\\n?",
@@ -278,9 +1850,12 @@
     "baseWithoutDirectives": "public class Foo {\n  // Some comment\n  public void bar() {\n    System.out.println(\"Hello, world!\");\n  }\n}\n",
     "baseWithDirectives": "public class Foo {\n  // SCRUB:strip_line\n  public void bar() {\n    // SCRUB:begin_strip\n    System.out.println(\"Secret code\");\n    // SCRUB:end_strip\n  }\n}\n"
   },
-
   "realWorldRegex": {
-    "textSizes": [1000, 10000, 100000],
+    "textSizes": [
+      1000,
+      10000,
+      100000
+    ],
     "safeDelimiterAlphabet": " ",
     "seed": 42,
     "cases": [
@@ -515,7 +2090,7 @@
         "name": "turnTitleWhitespaceCjk",
         "pattern": "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+",
         "op": "replaceAllEmpty",
-        "match": "いくつもの\u3000中国語と日本語の文字\u3000がここにあります\u3000そして\u3000いくつかのスペース\u3000があります",
+        "match": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
         "nonMatch": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
         "matchInput": {
           "kind": "repeat"
@@ -554,7 +2129,6 @@
       }
     ]
   },
-
   "application": [
     {
       "id": "ApplicationBenchmark.uuidValidation",
@@ -583,7 +2157,10 @@
         "debug line without structured prefix",
         "2026-03-31 14:22:11 INFO api.gateway - malformed timestamp"
       ],
-      "groups": [2, 3],
+      "groups": [
+        2,
+        3
+      ],
       "expected": 39
     },
     {
@@ -599,7 +2176,10 @@
         "/api/v1/users/",
         "/api/latest/users/12345"
       ],
-      "groups": [1, 2],
+      "groups": [
+        1,
+        2
+      ],
       "expected": 41
     },
     {
@@ -608,7 +2188,10 @@
       "op": "findAllGroupLengthSum",
       "pattern": "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
       "text": "java.lang.IllegalStateException: failed to process request\n\tat org.example.api.Handler.handle(Handler.java:87)\n\tat org.example.api.Router.dispatch(Router.java:142)\n\tat org.example.Main.main(Main.java:25)\nCaused by: java.io.IOException: timeout\n\tat org.example.net.Client.read(Client.java:203)",
-      "groups": [1, 4],
+      "groups": [
+        1,
+        4
+      ],
       "expected": 93
     },
     {
@@ -645,18 +2228,41 @@
       "expected": "user=service password=REDACTED token=REDACTED path=/api secret=REDACTED debug=true"
     }
   ],
-
   "pathological": {
-    "nValues": [10, 15, 20, 25, 30, 50, 100],
-    "nValuesComparison": [10, 15, 20],
+    "nValues": [
+      10,
+      15,
+      20,
+      25,
+      30,
+      50,
+      100
+    ],
+    "nValuesComparison": [
+      10,
+      15,
+      20
+    ],
     "note": "Pattern is 'a?' repeated n times followed by 'a' repeated n times. Text is 'a' repeated n times."
   },
-
   "fanout": {
     "unicodeFanout": {
       "id": "FanoutBenchmark.fanoutUnicode",
       "pattern": "(?:[\\x{80}-\\x{10FFFF}]?){100}[\\x{80}-\\x{10FFFF}]",
-      "codePoints": [19968, 19969, 19970, 233, 241, 252, 1040, 1041, 1042, 12354, 12356, 12358],
+      "codePoints": [
+        19968,
+        19969,
+        19970,
+        233,
+        241,
+        252,
+        1040,
+        1041,
+        1042,
+        12354,
+        12356,
+        12358
+      ],
       "seed": 42
     },
     "nestedQuantifier": {
@@ -665,36 +2271,84 @@
       "alphabet": "abcdefghijklmnopqrstuvwxyz",
       "seed": 42
     },
-    "textSizes": [1024, 10240, 102400]
+    "textSizes": [
+      1024,
+      10240,
+      102400
+    ]
   },
-
   "patternSet": {
     "basePatterns": [
-      "ERROR", "WARNING", "INFO", "DEBUG", "FATAL",
-      "connection\\s+timeout", "\\d+\\.\\d+\\.\\d+\\.\\d+",
-      "host\\s+\\S+", "port\\s*:\\s*\\d+", "after\\s+\\d+s",
-      "[A-Z]{2,}:", "\\w+\\.internal", "db-\\w+",
+      "ERROR",
+      "WARNING",
+      "INFO",
+      "DEBUG",
+      "FATAL",
+      "connection\\s+timeout",
+      "\\d+\\.\\d+\\.\\d+\\.\\d+",
+      "host\\s+\\S+",
+      "port\\s*:\\s*\\d+",
+      "after\\s+\\d+s",
+      "[A-Z]{2,}:",
+      "\\w+\\.internal",
+      "db-\\w+",
       "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+",
-      "timeout|refused|reset|closed", "\\[\\w+\\]",
-      "status\\s*=\\s*\\d+", "retry\\s+\\d+/\\d+",
-      "latency\\s*>\\s*\\d+ms", "queue\\s+full",
-      "memory\\s+\\d+[kmg]b?", "cpu\\s+\\d+%", "disk\\s+(full|low)",
-      "\\w+Exception", "at\\s+\\w+\\.\\w+\\(",
-      "null\\s*pointer", "stack\\s*overflow", "out\\s+of\\s+memory",
-      "permission\\s+denied", "not\\s+found",
-      "already\\s+exists", "invalid\\s+\\w+", "expired",
-      "unauthorized", "rate\\s+limit", "circuit\\s+breaker",
-      "health\\s+check\\s+failed", "graceful\\s+shutdown",
-      "leader\\s+election", "split\\s+brain", "rebalancing",
-      "partition\\s+\\d+", "offset\\s+\\d+", "consumer\\s+group",
-      "dead\\s+letter", "backpressure", "throttled", "degraded",
-      "failover", "rollback", "checkpoint\\s+\\d+", "snapshot\\s+\\w+",
-      "compaction", "gc\\s+pause\\s+\\d+ms", "safepoint",
-      "jit\\s+compilation", "class\\s+loading", "thread\\s+pool\\s+\\w+",
-      "blocked\\s+thread", "deadlock", "lock\\s+contention",
-      "cache\\s+(hit|miss)", "eviction", "bloom\\s+filter"
+      "timeout|refused|reset|closed",
+      "\\[\\w+\\]",
+      "status\\s*=\\s*\\d+",
+      "retry\\s+\\d+/\\d+",
+      "latency\\s*>\\s*\\d+ms",
+      "queue\\s+full",
+      "memory\\s+\\d+[kmg]b?",
+      "cpu\\s+\\d+%",
+      "disk\\s+(full|low)",
+      "\\w+Exception",
+      "at\\s+\\w+\\.\\w+\\(",
+      "null\\s*pointer",
+      "stack\\s*overflow",
+      "out\\s+of\\s+memory",
+      "permission\\s+denied",
+      "not\\s+found",
+      "already\\s+exists",
+      "invalid\\s+\\w+",
+      "expired",
+      "unauthorized",
+      "rate\\s+limit",
+      "circuit\\s+breaker",
+      "health\\s+check\\s+failed",
+      "graceful\\s+shutdown",
+      "leader\\s+election",
+      "split\\s+brain",
+      "rebalancing",
+      "partition\\s+\\d+",
+      "offset\\s+\\d+",
+      "consumer\\s+group",
+      "dead\\s+letter",
+      "backpressure",
+      "throttled",
+      "degraded",
+      "failover",
+      "rollback",
+      "checkpoint\\s+\\d+",
+      "snapshot\\s+\\w+",
+      "compaction",
+      "gc\\s+pause\\s+\\d+ms",
+      "safepoint",
+      "jit\\s+compilation",
+      "class\\s+loading",
+      "thread\\s+pool\\s+\\w+",
+      "blocked\\s+thread",
+      "deadlock",
+      "lock\\s+contention",
+      "cache\\s+(hit|miss)",
+      "eviction",
+      "bloom\\s+filter"
     ],
-    "patternCounts": [4, 16, 64],
+    "patternCounts": [
+      4,
+      16,
+      64
+    ],
     "matchText": "ERROR: connection timeout after 30s to host db-primary.internal:5432",
     "noMatchText": "The quick brown fox jumps over the lazy dog near the riverbank"
   }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -7,8 +7,6 @@ package org.safere.benchmark;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -18,14 +16,17 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
  * Materializes resolved benchmark configuration and deterministic UTF-8 input files.
  *
- * <p>The compact recipes in {@code benchmark-data.json} remain the human-editable source of truth.
+ * <p>The bounded recipes in {@code benchmark-data.json} remain the human-editable source of truth.
  * Benchmark engines consume only the resulting byte-identical corpus.
  */
 public final class BenchmarkInputMaterializer {
@@ -35,11 +36,22 @@ public final class BenchmarkInputMaterializer {
 
   private final JsonObject data;
   private final String benchmarkDataSha256;
+  private final Map<String, DeclarativeBenchmarkPlan.InputDeclaration> declarations;
   private final Map<String, byte[]> inputs = new LinkedHashMap<>();
+  private final Set<String> activeRecipes = new LinkedHashSet<>();
 
   private BenchmarkInputMaterializer(JsonObject data, String benchmarkDataSha256) {
     this.data = data;
     this.benchmarkDataSha256 = benchmarkDataSha256;
+    if (!data.has("schemaVersion")
+        || data.get("schemaVersion").getAsInt() != DeclarativeBenchmarkPlan.SCHEMA_VERSION) {
+      throw new IllegalArgumentException(
+          "benchmark-data.json requires schemaVersion " + DeclarativeBenchmarkPlan.SCHEMA_VERSION);
+    }
+    if (!data.has("inputs") || !data.get("inputs").isJsonArray()) {
+      throw new IllegalArgumentException("benchmark-data.json requires declarative inputs");
+    }
+    declarations = DeclarativeBenchmarkPlan.parseInputDeclarations(data.getAsJsonArray("inputs"));
   }
 
   /**
@@ -74,245 +86,180 @@ public final class BenchmarkInputMaterializer {
     materializer.write(outputDirectory);
   }
 
-  private void generate() {
-    generateCrossEngineInputs();
-    generateUtf8Matching();
-    generateSearchScaling();
-    generateIssue481Scaling();
-    generateIssue488ReplaceAll();
-    generateRealWorldRegex();
-    generateScrubber();
-    generatePathological();
-    generateFanout();
-    add("memory.dfaCacheText", "contact user.name+tag@example.co.uk for info".repeat(200));
-  }
-
-  private void generateCrossEngineInputs() {
-    JsonObject regex = object("regex");
-    for (Map.Entry<String, JsonElement> entry : regex.entrySet()) {
-      JsonObject workload = entry.getValue().getAsJsonObject();
-      add(
-          crossEngineInputKey(workload.get("id").getAsString()),
-          workload.get("text").getAsString());
-    }
-
-    for (JsonElement element : data.getAsJsonArray("application")) {
-      ApplicationCase workload = ApplicationCase.fromJson(element.getAsJsonObject());
-      if (!workload.texts.isEmpty()) {
-        for (int index = 0; index < workload.texts.size(); index++) {
-          add(crossEngineInputKey(workload.id) + "." + index, workload.texts.get(index));
-        }
-      } else {
-        add(crossEngineInputKey(workload.id), workload.text);
-      }
-    }
-
-    String fullId = string("http.workloadIds.full");
-    add(crossEngineInputKey(fullId), string("http.fullRequest"));
-    String smallId = string("http.workloadIds.small");
-    add(crossEngineInputKey(smallId), string("http.smallRequest"));
+  static Map<String, byte[]> materialize(JsonObject data) {
+    BenchmarkInputMaterializer materializer =
+        new BenchmarkInputMaterializer(
+            data, sha256(GSON.toJson(data).getBytes(StandardCharsets.UTF_8)));
+    materializer.generate();
+    Map<String, byte[]> result = new LinkedHashMap<>();
+    materializer.inputs.forEach((id, bytes) -> result.put(id, bytes.clone()));
+    return result;
   }
 
   static String crossEngineInputKey(String workloadId) {
     return "crossEngine." + workloadId + ".input";
   }
 
-  private void generateUtf8Matching() {
-    String prefix = "utf8Matching.literalScan.";
-    String alphabet = string(prefix + "alphabet");
-    int size = integer(prefix + "textSize");
-    Random random = new Random(integer(prefix + "seed"));
-    StringBuilder text = new StringBuilder(size);
-    for (int index = 0; index < size; index++) {
-      text.append(alphabet.charAt(random.nextInt(alphabet.length())));
+  private void generate() {
+    for (String inputId : declarations.keySet()) {
+      materialize(inputId);
     }
-    add("utf8Matching.literalScan.text", text.toString());
-
-    prefix = "utf8Matching.requiredClassNonmatch.";
-    add(
-        "utf8Matching.requiredClassNonmatch.text",
-        repeatToSize(string(prefix + "unit"), integer(prefix + "textSize")));
-
-    for (int textSize : integers("utf8Matching.hardFailure.textSizes")) {
-      add(
-          "utf8Matching.hardFailure." + textSize,
-          repeatToSize(string("utf8Matching.hardFailure.unit"), textSize));
+    if (inputs.size() != declarations.size()) {
+      throw new IllegalStateException(
+          "Materialized " + inputs.size() + " inputs for " + declarations.size() + " declarations");
     }
   }
 
-  private void generateSearchScaling() {
-    String alphabet = string("searchScaling.randomText.alphabet");
-    int seed = integer("searchScaling.randomText.seed");
-    String matchSuffix = string("searchScaling.matchSuffix");
-    String proseUnit = string("searchScaling.proseUnit");
-    for (int textSize : integers("searchScaling.textSizes")) {
-      Random random = new Random(seed);
-      char[] characters = new char[textSize];
-      for (int index = 0; index < textSize; index++) {
-        characters[index] = alphabet.charAt(random.nextInt(alphabet.length()));
+  private byte[] materialize(String inputId) {
+    byte[] existing = inputs.get(inputId);
+    if (existing != null) {
+      return existing;
+    }
+    DeclarativeBenchmarkPlan.InputDeclaration declaration = declarations.get(inputId);
+    if (declaration == null) {
+      throw new IllegalArgumentException(
+          "Input recipe references unknown materialized input: " + inputId);
+    }
+    if (!activeRecipes.add(inputId)) {
+      throw new IllegalArgumentException(
+          "Cyclic materialized input recipe dependency: "
+              + String.join(" -> ", activeRecipes)
+              + " -> "
+              + inputId);
+    }
+    try {
+      byte[] bytes = evaluate(declaration.recipe()).getBytes(StandardCharsets.UTF_8);
+      if (inputs.put(inputId, bytes) != null) {
+        throw new IllegalArgumentException("Duplicate materialized input key: " + inputId);
       }
-      String randomText = new String(characters);
-      add("searchScaling.random." + textSize, randomText);
-      add("searchScaling.success." + textSize, randomText + matchSuffix);
-
-      StringBuilder prose = new StringBuilder(textSize + proseUnit.length());
-      while (prose.length() < textSize) {
-        prose.append(proseUnit);
-      }
-      add("searchScaling.prose." + textSize, prose.toString());
+      return bytes;
+    } finally {
+      activeRecipes.remove(inputId);
     }
   }
 
-  private void generateIssue481Scaling() {
-    for (int textSize : integers("issue481Scaling.textSizes")) {
-      add(
-          "issue481Scaling.splitW." + textSize,
-          repeatToSize(string("issue481Scaling.splitW.unit"), textSize));
-      add(
-          "issue481Scaling.block." + textSize,
+  private String evaluate(DeclarativeBenchmarkPlan.InputRecipe recipe) {
+    Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments = recipe.arguments();
+    return switch (recipe.kind()) {
+      case LITERAL -> string(arguments, "text");
+      case REPEAT -> string(arguments, "value").repeat(integer(arguments, "count"));
+      case REPEAT_TO_LENGTH ->
+          repeatToSize(string(arguments, "unit"), integer(arguments, "length"));
+      case REPEAT_AT_LEAST_LENGTH ->
+          repeatAtLeastSize(string(arguments, "unit"), integer(arguments, "minimumLength"));
+      case DELIMITED_REPEAT_TO_LENGTH ->
+          repeatedInput(
+              string(arguments, "value"),
+              integer(arguments, "length"),
+              string(arguments, "delimiterAlphabet"),
+              integer(arguments, "seed"));
+      case APPEND_INPUT ->
+          new String(materialize(string(arguments, "input")), StandardCharsets.UTF_8)
+              + string(arguments, "suffix");
+      case RANDOM_CHARS ->
+          randomChars(
+              string(arguments, "alphabet"),
+              integer(arguments, "length"),
+              integer(arguments, "seed"));
+      case RANDOM_CODE_POINTS ->
+          randomCodePoints(
+              integers(arguments, "codePoints"),
+              integer(arguments, "minimumCodeUnits"),
+              integer(arguments, "seed"));
+      case SURROUND_TO_LENGTH ->
           surroundToSize(
-              string("issue481Scaling.block.prefix"),
-              string("issue481Scaling.block.unit"),
-              string("issue481Scaling.block.suffix"),
-              textSize));
-      add(
-          "issue481Scaling.blockNegative." + textSize,
-          surroundToSize(
-              string("issue481Scaling.block.prefix"),
-              string("issue481Scaling.block.unit"),
-              string("issue481Scaling.block.negativeSuffix"),
-              textSize));
-      add(
-          "issue481Scaling.tag." + textSize,
+              string(arguments, "prefix"),
+              string(arguments, "unit"),
+              string(arguments, "suffix"),
+              integer(arguments, "length"));
+      case SUFFIX_TO_LENGTH ->
           suffixMatchToSize(
-              string("issue481Scaling.tag.prefixUnit"),
-              string("issue481Scaling.tag.match"),
-              textSize));
-      add(
-          "issue481Scaling.tagNegative." + textSize,
-          suffixMatchToSize(
-              string("issue481Scaling.tag.prefixUnit"),
-              string("issue481Scaling.tag.negativeMatch"),
-              textSize));
-      add(
-          "issue481Scaling.scheme." + textSize,
-          suffixMatchToSize(
-              string("issue481Scaling.scheme.prefixUnit"),
-              string("issue481Scaling.scheme.match"),
-              textSize));
-      add(
-          "issue481Scaling.schemeNegative." + textSize,
-          suffixMatchToSize(
-              string("issue481Scaling.scheme.prefixUnit"),
-              string("issue481Scaling.scheme.negativeMatch"),
-              textSize));
-    }
-  }
-
-  private void generateIssue488ReplaceAll() {
-    for (int textSize : integers("issue488ReplaceAll.textSizes")) {
-      add(
-          "issue488ReplaceAll.lazyAlt." + textSize,
-          lazyAltInput(
-              string("issue488ReplaceAll.lazyAlt.prefixUnit"),
-              string("issue488ReplaceAll.lazyAlt.match"),
-              string("issue488ReplaceAll.lazyAlt.suffixUnit"),
-              textSize));
-      add(
-          "issue488ReplaceAll.altCapture." + textSize,
-          altCaptureInput(
-              string("issue488ReplaceAll.altCapture.hitUnit"),
-              string("issue488ReplaceAll.altCapture.missUnit"),
-              integer("issue488ReplaceAll.altCapture.hitInterval"),
-              textSize));
-    }
-  }
-
-  private void generateRealWorldRegex() {
-    JsonObject section = object("realWorldRegex");
-    int[] textSizes = integers("realWorldRegex.textSizes");
-    String alphabet = string("realWorldRegex.safeDelimiterAlphabet");
-    int seed = integer("realWorldRegex.seed");
-    for (JsonElement element : section.getAsJsonArray("cases")) {
-      RealWorldRegexCase benchmarkCase = RealWorldRegexCase.fromJson(element.getAsJsonObject());
-      for (boolean match : new boolean[] {true, false}) {
-        String label = match ? "match" : "noMatch";
-        RealWorldRegexCase.InputSpec inputSpec =
-            match ? benchmarkCase.matchInput : benchmarkCase.nonMatchInput;
-        for (int textSize : textSizes) {
-          add(
-              "realWorldRegex." + benchmarkCase.name + "." + label + "." + textSize,
-              realWorldInput(benchmarkCase, inputSpec, match, textSize, alphabet, seed));
-        }
-      }
-    }
-  }
-
-  private void generateScrubber() {
-    int repeatCount = integer("scrubber.repeatCount");
-    add("scrubber.withoutDirectives", string("scrubber.baseWithoutDirectives").repeat(repeatCount));
-    add("scrubber.withDirectives", string("scrubber.baseWithDirectives").repeat(repeatCount));
-  }
-
-  private void generatePathological() {
-    for (int n : integers("pathological.nValues")) {
-      add("pathological.pattern." + n, "a?".repeat(n) + "a".repeat(n));
-      add("pathological.text." + n, "a".repeat(n));
-    }
-  }
-
-  private void generateFanout() {
-    int[] codePoints = integers("fanout.unicodeFanout.codePoints");
-    int unicodeSeed = integer("fanout.unicodeFanout.seed");
-    String alphabet = string("fanout.nestedQuantifier.alphabet");
-    int asciiSeed = integer("fanout.nestedQuantifier.seed");
-    for (int textSize : integers("fanout.textSizes")) {
-      Random unicodeRandom = new Random(unicodeSeed);
-      StringBuilder unicodeText = new StringBuilder();
-      while (unicodeText.length() < textSize) {
-        unicodeText.appendCodePoint(codePoints[unicodeRandom.nextInt(codePoints.length)]);
-      }
-      add("fanout.unicode." + textSize, unicodeText.toString());
-
-      Random asciiRandom = new Random(asciiSeed);
-      char[] asciiText = new char[textSize];
-      for (int index = 0; index < textSize; index++) {
-        asciiText[index] = alphabet.charAt(asciiRandom.nextInt(alphabet.length()));
-      }
-      add("fanout.ascii." + textSize, new String(asciiText));
-    }
-  }
-
-  private String realWorldInput(
-      RealWorldRegexCase benchmarkCase,
-      RealWorldRegexCase.InputSpec inputSpec,
-      boolean match,
-      int size,
-      String alphabet,
-      int seed) {
-    String template = match ? benchmarkCase.match : benchmarkCase.nonMatch;
-    return switch (inputSpec.kind) {
-      case "repeat" -> repeatedInput(template, size, alphabet, seed);
-      case "prefixedRepeat" -> prefixedInput(inputSpec.prefix, template, size, alphabet, seed);
-      case "sparseMatch" ->
+              string(arguments, "prefixUnit"),
+              string(arguments, "suffix"),
+              integer(arguments, "length"));
+      case PREFIXED_REPEAT_TO_LENGTH ->
+          prefixedInput(
+              string(arguments, "prefix"),
+              string(arguments, "value"),
+              integer(arguments, "length"),
+              string(arguments, "delimiterAlphabet"),
+              integer(arguments, "seed"));
+      case SPARSE_MATCH_TO_LENGTH ->
           sparseInput(
-              benchmarkCase.match,
-              benchmarkCase.nonMatch,
-              size,
-              seed,
-              inputSpec.nonMatchRepeats,
-              inputSpec.delimiterAlphabet);
-      case "surroundWithSpaces" -> surroundWithSpaces(inputSpec.body, size);
-      case "scaledSurroundWithSpaces" ->
+              string(arguments, "match"),
+              string(arguments, "nonMatch"),
+              integer(arguments, "length"),
+              integer(arguments, "seed"),
+              integer(arguments, "nonMatchRepeats"),
+              string(arguments, "delimiterAlphabet"));
+      case CENTER_IN_SPACES ->
+          surroundWithSpaces(string(arguments, "body"), integer(arguments, "length"));
+      case SCALED_CENTER_IN_SPACES ->
           scaledSurroundWithSpaces(
-              inputSpec.bodyPrefix,
-              inputSpec.bodySuffix,
-              inputSpec.bodyFill,
-              inputSpec.bodyScalePercent,
-              size);
-      default ->
-          throw new IllegalArgumentException("Unknown real-world input kind: " + inputSpec.kind);
+              string(arguments, "bodyPrefix"),
+              string(arguments, "bodySuffix"),
+              string(arguments, "bodyFill"),
+              integer(arguments, "bodyScalePercent"),
+              integer(arguments, "length"));
+      case LAZY_ALTERNATION_TO_LENGTH ->
+          lazyAltInput(
+              string(arguments, "prefixUnit"),
+              string(arguments, "match"),
+              string(arguments, "suffixUnit"),
+              integer(arguments, "length"));
+      case PERIODIC_ALTERNATION_TO_LENGTH ->
+          altCaptureInput(
+              string(arguments, "hitUnit"),
+              string(arguments, "missUnit"),
+              integer(arguments, "hitInterval"),
+              integer(arguments, "length"));
+      case OPTIONAL_REQUIRED_REPEAT_PATTERN ->
+          string(arguments, "literal").concat("?").repeat(integer(arguments, "count"))
+              + string(arguments, "literal").repeat(integer(arguments, "count"));
     };
+  }
+
+  private static String randomChars(String alphabet, int size, int seed) {
+    Random random = new Random(seed);
+    char[] characters = new char[size];
+    for (int index = 0; index < size; index++) {
+      characters[index] = alphabet.charAt(random.nextInt(alphabet.length()));
+    }
+    return new String(characters);
+  }
+
+  private static String randomCodePoints(List<Integer> codePoints, int minimumSize, int seed) {
+    Random random = new Random(seed);
+    StringBuilder result = new StringBuilder(minimumSize);
+    while (result.length() < minimumSize) {
+      result.appendCodePoint(codePoints.get(random.nextInt(codePoints.size())));
+    }
+    return result.toString();
+  }
+
+  private static String repeatAtLeastSize(String unit, int minimumSize) {
+    if (minimumSize == 0) {
+      return "";
+    }
+    StringBuilder result = new StringBuilder(minimumSize + unit.length());
+    while (result.length() < minimumSize) {
+      result.append(unit);
+    }
+    return result.toString();
+  }
+
+  static String repeatToSize(String unit, int size) {
+    if (size == 0) {
+      return "";
+    }
+    if (unit.isEmpty()) {
+      throw new IllegalArgumentException("Repeat unit must not be empty when size is positive");
+    }
+    StringBuilder result = new StringBuilder(size + unit.length());
+    while (result.length() < size) {
+      result.append(unit);
+    }
+    return result.substring(0, size);
   }
 
   private static String repeatedInput(String template, int size, String alphabet, int seed) {
@@ -377,20 +324,6 @@ public final class BenchmarkInputMaterializer {
     return " ".repeat(leading) + body + " ".repeat(padding - leading);
   }
 
-  static String repeatToSize(String unit, int size) {
-    if (size == 0) {
-      return "";
-    }
-    if (unit.isEmpty()) {
-      throw new IllegalArgumentException("Repeat unit must not be empty when size is positive");
-    }
-    StringBuilder result = new StringBuilder(size + unit.length());
-    while (result.length() < size) {
-      result.append(unit);
-    }
-    return result.substring(0, size);
-  }
-
   private static String surroundToSize(String prefix, String unit, String suffix, int size) {
     int bodySize = Math.max(0, size - prefix.length() - suffix.length());
     return prefix + repeatToSize(unit, bodySize) + suffix;
@@ -424,11 +357,19 @@ public final class BenchmarkInputMaterializer {
     return result.substring(0, size);
   }
 
-  private void add(String key, String value) {
-    byte[] previous = inputs.put(key, value.getBytes(StandardCharsets.UTF_8));
-    if (previous != null) {
-      throw new IllegalArgumentException("Duplicate materialized input key: " + key);
-    }
+  private static String string(
+      Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments, String name) {
+    return ((DeclarativeBenchmarkPlan.RecipeString) arguments.get(name)).value();
+  }
+
+  private static int integer(
+      Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments, String name) {
+    return ((DeclarativeBenchmarkPlan.RecipeInteger) arguments.get(name)).value();
+  }
+
+  private static List<Integer> integers(
+      Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments, String name) {
+    return ((DeclarativeBenchmarkPlan.RecipeIntegerList) arguments.get(name)).values();
   }
 
   private void write(Path corpusDirectory) throws IOException {
@@ -473,8 +414,10 @@ public final class BenchmarkInputMaterializer {
     for (Map.Entry<String, byte[]> input : inputs.entrySet()) {
       byte[] bytes = input.getValue();
       String text = new String(bytes, StandardCharsets.UTF_8);
+      DeclarativeBenchmarkPlan.InputDeclaration declaration = declarations.get(input.getKey());
       JsonObject entry = new JsonObject();
       entry.addProperty("file", input.getKey().replace('.', '/') + ".txt");
+      entry.addProperty("shared", declaration.shared());
       entry.addProperty("utf8Bytes", bytes.length);
       entry.addProperty("utf16CodeUnits", text.length());
       entry.addProperty("unicodeScalars", text.codePointCount(0, text.length()));
@@ -491,37 +434,5 @@ public final class BenchmarkInputMaterializer {
     } catch (NoSuchAlgorithmException exception) {
       throw new AssertionError("SHA-256 must be available", exception);
     }
-  }
-
-  private JsonObject object(String path) {
-    return element(path).getAsJsonObject();
-  }
-
-  private String string(String path) {
-    return element(path).getAsString();
-  }
-
-  private int integer(String path) {
-    return element(path).getAsInt();
-  }
-
-  private int[] integers(String path) {
-    JsonArray array = element(path).getAsJsonArray();
-    int[] values = new int[array.size()];
-    for (int index = 0; index < array.size(); index++) {
-      values[index] = array.get(index).getAsInt();
-    }
-    return values;
-  }
-
-  private JsonElement element(String path) {
-    JsonElement current = data;
-    for (String part : path.split("\\.")) {
-      current = current.getAsJsonObject().get(part);
-      if (current == null) {
-        throw new IllegalArgumentException("No benchmark data at path: " + path);
-      }
-    }
-    return current;
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -14,6 +14,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -38,7 +40,6 @@ public final class BenchmarkInputMaterializer {
   private final String benchmarkDataSha256;
   private final Map<String, DeclarativeBenchmarkPlan.InputDeclaration> declarations;
   private final Map<String, byte[]> inputs = new LinkedHashMap<>();
-  private final Set<String> activeRecipes = new LinkedHashSet<>();
 
   private BenchmarkInputMaterializer(JsonObject data, String benchmarkDataSha256) {
     this.data = data;
@@ -111,31 +112,57 @@ public final class BenchmarkInputMaterializer {
   }
 
   private byte[] materialize(String inputId) {
-    byte[] existing = inputs.get(inputId);
-    if (existing != null) {
-      return existing;
-    }
-    DeclarativeBenchmarkPlan.InputDeclaration declaration = declarations.get(inputId);
-    if (declaration == null) {
-      throw new IllegalArgumentException(
-          "Input recipe references unknown materialized input: " + inputId);
-    }
-    if (!activeRecipes.add(inputId)) {
-      throw new IllegalArgumentException(
-          "Cyclic materialized input recipe dependency: "
-              + String.join(" -> ", activeRecipes)
-              + " -> "
-              + inputId);
-    }
-    try {
-      byte[] bytes = evaluate(declaration.recipe()).getBytes(StandardCharsets.UTF_8);
-      if (inputs.put(inputId, bytes) != null) {
-        throw new IllegalArgumentException("Duplicate materialized input key: " + inputId);
+    Deque<MaterializationFrame> pending = new ArrayDeque<>();
+    Set<String> activeRecipes = new LinkedHashSet<>();
+    pending.push(new MaterializationFrame(inputId, false));
+    while (!pending.isEmpty()) {
+      MaterializationFrame frame = pending.pop();
+      if (inputs.containsKey(frame.inputId())) {
+        activeRecipes.remove(frame.inputId());
+        continue;
       }
-      return bytes;
-    } finally {
-      activeRecipes.remove(inputId);
+      DeclarativeBenchmarkPlan.InputDeclaration declaration = declarations.get(frame.inputId());
+      if (declaration == null) {
+        throw new IllegalArgumentException(
+            "Input recipe references unknown materialized input: " + frame.inputId());
+      }
+      if (frame.dependenciesResolved()) {
+        byte[] bytes = evaluate(declaration.recipe()).getBytes(StandardCharsets.UTF_8);
+        if (inputs.put(frame.inputId(), bytes) != null) {
+          throw new IllegalArgumentException(
+              "Duplicate materialized input key: " + frame.inputId());
+        }
+        activeRecipes.remove(frame.inputId());
+        continue;
+      }
+      if (!activeRecipes.add(frame.inputId())) {
+        throw new IllegalArgumentException(
+            "Cyclic materialized input recipe dependency: "
+                + String.join(" -> ", activeRecipes)
+                + " -> "
+                + frame.inputId());
+      }
+      pending.push(new MaterializationFrame(frame.inputId(), true));
+      String dependency = inputDependency(declaration.recipe());
+      if (dependency != null && !inputs.containsKey(dependency)) {
+        if (activeRecipes.contains(dependency)) {
+          throw new IllegalArgumentException(
+              "Cyclic materialized input recipe dependency: "
+                  + String.join(" -> ", activeRecipes)
+                  + " -> "
+                  + dependency);
+        }
+        pending.push(new MaterializationFrame(dependency, false));
+      }
     }
+    return inputs.get(inputId);
+  }
+
+  private static String inputDependency(DeclarativeBenchmarkPlan.InputRecipe recipe) {
+    if (recipe.kind() != DeclarativeBenchmarkPlan.RecipeKind.APPEND_INPUT) {
+      return null;
+    }
+    return string(recipe.arguments(), "input");
   }
 
   private String evaluate(DeclarativeBenchmarkPlan.InputRecipe recipe) {
@@ -154,7 +181,7 @@ public final class BenchmarkInputMaterializer {
               string(arguments, "delimiterAlphabet"),
               integer(arguments, "seed"));
       case APPEND_INPUT ->
-          new String(materialize(string(arguments, "input")), StandardCharsets.UTF_8)
+          new String(inputs.get(string(arguments, "input")), StandardCharsets.UTF_8)
               + string(arguments, "suffix");
       case RANDOM_CHARS ->
           randomChars(
@@ -218,6 +245,8 @@ public final class BenchmarkInputMaterializer {
               + string(arguments, "literal").repeat(integer(arguments, "count"));
     };
   }
+
+  private record MaterializationFrame(String inputId, boolean dependenciesResolved) {}
 
   private static String randomChars(String alphabet, int size, int seed) {
     Random random = new Random(seed);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -51,14 +51,7 @@ final class DeclarativeBenchmarkPlan {
           "Unsupported benchmark plan schema version: " + schemaVersion);
     }
 
-    Map<String, InputDeclaration> inputs = new LinkedHashMap<>();
-    for (JsonElement element : root.requiredArray("inputs")) {
-      for (InputDeclaration input : parseInputs(element)) {
-        if (inputs.put(input.id(), input) != null) {
-          throw new IllegalArgumentException("Duplicate benchmark input ID: " + input.id());
-        }
-      }
-    }
+    Map<String, InputDeclaration> inputs = parseInputDeclarations(root.requiredArray("inputs"));
 
     List<WorkloadDeclaration> workloads = new ArrayList<>();
     Set<String> workloadTemplates = new LinkedHashSet<>();
@@ -81,6 +74,18 @@ final class DeclarativeBenchmarkPlan {
 
   Map<String, InputDeclaration> inputs() {
     return inputs;
+  }
+
+  static Map<String, InputDeclaration> parseInputDeclarations(JsonArray declarations) {
+    Map<String, InputDeclaration> inputs = new LinkedHashMap<>();
+    for (JsonElement element : declarations) {
+      for (InputDeclaration input : parseInputs(element)) {
+        if (inputs.put(input.id(), input) != null) {
+          throw new IllegalArgumentException("Duplicate benchmark input ID: " + input.id());
+        }
+      }
+    }
+    return Collections.unmodifiableMap(inputs);
   }
 
   List<WorkloadDeclaration> workloads() {
@@ -1090,6 +1095,20 @@ final class DeclarativeBenchmarkPlan {
         "repeatToLength",
         field("unit", RecipeValueType.STRING),
         field("length", RecipeValueType.INTEGER)),
+    REPEAT_AT_LEAST_LENGTH(
+        "repeatAtLeastLength",
+        field("unit", RecipeValueType.STRING),
+        field("minimumLength", RecipeValueType.INTEGER)),
+    DELIMITED_REPEAT_TO_LENGTH(
+        "delimitedRepeatToLength",
+        field("value", RecipeValueType.STRING),
+        field("delimiterAlphabet", RecipeValueType.STRING),
+        field("seed", RecipeValueType.INTEGER),
+        field("length", RecipeValueType.INTEGER)),
+    APPEND_INPUT(
+        "appendInput",
+        field("input", RecipeValueType.STRING),
+        field("suffix", RecipeValueType.STRING)),
     RANDOM_CHARS(
         "randomChars",
         field("alphabet", RecipeValueType.STRING),
@@ -1186,6 +1205,16 @@ final class DeclarativeBenchmarkPlan {
           requireNonNegative(arguments, "length");
           requireUnitWhenOutputIsRequired(arguments, "unit", "length", 0);
         }
+        case REPEAT_AT_LEAST_LENGTH -> {
+          requireNonNegative(arguments, "minimumLength");
+          requireUnitWhenOutputIsRequired(arguments, "unit", "minimumLength", 0);
+        }
+        case DELIMITED_REPEAT_TO_LENGTH -> {
+          requireNonNegative(arguments, "length");
+          requireNonEmpty(arguments, "value");
+          requireNonEmpty(arguments, "delimiterAlphabet");
+        }
+        case APPEND_INPUT -> requireNonEmpty(arguments, "input");
         case RANDOM_CHARS -> {
           requireNonNegative(arguments, "length");
           requireNonEmpty(arguments, "alphabet");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -8,9 +8,111 @@ package org.safere.benchmark;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class BenchmarkInputMaterializerTest {
+  @TempDir Path tempDirectory;
+
+  @Test
+  void declaredBenchmarkCorpusMaterializesDeterministically() throws IOException {
+    JsonObject benchmarkData =
+        JsonParser.parseString(Files.readString(Path.of("benchmark-data.json"))).getAsJsonObject();
+
+    Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
+    Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
+
+    assertThat(first).hasSize(262);
+    assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
+    first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
+    assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
+    assertThat(text(first, "pathological.pattern.10")).isEqualTo("a?".repeat(10) + "a".repeat(10));
+    assertThat(text(first, "searchScaling.success.1024"))
+        .hasSize(1050)
+        .endsWith("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    assertThat(text(first, "fanout.unicode.1024")).hasSize(1024);
+  }
+
+  @Test
+  void appendRecipeRejectsUnknownInput() {
+    JsonObject benchmarkData =
+        JsonParser.parseString(
+                """
+                {
+                  "schemaVersion": 1,
+                  "inputs": [{
+                    "id": "derived",
+                    "recipe": {"kind": "appendInput", "input": "missing", "suffix": "!"},
+                    "shared": true
+                  }]
+                }
+                """)
+            .getAsJsonObject();
+
+    assertThatThrownBy(() -> BenchmarkInputMaterializer.materialize(benchmarkData))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Input recipe references unknown materialized input: missing");
+  }
+
+  @Test
+  void appendRecipeRejectsDependencyCycle() {
+    JsonObject benchmarkData =
+        JsonParser.parseString(
+                """
+                {
+                  "schemaVersion": 1,
+                  "inputs": [
+                    {
+                      "id": "first",
+                      "recipe": {"kind": "appendInput", "input": "second", "suffix": "!"},
+                      "shared": true
+                    },
+                    {
+                      "id": "second",
+                      "recipe": {"kind": "appendInput", "input": "first", "suffix": "?"},
+                      "shared": true
+                    }
+                  ]
+                }
+                """)
+            .getAsJsonObject();
+
+    assertThatThrownBy(() -> BenchmarkInputMaterializer.materialize(benchmarkData))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cyclic materialized input recipe dependency: first -> second -> first");
+  }
+
+  @Test
+  void manifestAttributesInputsAndRecordsExactEncodingMetadata() throws Exception {
+    BenchmarkInputMaterializer.main(
+        new String[] {
+          Path.of(".").toAbsolutePath().normalize().toString(), tempDirectory.toString()
+        });
+
+    JsonObject manifest =
+        JsonParser.parseString(Files.readString(tempDirectory.resolve("manifest.json")))
+            .getAsJsonObject();
+    JsonObject entry =
+        manifest
+            .getAsJsonObject("inputs")
+            .getAsJsonObject("crossEngine.RegexBenchmark.literalMatch.input");
+
+    assertThat(entry.get("file").getAsString())
+        .isEqualTo("crossEngine/RegexBenchmark/literalMatch/input.txt");
+    assertThat(entry.get("shared").getAsBoolean()).isTrue();
+    assertThat(entry.get("utf8Bytes").getAsInt()).isEqualTo(5);
+    assertThat(entry.get("utf16CodeUnits").getAsInt()).isEqualTo(5);
+    assertThat(entry.get("unicodeScalars").getAsInt()).isEqualTo(5);
+    assertThat(entry.get("sha256").getAsString())
+        .isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  }
 
   @Test
   void emptyRepeatUnitIsRejectedWhenOutputIsRequired() {
@@ -22,5 +124,9 @@ class BenchmarkInputMaterializerTest {
   @Test
   void emptyRepeatUnitCanProduceEmptyOutput() {
     assertThat(BenchmarkInputMaterializer.repeatToSize("", 0)).isEmpty();
+  }
+
+  private static String text(Map<String, byte[]> inputs, String id) {
+    return new String(inputs.get(id), StandardCharsets.UTF_8);
   }
 }

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -8,6 +8,7 @@ package org.safere.benchmark;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.IOException;
@@ -87,6 +88,39 @@ class BenchmarkInputMaterializerTest {
     assertThatThrownBy(() -> BenchmarkInputMaterializer.materialize(benchmarkData))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cyclic materialized input recipe dependency: first -> second -> first");
+  }
+
+  @Test
+  void deeplyChainedAppendRecipesMaterializeWithoutUsingTheCallStack() {
+    int dependencyCount = 5_000;
+    JsonObject benchmarkData = new JsonObject();
+    benchmarkData.addProperty("schemaVersion", 1);
+    JsonArray inputs = new JsonArray();
+    for (int index = dependencyCount; index >= 1; index--) {
+      JsonObject declaration = new JsonObject();
+      declaration.addProperty("id", "input" + index);
+      JsonObject recipe = new JsonObject();
+      recipe.addProperty("kind", "appendInput");
+      recipe.addProperty("input", "input" + (index - 1));
+      recipe.addProperty("suffix", "x");
+      declaration.add("recipe", recipe);
+      declaration.addProperty("shared", true);
+      inputs.add(declaration);
+    }
+    JsonObject base = new JsonObject();
+    base.addProperty("id", "input0");
+    JsonObject baseRecipe = new JsonObject();
+    baseRecipe.addProperty("kind", "literal");
+    baseRecipe.addProperty("text", "");
+    base.add("recipe", baseRecipe);
+    base.addProperty("shared", true);
+    inputs.add(base);
+    benchmarkData.add("inputs", inputs);
+
+    Map<String, byte[]> materialized = BenchmarkInputMaterializer.materialize(benchmarkData);
+
+    assertThat(text(materialized, "input" + dependencyCount))
+        .isEqualTo("x".repeat(dependencyCount));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- declare every existing benchmark input in `benchmark-data.json`
- replace workload-family materializer methods with generic bounded recipe evaluation
- preserve all existing corpus paths and bytes while adding declaration attribution to the manifest
- reject unknown and cyclic input dependencies
- evaluate deeply chained input dependencies with an explicit worklist so materialization remains stack-safe

## Verification

- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere-benchmarks verify -DskipTests -q`
- `./materialize-benchmark-inputs.sh`
- compared all 262 generated input paths and SHA-256 hashes with the pre-change corpus; no differences
- regression coverage materializes a 5,000-input dependency chain without recursion
- `./run-java-benchmarks.sh --smoke --fastbuild '^org\.safere\.benchmark\.CrossEngineBenchmark\.' -- -p crossEngineTrial=RegexBenchmark.emailFind@safere-string`
- review/fix loop completed with no remaining P2+ findings

Full C++ and Go benchmark smoke suites were not run for this PR.

Fixes #609
Part of #606

Stacked on #615.
