### PR TITLE
Migrate specialized benchmarks to declarative modes

### DIFF
--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -36,7 +36,8 @@
 #                        initialization and short-lived CLI analysis.
 #
 # Workloads that declare the noFork constraint run through the generic
-# CrossEngineNoForkBenchmark entry point with -f 0.
+# CrossEngineNoForkBenchmark entry point with -f 0. The legacy pathological
+# classes also retain no-fork handling until their migration is complete.
 #
 # CrosscheckOverheadBenchmark is excluded from default no-argument runs. Run it
 # explicitly when working on safere-crosscheck performance.
@@ -224,8 +225,48 @@ run_benchmark() {
   local bench="$1"
   local opts="$JMH_OPTS"
   case "$bench" in
-    *CrossEngineNoForkBenchmark*) opts="$NO_FORK_JMH_OPTS" ;;
-    *CrossEngineColdStartBenchmark*) opts="$COLD_START_JMH_OPTS" ;;
+    *CrossEngineNoForkBenchmark*|*PathologicalBenchmark*|*PathologicalComparisonBenchmark*)
+      opts="$NO_FORK_JMH_OPTS"
+      ;;
+    *CrossEngineColdStartBenchmark*)
+      local trials="$CROSS_ENGINE_COLD_START_TRIALS"
+      local extra_args=()
+      local index=0
+      while [ "$index" -lt "${#JMH_EXTRA_ARGS[@]}" ]; do
+        if [ "${JMH_EXTRA_ARGS[$index]}" = "-p" ] \
+          && [ "$((index + 1))" -lt "${#JMH_EXTRA_ARGS[@]}" ] \
+          && [[ "${JMH_EXTRA_ARGS[$((index + 1))]}" = crossEngineColdStartTrial=* ]]; then
+          trials="${JMH_EXTRA_ARGS[$((index + 1))]#crossEngineColdStartTrial=}"
+          index=$((index + 2))
+        else
+          extra_args+=("${JMH_EXTRA_ARGS[$index]}")
+          index=$((index + 1))
+        fi
+      done
+      IFS=',' read -r -a cold_start_trials <<< "$trials"
+      for trial in "${cold_start_trials[@]}"; do
+        echo "=== Running $bench ($COLD_START_JMH_OPTS; isolated trial $trial) ==="
+        if [ ${#extra_args[@]} -gt 0 ]; then
+          java \
+            $JVM_ARGS \
+            -jar "$BENCHMARK_JAR" \
+            -jvmArgs "$JVM_ARGS" \
+            $COLD_START_JMH_OPTS \
+            -p "crossEngineColdStartTrial=$trial" \
+            "${extra_args[@]}" \
+            "$bench"
+        else
+          java \
+            $JVM_ARGS \
+            -jar "$BENCHMARK_JAR" \
+            -jvmArgs "$JVM_ARGS" \
+            $COLD_START_JMH_OPTS \
+            -p "crossEngineColdStartTrial=$trial" \
+            "$bench"
+        fi
+      done
+      return
+      ;;
   esac
   if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
     echo "=== Running $bench ($opts ${JMH_EXTRA_ARGS[*]}) ==="

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -35,9 +35,8 @@
 #                        1 single-shot measurement. Use for cold Unicode table
 #                        initialization and short-lived CLI analysis.
 #
-# Pathological benchmarks (PathologicalBenchmark, PathologicalComparisonBenchmark)
-# always run with -f 0 (no forking) because the JDK engine can hang on large
-# inputs, making forked JVM processes unrecoverable.
+# Workloads that declare the noFork constraint run through the generic
+# CrossEngineNoForkBenchmark entry point with -f 0.
 #
 # CrosscheckOverheadBenchmark is excluded from default no-argument runs. Run it
 # explicitly when working on safere-crosscheck performance.
@@ -54,7 +53,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BENCHMARK_JAR="$SCRIPT_DIR/safere-benchmarks/target/benchmarks.jar"
 BENCHMARK_CORPUS="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus"
 RE2_SHIM_DIR="$SCRIPT_DIR/safere-ffm-re2/build"
-DEFAULT_BENCHMARK_REGEX="^(?!org\\.safere\\.benchmark\\.CrosscheckOverheadBenchmark\\.).*$"
+DEFAULT_BENCHMARK_REGEX="^(?!org\\.safere\\.benchmark\\.(CrosscheckOverheadBenchmark|CrossEngineNoForkBenchmark|CrossEngineColdStartBenchmark|PathologicalBenchmark|PathologicalComparisonBenchmark|PatternSetBenchmark|UnicodeFirstCompileBenchmark)\\.).*$"
 
 # Empirically selected Java benchmark settings. See
 # safere-benchmarks/CONFIGURATION_EVALUATION.md.
@@ -62,11 +61,12 @@ STANDARD_OPTS="-f 2 -wi 2 -w 500ms -i 5 -r 500ms"
 LONG_OPTS="-f 2 -wi 3 -w 1 -i 5 -r 1"
 SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 FIRST_COMPILE_OPTS="-f 10 -wi 0 -i 1 -r 1 -bm ss"
+COLD_START_SMOKE_OPTS="-f 1 -wi 0 -i 1 -r 1 -bm ss"
 
-# Pathological benchmarks must run without forking (JDK can hang).
-PATHOLOGICAL_STANDARD_OPTS="-f 0 -wi 2 -w 500ms -i 5 -r 500ms"
-PATHOLOGICAL_LONG_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
-PATHOLOGICAL_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
+# Generic options for workloads whose declarations require no-fork execution.
+NO_FORK_STANDARD_OPTS="-f 0 -wi 2 -w 500ms -i 5 -r 500ms"
+NO_FORK_LONG_OPTS="-f 0 -wi 3 -w 1 -i 5 -r 1"
+NO_FORK_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 
 usage() {
   cat <<EOF
@@ -131,19 +131,23 @@ done
 
 if [ "$MODE" = "first-compile" ]; then
   JMH_OPTS="$FIRST_COMPILE_OPTS"
-  PATHOLOGICAL_JMH_OPTS="$FIRST_COMPILE_OPTS"
+  NO_FORK_JMH_OPTS="$FIRST_COMPILE_OPTS"
+  COLD_START_JMH_OPTS="$FIRST_COMPILE_OPTS"
   echo "=== First-compile mode (cold Unicode/CLI signal) ==="
 elif [ "$MODE" = "smoke" ]; then
   JMH_OPTS="$SMOKE_OPTS"
-  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_SMOKE_OPTS"
+  NO_FORK_JMH_OPTS="$NO_FORK_SMOKE_OPTS"
+  COLD_START_JMH_OPTS="$COLD_START_SMOKE_OPTS"
   echo "=== Smoke-test mode (CI only) ==="
 elif [ "$MODE" = "long" ]; then
   JMH_OPTS="$LONG_OPTS"
-  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_LONG_OPTS"
+  NO_FORK_JMH_OPTS="$NO_FORK_LONG_OPTS"
+  COLD_START_JMH_OPTS="$FIRST_COMPILE_OPTS"
   echo "=== Long mode (confirmation run) ==="
 else
   JMH_OPTS="$STANDARD_OPTS"
-  PATHOLOGICAL_JMH_OPTS="$PATHOLOGICAL_STANDARD_OPTS"
+  NO_FORK_JMH_OPTS="$NO_FORK_STANDARD_OPTS"
+  COLD_START_JMH_OPTS="$FIRST_COMPILE_OPTS"
   echo "=== Standard mode ==="
 fi
 
@@ -184,6 +188,21 @@ CROSS_ENGINE_SCALING_TRIALS="$(
     -cp "$BENCHMARK_JAR" \
     org.safere.benchmark.CrossEngineBenchmarkPlan microseconds
 )"
+CROSS_ENGINE_NO_FORK_TRIALS="$(
+  java $JVM_ARGS \
+    -cp "$BENCHMARK_JAR" \
+    org.safere.benchmark.CrossEngineBenchmarkPlan no-fork-microseconds
+)"
+CROSS_ENGINE_COLD_START_TRIALS="$(
+  java $JVM_ARGS \
+    -cp "$BENCHMARK_JAR" \
+    org.safere.benchmark.CrossEngineBenchmarkPlan cold-start
+)"
+SPECIALIZED_TRIALS="$(
+  java $JVM_ARGS \
+    -cp "$BENCHMARK_JAR" \
+    org.safere.benchmark.SpecializedBenchmarkPlan average-time
+)"
 CROSS_ENGINE_PARAM_ARGS=()
 if [[ ! " ${JMH_EXTRA_ARGS[*]-} " =~ [[:space:]]crossEngineTrial= ]]; then
   CROSS_ENGINE_PARAM_ARGS+=(-p "crossEngineTrial=$CROSS_ENGINE_TRIALS")
@@ -191,21 +210,23 @@ fi
 if [[ ! " ${JMH_EXTRA_ARGS[*]-} " =~ [[:space:]]crossEngineScalingTrial= ]]; then
   CROSS_ENGINE_PARAM_ARGS+=(-p "crossEngineScalingTrial=$CROSS_ENGINE_SCALING_TRIALS")
 fi
-
-# Returns true if the benchmark name matches a pathological benchmark.
-is_pathological() {
-  case "$1" in
-    *Pathological*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
+if [[ ! " ${JMH_EXTRA_ARGS[*]-} " =~ [[:space:]]crossEngineNoForkTrial= ]]; then
+  CROSS_ENGINE_PARAM_ARGS+=(-p "crossEngineNoForkTrial=$CROSS_ENGINE_NO_FORK_TRIALS")
+fi
+if [[ ! " ${JMH_EXTRA_ARGS[*]-} " =~ [[:space:]]crossEngineColdStartTrial= ]]; then
+  CROSS_ENGINE_PARAM_ARGS+=(-p "crossEngineColdStartTrial=$CROSS_ENGINE_COLD_START_TRIALS")
+fi
+if [[ ! " ${JMH_EXTRA_ARGS[*]-} " =~ [[:space:]]specializedTrial= ]]; then
+  CROSS_ENGINE_PARAM_ARGS+=(-p "specializedTrial=$SPECIALIZED_TRIALS")
+fi
 
 run_benchmark() {
   local bench="$1"
   local opts="$JMH_OPTS"
-  if is_pathological "$bench"; then
-    opts="$PATHOLOGICAL_JMH_OPTS"
-  fi
+  case "$bench" in
+    *CrossEngineNoForkBenchmark*) opts="$NO_FORK_JMH_OPTS" ;;
+    *CrossEngineColdStartBenchmark*) opts="$COLD_START_JMH_OPTS" ;;
+  esac
   if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
     echo "=== Running $bench ($opts ${JMH_EXTRA_ARGS[*]}) ==="
     java \

--- a/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
+++ b/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
@@ -74,5 +74,7 @@ construction and mutations such as reset or region configuration occur inside
 the timed invocation.
 
 Specialized benchmarks remain separate only when their mechanics require a
-dedicated execution mode, including memory, cold start, pathological
-safeguards, PatternSet, and dedicated UTF-8 API behavior.
+dedicated execution mode, including retained memory, cold start, declared
+no-fork safeguards, PatternSet, diagnostics, and dedicated UTF-8 API behavior.
+Those shapes use generic runners selected from the declaration; see
+[`SPECIALIZED_MEASUREMENT_MODES.md`](SPECIALIZED_MEASUREMENT_MODES.md).

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -58,9 +58,11 @@ version is used by a released benchmark plan.
 ## Stable identities and expansion
 
 Input and workload `axes` are ordered maps. Expansion is a deterministic
-Cartesian product in declaration order. Axis values are strings, integers, or
-booleans, and every workload axis must appear in the workload ID. This makes
-the expanded ID an unambiguous historical result identity.
+Cartesian product in declaration order. Axis values are strings, integers,
+booleans, or labeled `{"id": "...", "value": ...}` scalars. A labeled value
+uses `id` in the stable workload identity and `value` in the expanded pattern.
+Every workload axis must appear in the workload ID. This makes the expanded ID
+an unambiguous historical result identity.
 
 Axis references use `{axisName}` in IDs, input references, patterns, string
 recipe arguments, and scalar integer recipe arguments. Expanded workload IDs
@@ -128,16 +130,17 @@ Version 1 operations are grouped below. Names are exact JSON values.
 |---|---|
 | Matching | `matches`, `find`, `lookingAt`, `findAllCount`, `findAllLengthSum`, `findAllGroupLengthSum`, `matchesCorpus`, `matchesGroupLengthSum`, `findGroupPresent`, `findGroup`, `captureGroups` |
 | Replacement and splitting | `replaceFirst`, `replaceAll`, `replaceAllLengthSum`, `appendReplacement`, `manualReplaceAll`, `split`, `splitLengthSum` |
-| Compilation and matcher state | `compile`, `compileAndFind`, `matcherConstruction`, `matcherResetFind`, `matcherRegionFind`, `findInWindow` |
+| Compilation and matcher state | `compile`, `compileAndFind`, `findRotatingUtf16`, `compileAndFindRotatingUtf16`, `matcherConstruction`, `matcherResetFind`, `matcherRegionFind`, `findInWindow` |
 | Pattern collections | `patternSetCompile`, `patternSetFind`, `patternSetMatches` |
-| UTF-8 | `utf8CaptureBounds`, `utf8Replacement` |
+| UTF-8 | `utf8CaptureBounds`, `utf8DecodeFind`, `utf8Replacement` |
 | Diagnostics and memory | `analyzePattern`, `cachedAnalysis`, `compileAndAnalyze`, `dfaCacheGrowth`, `diagnosticsFind` |
 
 Operation-specific data uses a strict `arguments` object rather than
 workload-family fields. Group-consuming operations use `group` or `groups`;
 replacement operations require `replacement`; split operations accept `limit`;
-and PatternSet operations require `anchor` with `anchored` or `unanchored`.
-Arguments may reference declared axes.
+PatternSet operations require `anchor` with `anchored` or `unanchored` and may
+declare `patternCount`; flagged compilation uses `flagSet`; rotating UTF-16
+operations use `seed` and `count`. Arguments may reference declared axes.
 
 Flags are `caseInsensitive`, `multiline`, `dotAll`, `unicodeCase`,
 `comments`, `literal`, and `unicodeCharacterClass`. Engine adapters declare
@@ -148,10 +151,11 @@ Engine-neutral requirements are `find`, `matches`, `lookingAt`,
 `captureText`, `namedGroups`, `replace`, `numberedReplacement`,
 `namedReplacement`, `appendReplacement`, `functionalReplacement`, `split`,
 `matcherState`, `regions`, `bounds`, `patternSet`, `utf8Input`,
-`utf8Replacement`, `diagnostics`, and `dfaCache`. Operations and lifecycle
-steps derive their intrinsic requirements automatically. Declarations add
-requirements only for semantic details that cannot be inferred, such as the
-replacement-reference form.
+`utf8Replacement`, `diagnostics`, `dfaCache`, `flaggedCompile`,
+`javaCharacterClass`, `linearTime`, and `retainedHeap`. Operations and
+lifecycle steps derive their intrinsic requirements automatically.
+Declarations add requirements only for semantic details that cannot be
+inferred, such as the replacement-reference form.
 
 Input representations are `javaString`, `preexistingUtf8`, and
 `javaStringWithTimedUtf8Conversion`. Result consumption is `boolean`,
@@ -201,6 +205,9 @@ The version 1 modes are:
 | `retainedMemory` | Retained-size measurement |
 | `subprocessMemory` | Process-level memory measurement |
 
+Generic runner selection and the boundary of each unusual mode are documented in
+[`SPECIALIZED_MEASUREMENT_MODES.md`](SPECIALIZED_MEASUREMENT_MODES.md).
+
 Timing units are `nanoseconds`, `microseconds`, `milliseconds`, or `bytes`.
 Constraints are `noFork`, `freshProcessPerInvocation`, `retainState`,
 `prematerializedInput`, and `allocationProfile`. Incompatible combinations,
@@ -227,6 +234,5 @@ The schema uses generic concepts for every current family:
 | Diagnostics and analysis | Diagnostics/analysis operations and requirements |
 | Memory and cold start | Retained-memory, subprocess-memory, and cold-start modes |
 
-Future migration issues replace the legacy declarations and runners with this
-model. They must preserve existing stable IDs and timing boundaries unless a
-change is explicitly documented.
+The generic runners now execute these declarations. Legacy benchmark classes
+remain temporary mirrors until the cleanup tracked separately under #606.

--- a/safere-benchmarks/SPECIALIZED_MEASUREMENT_MODES.md
+++ b/safere-benchmarks/SPECIALIZED_MEASUREMENT_MODES.md
@@ -1,0 +1,47 @@
+# Specialized benchmark measurement modes
+
+Specialized workloads use the same declarations, capability join, stable trial IDs, and
+materialized inputs as ordinary cross-engine workloads. Separate runners exist only where the
+measurement boundary requires different JMH or process machinery.
+
+| Declared mode or constraint | Generic runner | Boundary |
+| --- | --- | --- |
+| `averageTime` | `CrossEngineBenchmark`, `CrossEngineScalingBenchmark` | Normal forked JMH execution |
+| `noFork` | `CrossEngineNoForkBenchmark` | In-process JMH execution (`-f 0`) |
+| `singleShotColdStart` | `CrossEngineColdStartBenchmark` | One invocation in each fresh fork |
+| SafeRE-specific `averageTime` operation | `SpecializedBenchmark` | One operation adapter selected from the plan |
+| `retainedMemory` | `MemoryBenchmark` | Standalone heap-delta process with retained objects |
+
+`run-java-benchmarks.sh` obtains each runner's trial parameter values from the plan. No-fork
+scheduling therefore depends on the `noFork` constraint, not on a benchmark family or class-name
+substring. Cold-start setup resolves a declaration but does not compile its pattern before the
+single measured invocation.
+
+The schema also validates `subprocessMemory`. The current suite has no RSS or other
+subprocess-memory workload, so there is no active runner invocation for that mode. Process launch,
+output capture, and OS-specific resident-set observation are measurement infrastructure rather
+than a hidden workload; a future declaration using this mode must add its generic process observer
+before it can be included in the implemented-operation set.
+
+## Specialized operations
+
+The generic SafeRE-specific runner implements PatternSet matching, direct UTF-8 capture bounds,
+decode-inclusive UTF-8 matching, byte-native replacement, borrowed UTF-8 windows, UTF-8 view
+construction, static pattern analysis, and diagnostics listener modes. Retained-memory execution
+implements compiled-pattern size and DFA-cache growth. Cases, patterns, parameters, inputs,
+listener choices, anchors, and timing boundaries are all declared in `benchmark-data.json`.
+
+The following remaining Java classes are measurement infrastructure or temporary legacy mirrors,
+not additional workload definitions:
+
+- `MemoryScalingBenchmark` applies JMH's allocation profiler to trials already declared in the
+  cross-engine plan.
+- `CrosscheckOverheadBenchmark` measures optional crosscheck instrumentation and remains excluded
+  from normal benchmark collection.
+- `UnicodeColdStartMain` is a plain-process diagnostic harness; declared cold-start measurements
+  use `CrossEngineColdStartBenchmark`.
+- `ByteMatchingBenchmark` contains legacy representation-adapter comparisons whose logical regex
+  workloads are declared in the ordinary plan. Decode-inclusive representation variants belong in
+  engine adapters, not workload declarations.
+- Workload-specific JMH classes retained during the migration mirror declarations and are removed
+  by the final cleanup and coverage audit (#614).

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1605,6 +1605,209 @@
         "kind": "literal",
         "text": "item1 item22 item333"
       }
+    },
+    {
+      "id": "patternSet.match",
+      "recipe": {
+        "kind": "literal",
+        "text": "ERROR: connection timeout after 30s to host db-primary.internal:5432"
+      }
+    },
+    {
+      "id": "patternSet.noMatch",
+      "recipe": {
+        "kind": "literal",
+        "text": "The quick brown fox jumps over the lazy dog near the riverbank"
+      }
+    },
+    {
+      "id": "utf8.captureFree.asciiEarly",
+      "recipe": {
+        "kind": "literal",
+        "text": "ERROR request completed"
+      }
+    },
+    {
+      "id": "utf8.captureFree.asciiLate",
+      "recipe": {
+        "kind": "literal",
+        "text": "request completed with ERROR"
+      }
+    },
+    {
+      "id": "utf8.captureFree.asciiNoMatch",
+      "recipe": {
+        "kind": "literal",
+        "text": "request completed normally"
+      }
+    },
+    {
+      "id": "utf8.captureFree.multibyteEarly",
+      "recipe": {
+        "kind": "literal",
+        "text": "错误：请求失败"
+      }
+    },
+    {
+      "id": "utf8.captureFree.multibyteLate",
+      "recipe": {
+        "kind": "literal",
+        "text": "请求处理结束：错误"
+      }
+    },
+    {
+      "id": "utf8.captureFree.multibyteNoMatch",
+      "recipe": {
+        "kind": "literal",
+        "text": "请求处理成功"
+      }
+    },
+    {
+      "id": "utf8.repeatedFind.ascii",
+      "recipe": {
+        "kind": "literal",
+        "text": "one two three four five"
+      }
+    },
+    {
+      "id": "utf8.repeatedFind.multibyte",
+      "recipe": {
+        "kind": "literal",
+        "text": "one café 東京 naïve"
+      }
+    },
+    {
+      "id": "utf8.captureBounds.numbered",
+      "recipe": {
+        "kind": "literal",
+        "text": "user=service&token=abc123"
+      }
+    },
+    {
+      "id": "utf8.captureBounds.named",
+      "recipe": {
+        "kind": "literal",
+        "text": "city=東京&name=Renée"
+      }
+    },
+    {
+      "id": "utf8.captureBounds.nonparticipating",
+      "recipe": {
+        "kind": "literal",
+        "text": "dog"
+      }
+    },
+    {
+      "id": "utf8.emptyMatch",
+      "recipe": {
+        "kind": "literal",
+        "text": "a💰有"
+      }
+    },
+    {
+      "id": "utf8.window",
+      "recipe": {
+        "kind": "literal",
+        "text": "sentinel-before-city=東京&name=Renée-sentinel-after"
+      }
+    },
+    {
+      "id": "utf8.construction",
+      "recipe": {
+        "kind": "literal",
+        "text": "one café 東京 naïve"
+      }
+    },
+    {
+      "id": "utf8.replacement.literal",
+      "recipe": {
+        "kind": "literal",
+        "text": "错误 then 错误"
+      }
+    },
+    {
+      "id": "utf8.replacement.numbered",
+      "recipe": {
+        "kind": "literal",
+        "text": "city=東京&name=Renée"
+      }
+    },
+    {
+      "id": "utf8.replacement.named",
+      "recipe": {
+        "kind": "literal",
+        "text": "city=東京&name=Renée"
+      }
+    },
+    {
+      "id": "diagnostics.tinyLiteralMatches",
+      "recipe": {
+        "kind": "literal",
+        "text": "abc"
+      }
+    },
+    {
+      "id": "diagnostics.tinyLiteralFindHit",
+      "recipe": {
+        "kind": "literal",
+        "text": "xabc"
+      }
+    },
+    {
+      "id": "diagnostics.tinyLiteralFindMiss",
+      "recipe": {
+        "kind": "literal",
+        "text": "xyz"
+      }
+    },
+    {
+      "id": "diagnostics.onePassMatches",
+      "recipe": {
+        "kind": "literal",
+        "text": "HEADER:12345"
+      }
+    },
+    {
+      "id": "diagnostics.dfaLongFind",
+      "recipe": {
+        "kind": "literal",
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxaaab"
+      }
+    },
+    {
+      "id": "diagnostics.bitStateShortMatches",
+      "recipe": {
+        "kind": "literal",
+        "text": "aaaaab"
+      }
+    },
+    {
+      "id": "diagnostics.nfaLongMatches",
+      "recipe": {
+        "kind": "literal",
+        "text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"
+      }
+    },
+    {
+      "id": "diagnostics.dfaSparseReplaceAll",
+      "recipe": {
+        "kind": "literal",
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx aaab xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+    },
+    {
+      "id": "diagnostics.charClassDenseReplaceAll",
+      "recipe": {
+        "kind": "literal",
+        "text": "1 22 333 4444 55555 666666"
+      }
+    },
+    {
+      "id": "diagnostics.charClassNoMatchReplaceAll",
+      "recipe": {
+        "kind": "literal",
+        "text": "no digits here"
+      }
     }
   ],
   "regex": {
@@ -5906,6 +6109,2775 @@
           {
             "kind": "reset"
           }
+        ]
+      }
+    },
+    {
+      "id": "PathologicalComparisonBenchmark.pathological.10",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?aaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.10"
+      ],
+      "requirements": [],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalComparisonBenchmark.pathological.15",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.15"
+      ],
+      "requirements": [],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalComparisonBenchmark.pathological.20",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.20"
+      ],
+      "requirements": [],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.10",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?aaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.10"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.15",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.15"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.20",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.20"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.25",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.25"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.30",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.30"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.50",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.50"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PathologicalBenchmark.pathological.100",
+      "operation": "matches",
+      "patterns": [
+        "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ],
+      "inputs": [
+        "pathological.text.100"
+      ],
+      "requirements": [
+        "linearTime"
+      ],
+      "inputRepresentations": [
+        "javaString",
+        "javaStringWithTimedUtf8Conversion"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "noFork",
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "UnicodeCompileBenchmark.compile.{regex}.{flagSet}",
+      "operation": "compile",
+      "patterns": [
+        "{regex}"
+      ],
+      "axes": {
+        "regex": [
+          {
+            "id": "letter",
+            "value": "\\p{L}+"
+          },
+          {
+            "id": "uppercaseLetter",
+            "value": "\\p{Lu}+"
+          },
+          {
+            "id": "lowercaseLetter",
+            "value": "\\p{Ll}+"
+          },
+          {
+            "id": "titlecaseLetter",
+            "value": "\\p{Lt}+"
+          },
+          {
+            "id": "alphabetic",
+            "value": "\\p{IsAlphabetic}+"
+          },
+          {
+            "id": "ideographic",
+            "value": "\\p{IsIdeographic}+"
+          },
+          {
+            "id": "emoji",
+            "value": "\\p{IsEmoji}+"
+          },
+          {
+            "id": "extendedPictographic",
+            "value": "\\p{IsExtended_Pictographic}+"
+          },
+          {
+            "id": "scriptLatin",
+            "value": "\\p{script=Latin}+"
+          },
+          {
+            "id": "scriptHan",
+            "value": "\\p{script=Han}+"
+          },
+          {
+            "id": "blockBasicLatin",
+            "value": "\\p{block=BasicLatin}+"
+          },
+          {
+            "id": "blockCjk",
+            "value": "\\p{block=CJK_Unified_Ideographs}+"
+          },
+          {
+            "id": "word",
+            "value": "\\w+"
+          },
+          {
+            "id": "digit",
+            "value": "\\d+"
+          },
+          {
+            "id": "space",
+            "value": "\\s+"
+          },
+          {
+            "id": "asciiLower",
+            "value": "[a-z]+"
+          },
+          {
+            "id": "asciiRange",
+            "value": "[h-j]+"
+          },
+          {
+            "id": "letterIntersection",
+            "value": "[\\p{L}&&[^\\p{Lu}]]+"
+          },
+          {
+            "id": "identifier",
+            "value": "\\p{L}[\\p{L}\\p{Nd}_]*"
+          }
+        ],
+        "flagSet": [
+          "0",
+          "CASE_INSENSITIVE",
+          "CASE_INSENSITIVE_UNICODE_CASE",
+          "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS"
+        ]
+      },
+      "arguments": {
+        "flagSet": "{flagSet}"
+      },
+      "requirements": [
+        "flaggedCompile"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "compileOnly",
+        "timingUnit": "microseconds"
+      }
+    },
+    {
+      "id": "UnicodeFirstCompileBenchmark.firstCompile.{regex}.{flagSet}",
+      "operation": "compile",
+      "patterns": [
+        "{regex}"
+      ],
+      "axes": {
+        "regex": [
+          {
+            "id": "letter",
+            "value": "\\p{L}+"
+          },
+          {
+            "id": "uppercaseLetter",
+            "value": "\\p{Lu}+"
+          },
+          {
+            "id": "alphabetic",
+            "value": "\\p{IsAlphabetic}+"
+          },
+          {
+            "id": "emoji",
+            "value": "\\p{IsEmoji}+"
+          },
+          {
+            "id": "extendedPictographic",
+            "value": "\\p{IsExtended_Pictographic}+"
+          },
+          {
+            "id": "scriptLatin",
+            "value": "\\p{script=Latin}+"
+          },
+          {
+            "id": "scriptHan",
+            "value": "\\p{script=Han}+"
+          },
+          {
+            "id": "blockBasicLatin",
+            "value": "\\p{block=BasicLatin}+"
+          },
+          {
+            "id": "word",
+            "value": "\\w+"
+          },
+          {
+            "id": "asciiLower",
+            "value": "[a-z]+"
+          },
+          {
+            "id": "asciiRange",
+            "value": "[h-j]+"
+          },
+          {
+            "id": "identifier",
+            "value": "\\p{L}[\\p{L}\\p{Nd}_]*"
+          }
+        ],
+        "flagSet": [
+          "0",
+          "CASE_INSENSITIVE_UNICODE_CASE",
+          "UNICODE_CHARACTER_CLASS"
+        ]
+      },
+      "arguments": {
+        "flagSet": "{flagSet}"
+      },
+      "requirements": [
+        "flaggedCompile"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "singleShotColdStart",
+        "timingUnit": "milliseconds",
+        "constraints": [
+          "freshProcessPerInvocation"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.compileSimple",
+      "operation": "compile",
+      "patterns": [
+        "hello"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.compileMedium",
+      "operation": "compile",
+      "patterns": [
+        "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.compileComplex",
+      "operation": "compile",
+      "patterns": [
+        "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.compileAlternation",
+      "operation": "compile",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply|waldo|fred|plugh|xyzzy"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.literalMatch",
+      "operation": "compile",
+      "patterns": [
+        "hello"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.charClassMatch",
+      "operation": "compile",
+      "patterns": [
+        "[a-zA-Z]+"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.alternationFind",
+      "operation": "compile",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.captureGroups",
+      "operation": "compile",
+      "patterns": [
+        "(\\d{4})-(\\d{2})-(\\d{2})"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.findInText",
+      "operation": "compile",
+      "patterns": [
+        "\\b\\w+ing\\b"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.emailFind",
+      "operation": "compile",
+      "patterns": [
+        "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+      ],
+      "requirements": [
+        "retainedHeap"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "compiledObject",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.dfaCacheGrowth.simple",
+      "operation": "dfaCacheGrowth",
+      "patterns": [
+        "hello"
+      ],
+      "inputs": [
+        "memory.dfaCacheText"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.dfaCacheGrowth.medium",
+      "operation": "dfaCacheGrowth",
+      "patterns": [
+        "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})"
+      ],
+      "inputs": [
+        "memory.dfaCacheText"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.dfaCacheGrowth.complex",
+      "operation": "dfaCacheGrowth",
+      "patterns": [
+        "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+      ],
+      "inputs": [
+        "memory.dfaCacheText"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "MemoryBenchmark.dfaCacheGrowth.alternation",
+      "operation": "dfaCacheGrowth",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply|waldo|fred|plugh|xyzzy"
+      ],
+      "inputs": [
+        "memory.dfaCacheText"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "retainedMemory",
+        "timingUnit": "bytes",
+        "constraints": [
+          "retainState"
+        ]
+      }
+    },
+    {
+      "id": "PatternSetBenchmark.unanchoredMatch.{patternCount}",
+      "operation": "patternSetMatches",
+      "patterns": [
+        "ERROR",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "FATAL",
+        "connection\\s+timeout",
+        "\\d+\\.\\d+\\.\\d+\\.\\d+",
+        "host\\s+\\S+",
+        "port\\s*:\\s*\\d+",
+        "after\\s+\\d+s",
+        "[A-Z]{2,}:",
+        "\\w+\\.internal",
+        "db-\\w+",
+        "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+",
+        "timeout|refused|reset|closed",
+        "\\[\\w+\\]",
+        "status\\s*=\\s*\\d+",
+        "retry\\s+\\d+/\\d+",
+        "latency\\s*>\\s*\\d+ms",
+        "queue\\s+full",
+        "memory\\s+\\d+[kmg]b?",
+        "cpu\\s+\\d+%",
+        "disk\\s+(full|low)",
+        "\\w+Exception",
+        "at\\s+\\w+\\.\\w+\\(",
+        "null\\s*pointer",
+        "stack\\s*overflow",
+        "out\\s+of\\s+memory",
+        "permission\\s+denied",
+        "not\\s+found",
+        "already\\s+exists",
+        "invalid\\s+\\w+",
+        "expired",
+        "unauthorized",
+        "rate\\s+limit",
+        "circuit\\s+breaker",
+        "health\\s+check\\s+failed",
+        "graceful\\s+shutdown",
+        "leader\\s+election",
+        "split\\s+brain",
+        "rebalancing",
+        "partition\\s+\\d+",
+        "offset\\s+\\d+",
+        "consumer\\s+group",
+        "dead\\s+letter",
+        "backpressure",
+        "throttled",
+        "degraded",
+        "failover",
+        "rollback",
+        "checkpoint\\s+\\d+",
+        "snapshot\\s+\\w+",
+        "compaction",
+        "gc\\s+pause\\s+\\d+ms",
+        "safepoint",
+        "jit\\s+compilation",
+        "class\\s+loading",
+        "thread\\s+pool\\s+\\w+",
+        "blocked\\s+thread",
+        "deadlock",
+        "lock\\s+contention",
+        "cache\\s+(hit|miss)",
+        "eviction",
+        "bloom\\s+filter"
+      ],
+      "inputs": [
+        "patternSet.match"
+      ],
+      "axes": {
+        "patternCount": [
+          4,
+          16,
+          64
+        ]
+      },
+      "arguments": {
+        "anchor": "unanchored",
+        "patternCount": "{patternCount}"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PatternSetBenchmark.unanchoredNoMatch.{patternCount}",
+      "operation": "patternSetMatches",
+      "patterns": [
+        "ERROR",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "FATAL",
+        "connection\\s+timeout",
+        "\\d+\\.\\d+\\.\\d+\\.\\d+",
+        "host\\s+\\S+",
+        "port\\s*:\\s*\\d+",
+        "after\\s+\\d+s",
+        "[A-Z]{2,}:",
+        "\\w+\\.internal",
+        "db-\\w+",
+        "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+",
+        "timeout|refused|reset|closed",
+        "\\[\\w+\\]",
+        "status\\s*=\\s*\\d+",
+        "retry\\s+\\d+/\\d+",
+        "latency\\s*>\\s*\\d+ms",
+        "queue\\s+full",
+        "memory\\s+\\d+[kmg]b?",
+        "cpu\\s+\\d+%",
+        "disk\\s+(full|low)",
+        "\\w+Exception",
+        "at\\s+\\w+\\.\\w+\\(",
+        "null\\s*pointer",
+        "stack\\s*overflow",
+        "out\\s+of\\s+memory",
+        "permission\\s+denied",
+        "not\\s+found",
+        "already\\s+exists",
+        "invalid\\s+\\w+",
+        "expired",
+        "unauthorized",
+        "rate\\s+limit",
+        "circuit\\s+breaker",
+        "health\\s+check\\s+failed",
+        "graceful\\s+shutdown",
+        "leader\\s+election",
+        "split\\s+brain",
+        "rebalancing",
+        "partition\\s+\\d+",
+        "offset\\s+\\d+",
+        "consumer\\s+group",
+        "dead\\s+letter",
+        "backpressure",
+        "throttled",
+        "degraded",
+        "failover",
+        "rollback",
+        "checkpoint\\s+\\d+",
+        "snapshot\\s+\\w+",
+        "compaction",
+        "gc\\s+pause\\s+\\d+ms",
+        "safepoint",
+        "jit\\s+compilation",
+        "class\\s+loading",
+        "thread\\s+pool\\s+\\w+",
+        "blocked\\s+thread",
+        "deadlock",
+        "lock\\s+contention",
+        "cache\\s+(hit|miss)",
+        "eviction",
+        "bloom\\s+filter"
+      ],
+      "inputs": [
+        "patternSet.noMatch"
+      ],
+      "axes": {
+        "patternCount": [
+          4,
+          16,
+          64
+        ]
+      },
+      "arguments": {
+        "anchor": "unanchored",
+        "patternCount": "{patternCount}"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PatternSetBenchmark.anchoredMatch.{patternCount}",
+      "operation": "patternSetMatches",
+      "patterns": [
+        "ERROR",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "FATAL",
+        "connection\\s+timeout",
+        "\\d+\\.\\d+\\.\\d+\\.\\d+",
+        "host\\s+\\S+",
+        "port\\s*:\\s*\\d+",
+        "after\\s+\\d+s",
+        "[A-Z]{2,}:",
+        "\\w+\\.internal",
+        "db-\\w+",
+        "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+",
+        "timeout|refused|reset|closed",
+        "\\[\\w+\\]",
+        "status\\s*=\\s*\\d+",
+        "retry\\s+\\d+/\\d+",
+        "latency\\s*>\\s*\\d+ms",
+        "queue\\s+full",
+        "memory\\s+\\d+[kmg]b?",
+        "cpu\\s+\\d+%",
+        "disk\\s+(full|low)",
+        "\\w+Exception",
+        "at\\s+\\w+\\.\\w+\\(",
+        "null\\s*pointer",
+        "stack\\s*overflow",
+        "out\\s+of\\s+memory",
+        "permission\\s+denied",
+        "not\\s+found",
+        "already\\s+exists",
+        "invalid\\s+\\w+",
+        "expired",
+        "unauthorized",
+        "rate\\s+limit",
+        "circuit\\s+breaker",
+        "health\\s+check\\s+failed",
+        "graceful\\s+shutdown",
+        "leader\\s+election",
+        "split\\s+brain",
+        "rebalancing",
+        "partition\\s+\\d+",
+        "offset\\s+\\d+",
+        "consumer\\s+group",
+        "dead\\s+letter",
+        "backpressure",
+        "throttled",
+        "degraded",
+        "failover",
+        "rollback",
+        "checkpoint\\s+\\d+",
+        "snapshot\\s+\\w+",
+        "compaction",
+        "gc\\s+pause\\s+\\d+ms",
+        "safepoint",
+        "jit\\s+compilation",
+        "class\\s+loading",
+        "thread\\s+pool\\s+\\w+",
+        "blocked\\s+thread",
+        "deadlock",
+        "lock\\s+contention",
+        "cache\\s+(hit|miss)",
+        "eviction",
+        "bloom\\s+filter"
+      ],
+      "inputs": [
+        "patternSet.match"
+      ],
+      "axes": {
+        "patternCount": [
+          4,
+          16,
+          64
+        ]
+      },
+      "arguments": {
+        "anchor": "anchored",
+        "patternCount": "{patternCount}"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PatternSetBenchmark.anchoredNoMatch.{patternCount}",
+      "operation": "patternSetMatches",
+      "patterns": [
+        "ERROR",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "FATAL",
+        "connection\\s+timeout",
+        "\\d+\\.\\d+\\.\\d+\\.\\d+",
+        "host\\s+\\S+",
+        "port\\s*:\\s*\\d+",
+        "after\\s+\\d+s",
+        "[A-Z]{2,}:",
+        "\\w+\\.internal",
+        "db-\\w+",
+        "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+",
+        "timeout|refused|reset|closed",
+        "\\[\\w+\\]",
+        "status\\s*=\\s*\\d+",
+        "retry\\s+\\d+/\\d+",
+        "latency\\s*>\\s*\\d+ms",
+        "queue\\s+full",
+        "memory\\s+\\d+[kmg]b?",
+        "cpu\\s+\\d+%",
+        "disk\\s+(full|low)",
+        "\\w+Exception",
+        "at\\s+\\w+\\.\\w+\\(",
+        "null\\s*pointer",
+        "stack\\s*overflow",
+        "out\\s+of\\s+memory",
+        "permission\\s+denied",
+        "not\\s+found",
+        "already\\s+exists",
+        "invalid\\s+\\w+",
+        "expired",
+        "unauthorized",
+        "rate\\s+limit",
+        "circuit\\s+breaker",
+        "health\\s+check\\s+failed",
+        "graceful\\s+shutdown",
+        "leader\\s+election",
+        "split\\s+brain",
+        "rebalancing",
+        "partition\\s+\\d+",
+        "offset\\s+\\d+",
+        "consumer\\s+group",
+        "dead\\s+letter",
+        "backpressure",
+        "throttled",
+        "degraded",
+        "failover",
+        "rollback",
+        "checkpoint\\s+\\d+",
+        "snapshot\\s+\\w+",
+        "compaction",
+        "gc\\s+pause\\s+\\d+ms",
+        "safepoint",
+        "jit\\s+compilation",
+        "class\\s+loading",
+        "thread\\s+pool\\s+\\w+",
+        "blocked\\s+thread",
+        "deadlock",
+        "lock\\s+contention",
+        "cache\\s+(hit|miss)",
+        "eviction",
+        "bloom\\s+filter"
+      ],
+      "inputs": [
+        "patternSet.noMatch"
+      ],
+      "axes": {
+        "patternCount": [
+          4,
+          16,
+          64
+        ]
+      },
+      "arguments": {
+        "anchor": "anchored",
+        "patternCount": "{patternCount}"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeDecode.asciiEarly",
+      "operation": "utf8DecodeFind",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiEarly"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeDecode.asciiLate",
+      "operation": "utf8DecodeFind",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiLate"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeDecode.asciiNoMatch",
+      "operation": "utf8DecodeFind",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiNoMatch"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteEarly",
+      "operation": "utf8DecodeFind",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteEarly"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteLate",
+      "operation": "utf8DecodeFind",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteLate"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteNoMatch",
+      "operation": "utf8DecodeFind",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteNoMatch"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeBytes.asciiEarly",
+      "operation": "find",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiEarly"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeBytes.asciiLate",
+      "operation": "find",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiLate"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeBytes.asciiNoMatch",
+      "operation": "find",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiNoMatch"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly",
+      "operation": "find",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteEarly"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteLate",
+      "operation": "find",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteLate"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch",
+      "operation": "find",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteNoMatch"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeString.asciiEarly",
+      "operation": "find",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiEarly"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeString.asciiLate",
+      "operation": "find",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiLate"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeString.asciiNoMatch",
+      "operation": "find",
+      "patterns": [
+        "ERROR"
+      ],
+      "inputs": [
+        "utf8.captureFree.asciiNoMatch"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeString.multibyteEarly",
+      "operation": "find",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteEarly"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeString.multibyteLate",
+      "operation": "find",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteLate"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureFreeString.multibyteNoMatch",
+      "operation": "find",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.captureFree.multibyteNoMatch"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.repeatedFind.ascii",
+      "operation": "utf8CaptureBounds",
+      "patterns": [
+        "[A-Za-z]+"
+      ],
+      "inputs": [
+        "utf8.repeatedFind.ascii"
+      ],
+      "arguments": {
+        "groups": [
+          0
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.repeatedFind.multibyte",
+      "operation": "utf8CaptureBounds",
+      "patterns": [
+        "\\p{L}+"
+      ],
+      "inputs": [
+        "utf8.repeatedFind.multibyte"
+      ],
+      "arguments": {
+        "groups": [
+          0
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureBounds.numbered",
+      "operation": "utf8CaptureBounds",
+      "patterns": [
+        "([A-Za-z]+)=([^&]+)"
+      ],
+      "inputs": [
+        "utf8.captureBounds.numbered"
+      ],
+      "arguments": {
+        "groups": [
+          0,
+          1,
+          2
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureBounds.named",
+      "operation": "utf8CaptureBounds",
+      "patterns": [
+        "(?<key>[A-Za-z]+)=(?<value>[^&]+)"
+      ],
+      "inputs": [
+        "utf8.captureBounds.named"
+      ],
+      "arguments": {
+        "groups": [
+          0,
+          1,
+          2
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.captureBounds.nonparticipating",
+      "operation": "utf8CaptureBounds",
+      "patterns": [
+        "(cat)|(dog)"
+      ],
+      "inputs": [
+        "utf8.captureBounds.nonparticipating"
+      ],
+      "arguments": {
+        "groups": [
+          0,
+          1,
+          2
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.emptyMatchIteration",
+      "operation": "utf8CaptureBounds",
+      "patterns": [
+        ""
+      ],
+      "inputs": [
+        "utf8.emptyMatch"
+      ],
+      "arguments": {
+        "groups": [
+          0
+        ],
+        "bounds": "start"
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.window",
+      "operation": "findInWindow",
+      "patterns": [
+        "東京"
+      ],
+      "inputs": [
+        "utf8.window"
+      ],
+      "arguments": {},
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "lifecycle": {
+        "matcher": "newPerInvocation",
+        "steps": [
+          {
+            "kind": "region",
+            "start": 16,
+            "end": 39
+          }
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.construction.trusted",
+      "operation": "matcherConstruction",
+      "patterns": [
+        ""
+      ],
+      "inputs": [
+        "utf8.construction"
+      ],
+      "arguments": {
+        "mode": "trusted"
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.construction.validated",
+      "operation": "matcherConstruction",
+      "patterns": [
+        ""
+      ],
+      "inputs": [
+        "utf8.construction"
+      ],
+      "arguments": {
+        "mode": "validated"
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.requiredClassNonmatchBytes",
+      "operation": "find",
+      "patterns": [
+        "[一-龥]{3,}"
+      ],
+      "inputs": [
+        "utf8Matching.requiredClassNonmatch.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.requiredClassNonmatchMatcher",
+      "operation": "find",
+      "patterns": [
+        "[一-龥]{3,}"
+      ],
+      "inputs": [
+        "utf8Matching.requiredClassNonmatch.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "lifecycle": {
+        "matcher": "newPerInvocation"
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.requiredClassNonmatchString",
+      "operation": "find",
+      "patterns": [
+        "[一-龥]{3,}"
+      ],
+      "inputs": [
+        "utf8Matching.requiredClassNonmatch.text"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.literalScan.fourByte",
+      "operation": "find",
+      "patterns": [
+        "qjxv"
+      ],
+      "inputs": [
+        "utf8Matching.literalScan.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.literalScan.shortWord",
+      "operation": "find",
+      "patterns": [
+        "literal"
+      ],
+      "inputs": [
+        "utf8Matching.literalScan.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.literalScan.longWord",
+      "operation": "find",
+      "patterns": [
+        "coolfunctionname"
+      ],
+      "inputs": [
+        "utf8Matching.literalScan.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.hardFailure.1024",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "utf8Matching.hardFailure.1024"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.hardFailure.10240",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "utf8Matching.hardFailure.10240"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.hardFailure.102400",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "utf8Matching.hardFailure.102400"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.hardFailure.1048576",
+      "operation": "find",
+      "patterns": [
+        "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "utf8Matching.hardFailure.1048576"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "ByteReplacementBenchmark.literal",
+      "operation": "utf8Replacement",
+      "patterns": [
+        "错误"
+      ],
+      "inputs": [
+        "utf8.replacement.literal"
+      ],
+      "arguments": {
+        "replacement": "OK"
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "ByteReplacementBenchmark.numbered",
+      "operation": "utf8Replacement",
+      "patterns": [
+        "([A-Za-z]+)=([^&]+)"
+      ],
+      "inputs": [
+        "utf8.replacement.numbered"
+      ],
+      "arguments": {
+        "replacement": "$1=[$2]"
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "ByteReplacementBenchmark.named",
+      "operation": "utf8Replacement",
+      "patterns": [
+        "(?<key>[A-Za-z]+)=(?<value>[^&]+)"
+      ],
+      "inputs": [
+        "utf8.replacement.named"
+      ],
+      "arguments": {
+        "replacement": "${key}=[${value}]"
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "PatternAnalysisBenchmark.cachedAnalysis",
+      "operation": "cachedAnalysis",
+      "patterns": [
+        "^(?:(a)?)*$|(?i)\\b(error|warning|timeout)\\b"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds"
+      }
+    },
+    {
+      "id": "PatternAnalysisBenchmark.compileOnly",
+      "operation": "analyzePattern",
+      "patterns": [
+        "^(?:(a)?)*$|(?i)\\b(error|warning|timeout)\\b"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds"
+      }
+    },
+    {
+      "id": "PatternAnalysisBenchmark.compileAndAnalyze",
+      "operation": "compileAndAnalyze",
+      "patterns": [
+        "^(?:(a)?)*$|(?i)\\b(error|warning|timeout)\\b"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds"
+      }
+    },
+    {
+      "id": "JavaCharacterClassBenchmark.compileAndFindJavaLetter",
+      "operation": "compileAndFindRotatingUtf16",
+      "patterns": [
+        "\\p{javaLetter}"
+      ],
+      "arguments": {
+        "seed": 95413077,
+        "count": 4096
+      },
+      "requirements": [
+        "javaCharacterClass"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds"
+      }
+    },
+    {
+      "id": "JavaCharacterClassBenchmark.findJavaLetter",
+      "operation": "findRotatingUtf16",
+      "patterns": [
+        "\\p{javaLetter}"
+      ],
+      "arguments": {
+        "seed": 95413077,
+        "count": 4096
+      },
+      "requirements": [
+        "javaCharacterClass"
+      ],
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds"
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.tinyLiteralMatches",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "abc"
+      ],
+      "inputs": [
+        "diagnostics.tinyLiteralMatches"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "matches",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.tinyLiteralFindHit",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "abc"
+      ],
+      "inputs": [
+        "diagnostics.tinyLiteralFindHit"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "find",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.tinyLiteralFindMiss",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "abc"
+      ],
+      "inputs": [
+        "diagnostics.tinyLiteralFindMiss"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "find",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.onePassMatches",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "^([A-Z]+):(\\d+)$"
+      ],
+      "inputs": [
+        "diagnostics.onePassMatches"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "matches",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.dfaLongFind",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "a+b"
+      ],
+      "inputs": [
+        "diagnostics.dfaLongFind"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "find",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.bitStateShortMatches",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "(?:a|aa)+b"
+      ],
+      "inputs": [
+        "diagnostics.bitStateShortMatches"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "matches",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.nfaLongMatches",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "(?:a|aa)+b"
+      ],
+      "inputs": [
+        "diagnostics.nfaLongMatches"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "matches",
+        "listener": "disabled",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.dfaSparseReplaceAll",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "a+b"
+      ],
+      "inputs": [
+        "diagnostics.dfaSparseReplaceAll"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "replaceAll",
+        "listener": "disabled",
+        "replacement": "z"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.charClassDenseReplaceAll",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "[0-9]+"
+      ],
+      "inputs": [
+        "diagnostics.charClassDenseReplaceAll"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "replaceAll",
+        "listener": "disabled",
+        "replacement": "#"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsDisabledBenchmark.charClassNoMatchReplaceAll",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "[0-9]+"
+      ],
+      "inputs": [
+        "diagnostics.charClassNoMatchReplaceAll"
+      ],
+      "axes": {},
+      "arguments": {
+        "action": "replaceAll",
+        "listener": "disabled",
+        "replacement": "#"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.tinyLiteralMatches.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "abc"
+      ],
+      "inputs": [
+        "diagnostics.tinyLiteralMatches"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "matches",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.tinyLiteralFindHit.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "abc"
+      ],
+      "inputs": [
+        "diagnostics.tinyLiteralFindHit"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "find",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.tinyLiteralFindMiss.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "abc"
+      ],
+      "inputs": [
+        "diagnostics.tinyLiteralFindMiss"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "find",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.onePassMatches.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "^([A-Z]+):(\\d+)$"
+      ],
+      "inputs": [
+        "diagnostics.onePassMatches"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "matches",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.dfaLongFind.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "a+b"
+      ],
+      "inputs": [
+        "diagnostics.dfaLongFind"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "find",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.bitStateShortMatches.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "(?:a|aa)+b"
+      ],
+      "inputs": [
+        "diagnostics.bitStateShortMatches"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "matches",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.nfaLongMatches.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "(?:a|aa)+b"
+      ],
+      "inputs": [
+        "diagnostics.nfaLongMatches"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "matches",
+        "listener": "{listener}",
+        "replacement": ""
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.dfaSparseReplaceAll.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "a+b"
+      ],
+      "inputs": [
+        "diagnostics.dfaSparseReplaceAll"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "replaceAll",
+        "listener": "{listener}",
+        "replacement": "z"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.charClassDenseReplaceAll.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "[0-9]+"
+      ],
+      "inputs": [
+        "diagnostics.charClassDenseReplaceAll"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "replaceAll",
+        "listener": "{listener}",
+        "replacement": "#"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "DiagnosticsEnabledBenchmark.charClassNoMatchReplaceAll.{listener}",
+      "operation": "diagnosticsFind",
+      "patterns": [
+        "[0-9]+"
+      ],
+      "inputs": [
+        "diagnostics.charClassNoMatchReplaceAll"
+      ],
+      "axes": {
+        "listener": [
+          "noop",
+          "longAdder"
+        ]
+      },
+      "arguments": {
+        "action": "replaceAll",
+        "listener": "{listener}",
+        "replacement": "#"
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "blackholeObject",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
         ]
       }
     }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkOperation.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkOperation.java
@@ -7,6 +7,7 @@ package org.safere.benchmark;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Random;
 import org.openjdk.jmh.infra.Blackhole;
 
 /** Generic operation semantics and result consumption for cross-engine regex workloads. */
@@ -26,6 +27,9 @@ enum BenchmarkOperation {
   MANUAL_REPLACE_ALL(EngineCapability.APPEND_REPLACEMENT),
   SPLIT_LENGTH_SUM(EngineCapability.SPLIT),
   COMPILE(EngineCapability.COMPILE),
+  COMPILE_AND_FIND(EngineCapability.COMPILE, EngineCapability.FIND),
+  FIND_ROTATING_UTF16(EngineCapability.FIND),
+  COMPILE_AND_FIND_ROTATING_UTF16(EngineCapability.COMPILE, EngineCapability.FIND),
   MATCHER_RESET_FIND(EngineCapability.FIND, EngineCapability.MATCHER_RESET),
   MATCHER_REGION_FIND(EngineCapability.FIND, EngineCapability.REGIONS),
   FIND_GROUP_PRESENT(EngineCapability.FIND, EngineCapability.GROUP_TEXT),
@@ -57,6 +61,9 @@ enum BenchmarkOperation {
       case MANUAL_REPLACE_ALL -> MANUAL_REPLACE_ALL;
       case SPLIT_LENGTH_SUM -> SPLIT_LENGTH_SUM;
       case COMPILE -> COMPILE;
+      case COMPILE_AND_FIND -> COMPILE_AND_FIND;
+      case FIND_ROTATING_UTF16 -> FIND_ROTATING_UTF16;
+      case COMPILE_AND_FIND_ROTATING_UTF16 -> COMPILE_AND_FIND_ROTATING_UTF16;
       case MATCHER_RESET_FIND -> MATCHER_RESET_FIND;
       case MATCHER_REGION_FIND -> MATCHER_REGION_FIND;
       case FIND_GROUP_PRESENT -> FIND_GROUP_PRESENT;
@@ -79,15 +86,31 @@ enum BenchmarkOperation {
       int[] groups,
       String replacement,
       int limit,
-      DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle) {
+      DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
+      String flagSet,
+      int seed,
+      int count) {
     if (this == COMPILE) {
-      return blackhole -> blackhole.consume(variant.compileForBenchmark(patternSources.getFirst()));
+      return blackhole ->
+          blackhole.consume(variant.compileForBenchmark(patternSources.getFirst(), flagSet));
+    }
+    if (this == FIND_ROTATING_UTF16 || this == COMPILE_AND_FIND_ROTATING_UTF16) {
+      return rotatingUtf16Task(
+          variant,
+          patternSources.getFirst(),
+          patterns,
+          seed,
+          count,
+          this == COMPILE_AND_FIND_ROTATING_UTF16);
     }
     RegexEngineVariant.CompiledRegex pattern = patterns.getFirst();
     RegexEngineVariant.RegexInput input = inputs.getFirst();
     return switch (this) {
       case MATCHES -> blackhole -> blackhole.consume(pattern.matches(input));
-      case FIND -> blackhole -> blackhole.consume(pattern.find(input));
+      case FIND ->
+          lifecycle.matcher() == DeclarativeBenchmarkPlan.MatcherReuse.NONE
+              ? blackhole -> blackhole.consume(pattern.find(input))
+              : blackhole -> blackhole.consume(pattern.matcher(input).find());
       case LOOKING_AT -> blackhole -> blackhole.consume(pattern.matcher(input).lookingAt());
       case FIND_ALL_COUNT -> blackhole -> blackhole.consume(findAllCount(pattern.matcher(input)));
       case MATCHES_CORPUS -> blackhole -> blackhole.consume(matchesCorpus(pattern, inputs));
@@ -108,6 +131,13 @@ enum BenchmarkOperation {
           blackhole -> blackhole.consume(manualReplaceAll(pattern.matcher(input), replacement));
       case SPLIT_LENGTH_SUM ->
           blackhole -> blackhole.consume(splitLengthSum(pattern.split(input, limit)));
+      case COMPILE_AND_FIND ->
+          blackhole -> {
+            try (RegexEngineVariant.CompiledRegex compiled =
+                variant.compile(patternSources.getFirst())) {
+              blackhole.consume(compiled.find(input));
+            }
+          };
       case MATCHER_RESET_FIND -> {
         RegexEngineVariant.MatchCursor matcher = pattern.matcher(input);
         yield blackhole -> {
@@ -128,6 +158,7 @@ enum BenchmarkOperation {
       case FIND_GROUP ->
           blackhole -> blackhole.consume(findGroup(pattern.matcher(input), groups[0]));
       case COMPILE -> throw new AssertionError();
+      case FIND_ROTATING_UTF16, COMPILE_AND_FIND_ROTATING_UTF16 -> throw new AssertionError();
     };
   }
 
@@ -139,16 +170,30 @@ enum BenchmarkOperation {
       int[] groups,
       String replacement,
       int limit,
-      DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle) {
+      DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
+      String flagSet,
+      int seed,
+      int count) {
     if (this == COMPILE) {
-      variant.compileForBenchmark(patternSources.getFirst());
       return true;
+    }
+    if (this == FIND_ROTATING_UTF16 || this == COMPILE_AND_FIND_ROTATING_UTF16) {
+      String input = rotatingUtf16Inputs(seed, count)[0];
+      if (this == FIND_ROTATING_UTF16) {
+        return patterns.getFirst().find(new RegexEngineVariant.StringRegexInput(input));
+      }
+      try (RegexEngineVariant.CompiledRegex compiled = variant.compile(patternSources.getFirst())) {
+        return compiled.find(new RegexEngineVariant.StringRegexInput(input));
+      }
     }
     RegexEngineVariant.CompiledRegex pattern = patterns.getFirst();
     RegexEngineVariant.RegexInput input = inputs.getFirst();
     return switch (this) {
       case MATCHES -> pattern.matches(input);
-      case FIND -> pattern.find(input);
+      case FIND ->
+          lifecycle.matcher() == DeclarativeBenchmarkPlan.MatcherReuse.NONE
+              ? pattern.find(input)
+              : pattern.matcher(input).find();
       case LOOKING_AT -> pattern.matcher(input).lookingAt();
       case FIND_ALL_COUNT -> findAllCount(pattern.matcher(input));
       case MATCHES_CORPUS -> matchesCorpus(pattern, inputs);
@@ -161,6 +206,12 @@ enum BenchmarkOperation {
       case REPLACE_ALL_LENGTH_SUM -> replaceAllLengthSum(patterns, input, replacement);
       case MANUAL_REPLACE_ALL -> manualReplaceAll(pattern.matcher(input), replacement);
       case SPLIT_LENGTH_SUM -> splitLengthSum(pattern.split(input, limit));
+      case COMPILE_AND_FIND -> {
+        try (RegexEngineVariant.CompiledRegex compiled =
+            variant.compile(patternSources.getFirst())) {
+          yield compiled.find(input);
+        }
+      }
       case MATCHER_RESET_FIND -> {
         RegexEngineVariant.MatchCursor matcher = pattern.matcher(input);
         matcher.reset();
@@ -175,7 +226,43 @@ enum BenchmarkOperation {
       case FIND_GROUP_PRESENT -> findGroupPresent(pattern.matcher(input), groups[0]);
       case FIND_GROUP -> findGroup(pattern.matcher(input), groups[0]);
       case COMPILE -> throw new AssertionError();
+      case FIND_ROTATING_UTF16, COMPILE_AND_FIND_ROTATING_UTF16 -> throw new AssertionError();
     };
+  }
+
+  private static BenchmarkTask rotatingUtf16Task(
+      RegexEngineVariant variant,
+      String patternSource,
+      List<RegexEngineVariant.CompiledRegex> patterns,
+      int seed,
+      int count,
+      boolean compileEachInvocation) {
+    String[] inputs = rotatingUtf16Inputs(seed, count);
+    int[] index = {0};
+    if (!compileEachInvocation) {
+      RegexEngineVariant.CompiledRegex pattern = patterns.getFirst();
+      return blackhole -> {
+        String input = inputs[index[0]];
+        index[0] = (index[0] + 1) % inputs.length;
+        blackhole.consume(pattern.find(new RegexEngineVariant.StringRegexInput(input)));
+      };
+    }
+    return blackhole -> {
+      String input = inputs[index[0]];
+      index[0] = (index[0] + 1) % inputs.length;
+      try (RegexEngineVariant.CompiledRegex compiled = variant.compile(patternSource)) {
+        blackhole.consume(compiled.find(new RegexEngineVariant.StringRegexInput(input)));
+      }
+    };
+  }
+
+  private static String[] rotatingUtf16Inputs(int seed, int count) {
+    Random random = new Random(seed);
+    String[] inputs = new String[count];
+    for (int i = 0; i < count; i++) {
+      inputs[i] = new String(new char[] {(char) random.nextInt()});
+    }
+    return inputs;
   }
 
   private static DeclarativeBenchmarkPlan.LifecycleStep region(

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 /** Expands and validates the declarative ordinary cross-engine workload matrix. */
 final class CrossEngineBenchmarkPlan {
-  private static final EnumSet<DeclarativeBenchmarkPlan.Operation> IMPLEMENTED_OPERATIONS =
+  private static final EnumSet<DeclarativeBenchmarkPlan.Operation> CROSS_ENGINE_OPERATIONS =
       EnumSet.of(
           DeclarativeBenchmarkPlan.Operation.MATCHES,
           DeclarativeBenchmarkPlan.Operation.FIND,
@@ -35,10 +35,29 @@ final class CrossEngineBenchmarkPlan {
           DeclarativeBenchmarkPlan.Operation.MANUAL_REPLACE_ALL,
           DeclarativeBenchmarkPlan.Operation.SPLIT_LENGTH_SUM,
           DeclarativeBenchmarkPlan.Operation.COMPILE,
+          DeclarativeBenchmarkPlan.Operation.COMPILE_AND_FIND,
+          DeclarativeBenchmarkPlan.Operation.FIND_ROTATING_UTF16,
+          DeclarativeBenchmarkPlan.Operation.COMPILE_AND_FIND_ROTATING_UTF16,
           DeclarativeBenchmarkPlan.Operation.MATCHER_RESET_FIND,
           DeclarativeBenchmarkPlan.Operation.MATCHER_REGION_FIND,
           DeclarativeBenchmarkPlan.Operation.FIND_GROUP_PRESENT,
           DeclarativeBenchmarkPlan.Operation.FIND_GROUP);
+  private static final EnumSet<DeclarativeBenchmarkPlan.Operation> IMPLEMENTED_OPERATIONS =
+      EnumSet.copyOf(CROSS_ENGINE_OPERATIONS);
+
+  static {
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.ANALYZE_PATTERN);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.CACHED_ANALYSIS);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.COMPILE_AND_ANALYZE);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.DFA_CACHE_GROWTH);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.DIAGNOSTICS_FIND);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.FIND_IN_WINDOW);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.MATCHER_CONSTRUCTION);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.PATTERN_SET_MATCHES);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.UTF8_CAPTURE_BOUNDS);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.UTF8_DECODE_FIND);
+    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.UTF8_REPLACEMENT);
+  }
 
   private final Map<String, CrossEngineWorkload> workloads;
   private final Map<String, Trial> trials;
@@ -65,6 +84,10 @@ final class CrossEngineBenchmarkPlan {
       DeclarativeBenchmarkPlan.ExpandedPlan expanded) {
     Map<String, CrossEngineWorkload> workloads = new LinkedHashMap<>();
     for (DeclarativeBenchmarkPlan.ExpandedWorkload workload : expanded.workloads()) {
+      if (!CROSS_ENGINE_OPERATIONS.contains(workload.operation())
+          || !workload.measurement().timingUnit().isTime()) {
+        continue;
+      }
       CrossEngineWorkload converted = convert(workload);
       if (workloads.put(converted.id(), converted) != null) {
         throw new IllegalArgumentException("Duplicate cross-engine workload ID: " + converted.id());
@@ -74,18 +97,42 @@ final class CrossEngineBenchmarkPlan {
     Map<String, Trial> trials = new LinkedHashMap<>();
     for (DeclarativeBenchmarkPlan.Trial trial : expanded.trials()) {
       CrossEngineWorkload workload = workloads.get(trial.workload().id());
+      if (workload == null) {
+        continue;
+      }
       RegexEngineVariant variant = RegexEngineVariant.fromId(trial.engine().id());
       Trial converted = new Trial(workload, variant);
       if (trials.put(converted.id(), converted) != null) {
         throw new IllegalArgumentException("Duplicate cross-engine trial ID: " + converted.id());
       }
     }
-    return new CrossEngineBenchmarkPlan(workloads, trials, expanded.exclusions());
+    List<DeclarativeBenchmarkPlan.Exclusion> exclusions =
+        expanded.exclusions().stream()
+            .filter(exclusion -> workloads.containsKey(exclusion.workloadId()))
+            .toList();
+    return new CrossEngineBenchmarkPlan(workloads, trials, exclusions);
   }
 
   List<Trial> trials(CrossEngineWorkload.TimingGroup timingGroup) {
     return trials.values().stream()
         .filter(trial -> trial.workload().timingGroup() == timingGroup)
+        .toList();
+  }
+
+  List<Trial> trials(
+      CrossEngineWorkload.TimingGroup timingGroup,
+      DeclarativeBenchmarkPlan.MeasurementMode mode,
+      boolean noFork) {
+    return trials(timingGroup).stream()
+        .filter(trial -> trial.workload().measurement().mode() == mode)
+        .filter(
+            trial ->
+                trial
+                        .workload()
+                        .measurement()
+                        .constraints()
+                        .contains(DeclarativeBenchmarkPlan.ExecutionConstraint.NO_FORK)
+                    == noFork)
         .toList();
   }
 
@@ -139,17 +186,42 @@ final class CrossEngineBenchmarkPlan {
   static void main(String[] args) {
     if (args.length < 1) {
       throw new IllegalArgumentException(
-          "Usage: CrossEngineBenchmarkPlan <nanoseconds|microseconds> [workload-prefix ...]");
+          "Usage: CrossEngineBenchmarkPlan "
+              + "<nanoseconds|microseconds|no-fork-microseconds|cold-start> "
+              + "[workload-prefix ...]");
     }
-    CrossEngineWorkload.TimingGroup timingGroup =
+    Query query =
         switch (args[0]) {
-          case "nanoseconds" -> CrossEngineWorkload.TimingGroup.NANOSECONDS;
-          case "microseconds" -> CrossEngineWorkload.TimingGroup.MICROSECONDS;
+          case "nanoseconds" -> new Query(CrossEngineWorkload.TimingGroup.NANOSECONDS, null, false);
+          case "microseconds" ->
+              new Query(CrossEngineWorkload.TimingGroup.MICROSECONDS, null, false);
+          case "no-fork-microseconds" ->
+              new Query(
+                  CrossEngineWorkload.TimingGroup.MICROSECONDS,
+                  DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME,
+                  true);
+          case "cold-start" ->
+              new Query(
+                  CrossEngineWorkload.TimingGroup.MILLISECONDS,
+                  DeclarativeBenchmarkPlan.MeasurementMode.SINGLE_SHOT_COLD_START,
+                  false);
           default ->
               throw new IllegalArgumentException("Unknown cross-engine timing group: " + args[0]);
         };
+    CrossEngineBenchmarkPlan plan = load();
     String trialIds =
-        load().trials(timingGroup).stream()
+        plan.trials(query.timingGroup()).stream()
+            .filter(
+                trial ->
+                    query.mode() == null || trial.workload().measurement().mode() == query.mode())
+            .filter(
+                trial ->
+                    trial
+                            .workload()
+                            .measurement()
+                            .constraints()
+                            .contains(DeclarativeBenchmarkPlan.ExecutionConstraint.NO_FORK)
+                        == query.noFork())
             .filter(
                 trial ->
                     args.length == 1
@@ -158,10 +230,15 @@ final class CrossEngineBenchmarkPlan {
             .map(Trial::id)
             .collect(Collectors.joining(","));
     if (trialIds.isEmpty()) {
-      throw new IllegalStateException("No cross-engine trials for " + timingGroup);
+      throw new IllegalStateException("No cross-engine trials for " + args[0]);
     }
     System.out.println(trialIds);
   }
+
+  private record Query(
+      CrossEngineWorkload.TimingGroup timingGroup,
+      DeclarativeBenchmarkPlan.MeasurementMode mode,
+      boolean noFork) {}
 
   private static CrossEngineWorkload convert(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
     int[] groups = groups(workload.arguments());
@@ -171,9 +248,10 @@ final class CrossEngineBenchmarkPlan {
         switch (workload.measurement().timingUnit()) {
           case NANOSECONDS -> CrossEngineWorkload.TimingGroup.NANOSECONDS;
           case MICROSECONDS -> CrossEngineWorkload.TimingGroup.MICROSECONDS;
+          case MILLISECONDS -> CrossEngineWorkload.TimingGroup.MILLISECONDS;
           default ->
               throw new IllegalArgumentException(
-                  workload.id() + " is not an ordinary nanosecond or scaling microsecond workload");
+                  workload.id() + " is not a time-based cross-engine workload");
         };
     return new CrossEngineWorkload(
         workload.id(),
@@ -185,6 +263,10 @@ final class CrossEngineBenchmarkPlan {
         expectedValue(workload.expected()),
         limit,
         workload.lifecycle(),
+        stringArgument(workload.arguments(), "flagSet"),
+        integerArgument(workload.arguments(), "seed", 0),
+        integerArgument(workload.arguments(), "count", 0),
+        workload.measurement(),
         timingGroup);
   }
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineColdStartBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineColdStartBenchmark.java
@@ -1,0 +1,51 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Generic single-shot entry point for fresh-process cold-start declarations. */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class CrossEngineColdStartBenchmark {
+
+  /** Planned workload and execution-variant ID supplied by {@code run-java-benchmarks.sh}. */
+  @Param({})
+  public String crossEngineColdStartTrial;
+
+  private CrossEngineTrialRunner runner;
+
+  /** Resolves the declaration without performing the measured compile operation. */
+  @Setup
+  public void setup() {
+    runner =
+        CrossEngineTrialRunner.prepare(
+            crossEngineColdStartTrial, CrossEngineWorkload.TimingGroup.MILLISECONDS);
+  }
+
+  /** Releases resources retained by the selected execution variant. */
+  @TearDown
+  public void tearDown() {
+    runner.close();
+  }
+
+  /** Executes one declared cold-start operation. */
+  @Benchmark
+  public void run(Blackhole blackhole) {
+    runner.run(blackhole);
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineColdStartBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineColdStartBenchmark.java
@@ -33,7 +33,7 @@ public class CrossEngineColdStartBenchmark {
   @Setup
   public void setup() {
     runner =
-        CrossEngineTrialRunner.prepare(
+        CrossEngineTrialRunner.prepareColdStart(
             crossEngineColdStartTrial, CrossEngineWorkload.TimingGroup.MILLISECONDS);
   }
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineNoForkBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineNoForkBenchmark.java
@@ -1,0 +1,51 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Generic JMH entry point for declarations that require in-process no-fork execution. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class CrossEngineNoForkBenchmark {
+
+  /** Planned workload and execution-variant ID supplied by {@code run-java-benchmarks.sh}. */
+  @Param({})
+  public String crossEngineNoForkTrial;
+
+  private CrossEngineTrialRunner runner;
+
+  /** Prepares the selected engine, operation, and materialized input. */
+  @Setup
+  public void setup() {
+    runner =
+        CrossEngineTrialRunner.prepare(
+            crossEngineNoForkTrial, CrossEngineWorkload.TimingGroup.MICROSECONDS);
+  }
+
+  /** Releases resources retained by the selected execution variant. */
+  @TearDown
+  public void tearDown() {
+    runner.close();
+  }
+
+  /** Executes the pre-bound operation and consumes its result. */
+  @Benchmark
+  public void run(Blackhole blackhole) {
+    runner.run(blackhole);
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
@@ -25,6 +25,33 @@ final class CrossEngineTrialRunner implements AutoCloseable {
       String trialId, CrossEngineWorkload.TimingGroup expectedTimingGroup) {
     BenchmarkData data = BenchmarkData.get();
     CrossEngineBenchmarkPlan.Trial trial = CrossEngineBenchmarkPlan.load().resolve(trialId);
+    return prepare(data, trial, expectedTimingGroup, true);
+  }
+
+  static CrossEngineTrialRunner prepareColdStart(
+      String trialId, CrossEngineWorkload.TimingGroup expectedTimingGroup) {
+    BenchmarkData data = BenchmarkData.get();
+    CrossEngineBenchmarkPlan.Trial trial = CrossEngineBenchmarkPlan.load().resolve(trialId);
+    return prepareColdStart(data, trial, expectedTimingGroup);
+  }
+
+  static CrossEngineTrialRunner prepareColdStart(
+      BenchmarkData data,
+      CrossEngineBenchmarkPlan.Trial trial,
+      CrossEngineWorkload.TimingGroup expectedTimingGroup) {
+    if (trial.workload().operation() != BenchmarkOperation.COMPILE) {
+      throw new IllegalArgumentException(
+          trial.id() + " cold-start execution requires the compile operation");
+    }
+    return prepare(data, trial, expectedTimingGroup, false);
+  }
+
+  private static CrossEngineTrialRunner prepare(
+      BenchmarkData data,
+      CrossEngineBenchmarkPlan.Trial trial,
+      CrossEngineWorkload.TimingGroup expectedTimingGroup,
+      boolean validateBeforeMeasurement) {
+    String trialId = trial.id();
     CrossEngineWorkload workload = trial.workload();
     if (workload.timingGroup() != expectedTimingGroup) {
       throw new IllegalArgumentException(
@@ -40,22 +67,24 @@ final class CrossEngineTrialRunner implements AutoCloseable {
           patterns.add(trial.variant().compile(pattern));
         }
       }
-      Object actual =
-          workload
-              .operation()
-              .execute(
-                  trial.variant(),
-                  workload.patterns(),
-                  patterns,
-                  inputs,
-                  workload.groups(),
-                  workload.replacement(),
-                  workload.limit(),
-                  workload.lifecycle(),
-                  workload.flagSet(),
-                  workload.seed(),
-                  workload.count());
-      trial.validate(actual);
+      if (validateBeforeMeasurement) {
+        Object actual =
+            workload
+                .operation()
+                .execute(
+                    trial.variant(),
+                    workload.patterns(),
+                    patterns,
+                    inputs,
+                    workload.groups(),
+                    workload.replacement(),
+                    workload.limit(),
+                    workload.lifecycle(),
+                    workload.flagSet(),
+                    workload.seed(),
+                    workload.count());
+        trial.validate(actual);
+      }
       BenchmarkOperation.BenchmarkTask task =
           workload
               .operation()

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
@@ -51,7 +51,10 @@ final class CrossEngineTrialRunner implements AutoCloseable {
                   workload.groups(),
                   workload.replacement(),
                   workload.limit(),
-                  workload.lifecycle());
+                  workload.lifecycle(),
+                  workload.flagSet(),
+                  workload.seed(),
+                  workload.count());
       trial.validate(actual);
       BenchmarkOperation.BenchmarkTask task =
           workload
@@ -64,7 +67,10 @@ final class CrossEngineTrialRunner implements AutoCloseable {
                   workload.groups(),
                   workload.replacement(),
                   workload.limit(),
-                  workload.lifecycle());
+                  workload.lifecycle(),
+                  workload.flagSet(),
+                  workload.seed(),
+                  workload.count());
       return new CrossEngineTrialRunner(List.copyOf(patterns), task);
     } catch (RuntimeException | Error exception) {
       close(patterns);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineWorkload.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineWorkload.java
@@ -19,6 +19,10 @@ record CrossEngineWorkload(
     Object expected,
     int limit,
     DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
+    String flagSet,
+    int seed,
+    int count,
+    DeclarativeBenchmarkPlan.Measurement measurement,
     TimingGroup timingGroup) {
 
   CrossEngineWorkload {
@@ -28,6 +32,7 @@ record CrossEngineWorkload(
     inputKeys = List.copyOf(inputKeys);
     groups = groups.clone();
     Objects.requireNonNull(lifecycle);
+    Objects.requireNonNull(measurement);
     Objects.requireNonNull(timingGroup);
     if (id.isBlank()) {
       throw new IllegalArgumentException("Cross-engine workload ID must not be blank");
@@ -38,7 +43,10 @@ record CrossEngineWorkload(
     if (patterns.isEmpty()) {
       throw new IllegalArgumentException(id + " requires at least one pattern");
     }
-    if (inputKeys.isEmpty() && operation != BenchmarkOperation.COMPILE) {
+    if (inputKeys.isEmpty()
+        && operation != BenchmarkOperation.COMPILE
+        && operation != BenchmarkOperation.FIND_ROTATING_UTF16
+        && operation != BenchmarkOperation.COMPILE_AND_FIND_ROTATING_UTF16) {
       throw new IllegalArgumentException(id + " requires at least one input");
     }
   }
@@ -46,6 +54,7 @@ record CrossEngineWorkload(
   /** Benchmark schedule group, kept separate so historical output units remain stable. */
   enum TimingGroup {
     NANOSECONDS,
-    MICROSECONDS
+    MICROSECONDS,
+    MILLISECONDS
   }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -543,6 +543,19 @@ final class DeclarativeBenchmarkPlan {
 
   private static String substitute(
       String template, Map<String, ParameterValue> parameters, String context) {
+    return substitute(template, parameters, context, true);
+  }
+
+  private static String substituteValue(
+      String template, Map<String, ParameterValue> parameters, String context) {
+    return substitute(template, parameters, context, false);
+  }
+
+  private static String substitute(
+      String template,
+      Map<String, ParameterValue> parameters,
+      String context,
+      boolean useStableText) {
     Matcher matcher = PLACEHOLDER.matcher(template);
     StringBuilder result = new StringBuilder();
     while (matcher.find()) {
@@ -551,7 +564,8 @@ final class DeclarativeBenchmarkPlan {
         throw new IllegalArgumentException(
             context + " references unknown axis: " + matcher.group(1));
       }
-      matcher.appendReplacement(result, Matcher.quoteReplacement(value.stableText()));
+      String replacement = useStableText ? value.stableText() : value.valueText();
+      matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
     }
     matcher.appendTail(result);
     return result.toString();
@@ -972,7 +986,7 @@ final class DeclarativeBenchmarkPlan {
     public RecipeValue substitute(
         Map<String, ParameterValue> parameters, String inputId, String argumentName) {
       return new RecipeString(
-          DeclarativeBenchmarkPlan.substitute(
+          DeclarativeBenchmarkPlan.substituteValue(
               value, parameters, inputId + " recipe " + argumentName));
     }
   }
@@ -1009,7 +1023,7 @@ final class DeclarativeBenchmarkPlan {
           values.stream()
               .map(
                   value ->
-                      DeclarativeBenchmarkPlan.substitute(
+                      DeclarativeBenchmarkPlan.substituteValue(
                           value, parameters, inputId + " recipe " + argumentName))
               .toList());
     }
@@ -1054,7 +1068,7 @@ final class DeclarativeBenchmarkPlan {
           }
           yield new RecipeInteger((Integer) value.value());
         }
-        case STRING -> new RecipeString(value.stableText());
+        case STRING -> new RecipeString(value.valueText());
         case STRING_LIST, INTEGER_LIST ->
             throw new IllegalArgumentException(
                 inputId + " recipe " + argumentName + " cannot reference a scalar axis");

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -31,7 +31,7 @@ final class DeclarativeBenchmarkPlan {
 
   static final int SCHEMA_VERSION = 1;
   private static final java.util.regex.Pattern PLACEHOLDER =
-      java.util.regex.Pattern.compile("\\{([A-Za-z][A-Za-z0-9_]*)}");
+      java.util.regex.Pattern.compile("(?<!\\$)\\{([A-Za-z][A-Za-z0-9_]*)}");
 
   private final Map<String, InputDeclaration> inputs;
   private final List<WorkloadDeclaration> workloads;
@@ -565,7 +565,7 @@ final class DeclarativeBenchmarkPlan {
       if (value == null) {
         matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group()));
       } else {
-        matcher.appendReplacement(result, Matcher.quoteReplacement(value.stableText()));
+        matcher.appendReplacement(result, Matcher.quoteReplacement(value.valueText()));
       }
     }
     matcher.appendTail(result);
@@ -1062,33 +1062,53 @@ final class DeclarativeBenchmarkPlan {
     }
   }
 
-  record ParameterValue(ParameterType type, Object value) {
+  record ParameterValue(ParameterType type, Object value, String stableText) {
     static ParameterValue parse(JsonElement element, String axis) {
+      return parse(element, axis, true);
+    }
+
+    private static ParameterValue parse(
+        JsonElement element, String axis, boolean validateStableValue) {
+      if (element.isJsonObject()) {
+        JsonReader labeled = JsonReader.object("benchmark axis value", element);
+        labeled.requireOnly("id", "value");
+        String id = labeled.requiredString("id");
+        validateStableText(id);
+        ParameterValue value = parse(element.getAsJsonObject().get("value"), axis, false);
+        return new ParameterValue(value.type(), value.value(), id);
+      }
       if (!element.isJsonPrimitive()) {
         throw new IllegalArgumentException(
-            "Benchmark axis values must be strings, integers, or booleans: " + axis);
+            "Benchmark axis values must be scalars or labeled {id,value} objects: " + axis);
       }
       JsonPrimitive primitive = element.getAsJsonPrimitive();
       if (primitive.isBoolean()) {
-        return new ParameterValue(ParameterType.BOOLEAN, primitive.getAsBoolean());
+        boolean value = primitive.getAsBoolean();
+        return new ParameterValue(ParameterType.BOOLEAN, value, Boolean.toString(value));
       }
       if (primitive.isNumber()) {
         try {
-          return new ParameterValue(
-              ParameterType.INTEGER, primitive.getAsBigDecimal().intValueExact());
+          int value = primitive.getAsBigDecimal().intValueExact();
+          return new ParameterValue(ParameterType.INTEGER, value, Integer.toString(value));
         } catch (ArithmeticException | NumberFormatException exception) {
           throw new IllegalArgumentException(
               "Benchmark axis numeric values must be integers: " + axis, exception);
         }
       }
       String value = primitive.getAsString();
+      if (validateStableValue) {
+        validateStableText(value);
+      }
+      return new ParameterValue(ParameterType.STRING, value, value);
+    }
+
+    private static void validateStableText(String value) {
       if (value.isBlank() || value.contains("@") || value.contains("{") || value.contains("}")) {
         throw new IllegalArgumentException("Invalid stable benchmark axis value: " + value);
       }
-      return new ParameterValue(ParameterType.STRING, value);
     }
 
-    String stableText() {
+    String valueText() {
       return String.valueOf(value);
     }
   }
@@ -1387,7 +1407,9 @@ final class DeclarativeBenchmarkPlan {
     SPLIT_LENGTH_SUM("splitLengthSum", false, true, Feature.SPLIT),
     COMPILE("compile", false, false),
     COMPILE_AND_FIND("compileAndFind", false, true, Feature.FIND),
-    MATCHER_CONSTRUCTION("matcherConstruction", false, true, Feature.MATCHER_STATE),
+    FIND_ROTATING_UTF16("findRotatingUtf16", false, false, Feature.FIND),
+    COMPILE_AND_FIND_ROTATING_UTF16("compileAndFindRotatingUtf16", false, false, Feature.FIND),
+    MATCHER_CONSTRUCTION("matcherConstruction", false, true, Feature.UTF8_INPUT),
     MATCHER_RESET_FIND("matcherResetFind", true, true, Feature.FIND, Feature.MATCHER_STATE),
     MATCHER_REGION_FIND(
         "matcherRegionFind", true, true, Feature.FIND, Feature.MATCHER_STATE, Feature.REGIONS),
@@ -1396,6 +1418,7 @@ final class DeclarativeBenchmarkPlan {
     PATTERN_SET_FIND("patternSetFind", false, true, Feature.PATTERN_SET),
     PATTERN_SET_MATCHES("patternSetMatches", false, true, Feature.PATTERN_SET),
     UTF8_CAPTURE_BOUNDS("utf8CaptureBounds", false, true, Feature.FIND, Feature.UTF8_INPUT),
+    UTF8_DECODE_FIND("utf8DecodeFind", false, true, Feature.FIND, Feature.UTF8_INPUT),
     UTF8_REPLACEMENT("utf8Replacement", false, true, Feature.UTF8_INPUT, Feature.UTF8_REPLACEMENT),
     ANALYZE_PATTERN("analyzePattern", false, false, Feature.DIAGNOSTICS),
     CACHED_ANALYSIS("cachedAnalysis", false, false, Feature.DIAGNOSTICS),
@@ -1495,12 +1518,18 @@ final class DeclarativeBenchmarkPlan {
             LOOKING_AT,
             FIND_GROUP_PRESENT,
             COMPILE_AND_FIND,
+            FIND_ROTATING_UTF16,
+            COMPILE_AND_FIND_ROTATING_UTF16,
             MATCHER_REGION_FIND,
             FIND_IN_WINDOW,
-            PATTERN_SET_FIND,
-            PATTERN_SET_MATCHES,
-            DIAGNOSTICS_FIND ->
+            UTF8_DECODE_FIND ->
             consumption == ResultConsumption.BOOLEAN;
+        case DIAGNOSTICS_FIND ->
+            consumption == ResultConsumption.BOOLEAN
+                || consumption == ResultConsumption.BLACKHOLE_OBJECT;
+        case PATTERN_SET_FIND, PATTERN_SET_MATCHES ->
+            consumption == ResultConsumption.BOOLEAN
+                || consumption == ResultConsumption.BLACKHOLE_OBJECT;
         case FIND_ALL_COUNT,
             FIND_ALL_LENGTH_SUM,
             FIND_ALL_GROUP_LENGTH_SUM,
@@ -1509,14 +1538,10 @@ final class DeclarativeBenchmarkPlan {
             MATCHER_RESET_FIND,
             REPLACE_ALL_LENGTH_SUM,
             SPLIT_LENGTH_SUM,
-            UTF8_CAPTURE_BOUNDS ->
-            consumption == ResultConsumption.INTEGER;
-        case FIND_GROUP,
-            REPLACE_FIRST,
-            REPLACE_ALL,
-            APPEND_REPLACEMENT,
-            MANUAL_REPLACE_ALL,
+            UTF8_CAPTURE_BOUNDS,
             UTF8_REPLACEMENT ->
+            consumption == ResultConsumption.INTEGER;
+        case FIND_GROUP, REPLACE_FIRST, REPLACE_ALL, APPEND_REPLACEMENT, MANUAL_REPLACE_ALL ->
             consumption == ResultConsumption.STRING;
         case CAPTURE_GROUPS ->
             consumption == ResultConsumption.STRING || consumption == ResultConsumption.STRING_LIST;
@@ -1532,11 +1557,12 @@ final class DeclarativeBenchmarkPlan {
 
     Map<String, RecipeValueType> argumentTypes() {
       return switch (this) {
-        case FIND_ALL_GROUP_LENGTH_SUM,
-            MATCHES_GROUP_LENGTH_SUM,
-            CAPTURE_GROUPS,
-            UTF8_CAPTURE_BOUNDS ->
+        case FIND_ALL_GROUP_LENGTH_SUM, MATCHES_GROUP_LENGTH_SUM, CAPTURE_GROUPS ->
             Map.of("groups", RecipeValueType.INTEGER_LIST);
+        case UTF8_CAPTURE_BOUNDS ->
+            Map.of(
+                "groups", RecipeValueType.INTEGER_LIST,
+                "bounds", RecipeValueType.STRING);
         case FIND_GROUP_PRESENT, FIND_GROUP -> Map.of("group", RecipeValueType.INTEGER);
         case REPLACE_FIRST,
             REPLACE_ALL,
@@ -1546,8 +1572,21 @@ final class DeclarativeBenchmarkPlan {
             UTF8_REPLACEMENT ->
             Map.of("replacement", RecipeValueType.STRING);
         case SPLIT, SPLIT_LENGTH_SUM -> Map.of("limit", RecipeValueType.INTEGER);
+        case COMPILE -> Map.of("flagSet", RecipeValueType.STRING);
+        case MATCHER_CONSTRUCTION -> Map.of("mode", RecipeValueType.STRING);
+        case FIND_ROTATING_UTF16, COMPILE_AND_FIND_ROTATING_UTF16 ->
+            Map.of(
+                "seed", RecipeValueType.INTEGER,
+                "count", RecipeValueType.INTEGER);
+        case DIAGNOSTICS_FIND ->
+            Map.of(
+                "action", RecipeValueType.STRING,
+                "listener", RecipeValueType.STRING,
+                "replacement", RecipeValueType.STRING);
         case PATTERN_SET_COMPILE, PATTERN_SET_FIND, PATTERN_SET_MATCHES ->
-            Map.of("anchor", RecipeValueType.STRING);
+            Map.of(
+                "anchor", RecipeValueType.STRING,
+                "patternCount", RecipeValueType.INTEGER);
         default -> Map.of();
       };
     }
@@ -1568,6 +1607,7 @@ final class DeclarativeBenchmarkPlan {
             UTF8_REPLACEMENT ->
             Set.of("replacement");
         case PATTERN_SET_COMPILE, PATTERN_SET_FIND, PATTERN_SET_MATCHES -> Set.of("anchor");
+        case FIND_ROTATING_UTF16, COMPILE_AND_FIND_ROTATING_UTF16 -> Set.of("seed", "count");
         default -> Set.of();
       };
     }
@@ -1591,6 +1631,21 @@ final class DeclarativeBenchmarkPlan {
         if (!value.equals("unanchored") && !value.equals("anchored")) {
           throw new IllegalArgumentException(
               id + " anchor argument must be unanchored or anchored");
+        }
+      }
+      RecipeValue patternCount = arguments.get("patternCount");
+      if (patternCount != null && ((RecipeInteger) patternCount).value() <= 0) {
+        throw new IllegalArgumentException(id + " patternCount argument must be positive");
+      }
+      RecipeValue count = arguments.get("count");
+      if (count != null && ((RecipeInteger) count).value() <= 0) {
+        throw new IllegalArgumentException(id + " count argument must be positive");
+      }
+      RecipeValue bounds = arguments.get("bounds");
+      if (bounds != null) {
+        String value = ((RecipeString) bounds).value();
+        if (!value.equals("start") && !value.equals("startEnd")) {
+          throw new IllegalArgumentException(id + " bounds argument must be start or startEnd");
         }
       }
     }
@@ -1644,7 +1699,11 @@ final class DeclarativeBenchmarkPlan {
     UTF8_INPUT("utf8Input"),
     UTF8_REPLACEMENT("utf8Replacement"),
     DIAGNOSTICS("diagnostics"),
-    DFA_CACHE("dfaCache");
+    DFA_CACHE("dfaCache"),
+    FLAGGED_COMPILE("flaggedCompile"),
+    JAVA_CHARACTER_CLASS("javaCharacterClass"),
+    LINEAR_TIME("linearTime"),
+    RETAINED_HEAP("retainedHeap");
 
     private final String jsonName;
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
@@ -6,7 +6,9 @@
 package org.safere.benchmark;
 
 import java.util.Arrays;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Measures the retained heap size of compiled regex patterns across engines (SafeRE, JDK, RE2/J).
@@ -36,68 +38,38 @@ public final class MemoryBenchmark {
   private MemoryBenchmark() {}
 
   public static void main(String[] args) throws Exception {
-    BenchmarkData data = BenchmarkData.get();
-
-    System.out.println("=== Compiled Pattern Size (bytes, retained heap) ===");
-    System.out.println();
-    System.out.printf("%-18s %10s %10s %10s%n", "Pattern", "SafeRE", "JDK", "RE2/J");
-    System.out.println("─".repeat(52));
-
-    String[] patternNames = {"simple", "medium", "complex", "alternation"};
-
-    for (String name : patternNames) {
-      String pattern = data.getString("compile." + name + ".pattern");
-
-      long safereSize = measureRetainedSize(() -> org.safere.Pattern.compile(pattern));
-      long jdkSize = measureRetainedSize(() -> java.util.regex.Pattern.compile(pattern));
-      long re2jSize = measureRetainedSize(() -> com.google.re2j.Pattern.compile(pattern));
-
-      System.out.printf("%-18s %,10d %,10d %,10d%n", name, safereSize, jdkSize, re2jSize);
+    SpecializedBenchmarkPlan plan = SpecializedBenchmarkPlan.load();
+    Set<String> selected = Arrays.stream(args).collect(Collectors.toSet());
+    System.out.println("=== Declarative retained-memory measurements (bytes) ===");
+    for (SpecializedBenchmarkPlan.Trial trial : plan.retainedMemoryTrials()) {
+      if (!selected.isEmpty() && !selected.contains(trial.id())) {
+        continue;
+      }
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload = trial.workload();
+      long bytes =
+          switch (workload.operation()) {
+            case COMPILE ->
+                measureRetainedSize(
+                    () ->
+                        trial
+                            .variant()
+                            .compileForBenchmark(
+                                workload.patterns().getFirst(), flagSet(workload)));
+            case DFA_CACHE_GROWTH ->
+                measureDfaCacheGrowth(
+                    workload.patterns().getFirst(),
+                    BenchmarkData.get().getInputString(workload.inputIds().getFirst()));
+            default ->
+                throw new IllegalArgumentException(
+                    "Unsupported retained-memory operation: " + workload.operation());
+          };
+      System.out.printf("%s %,d%n", trial.id(), bytes);
     }
+  }
 
-    // Also measure the core regex benchmark patterns (match-time patterns).
-    System.out.println();
-    System.out.println("=== Match-Time Pattern Size (bytes, retained heap) ===");
-    System.out.println();
-    System.out.printf("%-18s %10s %10s %10s%n", "Pattern", "SafeRE", "JDK", "RE2/J");
-    System.out.println("─".repeat(52));
-
-    String[][] regexPatterns = {
-      {"literalMatch", "regex.literalMatch.pattern"},
-      {"charClassMatch", "regex.charClassMatch.pattern"},
-      {"alternationFind", "regex.alternationFind.pattern"},
-      {"captureGroups", "regex.captureGroups.pattern"},
-      {"findInText", "regex.findInText.pattern"},
-      {"emailFind", "regex.emailFind.pattern"},
-    };
-
-    for (String[] entry : regexPatterns) {
-      String name = entry[0];
-      String pattern = data.getString(entry[1]);
-
-      long safereSize = measureRetainedSize(() -> org.safere.Pattern.compile(pattern));
-      long jdkSize = measureRetainedSize(() -> java.util.regex.Pattern.compile(pattern));
-      long re2jSize = measureRetainedSize(() -> com.google.re2j.Pattern.compile(pattern));
-
-      System.out.printf("%-18s %,10d %,10d %,10d%n", name, safereSize, jdkSize, re2jSize);
-    }
-
-    // DFA cache growth: compile a single SafeRE pattern, measure heap before/after matching
-    // against a large text to populate the DFA state cache.
-    System.out.println();
-    System.out.println("=== DFA Cache Growth (SafeRE only, bytes) ===");
-    System.out.println();
-    System.out.printf("%-18s %12s%n", "Pattern", "Cache growth");
-    System.out.println("─".repeat(32));
-
-    // Build a large text to exercise DFA cache creation across many character classes.
-    String largeText = data.getInputString("memory.dfaCacheText");
-
-    for (String name : patternNames) {
-      String pattern = data.getString("compile." + name + ".pattern");
-      long growth = measureDfaCacheGrowth(pattern, largeText);
-      System.out.printf("%-18s %,12d%n", name, growth);
-    }
+  private static String flagSet(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    DeclarativeBenchmarkPlan.RecipeValue value = workload.arguments().get("flagSet");
+    return value == null ? null : ((DeclarativeBenchmarkPlan.RecipeString) value).value();
   }
 
   /**

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
@@ -390,6 +390,34 @@ enum RegexEngineVariant {
         }
       }
     }
+    switch (this) {
+      case SAFERE_STRING -> {
+        features.add(DeclarativeBenchmarkPlan.Feature.DFA_CACHE);
+        features.add(DeclarativeBenchmarkPlan.Feature.DIAGNOSTICS);
+        features.add(DeclarativeBenchmarkPlan.Feature.FLAGGED_COMPILE);
+        features.add(DeclarativeBenchmarkPlan.Feature.JAVA_CHARACTER_CLASS);
+        features.add(DeclarativeBenchmarkPlan.Feature.LINEAR_TIME);
+        features.add(DeclarativeBenchmarkPlan.Feature.PATTERN_SET);
+        features.add(DeclarativeBenchmarkPlan.Feature.RETAINED_HEAP);
+      }
+      case SAFERE_UTF8 -> {
+        features.add(DeclarativeBenchmarkPlan.Feature.LINEAR_TIME);
+        features.add(DeclarativeBenchmarkPlan.Feature.MATCHER_STATE);
+        features.add(DeclarativeBenchmarkPlan.Feature.REGIONS);
+        features.add(DeclarativeBenchmarkPlan.Feature.UTF8_INPUT);
+        features.add(DeclarativeBenchmarkPlan.Feature.UTF8_REPLACEMENT);
+      }
+      case JDK_STRING -> {
+        features.add(DeclarativeBenchmarkPlan.Feature.FLAGGED_COMPILE);
+        features.add(DeclarativeBenchmarkPlan.Feature.JAVA_CHARACTER_CLASS);
+        features.add(DeclarativeBenchmarkPlan.Feature.RETAINED_HEAP);
+      }
+      case RE2J_STRING -> {
+        features.add(DeclarativeBenchmarkPlan.Feature.LINEAR_TIME);
+        features.add(DeclarativeBenchmarkPlan.Feature.RETAINED_HEAP);
+      }
+      case RE2_FFM_STRING_CONVERSION -> features.add(DeclarativeBenchmarkPlan.Feature.LINEAR_TIME);
+    }
     DeclarativeBenchmarkPlan.InputRepresentation representation =
         switch (inputRepresentation) {
           case JAVA_STRING -> DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING;
@@ -415,12 +443,23 @@ enum RegexEngineVariant {
 
   abstract CompiledRegex compile(String regex);
 
-  Object compileForBenchmark(String regex) {
+  Object compileForBenchmark(String regex, String flagSet) {
+    int flags = flagSet == null ? 0 : BenchmarkFlags.parse(flagSet);
     return switch (this) {
-      case SAFERE_STRING, SAFERE_UTF8 -> org.safere.Pattern.compile(regex);
-      case JDK_STRING -> java.util.regex.Pattern.compile(regex);
-      case RE2J_STRING -> com.google.re2j.Pattern.compile(regex);
-      case RE2_FFM_STRING_CONVERSION -> org.safere.re2ffm.RE2FfmPattern.compile(regex);
+      case SAFERE_STRING, SAFERE_UTF8 -> org.safere.Pattern.compile(regex, flags);
+      case JDK_STRING -> java.util.regex.Pattern.compile(regex, flags);
+      case RE2J_STRING -> {
+        if (flags != 0) {
+          throw new UnsupportedOperationException("RE2/J flagged compilation is unsupported");
+        }
+        yield com.google.re2j.Pattern.compile(regex);
+      }
+      case RE2_FFM_STRING_CONVERSION -> {
+        if (flags != 0) {
+          throw new UnsupportedOperationException("RE2-FFM flagged compilation is unsupported");
+        }
+        yield org.safere.re2ffm.RE2FfmPattern.compile(regex);
+      }
     };
   }
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmark.java
@@ -1,0 +1,49 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** Generic JMH entry point for SafeRE-specific nanosecond workloads. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class SpecializedBenchmark {
+
+  /** Planned specialized workload and execution-variant ID. */
+  @Param({})
+  public String specializedTrial;
+
+  private SpecializedTrialRunner runner;
+
+  /** Prepares the selected specialized operation from its declaration. */
+  @Setup
+  public void setup() {
+    runner = SpecializedTrialRunner.prepare(specializedTrial);
+  }
+
+  /** Restores specialized global state after the trial. */
+  @TearDown
+  public void tearDown() {
+    runner.close();
+  }
+
+  /** Executes the selected operation. */
+  @Benchmark
+  public void run(Blackhole blackhole) {
+    runner.run(blackhole);
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
@@ -1,0 +1,129 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/** Resolves data-declared workloads that use specialized measurement machinery. */
+final class SpecializedBenchmarkPlan {
+  private final Map<String, Trial> trials;
+
+  private SpecializedBenchmarkPlan(Map<String, Trial> trials) {
+    this.trials = Collections.unmodifiableMap(new LinkedHashMap<>(trials));
+  }
+
+  static SpecializedBenchmarkPlan load() {
+    DeclarativeBenchmarkPlan plan =
+        DeclarativeBenchmarkPlan.parse(BenchmarkData.get().declarativePlan());
+    List<DeclarativeBenchmarkPlan.EngineDeclaration> engines =
+        Arrays.stream(RegexEngineVariant.values()).map(RegexEngineVariant::declaration).toList();
+    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
+        plan.expand(engines, EnumSet.allOf(DeclarativeBenchmarkPlan.Operation.class));
+    Map<String, Trial> trials = new LinkedHashMap<>();
+    for (DeclarativeBenchmarkPlan.Trial trial : expanded.trials()) {
+      if (!isSpecialized(trial.workload())) {
+        continue;
+      }
+      Trial converted = new Trial(trial.workload(), RegexEngineVariant.fromId(trial.engine().id()));
+      if (trials.put(converted.id(), converted) != null) {
+        throw new IllegalArgumentException("Duplicate specialized trial ID: " + converted.id());
+      }
+    }
+    return new SpecializedBenchmarkPlan(trials);
+  }
+
+  private static boolean isSpecialized(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    return switch (workload.operation()) {
+          case PATTERN_SET_MATCHES,
+              UTF8_CAPTURE_BOUNDS,
+              UTF8_DECODE_FIND,
+              UTF8_REPLACEMENT,
+              FIND_IN_WINDOW,
+              MATCHER_CONSTRUCTION,
+              ANALYZE_PATTERN,
+              CACHED_ANALYSIS,
+              COMPILE_AND_ANALYZE,
+              DIAGNOSTICS_FIND ->
+              true;
+          default -> false;
+        }
+        || workload.measurement().mode() == DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY
+        || workload.measurement().mode()
+            == DeclarativeBenchmarkPlan.MeasurementMode.SUBPROCESS_MEMORY;
+  }
+
+  Trial resolve(String id) {
+    Trial trial = trials.get(id);
+    if (trial == null) {
+      throw new IllegalArgumentException("Unknown specialized benchmark trial: " + id);
+    }
+    return trial;
+  }
+
+  List<Trial> patternSetTrials() {
+    return trials.values().stream()
+        .filter(
+            trial ->
+                trial.workload().operation()
+                    == DeclarativeBenchmarkPlan.Operation.PATTERN_SET_MATCHES)
+        .toList();
+  }
+
+  List<Trial> averageTimeTrials() {
+    return trials.values().stream()
+        .filter(
+            trial ->
+                trial.workload().measurement().mode()
+                    == DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME)
+        .toList();
+  }
+
+  List<Trial> retainedMemoryTrials() {
+    return trials.values().stream()
+        .filter(
+            trial ->
+                trial.workload().measurement().mode()
+                    == DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY)
+        .toList();
+  }
+
+  static void main(String[] args) {
+    if (args.length != 1) {
+      throw new IllegalArgumentException(
+          "Usage: SpecializedBenchmarkPlan <average-time|pattern-set|retained-memory>");
+    }
+    SpecializedBenchmarkPlan plan = load();
+    List<Trial> selected =
+        switch (args[0]) {
+          case "average-time" -> plan.averageTimeTrials();
+          case "pattern-set" -> plan.patternSetTrials();
+          case "retained-memory" -> plan.retainedMemoryTrials();
+          default -> throw new IllegalArgumentException("Unknown specialized mode: " + args[0]);
+        };
+    if (selected.isEmpty()) {
+      throw new IllegalStateException("No specialized trials for " + args[0]);
+    }
+    System.out.println(selected.stream().map(Trial::id).collect(Collectors.joining(",")));
+  }
+
+  record Trial(DeclarativeBenchmarkPlan.ExpandedWorkload workload, RegexEngineVariant variant) {
+    Trial {
+      Objects.requireNonNull(workload);
+      Objects.requireNonNull(variant);
+    }
+
+    String id() {
+      return workload.id() + "@" + variant.id();
+    }
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedTrialRunner.java
@@ -1,0 +1,237 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.LongAdder;
+import org.openjdk.jmh.infra.Blackhole;
+import org.safere.PatternSet;
+
+/** Prepared execution state for one SafeRE-specific declarative trial. */
+final class SpecializedTrialRunner implements AutoCloseable {
+  private static final org.safere.SafeReMatchDiagnostics NO_OP =
+      new org.safere.SafeReMatchDiagnostics() {};
+
+  private final Task task;
+  private final boolean diagnostics;
+
+  private SpecializedTrialRunner(Task task, boolean diagnostics) {
+    this.task = task;
+    this.diagnostics = diagnostics;
+  }
+
+  static SpecializedTrialRunner prepare(String trialId) {
+    SpecializedBenchmarkPlan.Trial trial = SpecializedBenchmarkPlan.load().resolve(trialId);
+    if (trial.variant() != RegexEngineVariant.SAFERE_STRING
+        && trial.variant() != RegexEngineVariant.SAFERE_UTF8) {
+      throw new IllegalArgumentException("Specialized SafeRE trial has wrong variant: " + trialId);
+    }
+    DeclarativeBenchmarkPlan.ExpandedWorkload workload = trial.workload();
+    return switch (workload.operation()) {
+      case PATTERN_SET_MATCHES -> new SpecializedTrialRunner(patternSet(workload), false);
+      case UTF8_CAPTURE_BOUNDS -> new SpecializedTrialRunner(captureBounds(workload), false);
+      case UTF8_DECODE_FIND -> new SpecializedTrialRunner(decodeFind(workload), false);
+      case UTF8_REPLACEMENT -> new SpecializedTrialRunner(utf8Replacement(workload), false);
+      case FIND_IN_WINDOW -> new SpecializedTrialRunner(findInWindow(workload), false);
+      case MATCHER_CONSTRUCTION -> new SpecializedTrialRunner(constructUtf8(workload), false);
+      case ANALYZE_PATTERN -> new SpecializedTrialRunner(analyze(workload), false);
+      case CACHED_ANALYSIS -> new SpecializedTrialRunner(cachedAnalysis(workload), false);
+      case COMPILE_AND_ANALYZE -> new SpecializedTrialRunner(compileAndAnalyze(workload), false);
+      case DIAGNOSTICS_FIND -> new SpecializedTrialRunner(diagnostics(workload), true);
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported specialized operation: " + workload.operation());
+    };
+  }
+
+  private static Task patternSet(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    String anchor = stringArgument(workload, "anchor", "unanchored");
+    int patternCount = integerArgument(workload, "patternCount", workload.patterns().size());
+    PatternSet.Anchor patternAnchor =
+        anchor.equals("anchored") ? PatternSet.Anchor.ANCHOR_START : PatternSet.Anchor.UNANCHORED;
+    PatternSet.Builder builder = new PatternSet.Builder(patternAnchor);
+    for (int i = 0; i < patternCount; i++) {
+      builder.add(workload.patterns().get(i % workload.patterns().size()));
+    }
+    PatternSet patternSet = builder.compile();
+    String input = inputString(workload);
+    return blackhole -> blackhole.consume(patternSet.match(input));
+  }
+
+  private static Task captureBounds(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    org.safere.Utf8Input input = utf8Input(workload);
+    int[] groups =
+        ((DeclarativeBenchmarkPlan.RecipeIntegerList) workload.arguments().get("groups"))
+            .values().stream().mapToInt(Integer::intValue).toArray();
+    boolean includeEnd = stringArgument(workload, "bounds", "startEnd").equals("startEnd");
+    return blackhole -> {
+      org.safere.Utf8Matcher matcher = pattern.matcher(input);
+      int sum = 0;
+      while (matcher.find()) {
+        for (int group : groups) {
+          sum += matcher.start(group);
+          if (includeEnd) {
+            sum += matcher.end(group);
+          }
+        }
+      }
+      blackhole.consume(sum);
+    };
+  }
+
+  private static Task decodeFind(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    byte[] bytes = BenchmarkData.get().getInputBytes(workload.inputIds().getFirst());
+    return blackhole ->
+        blackhole.consume(pattern.matcher(new String(bytes, StandardCharsets.UTF_8)).find());
+  }
+
+  private static Task utf8Replacement(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    org.safere.Utf8Input input = utf8Input(workload);
+    org.safere.Utf8Input replacement =
+        org.safere.Utf8Input.validated(
+            stringArgument(workload, "replacement", "").getBytes(StandardCharsets.UTF_8));
+    CountingSink sink = new CountingSink();
+    return blackhole -> {
+      sink.reset();
+      org.safere.Utf8Matcher matcher = pattern.matcher(input);
+      while (matcher.find()) {
+        matcher.appendReplacement(sink, replacement);
+      }
+      matcher.appendTail(sink);
+      blackhole.consume(sink.length());
+    };
+  }
+
+  private static Task findInWindow(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    byte[] storage = BenchmarkData.get().getInputBytes(workload.inputIds().getFirst());
+    DeclarativeBenchmarkPlan.LifecycleStep region =
+        workload.lifecycle().steps().stream()
+            .filter(step -> step.kind() == DeclarativeBenchmarkPlan.LifecycleStepKind.REGION)
+            .findFirst()
+            .orElseThrow();
+    org.safere.Utf8Input input =
+        org.safere.Utf8Input.trusted(storage, region.start(), region.end() - region.start());
+    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    return blackhole -> blackhole.consume(pattern.find(input));
+  }
+
+  private static Task constructUtf8(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    byte[] bytes = BenchmarkData.get().getInputBytes(workload.inputIds().getFirst());
+    boolean validated = stringArgument(workload, "mode", "trusted").equals("validated");
+    return blackhole ->
+        blackhole.consume(
+            validated
+                ? org.safere.Utf8Input.validated(bytes)
+                : org.safere.Utf8Input.trusted(bytes));
+  }
+
+  private static Task analyze(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    String regex = workload.patterns().getFirst();
+    return blackhole -> blackhole.consume(org.safere.Pattern.compile(regex));
+  }
+
+  private static Task cachedAnalysis(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    pattern.analysis();
+    return blackhole -> blackhole.consume(pattern.analysis());
+  }
+
+  private static Task compileAndAnalyze(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    String regex = workload.patterns().getFirst();
+    return blackhole -> blackhole.consume(org.safere.Pattern.compile(regex).analysis());
+  }
+
+  private static Task diagnostics(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    String listener = stringArgument(workload, "listener", "disabled");
+    org.safere.Pattern.setDiagnostics(
+        switch (listener) {
+          case "disabled" -> org.safere.SafeReMatchDiagnostics.NONE;
+          case "noop" -> NO_OP;
+          case "longAdder" -> new AggregatingDiagnostics();
+          default ->
+              throw new IllegalArgumentException("Unknown diagnostics listener: " + listener);
+        });
+    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    String input = inputString(workload);
+    String action = stringArgument(workload, "action", "find");
+    String replacement = stringArgument(workload, "replacement", "");
+    return switch (action) {
+      case "find" -> blackhole -> blackhole.consume(pattern.matcher(input).find());
+      case "matches" -> blackhole -> blackhole.consume(pattern.matcher(input).matches());
+      case "replaceAll" ->
+          blackhole -> blackhole.consume(pattern.matcher(input).replaceAll(replacement));
+      default -> throw new IllegalArgumentException("Unknown diagnostics action: " + action);
+    };
+  }
+
+  private static String inputString(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    return BenchmarkData.get().getInputString(workload.inputIds().getFirst());
+  }
+
+  private static org.safere.Utf8Input utf8Input(
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    return org.safere.Utf8Input.trusted(
+        BenchmarkData.get().getInputBytes(workload.inputIds().getFirst()));
+  }
+
+  private static String stringArgument(
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload, String name, String defaultValue) {
+    DeclarativeBenchmarkPlan.RecipeValue value = workload.arguments().get(name);
+    return value == null ? defaultValue : ((DeclarativeBenchmarkPlan.RecipeString) value).value();
+  }
+
+  private static int integerArgument(
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload, String name, int defaultValue) {
+    DeclarativeBenchmarkPlan.RecipeValue value = workload.arguments().get(name);
+    return value == null ? defaultValue : ((DeclarativeBenchmarkPlan.RecipeInteger) value).value();
+  }
+
+  void run(Blackhole blackhole) {
+    task.run(blackhole);
+  }
+
+  @Override
+  public void close() {
+    if (diagnostics) {
+      org.safere.Pattern.setDiagnostics(org.safere.SafeReMatchDiagnostics.NONE);
+    }
+  }
+
+  private interface Task {
+    void run(Blackhole blackhole);
+  }
+
+  private static final class CountingSink implements org.safere.Utf8Sink {
+    private int length;
+
+    @Override
+    public void append(byte[] bytes, int offset, int rangeLength) {
+      length += rangeLength;
+    }
+
+    void reset() {
+      length = 0;
+    }
+
+    int length() {
+      return length;
+    }
+  }
+
+  private static final class AggregatingDiagnostics extends org.safere.SafeReMatchDiagnostics {
+    private final LongAdder operations = new LongAdder();
+    private final LongAdder matches = new LongAdder();
+
+    @Override
+    public void onOperationCompleted(org.safere.OperationDiagnostics event) {
+      operations.increment();
+      matches.add(event.matchCount());
+    }
+  }
+}

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -30,7 +30,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(275);
+    assertThat(first).hasSize(304);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -197,6 +198,42 @@ class CrossEngineBenchmarkPlanTest {
             "ApplicationBenchmark.uuidValidation@safere-string",
             CrossEngineWorkload.TimingGroup.NANOSECONDS)) {
       assertThat(ignored).isNotNull();
+    }
+  }
+
+  @Test
+  void coldStartPreparationDefersCompilationUntilTheMeasuredTask() {
+    CrossEngineWorkload workload =
+        new CrossEngineWorkload(
+            "Synthetic.coldCompile",
+            BenchmarkOperation.COMPILE,
+            List.of("("),
+            List.of(),
+            new int[0],
+            null,
+            null,
+            0,
+            DeclarativeBenchmarkPlan.MatcherLifecycle.NONE,
+            "",
+            0,
+            1,
+            new DeclarativeBenchmarkPlan.Measurement(
+                DeclarativeBenchmarkPlan.MeasurementMode.SINGLE_SHOT_COLD_START,
+                DeclarativeBenchmarkPlan.TimingUnit.MILLISECONDS,
+                EnumSet.of(
+                    DeclarativeBenchmarkPlan.ExecutionConstraint.FRESH_PROCESS_PER_INVOCATION)),
+            CrossEngineWorkload.TimingGroup.MILLISECONDS);
+    CrossEngineBenchmarkPlan.Trial trial =
+        new CrossEngineBenchmarkPlan.Trial(workload, RegexEngineVariant.SAFERE_STRING);
+    Blackhole blackhole =
+        new Blackhole(
+            "Today's password is swordfish. I understand instantiating Blackholes directly is"
+                + " dangerous.");
+
+    try (CrossEngineTrialRunner runner =
+        CrossEngineTrialRunner.prepareColdStart(
+            BenchmarkData.get(), trial, CrossEngineWorkload.TimingGroup.MILLISECONDS)) {
+      assertThatThrownBy(() -> runner.run(blackhole)).isInstanceOf(IllegalArgumentException.class);
     }
   }
 

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -46,7 +46,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(254);
+    assertThat(ids).hasSize(400);
   }
 
   @Test
@@ -55,7 +55,8 @@ class CrossEngineBenchmarkPlanTest {
     List<CrossEngineBenchmarkPlan.Trial> allTrials =
         List.of(
                 plan.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS),
-                plan.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
+                plan.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS),
+                plan.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS))
             .stream()
             .flatMap(List::stream)
             .toList();
@@ -72,11 +73,11 @@ class CrossEngineBenchmarkPlanTest {
               allTrials.stream()
                   .filter(trial -> trial.workload().id().equals(workload.id()))
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
-          .contains(RegexEngineVariant.SAFERE_STRING);
+          .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1083);
-    assertThat(plan.exclusions()).hasSize(187);
-    assertThat(accounted).hasSize(254 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(1380);
+    assertThat(plan.exclusions()).hasSize(620);
+    assertThat(accounted).hasSize(400 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -90,14 +91,21 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(773);
+        .hasSize(809);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
             second.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(310);
+        .hasSize(499);
+    assertThat(first.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS))
+        .extracting(CrossEngineBenchmarkPlan.Trial::id)
+        .containsExactlyElementsOf(
+            second.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS).stream()
+                .map(CrossEngineBenchmarkPlan.Trial::id)
+                .toList())
+        .hasSize(72);
   }
 
   @Test
@@ -165,7 +173,10 @@ class CrossEngineBenchmarkPlanTest {
             new int[0],
             null,
             0,
-            DeclarativeBenchmarkPlan.MatcherLifecycle.NONE);
+            DeclarativeBenchmarkPlan.MatcherLifecycle.NONE,
+            null,
+            0,
+            0);
     Blackhole blackhole =
         new Blackhole(
             "Today's password is swordfish. I understand instantiating Blackholes directly is"
@@ -221,13 +232,61 @@ class CrossEngineBenchmarkPlanTest {
             "MatcherApiBenchmark.regionFind@jdk-string",
             "MatcherApiBenchmark.resetAndFind@safere-string",
             "MatcherApiBenchmark.resetAndFind@jdk-string",
-            "MatcherApiBenchmark.resetAndFind@re2j-string");
+            "MatcherApiBenchmark.resetAndFind@re2j-string",
+            "JavaCharacterClassBenchmark.compileAndFindJavaLetter@safere-string",
+            "JavaCharacterClassBenchmark.compileAndFindJavaLetter@jdk-string",
+            "JavaCharacterClassBenchmark.findJavaLetter@safere-string",
+            "JavaCharacterClassBenchmark.findJavaLetter@jdk-string");
     CrossEngineBenchmarkPlan plan = CrossEngineBenchmarkPlan.load();
 
     for (String trialId : trials) {
       CrossEngineWorkload.TimingGroup timingGroup = plan.resolve(trialId).workload().timingGroup();
       try (CrossEngineTrialRunner ignored = CrossEngineTrialRunner.prepare(trialId, timingGroup)) {
         assertThat(ignored).as(trialId).isNotNull();
+      }
+    }
+  }
+
+  @Test
+  void specializedMeasurementModesSelectStableGenericTrials() {
+    SpecializedBenchmarkPlan first = SpecializedBenchmarkPlan.load();
+    SpecializedBenchmarkPlan second = SpecializedBenchmarkPlan.load();
+
+    assertThat(first.averageTimeTrials())
+        .extracting(SpecializedBenchmarkPlan.Trial::id)
+        .containsExactlyElementsOf(
+            second.averageTimeTrials().stream().map(SpecializedBenchmarkPlan.Trial::id).toList())
+        .hasSize(63);
+    assertThat(first.retainedMemoryTrials())
+        .extracting(SpecializedBenchmarkPlan.Trial::id)
+        .containsExactlyElementsOf(
+            second.retainedMemoryTrials().stream().map(SpecializedBenchmarkPlan.Trial::id).toList())
+        .hasSize(34);
+  }
+
+  @Test
+  void everySpecializedOperationPreparesAndRunsThroughOneEntryPoint() {
+    List<String> trials =
+        List.of(
+            "PatternSetBenchmark.unanchoredMatch.4@safere-string",
+            "Utf8MatchingBenchmark.captureBounds.numbered@safere-utf8",
+            "Utf8MatchingBenchmark.captureFreeDecode.asciiEarly@safere-utf8",
+            "ByteReplacementBenchmark.numbered@safere-utf8",
+            "Utf8MatchingBenchmark.window@safere-utf8",
+            "Utf8MatchingBenchmark.construction.validated@safere-utf8",
+            "PatternAnalysisBenchmark.cachedAnalysis@safere-string",
+            "PatternAnalysisBenchmark.compileOnly@safere-string",
+            "PatternAnalysisBenchmark.compileAndAnalyze@safere-string",
+            "DiagnosticsDisabledBenchmark.tinyLiteralFindHit@safere-string",
+            "DiagnosticsEnabledBenchmark.charClassDenseReplaceAll.longAdder@safere-string");
+    Blackhole blackhole =
+        new Blackhole(
+            "Today's password is swordfish. I understand instantiating Blackholes directly is"
+                + " dangerous.");
+
+    for (String trial : trials) {
+      try (SpecializedTrialRunner runner = SpecializedTrialRunner.prepare(trial)) {
+        runner.run(blackhole);
       }
     }
   }

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
@@ -114,6 +114,42 @@ class DeclarativeBenchmarkPlanTest {
   }
 
   @Test
+  void labeledAxisSeparatesStableIdentityFromPatternValue() {
+    DeclarativeBenchmarkPlan plan =
+        parse(
+            """
+            {
+              "schemaVersion": 1,
+              "inputs": [],
+              "workloads": [{
+                  "id": "Synthetic.unicode.{regex}",
+                  "operation": "compile",
+                  "patterns": ["{regex}"],
+                  "axes": {
+                    "regex": [{"id": "letter", "value": "\\\\p{L}+"}]
+                  },
+                  "inputRepresentations": ["javaString"],
+                  "resultConsumption": "compiledObject",
+                  "measurement": {"mode": "compileOnly", "timingUnit": "microseconds"}
+              }]
+            }
+            """);
+    DeclarativeBenchmarkPlan.EngineDeclaration engine =
+        engine("string", DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING);
+
+    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
+        plan.expand(List.of(engine), EnumSet.of(DeclarativeBenchmarkPlan.Operation.COMPILE));
+
+    assertThat(expanded.workloads())
+        .singleElement()
+        .satisfies(
+            workload -> {
+              assertThat(workload.id()).isEqualTo("Synthetic.unicode.letter");
+              assertThat(workload.patterns()).containsExactly("\\p{L}+");
+            });
+  }
+
+  @Test
   void addingWorkloadAndEngineAxesProducesEveryCompatiblePair() {
     DeclarativeBenchmarkPlan plan =
         parse(

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
@@ -150,6 +150,57 @@ class DeclarativeBenchmarkPlanTest {
   }
 
   @Test
+  void labeledAxisUsesRuntimeValueInRecipeAndOperationArguments() {
+    DeclarativeBenchmarkPlan plan =
+        parse(
+            """
+            {
+              "schemaVersion": 1,
+              "inputs": [{
+                "id": "generated.{text}",
+                "axes": {
+                  "text": [{"id": "greeting", "value": "hello"}]
+                },
+                "recipe": {"kind": "literal", "text": "{text}"}
+              }],
+              "workloads": [{
+                "id": "Synthetic.replace.{replacement}",
+                "operation": "replaceAll",
+                "patterns": ["x"],
+                "inputs": ["generated.greeting"],
+                "axes": {
+                  "replacement": [{"id": "bang", "value": "$0!"}]
+                },
+                "arguments": {"replacement": "{replacement}"},
+                "inputRepresentations": ["javaString"],
+                "resultConsumption": "string",
+                "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+              }]
+            }
+            """);
+    DeclarativeBenchmarkPlan.EngineDeclaration engine =
+        engine(
+            "string",
+            DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+            DeclarativeBenchmarkPlan.Feature.REPLACE);
+
+    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
+        plan.expand(List.of(engine), EnumSet.of(DeclarativeBenchmarkPlan.Operation.REPLACE_ALL));
+
+    assertThat(plan.inputs()).containsKey("generated.greeting");
+    assertThat(plan.inputs().get("generated.greeting").recipe().arguments().get("text"))
+        .isEqualTo(new DeclarativeBenchmarkPlan.RecipeString("hello"));
+    assertThat(expanded.workloads())
+        .singleElement()
+        .satisfies(
+            workload -> {
+              assertThat(workload.id()).isEqualTo("Synthetic.replace.bang");
+              assertThat(workload.arguments().get("replacement"))
+                  .isEqualTo(new DeclarativeBenchmarkPlan.RecipeString("$0!"));
+            });
+  }
+
+  @Test
   void addingWorkloadAndEngineAxesProducesEveryCompatiblePair() {
     DeclarativeBenchmarkPlan plan =
         parse(


### PR DESCRIPTION
## Summary

- declare pathological, flagged/cold compilation, retained-memory, PatternSet, UTF-8, diagnostics, analysis, and Java-character-class workloads in the shared benchmark plan
- add generic no-fork, cold-start, SafeRE-specific, and retained-memory runner selection
- derive measurement boundaries and engine eligibility from declared modes and capabilities
- isolate each cold-start trial in its own fresh JMH invocation and keep compilation out of setup
- substitute labeled-axis runtime values separately from stable report IDs
- document the remaining non-workload measurement infrastructure

## Verification

- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere-benchmarks verify -DskipTests -q`
- `git diff --check`
- smoke-ran representative generic no-fork, cold-start, PatternSet, UTF-8 replacement, pattern-analysis, diagnostics, retained-memory, DFA-cache-growth, and Java-character-class trials
- confirmed two cold-start trials each run as `Fork: 1 of 1`
- confirmed pathological no-fork execution reports `Fork: N/A`
- regression coverage proves malformed cold-start patterns are compiled by the measured invocation, not setup
- review/fix loop completed with no remaining P2+ findings
- performance benchmarks were not run; this PR makes no performance claims

Fixes #612
Part of #606

Stacked on #618.
