### PR TITLE
Discover benchmark collection from declarations

### DIFF
--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -142,74 +142,57 @@ if [ "$MODE" = "long" ]; then
 fi
 
 if [ "$MODE" = "smoke" ]; then
-  run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
+  run_and_capture "$OUTPUT_DIR/java-declared.txt" \
     ./run-java-benchmarks.sh \
       --smoke \
-      '^org\.safere\.benchmark\.CrossEngineBenchmark\.run$' \
-      -- \
-      -p \
-      'crossEngineTrial=RegexBenchmark.emailFind@safere-string,RegexBenchmark.emailFind@safere-utf8,RegexBenchmark.emailFind@jdk-string,RegexBenchmark.emailFind@re2j-string,RegexBenchmark.emailFind@re2-ffm-string-conversion'
+      --declared
 
   log "Combining Java JMH output"
-  cp "$OUTPUT_DIR/java-01-core.txt" "$OUTPUT_DIR/jmh-output.txt"
+  cp "$OUTPUT_DIR/java-declared.txt" "$OUTPUT_DIR/jmh-output.txt"
 
   clean_benchmark_module
   run_and_capture "$OUTPUT_DIR/java-memory.txt" \
     ./run-java-memory-benchmarks.sh \
       --smoke \
-      '^org\.safere\.benchmark\.CrossEngineBenchmark\.run$' \
-      -- \
-      -p \
-      'crossEngineTrial=RegexBenchmark.emailFind@safere-string,RegexBenchmark.emailFind@safere-utf8,RegexBenchmark.emailFind@jdk-string,RegexBenchmark.emailFind@re2j-string,RegexBenchmark.emailFind@re2-ffm-string-conversion'
+      --declared
 else
-  run_and_capture "$OUTPUT_DIR/java-01-core.txt" \
-      ./run-java-benchmarks.sh \
-      "${JAVA_MODE_ARGS[@]}" \
-      '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
-
-  run_and_capture "$OUTPUT_DIR/java-02-scaling.txt" \
-      ./run-java-benchmarks.sh \
-      "${JAVA_MODE_ARGS[@]}" \
-      '^org\.safere\.benchmark\.CrossEngineScalingBenchmark\.'
-
-  run_and_capture "$OUTPUT_DIR/java-04-pathological.txt" \
+  run_and_capture "$OUTPUT_DIR/java-declared.txt" \
     ./run-java-benchmarks.sh \
       "${JAVA_MODE_ARGS[@]}" \
-      '^org\.safere\.benchmark\.PathologicalBenchmark\.' \
-      '^org\.safere\.benchmark\.PathologicalComparisonBenchmark\.'
-
-  run_and_capture "$OUTPUT_DIR/java-05-patternset.txt" \
-    ./run-java-benchmarks.sh "${JAVA_MODE_ARGS[@]}" '^org\.safere\.benchmark\.PatternSetBenchmark\.'
+      --declared
 
   log "Combining Java JMH output"
-  cat \
-    "$OUTPUT_DIR/java-01-core.txt" \
-    "$OUTPUT_DIR/java-02-scaling.txt" \
-    "$OUTPUT_DIR/java-04-pathological.txt" \
-    "$OUTPUT_DIR/java-05-patternset.txt" \
-    > "$OUTPUT_DIR/jmh-output.txt"
+  cp "$OUTPUT_DIR/java-declared.txt" "$OUTPUT_DIR/jmh-output.txt"
 
   clean_benchmark_module
-  run_and_capture "$OUTPUT_DIR/java-memory-core.txt" \
+  run_and_capture "$OUTPUT_DIR/java-memory.txt" \
     ./run-java-memory-benchmarks.sh \
-      --cross-engine-prefix 'RegexBenchmark.' \
-      '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
-  run_and_capture "$OUTPUT_DIR/java-memory-scaling.txt" \
-    ./run-java-memory-benchmarks.sh \
-      --cross-engine-scaling-prefix 'SearchScalingBenchmark.' \
-      '^org\.safere\.benchmark\.CrossEngineScalingBenchmark\.' \
-      '^org\.safere\.benchmark\.MemoryScalingBenchmark\.'
-  cat \
-    "$OUTPUT_DIR/java-memory-core.txt" \
-    "$OUTPUT_DIR/java-memory-scaling.txt" \
-    > "$OUTPUT_DIR/java-memory.txt"
+      --declared
 fi
 
-run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" \
-  java -Xms256m -Xmx256m \
-    -Dsafere.benchmark.corpus="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus" \
-    -cp safere-benchmarks/target/benchmarks.jar \
-    org.safere.benchmark.MemoryBenchmark
+PATTERN_MEMORY_COMMAND=(
+  java -Xms256m -Xmx256m
+  -Dsafere.benchmark.corpus="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus"
+  -cp safere-benchmarks/target/benchmarks.jar
+  org.safere.benchmark.MemoryBenchmark
+)
+if [ "$MODE" = "smoke" ]; then
+  RETAINED_TRIALS="$(
+    java \
+      -Dsafere.benchmark.corpus="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus" \
+      -cp safere-benchmarks/target/benchmarks.jar \
+      org.safere.benchmark.SpecializedBenchmarkPlan retained-memory
+  )"
+  PATTERN_MEMORY_COMMAND+=("${RETAINED_TRIALS%%,*}")
+fi
+run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" "${PATTERN_MEMORY_COMMAND[@]}"
+
+log "Writing declared report plan"
+java \
+  -Dsafere.benchmark.corpus="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus" \
+  -cp safere-benchmarks/target/benchmarks.jar \
+  org.safere.benchmark.BenchmarkCollectionPlan report-plan \
+  > "$OUTPUT_DIR/declared-report-plan.json"
 
 if [ "$OPENJDK_REGEX" = true ]; then
   OPENJDK_REGEX_ARGS=()
@@ -219,7 +202,6 @@ if [ "$OPENJDK_REGEX" = true ]; then
   if [ "$MODE" = "smoke" ]; then
     OPENJDK_REGEX_ARGS+=(
       --smoke
-      'org.safere.bench.openjdk.FindPatternComparison.*'
     )
   fi
   OPENJDK_REGEX_ARGS+=(
@@ -243,7 +225,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
       ./run-cpp-benchmarks.sh RegexBenchmark.emailFind
   else
     run_and_capture "$OUTPUT_DIR/cpp-raw.txt" \
-      ./run-cpp-benchmarks.sh Regex Application RealWorldRegex Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
+      ./run-cpp-benchmarks.sh
   fi
 
   log "Extracting C++ JSONL"
@@ -254,7 +236,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
       ./run-go-benchmarks.sh RegexBenchmark.emailFind
   else
     run_and_capture "$OUTPUT_DIR/go-raw.txt" \
-      ./run-go-benchmarks.sh Regex Application RealWorldRegex Compile SearchScaling Issue481Scaling CaptureScaling Http Replace Fanout Pathological
+      ./run-go-benchmarks.sh
   fi
 
   log "Extracting Go JSONL"
@@ -268,6 +250,7 @@ fi
 
 log "Generating markdown tables"
 COMPARE_ARGS+=(--engines "$COMPARE_ENGINES")
+COMPARE_ARGS+=(--declared-plan "$OUTPUT_DIR/declared-report-plan.json")
 if [ "$MODE" != "smoke" ]; then
   COMPARE_ARGS+=(
     --benchmark-data safere-benchmarks/benchmark-data.json
@@ -276,6 +259,14 @@ if [ "$MODE" != "smoke" ]; then
 fi
 python3 safere-benchmarks/scripts/compare-benchmarks.py "${COMPARE_ARGS[@]}" \
   > "$OUTPUT_DIR/merged-tables.md"
+
+if [ "$CROSS_LANGUAGE" = true ]; then
+  log "Generating separate cross-runtime context tables"
+  python3 safere-benchmarks/scripts/compare-benchmarks.py \
+    --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl" \
+    --engines re2_cpp,go \
+    > "$OUTPUT_DIR/cross-runtime-tables.md"
+fi
 
 if [ "$MODE" = "smoke" ]; then
   log "Verifying smoke output"
@@ -300,6 +291,7 @@ Point the agent at:
 
 Key files:
   jmh-output.txt
+  declared-report-plan.json
   merged-tables.md
   java-memory.txt
   java-pattern-memory.txt
@@ -309,6 +301,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
   cat <<EOF
   cpp-results.jsonl
   go-results.jsonl
+  cross-runtime-tables.md
 EOF
 fi
 

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -188,10 +188,14 @@ fi
 run_and_capture "$OUTPUT_DIR/java-pattern-memory.txt" "${PATTERN_MEMORY_COMMAND[@]}"
 
 log "Writing declared report plan"
+REPORT_PLAN_ARGS=(report-plan)
+if [ "$MODE" = "smoke" ]; then
+  REPORT_PLAN_ARGS+=(--smoke)
+fi
 java \
   -Dsafere.benchmark.corpus="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus" \
   -cp safere-benchmarks/target/benchmarks.jar \
-  org.safere.benchmark.BenchmarkCollectionPlan report-plan \
+  org.safere.benchmark.BenchmarkCollectionPlan "${REPORT_PLAN_ARGS[@]}" \
   > "$OUTPUT_DIR/declared-report-plan.json"
 
 if [ "$OPENJDK_REGEX" = true ]; then
@@ -202,6 +206,7 @@ if [ "$OPENJDK_REGEX" = true ]; then
   if [ "$MODE" = "smoke" ]; then
     OPENJDK_REGEX_ARGS+=(
       --smoke
+      'org.safere.bench.openjdk.FindPatternComparison.*'
     )
   fi
   OPENJDK_REGEX_ARGS+=(
@@ -271,7 +276,8 @@ fi
 if [ "$MODE" = "smoke" ]; then
   log "Verifying smoke output"
   missing_cell="$(printf '\342\200\224')"
-  if grep -q "$missing_cell" "$OUTPUT_DIR/merged-tables.md"; then
+  if grep -q "$missing_cell" "$OUTPUT_DIR/merged-tables.md" \
+    || grep -qw 'missing' "$OUTPUT_DIR/merged-tables.md"; then
     echo "ERROR: smoke merged table contains missing result cells" >&2
     exit 1
   fi

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -8,6 +8,7 @@
 #   ./run-java-benchmarks.sh '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
 #   ./run-java-benchmarks.sh --long '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
 #   ./run-java-benchmarks.sh --smoke '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
+#   ./run-java-benchmarks.sh --declared
 #   ./run-java-benchmarks.sh --first-compile \
 #     '^org\.safere\.benchmark\.UnicodeFirstCompileBenchmark\.'
 #   ./run-java-benchmarks.sh                         # run all benchmarks
@@ -34,6 +35,8 @@
 #   --first-compile:     Fresh-fork first-compile signal — 10 forks, no warmup,
 #                        1 single-shot measurement. Use for cold Unicode table
 #                        initialization and short-lived CLI analysis.
+#   --declared:          Discover and run every generic runner and trial from
+#                        the declarative collection plan.
 #
 # Workloads that declare the noFork constraint run through the generic
 # CrossEngineNoForkBenchmark entry point with -f 0. The legacy pathological
@@ -72,13 +75,14 @@ NO_FORK_SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 usage() {
   cat <<EOF
 Usage:
-  ./run-java-benchmarks.sh [--long|--smoke|--first-compile] [--fastbuild] [JmhBenchmarkRegex ...] [-- JmhArg ...]
+  ./run-java-benchmarks.sh [--long|--smoke|--first-compile] [--declared] [--fastbuild] [JmhBenchmarkRegex ...] [-- JmhArg ...]
 
 Modes:
   default          Standard benchmark run.
   --long           Longer confirmation run for close or important comparisons.
   --smoke          Minimal compile-and-run smoke test.
   --first-compile  Fresh-fork single-shot cold compile signal.
+  --declared       Discover generic runners and trials from the benchmark plan.
 
 Options:
   --fastbuild      Skip FFM native C++ builds and target only benchmark modules (saves ~1 minute).
@@ -88,6 +92,7 @@ EOF
 # Parse options and arguments.
 MODE="standard"
 FASTBUILD=false
+DECLARED=false
 BENCHMARKS=()
 JMH_EXTRA_ARGS=()
 
@@ -107,6 +112,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --fastbuild)
       FASTBUILD=true
+      shift
+      ;;
+    --declared)
+      DECLARED=true
       shift
       ;;
     -h|--help)
@@ -174,6 +183,39 @@ echo "=== Materializing shared benchmark inputs ==="
 
 # JVM args for FFM native access, native library path, and the resolved corpus.
 JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR -Dsafere.benchmark.corpus=$BENCHMARK_CORPUS"
+
+if [ "$DECLARED" = true ]; then
+  COLLECTION_QUERY=(runners)
+  if [ "$MODE" = "smoke" ]; then
+    COLLECTION_QUERY+=(--smoke)
+  fi
+  while IFS=$'\t' read -r profile benchmark parameter trial_ids; do
+    runner_opts="$JMH_OPTS"
+    if [ "$profile" = "noFork" ]; then
+      runner_opts="$NO_FORK_JMH_OPTS"
+    elif [ "$profile" = "coldStart" ]; then
+      runner_opts="$COLD_START_JMH_OPTS"
+    fi
+    echo "=== Running declared $benchmark ($profile; $runner_opts) ==="
+    RUNNER_COMMAND=(java \
+      $JVM_ARGS \
+      -jar "$BENCHMARK_JAR" \
+      -jvmArgs "$JVM_ARGS" \
+      $runner_opts \
+      -p "$parameter=$trial_ids")
+    if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
+      RUNNER_COMMAND+=("${JMH_EXTRA_ARGS[@]}")
+    fi
+    RUNNER_COMMAND+=("^${benchmark//./\\.}$")
+    "${RUNNER_COMMAND[@]}"
+  done < <(
+    java $JVM_ARGS \
+      -cp "$BENCHMARK_JAR" \
+      org.safere.benchmark.BenchmarkCollectionPlan \
+      "${COLLECTION_QUERY[@]}"
+  )
+  exit 0
+fi
 
 # JMH discovers benchmark methods statically, while the supported cross-engine
 # workload/variant matrix comes from benchmark-data.json and the centralized

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -196,6 +196,24 @@ if [ "$DECLARED" = true ]; then
     elif [ "$profile" = "coldStart" ]; then
       runner_opts="$COLD_START_JMH_OPTS"
     fi
+    if [ "$profile" = "coldStart" ]; then
+      IFS=',' read -r -a cold_start_trials <<< "$trial_ids"
+      for trial in "${cold_start_trials[@]}"; do
+        echo "=== Running declared $benchmark ($profile; $runner_opts; isolated trial $trial) ==="
+        RUNNER_COMMAND=(java \
+          $JVM_ARGS \
+          -jar "$BENCHMARK_JAR" \
+          -jvmArgs "$JVM_ARGS" \
+          $runner_opts \
+          -p "$parameter=$trial")
+        if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
+          RUNNER_COMMAND+=("${JMH_EXTRA_ARGS[@]}")
+        fi
+        RUNNER_COMMAND+=("^${benchmark//./\\.}$")
+        "${RUNNER_COMMAND[@]}"
+      done
+      continue
+    fi
     echo "=== Running declared $benchmark ($profile; $runner_opts) ==="
     RUNNER_COMMAND=(java \
       $JVM_ARGS \

--- a/run-java-benchmarks.sh
+++ b/run-java-benchmarks.sh
@@ -189,7 +189,21 @@ if [ "$DECLARED" = true ]; then
   if [ "$MODE" = "smoke" ]; then
     COLLECTION_QUERY+=(--smoke)
   fi
+  matched_runner=false
   while IFS=$'\t' read -r profile benchmark parameter trial_ids; do
+    if [ ${#BENCHMARKS[@]} -gt 0 ]; then
+      matches_filter=false
+      for filter in "${BENCHMARKS[@]}"; do
+        if [[ "$benchmark" =~ $filter ]]; then
+          matches_filter=true
+          break
+        fi
+      done
+      if [ "$matches_filter" = false ]; then
+        continue
+      fi
+    fi
+    matched_runner=true
     runner_opts="$JMH_OPTS"
     if [ "$profile" = "noFork" ]; then
       runner_opts="$NO_FORK_JMH_OPTS"
@@ -232,6 +246,10 @@ if [ "$DECLARED" = true ]; then
       org.safere.benchmark.BenchmarkCollectionPlan \
       "${COLLECTION_QUERY[@]}"
   )
+  if [ "$matched_runner" = false ]; then
+    echo "ERROR: no declared benchmark runner matches the requested filters" >&2
+    exit 1
+  fi
   exit 0
 fi
 

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -8,6 +8,7 @@
 #   ./run-java-memory-benchmarks.sh '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
 #   ./run-java-memory-benchmarks.sh --quick '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
 #   ./run-java-memory-benchmarks.sh --smoke '^org\.safere\.benchmark\.CrossEngineBenchmark\.'
+#   ./run-java-memory-benchmarks.sh --declared
 #   ./run-java-memory-benchmarks.sh                         # run all benchmarks
 #
 # This runs the same benchmarks as run-java-benchmarks.sh but adds JMH's
@@ -35,6 +36,7 @@ SMOKE_OPTS="-f 0 -wi 1 -w 1 -i 1 -r 1"
 
 # Parse mode flag.
 MODE="publish"
+DECLARED=false
 if [ "${1:-}" = "--quick" ]; then
   MODE="quick"
   shift
@@ -49,6 +51,10 @@ CROSS_ENGINE_PREFIXES=()
 CROSS_ENGINE_SCALING_PREFIXES=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --declared)
+      DECLARED=true
+      shift
+      ;;
     --cross-engine-prefix)
       CROSS_ENGINE_PREFIXES+=("$2")
       shift 2
@@ -88,6 +94,34 @@ echo "=== Materializing shared benchmark inputs ==="
 
 # JVM args for FFM native access, native library path, and the resolved corpus.
 JVM_ARGS="--enable-native-access=ALL-UNNAMED -Dre2shim.library.path=$RE2_SHIM_DIR -Dsafere.benchmark.corpus=$BENCHMARK_CORPUS"
+
+if [ "$DECLARED" = true ]; then
+  COLLECTION_QUERY=(allocation-runners)
+  if [ "$MODE" = "smoke" ]; then
+    COLLECTION_QUERY+=(--smoke)
+  fi
+  while IFS=$'\t' read -r profile benchmark parameter trial_ids; do
+    echo "=== Running declared allocation trials for $benchmark ==="
+    RUNNER_COMMAND=(java \
+      $JVM_ARGS \
+      -jar "$BENCHMARK_JAR" \
+      -jvmArgs "$JVM_ARGS" \
+      -prof gc \
+      $JMH_OPTS \
+      -p "$parameter=$trial_ids")
+    if [ ${#JMH_EXTRA_ARGS[@]} -gt 0 ]; then
+      RUNNER_COMMAND+=("${JMH_EXTRA_ARGS[@]}")
+    fi
+    RUNNER_COMMAND+=("^${benchmark//./\\.}$")
+    "${RUNNER_COMMAND[@]}"
+  done < <(
+    java $JVM_ARGS \
+      -cp "$BENCHMARK_JAR" \
+      org.safere.benchmark.BenchmarkCollectionPlan \
+      "${COLLECTION_QUERY[@]}"
+  )
+  exit 0
+fi
 
 if [ ${#CROSS_ENGINE_PREFIXES[@]} -gt 0 ]; then
   CROSS_ENGINE_TRIALS="$(

--- a/run-java-memory-benchmarks.sh
+++ b/run-java-memory-benchmarks.sh
@@ -100,7 +100,21 @@ if [ "$DECLARED" = true ]; then
   if [ "$MODE" = "smoke" ]; then
     COLLECTION_QUERY+=(--smoke)
   fi
+  matched_runner=false
   while IFS=$'\t' read -r profile benchmark parameter trial_ids; do
+    if [ ${#BENCHMARKS[@]} -gt 0 ]; then
+      matches_filter=false
+      for filter in "${BENCHMARKS[@]}"; do
+        if [[ "$benchmark" =~ $filter ]]; then
+          matches_filter=true
+          break
+        fi
+      done
+      if [ "$matches_filter" = false ]; then
+        continue
+      fi
+    fi
+    matched_runner=true
     echo "=== Running declared allocation trials for $benchmark ==="
     RUNNER_COMMAND=(java \
       $JVM_ARGS \
@@ -120,6 +134,10 @@ if [ "$DECLARED" = true ]; then
       org.safere.benchmark.BenchmarkCollectionPlan \
       "${COLLECTION_QUERY[@]}"
   )
+  if [ "$matched_runner" = false ]; then
+    echo "ERROR: no declared allocation runner matches the requested filters" >&2
+    exit 1
+  fi
   exit 0
 fi
 

--- a/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
+++ b/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
@@ -78,3 +78,7 @@ dedicated execution mode, including retained memory, cold start, declared
 no-fork safeguards, PatternSet, diagnostics, and dedicated UTF-8 API behavior.
 Those shapes use generic runners selected from the declaration; see
 [`SPECIALIZED_MEASUREMENT_MODES.md`](SPECIALIZED_MEASUREMENT_MODES.md).
+
+Full collection discovers those runners and their trial parameters through
+`BenchmarkCollectionPlan`; see
+[`DECLARATIVE_COLLECTION.md`](DECLARATIVE_COLLECTION.md).

--- a/safere-benchmarks/DECLARATIVE_COLLECTION.md
+++ b/safere-benchmarks/DECLARATIVE_COLLECTION.md
@@ -1,0 +1,37 @@
+# Declarative benchmark collection
+
+`BenchmarkCollectionPlan` is the collection and reporting query surface for the expanded benchmark
+plan. It discovers generic JMH runners and their exact trial parameters; collection scripts do not
+maintain workload-family or legacy benchmark-class lists.
+
+The supported queries are:
+
+```text
+BenchmarkCollectionPlan runners [--smoke]
+BenchmarkCollectionPlan allocation-runners [--smoke]
+BenchmarkCollectionPlan trials [--mode MODE] [--timing UNIT]
+                               [--prefix PREFIX] [--variant VARIANT]
+BenchmarkCollectionPlan report-plan
+```
+
+`runners` emits tab-separated execution profile, JMH entry point, parameter name, and planned trial
+IDs. `run-java-benchmarks.sh --declared` consumes those rows sequentially and applies standard,
+no-fork, or fresh-process settings from the selected profile. `allocation-runners` uses the
+declarative `collection.allocationWorkloadPrefixes` selection and is consumed by
+`run-java-memory-benchmarks.sh --declared`.
+
+`report-plan` emits JSON containing every scheduled workload/variant pair and every declared
+exclusion. The result normalizer uses this catalog to render `missing` when a supported trial did
+not produce a result and `excluded` when the plan intentionally rejected that variant. An em dash
+continues to mean that the column is outside the declared Java execution matrix, such as a
+cross-runtime context column.
+
+JMH parameter names are an execution detail. The normalizer recognizes all generic runner
+parameters and splits each `<workload-id>@<execution-variant>` value into its stable report row and
+engine column. `safere-utf8` remains a distinct column from `safere-string`, and
+`re2-ffm-string-conversion` remains distinct from native cross-runtime RE2 results, so input
+representation and timed conversion boundaries are not erased.
+
+C++ RE2 and Go `regexp` harnesses run in separate processes and emit JSONL with the same stable
+workload identities. Their results remain cross-runtime context; they are not treated as missing or
+excluded Java execution variants.

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -8886,6 +8886,74 @@
           "prematerializedInput"
         ]
       }
+    },
+    {
+      "id": "MemoryScalingBenchmark.searchEasy.{size}",
+      "operation": "find",
+      "patterns": [
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": false
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput",
+          "allocationProfile"
+        ]
+      }
+    },
+    {
+      "id": "MemoryScalingBenchmark.searchMedium.{size}",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
+      ],
+      "inputs": [
+        "searchScaling.random.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "resultConsumption": "boolean",
+      "expected": {
+        "type": "boolean",
+        "value": false
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput",
+          "allocationProfile"
+        ]
+      }
     }
   ]
 }

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1,5 +1,11 @@
 {
   "schemaVersion": 1,
+  "collection": {
+    "allocationWorkloadPrefixes": [
+      "RegexBenchmark.",
+      "SearchScalingBenchmark."
+    ]
+  },
   "inputs": [
     {
       "id": "crossEngine.RegexBenchmark.literalMatch.input",

--- a/safere-benchmarks/scripts/compare-benchmarks.py
+++ b/safere-benchmarks/scripts/compare-benchmarks.py
@@ -73,6 +73,13 @@ _CROSS_ENGINE_VARIANTS = {
     "re2j-string": "re2j",
     "re2-ffm-string-conversion": "re2_ffm",
 }
+_DECLARED_TRIAL_PARAMS = (
+    "crossEngineTrial",
+    "crossEngineScalingTrial",
+    "crossEngineNoForkTrial",
+    "crossEngineColdStartTrial",
+    "specializedTrial",
+)
 _JMH_MODES = {"avgt", "thrpt", "sample", "ss", "all"}
 
 
@@ -169,7 +176,11 @@ def _parse_jmh_parameterized_line(line, param_names):
     class_name = full_name[: dot]
     method = full_name[dot + 1 :]
 
-    trial = params.get("crossEngineTrial", params.get("crossEngineScalingTrial"))
+    trial = next(
+        (params.get(name) for name in _DECLARED_TRIAL_PARAMS
+         if params.get(name) and params.get(name) != "N/A"),
+        None,
+    )
     if trial and trial != "N/A":
         try:
             benchmark, variant = trial.rsplit("@", 1)
@@ -334,7 +345,23 @@ def _rpad(text, width):
     return " " * max(0, width - len(text)) + text
 
 
-def generate_tables(results, engines):
+def load_declared_plan(path):
+    """Load declared trial and exclusion identities emitted by BenchmarkCollectionPlan."""
+    with open(path) as fh:
+        plan = json.load(fh)
+    statuses = collections.OrderedDict()
+    for trial in plan.get("trials", []):
+        engine = _CROSS_ENGINE_VARIANTS.get(trial["executionVariant"])
+        if engine:
+            statuses[(trial["workloadId"], engine)] = "declared"
+    for exclusion in plan.get("exclusions", []):
+        engine = _CROSS_ENGINE_VARIANTS.get(exclusion["executionVariant"])
+        if engine:
+            statuses.setdefault((exclusion["workloadId"], engine), "excluded")
+    return statuses
+
+
+def generate_tables(results, engines, declared_statuses=None):
     """Generate markdown tables from *results*, one per benchmark class.
 
     Args:
@@ -353,6 +380,10 @@ def generate_tables(results, engines):
         index[key] = r
         all_benchmarks[r.benchmark] = True
         seen_engines.add(r.engine)
+    if declared_statuses:
+        for benchmark, engine in declared_statuses:
+            all_benchmarks.setdefault(benchmark, True)
+            seen_engines.add(engine)
 
     # If no explicit engine list, discover from data (preserving order).
     if not engines:
@@ -404,6 +435,10 @@ def generate_tables(results, engines):
                 r = index.get((bench, eng))
                 if r:
                     cells.append(_fmt_cell(r.score, r.error))
+                elif declared_statuses and declared_statuses.get((bench, eng)) == "excluded":
+                    cells.append("excluded")
+                elif declared_statuses and declared_statuses.get((bench, eng)) == "declared":
+                    cells.append("missing")
                 else:
                     cells.append("—")
             rows.append((method, cells))
@@ -494,6 +529,11 @@ def main(argv=None):
         description="Merge benchmark results from multiple engines into markdown tables.",
     )
     parser.add_argument(
+        "--declared-plan",
+        metavar="FILE",
+        help="JSON report plan emitted by BenchmarkCollectionPlan.",
+    )
+    parser.add_argument(
         "--jmh",
         metavar="FILE",
         help="Path to JMH text-output file.",
@@ -541,7 +581,10 @@ def main(argv=None):
     if args.check_application_names:
         verify_application_names(results, args.benchmark_data, engines)
 
-    print(generate_tables(results, engines))
+    declared_statuses = (
+        load_declared_plan(args.declared_plan) if args.declared_plan else None
+    )
+    print(generate_tables(results, engines, declared_statuses))
 
 
 if __name__ == "__main__":

--- a/safere-benchmarks/scripts/test_compare_benchmarks.py
+++ b/safere-benchmarks/scripts/test_compare_benchmarks.py
@@ -61,6 +61,99 @@ class CrossEngineResultParsingTest(unittest.TestCase):
         )
         self.assertEqual(results[0].engine, "jdk")
 
+    def test_normalizes_no_fork_and_cold_start_trial_ids(self):
+        results = self.parse(
+            "Benchmark (crossEngineNoForkTrial) Mode Cnt Score Error Units\n"
+            "org.safere.benchmark.CrossEngineNoForkBenchmark.run "
+            "PathologicalBenchmark.pathological.25@re2j-string "
+            "avgt 5 2.4 ± 0.2 us/op\n"
+            "Benchmark (crossEngineColdStartTrial) Mode Score Error Units\n"
+            "org.safere.benchmark.CrossEngineColdStartBenchmark.run "
+            "UnicodeFirstCompileBenchmark.firstCompile.letter.0@jdk-string "
+            "ss 7.0 ms/op\n"
+        )
+
+        self.assertEqual(
+            [(result.benchmark, result.engine) for result in results],
+            [
+                ("PathologicalBenchmark.pathological.25", "re2j"),
+                ("UnicodeFirstCompileBenchmark.firstCompile.letter.0", "jdk"),
+            ],
+        )
+
+    def test_normalizes_specialized_trial_and_preserves_representation_label(self):
+        results = self.parse(
+            "Benchmark (specializedTrial) Mode Cnt Score Error Units\n"
+            "org.safere.benchmark.SpecializedBenchmark.run "
+            "Utf8MatchingBenchmark.captureFreeDecode.asciiEarly@safere-utf8 "
+            "avgt 5 12.3 ± 0.4 ns/op\n"
+        )
+
+        self.assertEqual(results[0].engine, "safere_utf8")
+        self.assertEqual(
+            results[0].benchmark,
+            "Utf8MatchingBenchmark.captureFreeDecode.asciiEarly",
+        )
+
+    def test_preserves_timed_string_conversion_variant_label(self):
+        results = self.parse(
+            "Benchmark (crossEngineTrial) Mode Cnt Score Error Units\n"
+            "org.safere.benchmark.CrossEngineBenchmark.run "
+            "RegexBenchmark.emailFind@re2-ffm-string-conversion "
+            "avgt 5 12.3 ± 0.4 ns/op\n"
+        )
+
+        self.assertEqual(results[0].engine, "re2_ffm")
+
+    def test_declared_plan_distinguishes_missing_from_excluded(self):
+        plan = {
+            "trials": [
+                {
+                    "workloadId": "RegexBenchmark.literalMatch",
+                    "executionVariant": "safere-string",
+                }
+            ],
+            "exclusions": [
+                {
+                    "workloadId": "RegexBenchmark.literalMatch",
+                    "executionVariant": "safere-utf8",
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as plan_file:
+            json.dump(plan, plan_file)
+            plan_file.flush()
+            statuses = COMPARE.load_declared_plan(plan_file.name)
+
+        markdown = COMPARE.generate_tables(
+            [],
+            ["safere", "safere_utf8"],
+            statuses,
+        )
+
+        self.assertIn("missing", markdown)
+        self.assertIn("excluded", markdown)
+
+    def test_cross_language_json_row_keeps_stable_identity(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as output:
+            output.write(
+                '{"engine":"re2_cpp","benchmark":"RegexBenchmark.literalMatch",'
+                '"score":4.2,"error":0.1,"unit":"ns/op"}\n'
+            )
+            output.flush()
+            results = COMPARE.parse_jsonl(output.name)
+
+        self.assertEqual(
+            results[0],
+            COMPARE.Result(
+                "re2_cpp",
+                "RegexBenchmark.literalMatch",
+                4.2,
+                0.1,
+                "ns/op",
+            ),
+        )
+
     def test_application_name_check_respects_utf8_operation_coverage(self):
         benchmark_data = {
             "application": [

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
@@ -33,6 +33,11 @@ final class BenchmarkCollectionPlan {
   }
 
   List<Runner> runners() {
+    Set<String> allocationOnly = allocationOnlyTrialIds();
+    return filterRunners(allRunners(), trialId -> !allocationOnly.contains(trialId), false);
+  }
+
+  private List<Runner> allRunners() {
     return List.of(
         runner(
             "standard",
@@ -83,23 +88,43 @@ final class BenchmarkCollectionPlan {
   List<Runner> allocationRunners() {
     List<String> prefixes =
         BenchmarkData.get().getStringList("collection.allocationWorkloadPrefixes");
-    return runners().stream()
-        .filter(runner -> runner.profile().equals("standard"))
+    Set<String> allocationOnly = allocationOnlyTrialIds();
+    return filterRunners(
+        allRunners(),
+        trialId ->
+            allocationOnly.contains(trialId)
+                || prefixes.stream()
+                    .anyMatch(trialId.substring(0, trialId.lastIndexOf('@'))::startsWith),
+        true);
+  }
+
+  private static List<Runner> filterRunners(
+      List<Runner> runners,
+      java.util.function.Predicate<String> includeTrial,
+      boolean standardOnly) {
+    return runners.stream()
+        .filter(runner -> !standardOnly || runner.profile().equals("standard"))
         .map(
             runner ->
                 new Runner(
                     runner.profile(),
                     runner.benchmark(),
                     runner.parameter(),
-                    runner.trialIds().stream()
-                        .filter(
-                            trialId ->
-                                prefixes.stream()
-                                    .anyMatch(
-                                        trialId.substring(0, trialId.lastIndexOf('@'))::startsWith))
-                        .toList()))
+                    runner.trialIds().stream().filter(includeTrial).toList()))
         .filter(runner -> !runner.trialIds().isEmpty())
         .toList();
+  }
+
+  private Set<String> allocationOnlyTrialIds() {
+    return trials(Query.ALL).stream()
+        .filter(
+            trial ->
+                trial
+                    .measurement()
+                    .constraints()
+                    .contains(DeclarativeBenchmarkPlan.ExecutionConstraint.ALLOCATION_PROFILE))
+        .map(CollectionTrial::id)
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   private static Runner runner(
@@ -138,7 +163,16 @@ final class BenchmarkCollectionPlan {
   }
 
   ReportPlan reportPlan() {
-    List<CollectionTrial> trials = trials(Query.ALL);
+    return reportPlan(false);
+  }
+
+  ReportPlan reportPlan(boolean smoke) {
+    Set<String> collectedTrialIds =
+        runners().stream()
+            .flatMap(runner -> (smoke ? smokeTrialIds(runner) : runner.trialIds()).stream())
+            .collect(Collectors.toUnmodifiableSet());
+    List<CollectionTrial> trials =
+        trials(Query.ALL).stream().filter(trial -> collectedTrialIds.contains(trial.id())).toList();
     Set<String> workloadIds =
         trials.stream()
             .map(CollectionTrial::workloadId)
@@ -178,7 +212,7 @@ final class BenchmarkCollectionPlan {
                     runner.profile(),
                     runner.benchmark(),
                     runner.parameter(),
-                    String.join(",", smoke ? runner.trialIds().subList(0, 1) : runner.trialIds())));
+                    String.join(",", smoke ? smokeTrialIds(runner) : runner.trialIds())));
       }
       case "trials" -> {
         Query query = Query.parse(Arrays.copyOfRange(args, 1, args.length));
@@ -189,9 +223,24 @@ final class BenchmarkCollectionPlan {
         System.out.println(
             selected.stream().map(CollectionTrial::id).collect(Collectors.joining(",")));
       }
-      case "report-plan" -> System.out.println(GSON.toJson(plan.reportPlan()));
+      case "report-plan" -> {
+        boolean smoke = args.length == 2 && args[1].equals("--smoke");
+        if (args.length > 2 || (args.length == 2 && !smoke)) {
+          throw new IllegalArgumentException(
+              "Usage: BenchmarkCollectionPlan report-plan [--smoke]");
+        }
+        System.out.println(GSON.toJson(plan.reportPlan(smoke)));
+      }
       default -> throw new IllegalArgumentException("Unknown collection-plan command: " + args[0]);
     }
+  }
+
+  private static List<String> smokeTrialIds(Runner runner) {
+    String firstTrial = runner.trialIds().getFirst();
+    String firstWorkload = firstTrial.substring(0, firstTrial.lastIndexOf('@'));
+    return runner.trialIds().stream()
+        .filter(trialId -> trialId.startsWith(firstWorkload + "@"))
+        .toList();
   }
 
   record Runner(String profile, String benchmark, String parameter, List<String> trialIds) {}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
@@ -1,0 +1,247 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Discovers generic benchmark runners, trials, and report identities from the declared plan. */
+final class BenchmarkCollectionPlan {
+  private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+  private final CrossEngineBenchmarkPlan crossEngine;
+  private final SpecializedBenchmarkPlan specialized;
+
+  private BenchmarkCollectionPlan(
+      CrossEngineBenchmarkPlan crossEngine, SpecializedBenchmarkPlan specialized) {
+    this.crossEngine = crossEngine;
+    this.specialized = specialized;
+  }
+
+  static BenchmarkCollectionPlan load() {
+    return new BenchmarkCollectionPlan(
+        CrossEngineBenchmarkPlan.load(), SpecializedBenchmarkPlan.load());
+  }
+
+  List<Runner> runners() {
+    return List.of(
+        runner(
+            "standard",
+            CrossEngineBenchmark.class,
+            "crossEngineTrial",
+            crossEngine.trials(
+                CrossEngineWorkload.TimingGroup.NANOSECONDS,
+                DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME,
+                false)),
+        runner(
+            "standard",
+            CrossEngineScalingBenchmark.class,
+            "crossEngineScalingTrial",
+            crossEngine.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
+                .filter(
+                    trial ->
+                        !trial
+                            .workload()
+                            .measurement()
+                            .constraints()
+                            .contains(DeclarativeBenchmarkPlan.ExecutionConstraint.NO_FORK))
+                .toList()),
+        runner(
+            "noFork",
+            CrossEngineNoForkBenchmark.class,
+            "crossEngineNoForkTrial",
+            crossEngine.trials(
+                CrossEngineWorkload.TimingGroup.MICROSECONDS,
+                DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME,
+                true)),
+        runner(
+            "coldStart",
+            CrossEngineColdStartBenchmark.class,
+            "crossEngineColdStartTrial",
+            crossEngine.trials(
+                CrossEngineWorkload.TimingGroup.MILLISECONDS,
+                DeclarativeBenchmarkPlan.MeasurementMode.SINGLE_SHOT_COLD_START,
+                false)),
+        new Runner(
+            "standard",
+            SpecializedBenchmark.class.getName() + ".run",
+            "specializedTrial",
+            specialized.averageTimeTrials().stream()
+                .map(SpecializedBenchmarkPlan.Trial::id)
+                .toList()));
+  }
+
+  List<Runner> allocationRunners() {
+    List<String> prefixes =
+        BenchmarkData.get().getStringList("collection.allocationWorkloadPrefixes");
+    return runners().stream()
+        .filter(runner -> runner.profile().equals("standard"))
+        .map(
+            runner ->
+                new Runner(
+                    runner.profile(),
+                    runner.benchmark(),
+                    runner.parameter(),
+                    runner.trialIds().stream()
+                        .filter(
+                            trialId ->
+                                prefixes.stream()
+                                    .anyMatch(
+                                        trialId.substring(0, trialId.lastIndexOf('@'))::startsWith))
+                        .toList()))
+        .filter(runner -> !runner.trialIds().isEmpty())
+        .toList();
+  }
+
+  private static Runner runner(
+      String profile,
+      Class<?> runnerClass,
+      String parameter,
+      List<CrossEngineBenchmarkPlan.Trial> trials) {
+    return new Runner(
+        profile,
+        runnerClass.getName() + ".run",
+        parameter,
+        trials.stream().map(CrossEngineBenchmarkPlan.Trial::id).toList());
+  }
+
+  List<CollectionTrial> trials(Query query) {
+    List<CollectionTrial> trials = new ArrayList<>();
+    for (CrossEngineWorkload.TimingGroup group : CrossEngineWorkload.TimingGroup.values()) {
+      for (CrossEngineBenchmarkPlan.Trial trial : crossEngine.trials(group)) {
+        trials.add(
+            new CollectionTrial(
+                trial.id(),
+                trial.workload().id(),
+                trial.variant().id(),
+                trial.workload().measurement()));
+      }
+    }
+    for (SpecializedBenchmarkPlan.Trial trial : specialized.averageTimeTrials()) {
+      trials.add(
+          new CollectionTrial(
+              trial.id(),
+              trial.workload().id(),
+              trial.variant().id(),
+              trial.workload().measurement()));
+    }
+    return trials.stream().filter(query::matches).toList();
+  }
+
+  ReportPlan reportPlan() {
+    List<CollectionTrial> trials = trials(Query.ALL);
+    Set<String> workloadIds =
+        trials.stream()
+            .map(CollectionTrial::workloadId)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    List<ReportExclusion> exclusions = new ArrayList<>();
+    crossEngine.exclusions().stream()
+        .filter(exclusion -> workloadIds.contains(exclusion.workloadId()))
+        .map(ReportExclusion::from)
+        .forEach(exclusions::add);
+    specialized.exclusions().stream()
+        .filter(exclusion -> workloadIds.contains(exclusion.workloadId()))
+        .map(ReportExclusion::from)
+        .forEach(exclusions::add);
+    return new ReportPlan(trials, exclusions.stream().distinct().toList());
+  }
+
+  static void main(String[] args) {
+    if (args.length == 0) {
+      throw new IllegalArgumentException(
+          "Usage: BenchmarkCollectionPlan "
+              + "<runners|allocation-runners|trials|report-plan> [query options]");
+    }
+    BenchmarkCollectionPlan plan = load();
+    switch (args[0]) {
+      case "runners", "allocation-runners" -> {
+        boolean smoke = args.length == 2 && args[1].equals("--smoke");
+        if (args.length > 2 || (args.length == 2 && !smoke)) {
+          throw new IllegalArgumentException(
+              "Usage: BenchmarkCollectionPlan " + args[0] + " [--smoke]");
+        }
+        List<Runner> runners =
+            args[0].equals("runners") ? plan.runners() : plan.allocationRunners();
+        runners.forEach(
+            runner ->
+                System.out.printf(
+                    "%s\t%s\t%s\t%s%n",
+                    runner.profile(),
+                    runner.benchmark(),
+                    runner.parameter(),
+                    String.join(",", smoke ? runner.trialIds().subList(0, 1) : runner.trialIds())));
+      }
+      case "trials" -> {
+        Query query = Query.parse(Arrays.copyOfRange(args, 1, args.length));
+        List<CollectionTrial> selected = plan.trials(query);
+        if (selected.isEmpty()) {
+          throw new IllegalStateException("No declared trials match the query");
+        }
+        System.out.println(
+            selected.stream().map(CollectionTrial::id).collect(Collectors.joining(",")));
+      }
+      case "report-plan" -> System.out.println(GSON.toJson(plan.reportPlan()));
+      default -> throw new IllegalArgumentException("Unknown collection-plan command: " + args[0]);
+    }
+  }
+
+  record Runner(String profile, String benchmark, String parameter, List<String> trialIds) {}
+
+  record CollectionTrial(
+      String id,
+      String workloadId,
+      String executionVariant,
+      DeclarativeBenchmarkPlan.Measurement measurement) {}
+
+  record ReportExclusion(String workloadId, String executionVariant, String kind, String reason) {
+    static ReportExclusion from(DeclarativeBenchmarkPlan.Exclusion exclusion) {
+      return new ReportExclusion(
+          exclusion.workloadId(),
+          exclusion.engineId(),
+          exclusion.kind().name(),
+          exclusion.reason());
+    }
+  }
+
+  record ReportPlan(List<CollectionTrial> trials, List<ReportExclusion> exclusions) {}
+
+  record Query(String mode, String timing, String prefix, String variant) {
+    private static final Query ALL = new Query(null, null, null, null);
+
+    static Query parse(String[] args) {
+      String mode = null;
+      String timing = null;
+      String prefix = null;
+      String variant = null;
+      for (int index = 0; index < args.length; index += 2) {
+        if (index + 1 >= args.length) {
+          throw new IllegalArgumentException("Missing value for query option " + args[index]);
+        }
+        switch (args[index]) {
+          case "--mode" -> mode = args[index + 1];
+          case "--timing" -> timing = args[index + 1];
+          case "--prefix" -> prefix = args[index + 1];
+          case "--variant" -> variant = args[index + 1];
+          default -> throw new IllegalArgumentException("Unknown query option: " + args[index]);
+        }
+      }
+      return new Query(mode, timing, prefix, variant);
+    }
+
+    boolean matches(CollectionTrial trial) {
+      return (mode == null || trial.measurement().mode().jsonName().equals(mode))
+          && (timing == null || trial.measurement().timingUnit().jsonName().equals(timing))
+          && (prefix == null || trial.workloadId().startsWith(prefix))
+          && (variant == null || trial.executionVariant().equals(variant));
+    }
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
@@ -17,9 +17,12 @@ import java.util.stream.Collectors;
 /** Resolves data-declared workloads that use specialized measurement machinery. */
 final class SpecializedBenchmarkPlan {
   private final Map<String, Trial> trials;
+  private final List<DeclarativeBenchmarkPlan.Exclusion> exclusions;
 
-  private SpecializedBenchmarkPlan(Map<String, Trial> trials) {
+  private SpecializedBenchmarkPlan(
+      Map<String, Trial> trials, List<DeclarativeBenchmarkPlan.Exclusion> exclusions) {
     this.trials = Collections.unmodifiableMap(new LinkedHashMap<>(trials));
+    this.exclusions = List.copyOf(exclusions);
   }
 
   static SpecializedBenchmarkPlan load() {
@@ -39,7 +42,13 @@ final class SpecializedBenchmarkPlan {
         throw new IllegalArgumentException("Duplicate specialized trial ID: " + converted.id());
       }
     }
-    return new SpecializedBenchmarkPlan(trials);
+    var workloadIds =
+        trials.values().stream().map(trial -> trial.workload().id()).collect(Collectors.toSet());
+    List<DeclarativeBenchmarkPlan.Exclusion> exclusions =
+        expanded.exclusions().stream()
+            .filter(exclusion -> workloadIds.contains(exclusion.workloadId()))
+            .toList();
+    return new SpecializedBenchmarkPlan(trials, exclusions);
   }
 
   private static boolean isSpecialized(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
@@ -95,6 +104,10 @@ final class SpecializedBenchmarkPlan {
                 trial.workload().measurement().mode()
                     == DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY)
         .toList();
+  }
+
+  List<DeclarativeBenchmarkPlan.Exclusion> exclusions() {
+    return exclusions;
   }
 
   static void main(String[] args) {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -302,6 +302,44 @@ class CrossEngineBenchmarkPlanTest {
   }
 
   @Test
+  void collectionPlanDiscoversGenericRunnersAndStableReportRows() {
+    BenchmarkCollectionPlan plan = BenchmarkCollectionPlan.load();
+
+    assertThat(plan.runners())
+        .extracting(BenchmarkCollectionPlan.Runner::benchmark)
+        .containsExactly(
+            "org.safere.benchmark.CrossEngineBenchmark.run",
+            "org.safere.benchmark.CrossEngineScalingBenchmark.run",
+            "org.safere.benchmark.CrossEngineNoForkBenchmark.run",
+            "org.safere.benchmark.CrossEngineColdStartBenchmark.run",
+            "org.safere.benchmark.SpecializedBenchmark.run");
+    assertThat(plan.runners())
+        .allMatch(runner -> !runner.trialIds().isEmpty())
+        .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
+        .doesNotHaveDuplicates()
+        .hasSize(1443);
+    assertThat(plan.reportPlan().trials()).hasSize(1443);
+    assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
+  }
+
+  @Test
+  void collectionPlanQueriesModeTimingPrefixAndExecutionVariant() {
+    BenchmarkCollectionPlan plan = BenchmarkCollectionPlan.load();
+    BenchmarkCollectionPlan.Query query =
+        new BenchmarkCollectionPlan.Query(
+            "averageTime", "nanoseconds", "RegexBenchmark.", "safere-utf8");
+
+    assertThat(plan.trials(query))
+        .isNotEmpty()
+        .allMatch(
+            trial ->
+                trial.workloadId().startsWith("RegexBenchmark.")
+                    && trial.executionVariant().equals("safere-utf8")
+                    && trial.measurement().timingUnit()
+                        == DeclarativeBenchmarkPlan.TimingUnit.NANOSECONDS);
+  }
+
+  @Test
   void everySpecializedOperationPreparesAndRunsThroughOneEntryPoint() {
     List<String> trials =
         List.of(

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -47,7 +47,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(400);
+    assertThat(ids).hasSize(408);
   }
 
   @Test
@@ -76,9 +76,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1380);
-    assertThat(plan.exclusions()).hasSize(620);
-    assertThat(accounted).hasSize(400 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(1404);
+    assertThat(plan.exclusions()).hasSize(636);
+    assertThat(accounted).hasSize(408 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -99,7 +99,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(499);
+        .hasSize(523);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -320,6 +320,30 @@ class CrossEngineBenchmarkPlanTest {
         .hasSize(1443);
     assertThat(plan.reportPlan().trials()).hasSize(1443);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
+    assertThat(
+            plan.reportPlan(true).trials().stream()
+                .map(BenchmarkCollectionPlan.CollectionTrial::workloadId)
+                .distinct())
+        .hasSize(5);
+  }
+
+  @Test
+  void allocationCollectionPreservesMemoryScalingWithoutAddingTimingTrials() {
+    BenchmarkCollectionPlan plan = BenchmarkCollectionPlan.load();
+
+    assertThat(plan.allocationRunners())
+        .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
+        .contains(
+            "MemoryScalingBenchmark.searchEasy.1024@safere-string",
+            "MemoryScalingBenchmark.searchEasy.1024@jdk-string",
+            "MemoryScalingBenchmark.searchEasy.1024@re2j-string",
+            "MemoryScalingBenchmark.searchMedium.1048576@safere-string",
+            "MemoryScalingBenchmark.searchMedium.1048576@jdk-string",
+            "MemoryScalingBenchmark.searchMedium.1048576@re2j-string")
+        .noneMatch(trial -> trial.startsWith("MemoryScalingBenchmark.") && trial.contains("utf8"));
+    assertThat(plan.runners())
+        .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
+        .noneMatch(trial -> trial.startsWith("MemoryScalingBenchmark."));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add a collection-plan query surface for generic runners, trial filters, allocation selections, and report identities
- make Java timing, allocation, retained-memory, C++ RE2, and Go collection discover declared work instead of enumerating Java workload classes
- migrate memory-scaling allocation trials into the declarative plan
- normalize every generic JMH trial parameter to stable workload and execution-variant identities
- preserve UTF-8 and timed string-conversion labels and distinguish missing results from declared exclusions
- make smoke execution and reporting use the same representative workloads and supported variants
- emit cross-runtime results separately as contextual tables

## Verification

- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere-benchmarks verify -DskipTests -q`
- `python3 -m unittest safere-benchmarks/scripts/test_compare_benchmarks.py`
- `bash -n run-java-benchmarks.sh run-java-memory-benchmarks.sh collect-benchmark-results.sh`
- `git diff --check`
- focused GC-profiler smoke for the declarative memory-scaling cases
- complete aligned Java collection smoke, including allocation and retained-memory trials
- external OpenJDK-derived representative smoke
- review/fix loop completed with no remaining P2+ findings
- full performance collection was not run; smoke results are validation only and support no performance claims

Fixes #613
Part of #606

Stacked on #619.
