### PR TITLE
Update README examples for 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ SafeRE is available on [Maven Central](https://central.sonatype.com/artifact/org
 <dependency>
   <groupId>org.safere</groupId>
   <artifactId>safere</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
 </dependency>
 ```
 
 **Gradle (Kotlin DSL):**
 
 ```kotlin
-implementation("org.safere:safere:0.9.0")
+implementation("org.safere:safere:0.10.0")
 ```
 
 **Gradle (Groovy DSL):**
 
 ```groovy
-implementation 'org.safere:safere:0.9.0'
+implementation 'org.safere:safere:0.10.0'
 ```
 
 ## Quick Start


### PR DESCRIPTION
Updates the README installation examples to reference the upcoming SafeRE 0.10.0 release.

Verification:
- `git diff --check`

This is release preparation for v0.10.0.
