### PR TITLE
Bump version to 0.11.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.safere</groupId>
   <artifactId>safere-parent</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
+  <version>0.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SafeRE Parent</name>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-benchmarks</artifactId>

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-crosscheck</artifactId>

--- a/safere-exhaustive/pom.xml
+++ b/safere-exhaustive/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-exhaustive</artifactId>

--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-ffm-re2</artifactId>

--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-fuzz</artifactId>

--- a/safere-unicode/pom.xml
+++ b/safere-unicode/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-unicode-generator</artifactId>

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere</artifactId>


### PR DESCRIPTION
Bumps the Maven project and module versions to `0.11.0-SNAPSHOT` for post-release development after v0.10.0.

Verification:
- `mvn versions:set -DnewVersion=0.11.0-SNAPSHOT -DgenerateBackupPoms=false -q`
- `git diff --check`
