### PR TITLE
Expand cross-engine trials from declarations

### DIFF
--- a/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
+++ b/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
@@ -28,11 +28,14 @@ Materialization, UTF-8 validation, Java decoding, `Utf8Input` construction,
 pattern compilation, operation binding, and expected-result validation happen
 in JMH setup, outside the timed operation.
 
-Each variant declares native capabilities. The planner emits only supported
-workload/variant trials, so an unsupported operation is different from a
-missing implementation. In particular, SafeRE UTF-8 participates in direct
-`find` and repeated-`find` operations; it does not emulate String-only
-`matches`, group-text, replacement, or split APIs.
+Each variant declares native capabilities and one input representation. The
+planner joins those declarations with each workload's engine-neutral
+requirements and accepted representations. It emits a trial or a specific
+exclusion for every workload/variant pair, so an unsupported feature or
+representation is different from a missing adapter or operation
+implementation. In particular, SafeRE UTF-8 participates in direct `find` and
+repeated-`find` operations; it does not emulate String-only `matches`,
+group-text, replacement, or split APIs.
 
 ## JMH trials and result names
 

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -1,10 +1,11 @@
 # Declarative Benchmark Plan
 
 SafeRE's normalized benchmark plan is a strict, versioned object within
-`benchmark-data.json`. The initial schema version is `1`. The legacy sections
-remain authoritative until their workloads are migrated in the follow-up
-issues under #606; the schema foundation itself does not change any benchmark
-timing boundary.
+`benchmark-data.json`. The initial schema version is `1`. Normalized
+declarations are authoritative for materialized inputs and ordinary/scaling
+cross-engine workloads. Legacy sections remain authoritative only for
+specialized modes until their migration in the follow-up issues under #606.
+The schema does not change any benchmark timing boundary.
 
 The normalized plan has this shape:
 

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -2351,5 +2351,1976 @@
     ],
     "matchText": "ERROR: connection timeout after 30s to host db-primary.internal:5432",
     "noMatchText": "The quick brown fox jumps over the lazy dog near the riverbank"
-  }
+  },
+  "workloads": [
+    {
+      "id": "RegexBenchmark.literalMatch",
+      "operation": "matches",
+      "patterns": [
+        "hello"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.literalMatch.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.charClassMatch",
+      "operation": "matches",
+      "patterns": [
+        "[a-zA-Z]+"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.charClassMatch.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.alternationFind",
+      "operation": "findAllCount",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.alternationFind.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.findInText",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\b\\w+ing\\b"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.findInText.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.emailFind",
+      "operation": "find",
+      "patterns": [
+        "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.emailFind.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.uuidValidation",
+      "operation": "matchesCorpus",
+      "patterns": [
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.uuidValidation.input.0",
+        "crossEngine.ApplicationBenchmark.uuidValidation.input.1",
+        "crossEngine.ApplicationBenchmark.uuidValidation.input.2",
+        "crossEngine.ApplicationBenchmark.uuidValidation.input.3",
+        "crossEngine.ApplicationBenchmark.uuidValidation.input.4",
+        "crossEngine.ApplicationBenchmark.uuidValidation.input.5"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 3
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.logLineParse",
+      "operation": "matchesGroupLengthSum",
+      "patterns": [
+        "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\s+(INFO|WARN|ERROR)\\s+([A-Za-z0-9_.-]+)\\s+-\\s+(.+)$"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.logLineParse.input.0",
+        "crossEngine.ApplicationBenchmark.logLineParse.input.1",
+        "crossEngine.ApplicationBenchmark.logLineParse.input.2",
+        "crossEngine.ApplicationBenchmark.logLineParse.input.3",
+        "crossEngine.ApplicationBenchmark.logLineParse.input.4"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "groups": [
+          2,
+          3
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 39
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.apiRouteMatch",
+      "operation": "matchesGroupLengthSum",
+      "patterns": [
+        "^/api/v[0-9]+/(users|orders|inventory)/([A-Za-z0-9_-]+)(?:\\?.*)?$"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.apiRouteMatch.input.0",
+        "crossEngine.ApplicationBenchmark.apiRouteMatch.input.1",
+        "crossEngine.ApplicationBenchmark.apiRouteMatch.input.2",
+        "crossEngine.ApplicationBenchmark.apiRouteMatch.input.3",
+        "crossEngine.ApplicationBenchmark.apiRouteMatch.input.4",
+        "crossEngine.ApplicationBenchmark.apiRouteMatch.input.5"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "groups": [
+          1,
+          2
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 41
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.stackTraceExtract",
+      "operation": "findAllGroupLengthSum",
+      "patterns": [
+        "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.stackTraceExtract.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "groups": [
+          1,
+          4
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 93
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.caseInsensitiveKeywords",
+      "operation": "findAllCount",
+      "patterns": [
+        "(?i)\\b(error|warning|timeout|failed)\\b"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.caseInsensitiveKeywords.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 4
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.urlExtraction",
+      "operation": "findAllLengthSum",
+      "patterns": [
+        "(https?://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]*)?)"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.urlExtraction.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 124
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.csvFieldScan",
+      "operation": "findAllLengthSum",
+      "patterns": [
+        "(?m)(?:^|,)(?:\"([^\"]*)\"|([^,\\r\\n]+))"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.csvFieldScan.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "integer",
+        "value": 156
+      }
+    },
+    {
+      "id": "ApplicationBenchmark.secretRedaction",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?i)\\b(password|token|secret)=([^\\s&]+)"
+      ],
+      "inputs": [
+        "crossEngine.ApplicationBenchmark.secretRedaction.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "replacement": "$1=REDACTED"
+      },
+      "requirements": [
+        "numberedReplacement"
+      ],
+      "expected": {
+        "type": "string",
+        "value": "user=service password=REDACTED token=REDACTED path=/api secret=REDACTED debug=true"
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.mapFieldPath.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "([\\S]+)\\b\\[(.+)\\]"
+      ],
+      "inputs": [
+        "realWorldRegex.mapFieldPath.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.markupImageLink.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "<<!(image|media|link)(\\([^\\)]*\\))?/?>?>"
+      ],
+      "inputs": [
+        "realWorldRegex.markupImageLink.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.versionList.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]"
+      ],
+      "inputs": [
+        "realWorldRegex.versionList.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.malformedEntity.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "<[^>]*entity[^>]*>{1,2}"
+      ],
+      "inputs": [
+        "realWorldRegex.malformedEntity.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.markupEntity.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "<<!entity.*?>>"
+      ],
+      "inputs": [
+        "realWorldRegex.markupEntity.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.customProtocolLink.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "\\[(.*?)]\\(customProtocol://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)"
+      ],
+      "inputs": [
+        "realWorldRegex.customProtocolLink.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.wildcardSearch.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "(?is).*\\b(you|your)\\b.*"
+      ],
+      "inputs": [
+        "realWorldRegex.wildcardSearch.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.metadataBlock.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?s)<meta_start>.*?<meta_end>"
+      ],
+      "inputs": [
+        "realWorldRegex.metadataBlock.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.blockedTags1.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```"
+      ],
+      "inputs": [
+        "realWorldRegex.blockedTags1.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.blockedTags2.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>"
+      ],
+      "inputs": [
+        "realWorldRegex.blockedTags2.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.overlappingUrl.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?"
+      ],
+      "inputs": [
+        "realWorldRegex.overlappingUrl.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeyword.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?i)keyword_to_find"
+      ],
+      "inputs": [
+        "realWorldRegex.caseInsensitiveKeyword.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.boundedNameMatch.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)"
+      ],
+      "inputs": [
+        "realWorldRegex.boundedNameMatch.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.templateTagMatch.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)"
+      ],
+      "inputs": [
+        "realWorldRegex.templateTagMatch.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.sparseUrl.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?"
+      ],
+      "inputs": [
+        "realWorldRegex.sparseUrl.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.unprefixedWordBoundary.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "\\b[a-zA-Z]{3,5}\\b"
+      ],
+      "inputs": [
+        "realWorldRegex.unprefixedWordBoundary.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.fruitSearchQuery.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?is).*\\b(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)\\b.*"
+      ],
+      "inputs": [
+        "realWorldRegex.fruitSearchQuery.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": "$1"
+      },
+      "requirements": [
+        "numberedReplacement"
+      ]
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.fruitMarkupTag.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$"
+      ],
+      "inputs": [
+        "realWorldRegex.fruitMarkupTag.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": "$1"
+      },
+      "requirements": [
+        "numberedReplacement"
+      ]
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.jsonBlock.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(\\{[\\s\\S]*\\})"
+      ],
+      "inputs": [
+        "realWorldRegex.jsonBlock.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": "$1"
+      },
+      "requirements": [
+        "numberedReplacement"
+      ]
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.charReplace.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "a"
+      ],
+      "inputs": [
+        "realWorldRegex.charReplace.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": "xyz"
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.greedyOnePass.{matchLabel}.{size}",
+      "operation": "matches",
+      "patterns": [
+        "^(.+)"
+      ],
+      "inputs": [
+        "realWorldRegex.greedyOnePass.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.layoutBlock.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>"
+      ],
+      "inputs": [
+        "realWorldRegex.layoutBlock.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.turnTitleWhitespaceCjk.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+"
+      ],
+      "inputs": [
+        "realWorldRegex.turnTitleWhitespaceCjk.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "arguments": {
+        "replacement": ""
+      },
+      "requirements": []
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "[一-龥]{3,}"
+      ],
+      "inputs": [
+        "realWorldRegex.cjkSearch.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.emojiSearch.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "[😀-😇]"
+      ],
+      "inputs": [
+        "realWorldRegex.emojiSearch.{matchLabel}.{size}"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "HttpBenchmark.httpFull",
+      "operation": "findGroupPresent",
+      "patterns": [
+        "^(?:GET|POST) +([^ ]+) HTTP"
+      ],
+      "inputs": [
+        "crossEngine.HttpBenchmark.httpFull.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "group": 1
+      }
+    },
+    {
+      "id": "HttpBenchmark.httpSmall",
+      "operation": "findGroupPresent",
+      "patterns": [
+        "^(?:GET|POST) +([^ ]+) HTTP"
+      ],
+      "inputs": [
+        "crossEngine.HttpBenchmark.httpSmall.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "group": 1
+      }
+    },
+    {
+      "id": "HttpBenchmark.httpExtract",
+      "operation": "findGroup",
+      "patterns": [
+        "^(?:GET|POST) +([^ ]+) HTTP"
+      ],
+      "inputs": [
+        "crossEngine.HttpBenchmark.httpFull.input"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "group": 1
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasyFail.1024",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasySuccess.1024",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchMediumFail.1024",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchHardFail.1024",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.findIngScaled.1024",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\b\\w+ing\\b"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasyFail.10240",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasySuccess.10240",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchMediumFail.10240",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchHardFail.10240",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.findIngScaled.10240",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\b\\w+ing\\b"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasyFail.102400",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasySuccess.102400",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchMediumFail.102400",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchHardFail.102400",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.findIngScaled.102400",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\b\\w+ing\\b"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasyFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchEasySuccess.1048576",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchMediumFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.searchHardFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.findIngScaled.1048576",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\b\\w+ing\\b"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FanoutBenchmark.fanoutUnicode.1024",
+      "operation": "find",
+      "patterns": [
+        "(?:[\\x{80}-\\x{10FFFF}]?){100}[\\x{80}-\\x{10FFFF}]"
+      ],
+      "inputs": [
+        "fanout.unicode.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FanoutBenchmark.nestedQuantifier.1024",
+      "operation": "find",
+      "patterns": [
+        "(?:a?){20}a{20}"
+      ],
+      "inputs": [
+        "fanout.ascii.1024"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FanoutBenchmark.fanoutUnicode.10240",
+      "operation": "find",
+      "patterns": [
+        "(?:[\\x{80}-\\x{10FFFF}]?){100}[\\x{80}-\\x{10FFFF}]"
+      ],
+      "inputs": [
+        "fanout.unicode.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FanoutBenchmark.nestedQuantifier.10240",
+      "operation": "find",
+      "patterns": [
+        "(?:a?){20}a{20}"
+      ],
+      "inputs": [
+        "fanout.ascii.10240"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FanoutBenchmark.fanoutUnicode.102400",
+      "operation": "find",
+      "patterns": [
+        "(?:[\\x{80}-\\x{10FFFF}]?){100}[\\x{80}-\\x{10FFFF}]"
+      ],
+      "inputs": [
+        "fanout.unicode.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FanoutBenchmark.nestedQuantifier.102400",
+      "operation": "find",
+      "patterns": [
+        "(?:a?){20}a{20}"
+      ],
+      "inputs": [
+        "fanout.ascii.102400"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    }
+  ]
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -65,6 +65,14 @@ public final class BenchmarkData {
     return INSTANCE;
   }
 
+  JsonObject declarativePlan() {
+    JsonObject plan = new JsonObject();
+    plan.add("schemaVersion", root.get("schemaVersion").deepCopy());
+    plan.add("inputs", root.getAsJsonArray("inputs").deepCopy());
+    plan.add("workloads", root.getAsJsonArray("workloads").deepCopy());
+    return plan;
+  }
+
   /** Get a string value by dot-separated path (e.g., "regex.literalMatch.pattern"). */
   public String getString(String path) {
     String[] parts = path.split("\\.");

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -97,10 +97,6 @@ public final class BenchmarkInputMaterializer {
     return result;
   }
 
-  static String crossEngineInputKey(String workloadId) {
-    return "crossEngine." + workloadId + ".input";
-  }
-
   private void generate() {
     for (String inputId : declarations.keySet()) {
       materialize(inputId);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkOperation.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkOperation.java
@@ -31,6 +31,24 @@ enum BenchmarkOperation {
     }
   }
 
+  static BenchmarkOperation fromDeclarative(DeclarativeBenchmarkPlan.Operation operation) {
+    return switch (operation) {
+      case MATCHES -> MATCHES;
+      case FIND -> FIND;
+      case FIND_ALL_COUNT -> FIND_ALL_COUNT;
+      case MATCHES_CORPUS -> MATCHES_CORPUS;
+      case MATCHES_GROUP_LENGTH_SUM -> MATCHES_GROUP_LENGTH_SUM;
+      case FIND_ALL_LENGTH_SUM -> FIND_ALL_LENGTH_SUM;
+      case FIND_ALL_GROUP_LENGTH_SUM -> FIND_ALL_GROUP_LENGTH_SUM;
+      case REPLACE_ALL -> REPLACE_ALL;
+      case FIND_GROUP_PRESENT -> FIND_GROUP_PRESENT;
+      case FIND_GROUP -> FIND_GROUP;
+      default ->
+          throw new IllegalArgumentException(
+              "Operation is not implemented by the ordinary cross-engine runner: " + operation);
+    };
+  }
+
   boolean isSupportedBy(RegexEngineVariant variant) {
     return variant.capabilities().containsAll(requiredCapabilities);
   }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
@@ -5,51 +5,87 @@
 
 package org.safere.benchmark;
 
+import com.google.gson.JsonElement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-/** Builds and validates the supported cross-engine workload matrix. */
+/** Expands and validates the declarative ordinary cross-engine workload matrix. */
 final class CrossEngineBenchmarkPlan {
+  private static final EnumSet<DeclarativeBenchmarkPlan.Operation> IMPLEMENTED_OPERATIONS =
+      EnumSet.of(
+          DeclarativeBenchmarkPlan.Operation.MATCHES,
+          DeclarativeBenchmarkPlan.Operation.FIND,
+          DeclarativeBenchmarkPlan.Operation.FIND_ALL_COUNT,
+          DeclarativeBenchmarkPlan.Operation.MATCHES_CORPUS,
+          DeclarativeBenchmarkPlan.Operation.MATCHES_GROUP_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.FIND_ALL_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.FIND_ALL_GROUP_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.REPLACE_ALL,
+          DeclarativeBenchmarkPlan.Operation.FIND_GROUP_PRESENT,
+          DeclarativeBenchmarkPlan.Operation.FIND_GROUP);
 
   private final Map<String, CrossEngineWorkload> workloads;
+  private final Map<String, Trial> trials;
+  private final List<DeclarativeBenchmarkPlan.Exclusion> exclusions;
 
-  private CrossEngineBenchmarkPlan(List<CrossEngineWorkload> workloads) {
-    Map<String, CrossEngineWorkload> byId = new LinkedHashMap<>();
-    for (CrossEngineWorkload workload : workloads) {
-      if (byId.put(workload.id(), workload) != null) {
-        throw new IllegalArgumentException("Duplicate cross-engine workload ID: " + workload.id());
-      }
-    }
-    this.workloads = Collections.unmodifiableMap(new LinkedHashMap<>(byId));
+  private CrossEngineBenchmarkPlan(
+      Map<String, CrossEngineWorkload> workloads,
+      Map<String, Trial> trials,
+      List<DeclarativeBenchmarkPlan.Exclusion> exclusions) {
+    this.workloads = Collections.unmodifiableMap(new LinkedHashMap<>(workloads));
+    this.trials = Collections.unmodifiableMap(new LinkedHashMap<>(trials));
+    this.exclusions = List.copyOf(exclusions);
   }
 
   static CrossEngineBenchmarkPlan load() {
-    return new CrossEngineBenchmarkPlan(loadWorkloads(BenchmarkData.get()));
+    BenchmarkData data = BenchmarkData.get();
+    DeclarativeBenchmarkPlan plan = DeclarativeBenchmarkPlan.parse(data.declarativePlan());
+    List<DeclarativeBenchmarkPlan.EngineDeclaration> engines =
+        Arrays.stream(RegexEngineVariant.values()).map(RegexEngineVariant::declaration).toList();
+    return fromExpanded(plan.expand(engines, IMPLEMENTED_OPERATIONS));
+  }
+
+  private static CrossEngineBenchmarkPlan fromExpanded(
+      DeclarativeBenchmarkPlan.ExpandedPlan expanded) {
+    Map<String, CrossEngineWorkload> workloads = new LinkedHashMap<>();
+    for (DeclarativeBenchmarkPlan.ExpandedWorkload workload : expanded.workloads()) {
+      CrossEngineWorkload converted = convert(workload);
+      if (workloads.put(converted.id(), converted) != null) {
+        throw new IllegalArgumentException("Duplicate cross-engine workload ID: " + converted.id());
+      }
+    }
+
+    Map<String, Trial> trials = new LinkedHashMap<>();
+    for (DeclarativeBenchmarkPlan.Trial trial : expanded.trials()) {
+      CrossEngineWorkload workload = workloads.get(trial.workload().id());
+      RegexEngineVariant variant = RegexEngineVariant.fromId(trial.engine().id());
+      Trial converted = new Trial(workload, variant);
+      if (trials.put(converted.id(), converted) != null) {
+        throw new IllegalArgumentException("Duplicate cross-engine trial ID: " + converted.id());
+      }
+    }
+    return new CrossEngineBenchmarkPlan(workloads, trials, expanded.exclusions());
   }
 
   List<Trial> trials(CrossEngineWorkload.TimingGroup timingGroup) {
-    List<Trial> trials = new ArrayList<>();
-    for (CrossEngineWorkload workload : workloads.values()) {
-      if (workload.timingGroup() != timingGroup) {
-        continue;
-      }
-      for (RegexEngineVariant variant : RegexEngineVariant.values()) {
-        if (workload.operation().isSupportedBy(variant)) {
-          trials.add(new Trial(workload, variant));
-        }
-      }
-    }
-    return List.copyOf(trials);
+    return trials.values().stream()
+        .filter(trial -> trial.workload().timingGroup() == timingGroup)
+        .toList();
   }
 
   List<CrossEngineWorkload> workloads() {
     return List.copyOf(workloads.values());
+  }
+
+  List<DeclarativeBenchmarkPlan.Exclusion> exclusions() {
+    return exclusions;
   }
 
   Trial resolve(String trialId) {
@@ -58,24 +94,37 @@ final class CrossEngineBenchmarkPlan {
       throw new IllegalArgumentException(
           "Cross-engine trial must be <workload-id>@<variant-id>: " + trialId);
     }
+    Trial trial = trials.get(trialId);
+    if (trial != null) {
+      return trial;
+    }
     String workloadId = trialId.substring(0, separator);
     String variantId = trialId.substring(separator + 1);
     CrossEngineWorkload workload = workloads.get(workloadId);
     if (workload == null) {
       throw new IllegalArgumentException("Unknown cross-engine workload ID: " + workloadId);
     }
-    RegexEngineVariant variant = RegexEngineVariant.fromId(variantId);
-    if (!workload.operation().isSupportedBy(variant)) {
-      throw new IllegalArgumentException(
-          "Unsupported cross-engine combination: "
-              + workloadId
-              + " uses "
-              + workload.operation()
-              + ", which "
-              + variantId
-              + " does not support");
-    }
-    return new Trial(workload, variant);
+    RegexEngineVariant.fromId(variantId);
+    DeclarativeBenchmarkPlan.Exclusion exclusion =
+        exclusions.stream()
+            .filter(
+                candidate ->
+                    candidate.workloadId().equals(workloadId)
+                        && candidate.engineId().equals(variantId))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Unaccounted cross-engine combination: " + workloadId + "@" + variantId));
+    throw new IllegalArgumentException(
+        "Unsupported cross-engine combination: "
+            + trialId
+            + " uses "
+            + workload.operation()
+            + "; "
+            + exclusion.kind()
+            + ": "
+            + exclusion.reason());
   }
 
   static void main(String[] args) {
@@ -105,269 +154,74 @@ final class CrossEngineBenchmarkPlan {
     System.out.println(trialIds);
   }
 
-  private static List<CrossEngineWorkload> loadWorkloads(BenchmarkData data) {
-    List<CrossEngineWorkload> workloads = new ArrayList<>();
-    addRegexWorkloads(workloads, data);
-    addApplicationWorkloads(workloads, data);
-    addRealWorldWorkloads(workloads, data);
-    addHttpWorkloads(workloads, data);
-    addSearchScalingWorkloads(workloads, data);
-    addFanoutWorkloads(workloads, data);
-    return workloads;
-  }
-
-  private static void addRegexWorkloads(List<CrossEngineWorkload> workloads, BenchmarkData data) {
-    addRegexWorkload(workloads, data, "literalMatch", BenchmarkOperation.MATCHES, new int[0]);
-    addRegexWorkload(workloads, data, "charClassMatch", BenchmarkOperation.MATCHES, new int[0]);
-    addRegexWorkload(
-        workloads, data, "alternationFind", BenchmarkOperation.FIND_ALL_COUNT, new int[0]);
-    addRegexWorkload(workloads, data, "findInText", BenchmarkOperation.FIND_ALL_COUNT, new int[0]);
-    addRegexWorkload(workloads, data, "emailFind", BenchmarkOperation.FIND, new int[0]);
-  }
-
-  private static void addRegexWorkload(
-      List<CrossEngineWorkload> workloads,
-      BenchmarkData data,
-      String name,
-      BenchmarkOperation operation,
-      int[] groups) {
-    String path = "regex." + name;
-    String id = data.getString(path + ".id");
-    workloads.add(
-        workload(
-            id,
-            operation,
-            data.getString(path + ".pattern"),
-            List.of(BenchmarkInputMaterializer.crossEngineInputKey(id)),
-            groups,
-            null,
-            null,
-            CrossEngineWorkload.TimingGroup.NANOSECONDS));
-  }
-
-  private static void addApplicationWorkloads(
-      List<CrossEngineWorkload> workloads, BenchmarkData data) {
-    for (ApplicationCase applicationCase : data.getApplicationCases().values()) {
-      BenchmarkOperation operation =
-          switch (applicationCase.op) {
-            case "matchesCorpus" -> BenchmarkOperation.MATCHES_CORPUS;
-            case "matchesGroupLengthSum" -> BenchmarkOperation.MATCHES_GROUP_LENGTH_SUM;
-            case "findAllCount" -> BenchmarkOperation.FIND_ALL_COUNT;
-            case "findAllLengthSum" -> BenchmarkOperation.FIND_ALL_LENGTH_SUM;
-            case "findAllGroupLengthSum" -> BenchmarkOperation.FIND_ALL_GROUP_LENGTH_SUM;
-            case "replaceAll" -> BenchmarkOperation.REPLACE_ALL;
-            default ->
-                throw new IllegalArgumentException(
-                    "Unknown application benchmark op: " + applicationCase.op);
-          };
-      if (applicationCase.op.startsWith("findAll")
-          && org.safere.Pattern.compile(applicationCase.pattern).matcher("").find()) {
-        throw new IllegalArgumentException(
-            applicationCase.id + " uses an empty-width pattern with " + applicationCase.op);
-      }
-      String baseInputKey = BenchmarkInputMaterializer.crossEngineInputKey(applicationCase.id);
-      List<String> inputKeys = new ArrayList<>();
-      if (applicationCase.texts.isEmpty()) {
-        inputKeys.add(baseInputKey);
-      } else {
-        for (int index = 0; index < applicationCase.texts.size(); index++) {
-          inputKeys.add(baseInputKey + "." + index);
-        }
-      }
-      Object expected =
-          applicationCase.expectsString()
-              ? applicationCase.expectedString()
-              : applicationCase.expectedInt();
-      workloads.add(
-          workload(
-              applicationCase.id,
-              operation,
-              applicationCase.pattern,
-              inputKeys,
-              applicationCase.groups,
-              applicationCase.replacement,
-              expected,
-              CrossEngineWorkload.TimingGroup.NANOSECONDS));
+  private static CrossEngineWorkload convert(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    if (workload.patterns().size() != 1) {
+      throw new IllegalArgumentException(
+          workload.id() + " ordinary cross-engine workload requires exactly one pattern");
     }
-  }
-
-  private static void addRealWorldWorkloads(
-      List<CrossEngineWorkload> workloads, BenchmarkData data) {
-    int[] inputSizes = data.getIntArray("realWorldRegex.textSizes");
-    for (RealWorldRegexCase regexCase : data.getRealWorldRegexCases().values()) {
-      BenchmarkOperation operation =
-          switch (regexCase.op) {
-            case "find" -> BenchmarkOperation.FIND;
-            case "matches" -> BenchmarkOperation.MATCHES;
-            case "replaceAllEmpty", "replaceAllGroup1", "replaceAllLiteral" ->
-                BenchmarkOperation.REPLACE_ALL;
-            default ->
-                throw new IllegalArgumentException(
-                    "Unknown real-world regex benchmark op: " + regexCase.op);
-          };
-      String replacement =
-          switch (regexCase.op) {
-            case "replaceAllEmpty" -> "";
-            case "replaceAllGroup1" -> "$1";
-            case "replaceAllLiteral" -> "xyz";
-            default -> null;
-          };
-      for (boolean match : new boolean[] {true, false}) {
-        String matchLabel = match ? "match" : "noMatch";
-        for (int inputSize : inputSizes) {
-          String id = regexCase.id + "." + matchLabel + "." + inputSize;
-          workloads.add(
-              workload(
-                  id,
-                  operation,
-                  regexCase.pattern,
-                  List.of("realWorldRegex." + regexCase.name + "." + matchLabel + "." + inputSize),
-                  new int[0],
-                  replacement,
-                  null,
-                  CrossEngineWorkload.TimingGroup.NANOSECONDS));
-        }
-      }
-    }
-  }
-
-  private static void addHttpWorkloads(List<CrossEngineWorkload> workloads, BenchmarkData data) {
-    String pattern = data.getString("http.pattern");
-    String fullId = data.getString("http.workloadIds.full");
-    workloads.add(
-        workload(
-            fullId,
-            BenchmarkOperation.FIND_GROUP_PRESENT,
-            pattern,
-            List.of(BenchmarkInputMaterializer.crossEngineInputKey(fullId)),
-            new int[] {1},
-            null,
-            null,
-            CrossEngineWorkload.TimingGroup.NANOSECONDS));
-    String smallId = data.getString("http.workloadIds.small");
-    workloads.add(
-        workload(
-            smallId,
-            BenchmarkOperation.FIND_GROUP_PRESENT,
-            pattern,
-            List.of(BenchmarkInputMaterializer.crossEngineInputKey(smallId)),
-            new int[] {1},
-            null,
-            null,
-            CrossEngineWorkload.TimingGroup.NANOSECONDS));
-    String extractId = data.getString("http.workloadIds.extract");
-    workloads.add(
-        workload(
-            extractId,
-            BenchmarkOperation.FIND_GROUP,
-            pattern,
-            List.of(BenchmarkInputMaterializer.crossEngineInputKey(fullId)),
-            new int[] {1},
-            null,
-            null,
-            CrossEngineWorkload.TimingGroup.NANOSECONDS));
-  }
-
-  private static void addSearchScalingWorkloads(
-      List<CrossEngineWorkload> workloads, BenchmarkData data) {
-    int[] inputSizes = data.getIntArray("searchScaling.textSizes");
-    for (int inputSize : inputSizes) {
-      addScalingFind(
-          workloads,
-          data,
-          "searchScaling.workloadIds.easyFail",
-          "searchScaling.patterns.easy",
-          "searchScaling.random." + inputSize,
-          inputSize);
-      addScalingFind(
-          workloads,
-          data,
-          "searchScaling.workloadIds.easySuccess",
-          "searchScaling.patterns.easy",
-          "searchScaling.success." + inputSize,
-          inputSize);
-      addScalingFind(
-          workloads,
-          data,
-          "searchScaling.workloadIds.mediumFail",
-          "searchScaling.patterns.medium",
-          "searchScaling.random." + inputSize,
-          inputSize);
-      addScalingFind(
-          workloads,
-          data,
-          "searchScaling.workloadIds.hardFail",
-          "searchScaling.patterns.hard",
-          "searchScaling.random." + inputSize,
-          inputSize);
-      String findAllId =
-          data.getString("searchScaling.workloadIds.findIngScaled") + "." + inputSize;
-      workloads.add(
-          workload(
-              findAllId,
-              BenchmarkOperation.FIND_ALL_COUNT,
-              data.getString("searchScaling.findIngPattern"),
-              List.of("searchScaling.prose." + inputSize),
-              new int[0],
-              null,
-              null,
-              CrossEngineWorkload.TimingGroup.MICROSECONDS));
-    }
-  }
-
-  private static void addScalingFind(
-      List<CrossEngineWorkload> workloads,
-      BenchmarkData data,
-      String idPath,
-      String patternPath,
-      String inputKey,
-      int inputSize) {
-    workloads.add(
-        workload(
-            data.getString(idPath) + "." + inputSize,
-            BenchmarkOperation.FIND,
-            data.getString(patternPath),
-            List.of(inputKey),
-            new int[0],
-            null,
-            null,
-            CrossEngineWorkload.TimingGroup.MICROSECONDS));
-  }
-
-  private static void addFanoutWorkloads(List<CrossEngineWorkload> workloads, BenchmarkData data) {
-    int[] inputSizes = data.getIntArray("fanout.textSizes");
-    for (int inputSize : inputSizes) {
-      addScalingFind(
-          workloads,
-          data,
-          "fanout.unicodeFanout.id",
-          "fanout.unicodeFanout.pattern",
-          "fanout.unicode." + inputSize,
-          inputSize);
-      addScalingFind(
-          workloads,
-          data,
-          "fanout.nestedQuantifier.id",
-          "fanout.nestedQuantifier.pattern",
-          "fanout.ascii." + inputSize,
-          inputSize);
-    }
-  }
-
-  private static CrossEngineWorkload workload(
-      String id,
-      BenchmarkOperation operation,
-      String pattern,
-      List<String> inputKeys,
-      int[] groups,
-      String replacement,
-      Object expected,
-      CrossEngineWorkload.TimingGroup timingGroup) {
+    int[] groups = groups(workload.arguments());
+    String replacement = stringArgument(workload.arguments(), "replacement");
+    CrossEngineWorkload.TimingGroup timingGroup =
+        switch (workload.measurement().timingUnit()) {
+          case NANOSECONDS -> CrossEngineWorkload.TimingGroup.NANOSECONDS;
+          case MICROSECONDS -> CrossEngineWorkload.TimingGroup.MICROSECONDS;
+          default ->
+              throw new IllegalArgumentException(
+                  workload.id() + " is not an ordinary nanosecond or scaling microsecond workload");
+        };
     return new CrossEngineWorkload(
-        id, operation, pattern, inputKeys, groups, replacement, expected, timingGroup);
+        workload.id(),
+        BenchmarkOperation.fromDeclarative(workload.operation()),
+        workload.patterns().getFirst(),
+        workload.inputIds(),
+        groups,
+        replacement,
+        expectedValue(workload.expected()),
+        timingGroup);
+  }
+
+  private static int[] groups(Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments) {
+    DeclarativeBenchmarkPlan.RecipeValue groups = arguments.get("groups");
+    if (groups != null) {
+      return ((DeclarativeBenchmarkPlan.RecipeIntegerList) groups)
+          .values().stream().mapToInt(Integer::intValue).toArray();
+    }
+    DeclarativeBenchmarkPlan.RecipeValue group = arguments.get("group");
+    if (group != null) {
+      return new int[] {((DeclarativeBenchmarkPlan.RecipeInteger) group).value()};
+    }
+    return new int[0];
+  }
+
+  private static String stringArgument(
+      Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments, String name) {
+    DeclarativeBenchmarkPlan.RecipeValue value = arguments.get(name);
+    return value == null ? null : ((DeclarativeBenchmarkPlan.RecipeString) value).value();
+  }
+
+  private static Object expectedValue(DeclarativeBenchmarkPlan.ExpectedResult expected) {
+    if (expected == null) {
+      return null;
+    }
+    JsonElement value = expected.value();
+    return switch (expected.type()) {
+      case BOOLEAN -> value.getAsBoolean();
+      case INTEGER -> value.getAsInt();
+      case STRING -> value.getAsString();
+      case STRING_LIST -> {
+        List<String> values = new ArrayList<>();
+        value.getAsJsonArray().forEach(element -> values.add(element.getAsString()));
+        yield List.copyOf(values);
+      }
+    };
   }
 
   record Trial(CrossEngineWorkload workload, RegexEngineVariant variant) {
+    Trial {
+      Objects.requireNonNull(workload);
+      Objects.requireNonNull(variant);
+    }
+
     String id() {
       return workload.id() + "@" + variant.id();
     }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -205,7 +205,7 @@ final class DeclarativeBenchmarkPlan {
         }
         List<String> patterns =
             workload.patternTemplates().stream()
-                .map(template -> substitute(template, parameters, id + " pattern"))
+                .map(template -> substitutePattern(template, parameters))
                 .toList();
         Map<String, RecipeValue> arguments = new LinkedHashMap<>();
         for (Map.Entry<String, RecipeValue> argument : workload.arguments().entrySet()) {
@@ -242,9 +242,6 @@ final class DeclarativeBenchmarkPlan {
       requirePlaceholderCoverage(workload.idTemplate(), axisNames, workload.idTemplate());
       for (String inputTemplate : workload.inputTemplates()) {
         requireKnownPlaceholders(inputTemplate, axisNames, workload.idTemplate() + " input");
-      }
-      for (String patternTemplate : workload.patternTemplates()) {
-        requireKnownPlaceholders(patternTemplate, axisNames, workload.idTemplate() + " pattern");
       }
     }
     Set<String> referencedInputs = new LinkedHashSet<>();
@@ -555,6 +552,21 @@ final class DeclarativeBenchmarkPlan {
             context + " references unknown axis: " + matcher.group(1));
       }
       matcher.appendReplacement(result, Matcher.quoteReplacement(value.stableText()));
+    }
+    matcher.appendTail(result);
+    return result.toString();
+  }
+
+  private static String substitutePattern(String template, Map<String, ParameterValue> parameters) {
+    Matcher matcher = PLACEHOLDER.matcher(template);
+    StringBuilder result = new StringBuilder();
+    while (matcher.find()) {
+      ParameterValue value = parameters.get(matcher.group(1));
+      if (value == null) {
+        matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group()));
+      } else {
+        matcher.appendReplacement(result, Matcher.quoteReplacement(value.stableText()));
+      }
     }
     matcher.appendTail(result);
     return result.toString();

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexBenchmark.java
@@ -32,9 +32,7 @@ public class RegexBenchmark {
     BenchmarkData data = BenchmarkData.get();
     String pattern = data.getString("regex.captureGroups.pattern");
     text =
-        data.getInputString(
-            BenchmarkInputMaterializer.crossEngineInputKey(
-                data.getString("regex.captureGroups.id")));
+        data.getInputString("crossEngine." + data.getString("regex.captureGroups.id") + ".input");
     saferePattern = org.safere.Pattern.compile(pattern);
     jdkPattern = java.util.regex.Pattern.compile(pattern);
     re2jPattern = com.google.re2j.Pattern.compile(pattern);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
@@ -318,6 +318,31 @@ enum RegexEngineVariant {
     return capabilities.clone();
   }
 
+  DeclarativeBenchmarkPlan.EngineDeclaration declaration() {
+    EnumSet<DeclarativeBenchmarkPlan.Feature> features =
+        EnumSet.noneOf(DeclarativeBenchmarkPlan.Feature.class);
+    for (EngineCapability capability : capabilities) {
+      switch (capability) {
+        case FIND -> features.add(DeclarativeBenchmarkPlan.Feature.FIND);
+        case MATCHES -> features.add(DeclarativeBenchmarkPlan.Feature.MATCHES);
+        case GROUP_TEXT -> features.add(DeclarativeBenchmarkPlan.Feature.CAPTURE_TEXT);
+        case REPLACE -> {
+          features.add(DeclarativeBenchmarkPlan.Feature.REPLACE);
+          features.add(DeclarativeBenchmarkPlan.Feature.NUMBERED_REPLACEMENT);
+        }
+      }
+    }
+    DeclarativeBenchmarkPlan.InputRepresentation representation =
+        switch (inputRepresentation) {
+          case JAVA_STRING -> DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING;
+          case PREEXISTING_UTF8 -> DeclarativeBenchmarkPlan.InputRepresentation.PREEXISTING_UTF8;
+          case JAVA_STRING_WITH_TIMED_UTF8_CONVERSION ->
+              DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING_WITH_TIMED_UTF8_CONVERSION;
+        };
+    return new DeclarativeBenchmarkPlan.EngineDeclaration(
+        id, representation, features, EnumSet.noneOf(DeclarativeBenchmarkPlan.Flag.class), true);
+  }
+
   List<RegexInput> prepareInputs(BenchmarkData data, List<String> inputKeys) {
     List<RegexInput> inputs = new ArrayList<>(inputKeys.size());
     for (String inputKey : inputKeys) {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -11,7 +11,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,10 +46,11 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
+    assertThat(ids).hasSize(192);
   }
 
   @Test
-  void everyWorkloadHasEveryStringExecutionVariant() {
+  void everyWorkloadEnginePairIsScheduledOrExplicitlyExcluded() {
     CrossEngineBenchmarkPlan plan = CrossEngineBenchmarkPlan.load();
     List<CrossEngineBenchmarkPlan.Trial> allTrials =
         List.of(
@@ -56,6 +59,13 @@ class CrossEngineBenchmarkPlanTest {
             .stream()
             .flatMap(List::stream)
             .toList();
+    Set<String> accounted = new HashSet<>();
+    allTrials.forEach(trial -> assertThat(accounted.add(trial.id())).isTrue());
+    plan.exclusions()
+        .forEach(
+            exclusion ->
+                assertThat(accounted.add(exclusion.workloadId() + "@" + exclusion.engineId()))
+                    .isTrue());
 
     for (CrossEngineWorkload workload : plan.workloads()) {
       assertThat(
@@ -68,6 +78,30 @@ class CrossEngineBenchmarkPlanTest {
               RegexEngineVariant.RE2J_STRING,
               RegexEngineVariant.RE2_FFM_STRING_CONVERSION);
     }
+    assertThat(allTrials).hasSize(840);
+    assertThat(plan.exclusions()).hasSize(120);
+    assertThat(accounted).hasSize(192 * RegexEngineVariant.values().length);
+  }
+
+  @Test
+  void trialExpansionIsDeterministicAndPreservesTimingGroups() {
+    CrossEngineBenchmarkPlan first = CrossEngineBenchmarkPlan.load();
+    CrossEngineBenchmarkPlan second = CrossEngineBenchmarkPlan.load();
+
+    assertThat(first.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS))
+        .extracting(CrossEngineBenchmarkPlan.Trial::id)
+        .containsExactlyElementsOf(
+            second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
+                .map(CrossEngineBenchmarkPlan.Trial::id)
+                .toList())
+        .hasSize(710);
+    assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
+        .extracting(CrossEngineBenchmarkPlan.Trial::id)
+        .containsExactlyElementsOf(
+            second.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
+                .map(CrossEngineBenchmarkPlan.Trial::id)
+                .toList())
+        .hasSize(130);
   }
 
   @Test

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
@@ -82,6 +82,38 @@ class DeclarativeBenchmarkPlanTest {
   }
 
   @Test
+  void patternAxisSubstitutionPreservesRegexBraceSyntax() {
+    DeclarativeBenchmarkPlan plan =
+        parse(
+            planJson(
+                """
+                [{
+                  "id": "Synthetic.braces.{suffix}",
+                  "operation": "find",
+                  "patterns": ["\\\\x{feff}{suffix}"],
+                  "inputs": ["literal.input"],
+                  "axes": {"suffix": ["x"]},
+                  "inputRepresentations": ["javaString"],
+                  "resultConsumption": "boolean",
+                  "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                }]
+                """));
+    DeclarativeBenchmarkPlan.EngineDeclaration engine =
+        engine(
+            "string",
+            DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+            DeclarativeBenchmarkPlan.Feature.FIND);
+
+    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
+        plan.expand(List.of(engine), EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND));
+
+    assertThat(expanded.workloads())
+        .singleElement()
+        .extracting(workload -> workload.patterns().getFirst())
+        .isEqualTo("\\x{feff}x");
+  }
+
+  @Test
   void addingWorkloadAndEngineAxesProducesEveryCompatiblePair() {
     DeclarativeBenchmarkPlan plan =
         parse(


### PR DESCRIPTION
## Summary

- declare all ordinary and scaling cross-engine workloads in the normalized benchmark plan
- replace family-specific planner loading with generic workload/capability/representation expansion
- emit an explicit exclusion for every unsupported workload/engine pair
- preserve expected-result validation outside timed execution
- preserve the complete existing nanosecond and microsecond trial-ID streams, including order

## Verification

- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere-benchmarks verify -DskipTests -q`
- compared the generated nanosecond and microsecond trial-ID streams with the parent commit; both are byte-for-byte identical
- ordinary JMH smoke run covering SafeRE String, SafeRE UTF-8, JDK, RE2/J, and RE2-FFM
- scaling JMH smoke run covering SafeRE String, SafeRE UTF-8, JDK, RE2/J, and RE2-FFM

Full benchmark measurements were not run because this changes planning, not measured implementation behavior.

Fixes #610
Part of #606

Stacked on #616.
