### PR TITLE
Run CI for stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary

- run pull-request CI regardless of the PR's base branch
- preserve the existing restriction that push CI runs only on `main`
- allow stacked PRs to validate against their immediate parent branches

## Verification

- `git diff --check`
- reviewed the resulting workflow trigger configuration
- `actionlint` was not available locally

This infrastructure-only change does not modify project code.
