### PR TITLE
Add PCRE2 JIT to benchmark matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Materialize shared benchmark inputs
         run: ./materialize-benchmark-inputs.sh
 
-      - name: Compile C++ RE2 benchmarks
+      - name: Compile native C++ regex benchmarks
         run: |
           mkdir -p safere-benchmarks/cpp/build
           cmake -S safere-benchmarks/cpp -B safere-benchmarks/cpp/build \
@@ -180,8 +180,20 @@ jobs:
             --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
 
       - name: Smoke test C++ RE2 memory benchmarks
+        if: matrix.os == 'ubuntu-latest'
         run: |
           safere-benchmarks/cpp/build/re2_benchmark \
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark
+
+      - name: Smoke test PCRE2 JIT benchmarks
+        run: |
+          safere-benchmarks/cpp/build/pcre2_jit_benchmark \
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
+
+      - name: Smoke test PCRE2 JIT memory benchmarks
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          safere-benchmarks/cpp/build/pcre2_jit_benchmark \
             --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark
 
   benchmark-smoke-test-go:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,6 +362,16 @@ generic runners and trials:
   before execution. Java, C++, Go, Rust, and other harnesses read only those
   generated artifacts. Edit the JSON file to change workloads; never hardcode
   values or generation logic in a harness.
+- **Zero implicit benchmark syntax conversion.** Regex patterns and
+  replacement templates remain Java-canonical workload data. When an engine
+  needs different syntax, declare the engine's exact alternate beside the
+  canonical value in `benchmark-data.json`, with a reason, and have the adapter
+  select that profile or use the canonical value unchanged. Runners and
+  adapters must not parse, rewrite, translate, escape, or otherwise infer
+  engine-specific pattern or replacement syntax, including numbered or named
+  group references and quoting rules. If the schema cannot yet express the
+  required alternate, extend and validate the schema first; do not add a
+  conversion helper in a harness.
 
 ### Summary Statistics
 

--- a/README.md
+++ b/README.md
@@ -426,8 +426,8 @@ mvn javadoc:javadoc -pl safere
 SafeRE includes a [JMH](https://github.com/openjdk/jmh) benchmark suite in the
 `safere-benchmarks` module, comparing SafeRE against `java.util.regex` (JDK),
 [RE2/J](https://github.com/google/re2j), RE2-FFM (C++ RE2 via Java
-[FFM API](https://openjdk.org/jeps/454)), C++ RE2, Go `regexp`, and Rust
-[`regex`](https://crates.io/crates/regex).
+[FFM API](https://openjdk.org/jeps/454)), C++ RE2, PCRE2 JIT, Go `regexp`, and
+Rust [`regex`](https://crates.io/crates/regex).
 The suite includes focused microbenchmarks, data-driven application workloads,
 scaling/pathological cases, replacement, memory, and `PatternSet` benchmarks.
 Benchmark recipes and configuration live in
@@ -483,7 +483,7 @@ important comparisons:
 ```
 
 Use the cross-language mode only when you need broader ecosystem context from
-C++ RE2, Go `regexp`, and Rust `regex`:
+C++ RE2, PCRE2 JIT, Go `regexp`, and Rust `regex`:
 
 ```bash
 ./collect-benchmark-results.sh --cross-language
@@ -590,14 +590,17 @@ explicitly only when optimizing crosscheck:
 ./run-java-benchmarks.sh '^org\.safere\.benchmark\.CrosscheckOverheadBenchmark\.'
 ```
 
-### C++ RE2, Go, and Rust Benchmarks
+### Cross-Runtime Benchmarks
 
-The benchmark suite includes C++ RE2, Go `regexp`, and Rust `regex` harnesses
-for cross-language comparison. Prerequisites are
-[CMake ≥ 3.14](https://cmake.org/download/) with a C++17 compiler,
-[Go ≥ 1.21](https://go.dev/doc/install), and
-[Rust ≥ 1.85 with Cargo](https://rust-lang.org/tools/install/). Dependencies
-are fetched automatically.
+The benchmark suite includes C++ RE2, PCRE2 JIT, Go `regexp`, and Rust `regex`
+harnesses for
+cross-language comparison. Each runner executes every workload implemented by
+its adapter when no filter is supplied. The C++ engines share one workload
+harness, so PCRE2 does not use a narrower workload allowlist than RE2.
+
+Toolchain requirements, installation links, per-engine commands, JIT
+requirements, memory-platform limits, and smoke-test instructions are in
+[`safere-benchmarks/CROSS_RUNTIME_ENGINES.md`](safere-benchmarks/CROSS_RUNTIME_ENGINES.md).
 
 Benchmark patterns and replacement templates are written in Java syntax. A
 value that needs different syntax in another regex dialect declares exact
@@ -605,12 +608,14 @@ alternatives beside its Java-canonical definition in
 `safere-benchmarks/benchmark-data.json`; a missing alternate means that the Java
 value is used unchanged. Harnesses do not translate syntax or infer replacement
 templates from operation names. See the
-[pattern-profile schema](safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles)
+[syntax-profile schema](safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles)
 for profile mappings and validation rules.
 
 ```bash
-# C++ RE2 benchmarks
-./run-cpp-benchmarks.sh                    # all C++ benchmarks
+# All C++ engines, or one engine
+./run-cpp-benchmarks.sh                    # all native C++ benchmarks
+./run-cpp-benchmarks.sh --engine re2
+./run-cpp-benchmarks.sh --engine pcre2-jit
 ./run-cpp-benchmarks.sh Regex Application  # specific benchmark groups
 
 # Go regexp benchmarks
@@ -631,13 +636,14 @@ python3 safere-benchmarks/scripts/compare-benchmarks.py \
   --jmh jmh-output.txt
 ```
 
-Add C++, Go, and Rust JSON-lines files when comparing cross-language results:
+Add C++, Go, and Rust JSON-lines files when comparing cross-language results.
+The C++ file contains both `re2_cpp` and `pcre2_jit` records:
 
 ```bash
 python3 safere-benchmarks/scripts/compare-benchmarks.py \
   --jmh jmh-output.txt \
   --json cpp-results.jsonl go-results.jsonl rust-results.jsonl \
-  --engines safere,jdk,re2j,re2_ffm,re2_cpp,go,rust
+  --engines safere,jdk,re2j,re2_ffm,re2_cpp,pcre2_jit,go,rust
 ```
 
 To distinguish absent results from declared exclusions, include the report plan:

--- a/collect-benchmark-results.sh
+++ b/collect-benchmark-results.sh
@@ -16,7 +16,7 @@
 # batches sequentially, captures raw output, and generates markdown tables.
 # By default it collects the Java/JMH results and the separately licensed
 # OpenJDK-derived suite from an external checkout. Use --cross-language to also
-# collect C++ RE2, Go regexp, and Rust regex results.
+# collect C++ RE2, PCRE2 JIT, Go regexp, and Rust regex results.
 
 set -euo pipefail
 
@@ -42,7 +42,7 @@ Collects benchmark outputs for updating BENCHMARKS.md.
 
 Options:
   --long            Use the longer Java confirmation mode.
-  --cross-language  Also run C++ RE2, Go regexp, and Rust regex harnesses.
+  --cross-language  Also run C++ RE2, PCRE2 JIT, Go regexp, and Rust regex harnesses.
   --openjdk-regex-repo PATH
                     Select the external OpenJDK-derived suite checkout.
   --skip-openjdk-regex
@@ -270,7 +270,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
     --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl" \
       "$OUTPUT_DIR/rust-results.jsonl"
   )
-  COMPARE_ENGINES="safere,safere_utf8,jdk,re2j,re2_ffm,re2_cpp,go,rust"
+  COMPARE_ENGINES="safere,safere_utf8,jdk,re2j,re2_ffm,re2_cpp,pcre2_jit,go,rust"
 fi
 
 log "Generating markdown tables"
@@ -284,7 +284,7 @@ if [ "$CROSS_LANGUAGE" = true ]; then
   python3 safere-benchmarks/scripts/compare-benchmarks.py \
     --json "$OUTPUT_DIR/cpp-results.jsonl" "$OUTPUT_DIR/go-results.jsonl" \
       "$OUTPUT_DIR/rust-results.jsonl" \
-    --engines re2_cpp,go,rust \
+    --engines re2_cpp,pcre2_jit,go,rust \
     > "$OUTPUT_DIR/cross-runtime-tables.md"
 fi
 

--- a/run-cpp-benchmarks.sh
+++ b/run-cpp-benchmarks.sh
@@ -2,13 +2,14 @@
 # Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
 # See LICENSE file in the project root for details.
 #
-# Build and run C++ RE2 benchmarks.
+# Build and run native C++ RE2 and PCRE2 JIT benchmarks.
 #
 # Usage:
 #   ./run-cpp-benchmarks.sh                    # run all benchmarks
 #   ./run-cpp-benchmarks.sh RegexBenchmark     # run matching benchmarks
+#   ./run-cpp-benchmarks.sh --engine pcre2-jit RegexBenchmark
 #
-# Prerequisites: CMake >= 3.14, C++17 compiler.
+# Prerequisites: CMake >= 3.15, C++17 compiler.
 
 set -euo pipefail
 
@@ -16,14 +17,39 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CPP_DIR="$SCRIPT_DIR/safere-benchmarks/cpp"
 BUILD_DIR="$CPP_DIR/build"
 MANIFEST_FILE="$SCRIPT_DIR/safere-benchmarks/target/benchmark-corpus/manifest.json"
+ENGINE="all"
+
+if [ "${1:-}" = "--engine" ]; then
+  if [ $# -lt 2 ]; then
+    echo "ERROR: --engine requires all, re2, or pcre2-jit" >&2
+    exit 2
+  fi
+  ENGINE="$2"
+  shift 2
+fi
+
+case "$ENGINE" in
+  all|re2|pcre2-jit) ;;
+  *)
+    echo "ERROR: unknown native C++ benchmark engine: $ENGINE" >&2
+    exit 2
+    ;;
+esac
 
 echo "=== Materializing shared benchmark inputs ==="
 "$SCRIPT_DIR/materialize-benchmark-inputs.sh"
 
-echo "=== Building C++ RE2 benchmarks ==="
+echo "=== Building native C++ regex benchmarks ==="
 mkdir -p "$BUILD_DIR"
 cmake -S "$CPP_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -Wno-dev 2>&1 | tail -3
 cmake --build "$BUILD_DIR" -j8 2>&1 | tail -3
 
-echo "=== Running C++ RE2 benchmarks ==="
-"$BUILD_DIR/re2_benchmark" --manifest "$MANIFEST_FILE" "$@"
+if [ "$ENGINE" = "all" ] || [ "$ENGINE" = "re2" ]; then
+  echo "=== Running C++ RE2 benchmarks ==="
+  "$BUILD_DIR/re2_benchmark" --manifest "$MANIFEST_FILE" "$@"
+fi
+
+if [ "$ENGINE" = "all" ] || [ "$ENGINE" = "pcre2-jit" ]; then
+  echo "=== Running PCRE2 JIT benchmarks ==="
+  "$BUILD_DIR/pcre2_jit_benchmark" --manifest "$MANIFEST_FILE" "$@"
+fi

--- a/safere-benchmarks/BENCHMARK_INPUTS.md
+++ b/safere-benchmarks/BENCHMARK_INPUTS.md
@@ -9,8 +9,9 @@ parameters, expected results, and deterministic input recipes.
 
 Before execution, each benchmark runner invokes the central materializer. It
 writes a resolved manifest and exact UTF-8 inputs under
-`target/benchmark-corpus/`. Java, C++, Go, Rust, and future harnesses read only
-those generated artifacts; they do not read or interpret `benchmark-data.json`.
+`target/benchmark-corpus/`. Java, C++ RE2, PCRE2 JIT, Go, Rust, and future
+harnesses read only those generated artifacts; they do not read or interpret
+`benchmark-data.json`.
 Java string engines decode input files as UTF-8 during benchmark setup, while
 byte-oriented engines use the bytes directly. Materialization and decoding are
 outside the timed operation.

--- a/safere-benchmarks/CROSS_RUNTIME_ENGINES.md
+++ b/safere-benchmarks/CROSS_RUNTIME_ENGINES.md
@@ -1,0 +1,152 @@
+# Cross-runtime benchmark engines
+
+The cross-runtime matrix contains native C++ RE2, PCRE2 JIT, Go `regexp`, and
+Rust `regex`. All runners read the same materialized inputs, Java-canonical
+patterns and replacement templates, and stable workload identities from
+`benchmark-data.json`.
+
+## Workload coverage
+
+C++ RE2 and PCRE2 JIT compile the same C++ harness. Unless filters are
+supplied, each executable runs every native workload it can support. PCRE2
+does not run `PathologicalBenchmark` workloads because their declarations
+require `linearTime`, which a backtracking engine cannot provide. It also
+omits timed replacement workloads because PCRE2's substitution API performs
+interpreted matching rather than JIT matching; reporting those measurements
+under the `pcre2_jit` engine ID would be misleading. Filters are forwarded
+unchanged to the selected engines.
+
+Go `regexp` and Rust `regex` run every workload implemented by their respective
+harnesses. Engine-specific syntax is selected through declared pattern and
+replacement profiles; unsupported syntax is not rewritten by a runner. A new
+cross-runtime workload must be added to every capable harness, or its missing
+engine operation must remain explicit during review.
+
+These measurements are cross-runtime context rather than controlled same-JVM
+comparisons. C++, Go, and Rust consume the materialized UTF-8 bytes directly.
+
+## Shared prerequisites
+
+Every native runner first invokes the Java benchmark-input materializer.
+Install the following:
+
+| Tool | Requirement | Installation |
+|---|---|---|
+| JDK | JDK 25, matching `.sdkmanrc` | [Eclipse Temurin installation guide](https://adoptium.net/installation/) |
+| Maven | Maven available as `mvn` | [Apache Maven installation guide](https://maven.apache.org/install.html) |
+| Bash | Required by the repository runner scripts | Install [GNU Bash](https://www.gnu.org/software/bash/) from the operating system's package source |
+
+The first build requires network access because CMake, Go, and Cargo download
+pinned source or module dependencies. No runner installs system packages.
+
+## C++ RE2
+
+The RE2 executable uses the repository's pinned
+[RE2](https://github.com/google/re2) and Abseil revisions. CMake fetches and
+builds both, so a separate RE2 installation is neither required nor used.
+
+Additional requirements:
+
+| Tool | Requirement | Installation |
+|---|---|---|
+| CMake | 3.15 or newer | [CMake installation guide](https://cmake.org/install/) |
+| C++ compiler | C++17 support | [GCC binary installation options](https://gcc.gnu.org/install/binaries.html) or [Apple Xcode and command-line tools](https://developer.apple.com/xcode/resources/) |
+
+Run every native workload supported by the RE2 harness:
+
+```bash
+./run-cpp-benchmarks.sh --engine re2
+```
+
+## PCRE2 JIT
+
+The PCRE2 executable uses pinned
+[PCRE2 10.47](https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.47)
+in 8-bit UTF mode. CMake fetches and builds PCRE2 with JIT enabled, so a
+separate PCRE2 installation is neither required nor used. The CMake and C++17
+requirements are the same as for C++ RE2.
+
+The host must permit allocation of executable memory for JIT code. The runner
+rejects any selected pattern that does not produce JIT code; see the
+[PCRE2 JIT documentation](https://pcre2project.github.io/pcre2/doc/pcre2jit/)
+for platform constraints and behavior.
+
+Run every native workload supported by the PCRE2 adapter:
+
+```bash
+./run-cpp-benchmarks.sh --engine pcre2-jit
+```
+
+The `linearTime` pathological workload family is intentionally absent from
+PCRE2 output. Those patterns can exhaust PCRE2's match limit and do not measure
+the declared linear-time behavior. Replacement workloads are also absent
+because PCRE2 does not expose a JIT substitution operation. The engine
+self-test still checks substitution correctness outside benchmark measurement.
+
+On platforms with `mallinfo2`, both C++ engines also emit native heap deltas
+for memory workloads. Other platforms still run timing workloads and the
+engine self-tests, but do not emit that platform-specific heap measurement.
+
+## Go `regexp`
+
+The Go runner uses the standard-library
+[`regexp`](https://pkg.go.dev/regexp) engine.
+
+Additional requirement:
+
+| Tool | Requirement | Installation |
+|---|---|---|
+| Go | 1.21 or newer | [Go installation guide](https://go.dev/doc/install) |
+
+Run every workload supported by the Go harness:
+
+```bash
+./run-go-benchmarks.sh
+```
+
+## Rust `regex`
+
+The Rust runner uses the [`regex`](https://crates.io/crates/regex) crate and
+the exact dependency versions pinned in `safere-benchmarks/rust/Cargo.lock`.
+
+Additional requirement:
+
+| Tool | Requirement | Installation |
+|---|---|---|
+| Rust | Rust 1.85 with Cargo | [Rust installation guide](https://www.rust-lang.org/tools/install) |
+
+Run every workload supported by the Rust harness:
+
+```bash
+./run-rust-benchmarks.sh
+```
+
+## Smoke tests
+
+CI runs matching and, where supported, memory smoke workloads for every native
+engine. Fast local engine self-tests verify compilation, captures, replacement,
+and PCRE2 JIT generation:
+
+```bash
+./materialize-benchmark-inputs.sh
+cmake -S safere-benchmarks/cpp -B safere-benchmarks/cpp/build \
+  -DCMAKE_BUILD_TYPE=Release -Wno-dev
+cmake --build safere-benchmarks/cpp/build --parallel
+ctest --test-dir safere-benchmarks/cpp/build --output-on-failure
+
+cd safere-benchmarks/go
+go test ./...
+
+cd ../rust
+cargo test --locked --all-features
+```
+
+To smoke-test the actual timed workload path for one engine, supply a narrow
+filter:
+
+```bash
+./run-cpp-benchmarks.sh --engine re2 RegexBenchmark.literalMatch
+./run-cpp-benchmarks.sh --engine pcre2-jit RegexBenchmark.literalMatch
+./run-go-benchmarks.sh RegexBenchmark.literalMatch
+./run-rust-benchmarks.sh RegexBenchmark.literalMatch
+```

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -115,8 +115,10 @@ the Java values directly. RE2/J and RE2-FFM select the `re2` pattern profile;
 native C++ RE2 selects `re2` patterns and `re2-cpp` replacements; Go selects
 `re2` patterns and `go-regexp` replacements where adjacent text makes a Java
 capture reference ambiguous; and Rust `regex` selects `rust-regex` for both
-kinds. If the selected profile has no entry for a Java syntax value, the adapter
-uses the Java value unchanged.
+kinds. PCRE2 JIT selects `pcre2` for both kinds; this remains separate from
+`re2` because PCRE2 accepts some Java-canonical forms that RE2 does not, while
+other forms need PCRE2-specific equivalents. If the selected profile has no
+entry for a Java syntax value, the adapter uses the Java value unchanged.
 
 Alternates are exact reviewed strings. Runners must not rewrite regex or
 replacement syntax automatically or derive replacement templates from operation

--- a/safere-benchmarks/DECLARATIVE_COLLECTION.md
+++ b/safere-benchmarks/DECLARATIVE_COLLECTION.md
@@ -33,6 +33,8 @@ engine column. `safere-utf8` remains a distinct column from `safere-string`, and
 `re2-ffm-string-conversion` remains distinct from native cross-runtime RE2 results, so input
 representation and timed conversion boundaries are not erased.
 
-C++ RE2, Go `regexp`, and Rust `regex` harnesses run in separate processes and emit JSONL with the
-same stable workload identities. Their results remain cross-runtime context; they are not treated
-as missing or excluded Java execution variants.
+C++ RE2, PCRE2 JIT, Go `regexp`, and Rust `regex` harnesses run outside the JVM and emit JSONL
+with the same stable workload identities. RE2 and PCRE2 JIT share one C++ workload harness but emit
+distinct engine IDs. Their results remain cross-runtime context; they are not treated as missing or
+excluded Java execution variants. Per-engine workload, toolchain, and smoke-test details are documented in
+[`CROSS_RUNTIME_ENGINES.md`](CROSS_RUNTIME_ENGINES.md).

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -6205,6 +6205,10 @@
                 "rust-regex": {
                   "pattern": "[\\x{0}-\\x{7F}]+",
                   "reason": "Rust regex does not expose Java Unicode block names"
+                },
+                "pcre2": {
+                  "pattern": "[\\x{0}-\\x{7F}]+",
+                  "reason": "PCRE2 does not expose Java Unicode block names"
                 }
               }
             }
@@ -6221,6 +6225,10 @@
                 "rust-regex": {
                   "pattern": "[\\x{4E00}-\\x{9FFF}]+",
                   "reason": "Rust regex does not expose Java Unicode block names"
+                },
+                "pcre2": {
+                  "pattern": "[\\x{4E00}-\\x{9FFF}]+",
+                  "reason": "PCRE2 does not expose Java Unicode block names"
                 }
               }
             }
@@ -6253,6 +6261,10 @@
                 "re2": {
                   "pattern": "[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+",
                   "reason": "RE2 does not support Java character-class intersection"
+                },
+                "pcre2": {
+                  "pattern": "[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+",
+                  "reason": "PCRE2 default character classes do not use Java intersection syntax"
                 }
               }
             }
@@ -6349,6 +6361,10 @@
                 "rust-regex": {
                   "pattern": "[\\x{0}-\\x{7F}]+",
                   "reason": "Rust regex does not expose Java Unicode block names"
+                },
+                "pcre2": {
+                  "pattern": "[\\x{0}-\\x{7F}]+",
+                  "reason": "PCRE2 does not expose Java Unicode block names"
                 }
               }
             }
@@ -7979,6 +7995,10 @@
             "rust-regex": {
               "pattern": "\\p{L}",
               "reason": "Rust regex uses the Unicode letter category rather than Java properties"
+            },
+            "pcre2": {
+              "pattern": "\\p{L}",
+              "reason": "PCRE2 uses the Unicode letter category rather than Java character properties"
             }
           }
         }
@@ -8014,6 +8034,10 @@
             "rust-regex": {
               "pattern": "\\p{L}",
               "reason": "Rust regex uses the Unicode letter category rather than Java properties"
+            },
+            "pcre2": {
+              "pattern": "\\p{L}",
+              "reason": "PCRE2 uses the Unicode letter category rather than Java character properties"
             }
           }
         }

--- a/safere-benchmarks/cpp/CMakeLists.txt
+++ b/safere-benchmarks/cpp/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
 # See LICENSE file in the project root for details.
 
-cmake_minimum_required(VERSION 3.14)
-project(re2_benchmark CXX)
+cmake_minimum_required(VERSION 3.15)
+project(native_regex_benchmarks C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -17,6 +17,12 @@ include(FetchContent)
 # Disable install targets for dependencies (we only need to build them).
 set(ABSL_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 set(RE2_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(PCRE2_BUILD_PCRE2_8 ON CACHE BOOL "" FORCE)
+set(PCRE2_BUILD_PCRE2_16 OFF CACHE BOOL "" FORCE)
+set(PCRE2_BUILD_PCRE2_32 OFF CACHE BOOL "" FORCE)
+set(PCRE2_BUILD_PCRE2GREP OFF CACHE BOOL "" FORCE)
+set(PCRE2_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(PCRE2_SUPPORT_JIT ON CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
   re2
@@ -31,6 +37,12 @@ FetchContent_Declare(
   GIT_TAG        20250814.2
 )
 
+FetchContent_Declare(
+  pcre2
+  GIT_REPOSITORY https://github.com/PCRE2Project/pcre2.git
+  GIT_TAG        pcre2-10.47
+)
+
 # JSON parser (header-only).
 FetchContent_Declare(
   json
@@ -41,16 +53,30 @@ FetchContent_Declare(
 # Suppress install(EXPORT) errors from RE2.
 set(CMAKE_SKIP_INSTALL_RULES ON)
 
-FetchContent_MakeAvailable(abseil-cpp re2 json)
+FetchContent_MakeAvailable(abseil-cpp re2 pcre2 json)
 
-add_executable(re2_benchmark re2_benchmark.cc)
+add_executable(re2_benchmark native_regex_benchmark.cc)
 target_link_libraries(re2_benchmark re2::re2 nlohmann_json::nlohmann_json)
+
+add_executable(pcre2_jit_benchmark native_regex_benchmark.cc)
+target_compile_definitions(pcre2_jit_benchmark PRIVATE SAFERE_PCRE2_JIT)
+target_link_libraries(
+  pcre2_jit_benchmark
+  pcre2-8-static
+  nlohmann_json::nlohmann_json
+)
+
 if(SAFERE_HAVE_MALLINFO2)
   target_compile_definitions(re2_benchmark PRIVATE SAFERE_HAVE_MALLINFO2)
+  target_compile_definitions(pcre2_jit_benchmark PRIVATE SAFERE_HAVE_MALLINFO2)
 endif()
 
 include(CTest)
 if(BUILD_TESTING)
   add_test(NAME benchmark_sha256_test
            COMMAND re2_benchmark --sha256-self-test)
+  add_test(NAME re2_benchmark_self_test
+           COMMAND re2_benchmark --engine-self-test)
+  add_test(NAME pcre2_jit_benchmark_self_test
+           COMMAND pcre2_jit_benchmark --engine-self-test)
 endif()

--- a/safere-benchmarks/cpp/native_regex_benchmark.cc
+++ b/safere-benchmarks/cpp/native_regex_benchmark.cc
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
 // See LICENSE file in the project root for details.
 //
-// C++ RE2 benchmark harness. Runs the same patterns and inputs as the Java
-// JMH benchmarks and outputs JSON lines for cross-language comparison.
+// Native C++ regex benchmark harness. Runs the same patterns and inputs as the
+// Java JMH benchmarks and outputs JSON lines for cross-language comparison.
 // Patterns and inputs are loaded from a shared JSON data file.
 //
 // Build:
@@ -11,6 +11,7 @@
 //
 // Run:
 //   ./build/re2_benchmark [--manifest path/to/manifest.json] [filter...]
+//   ./build/pcre2_jit_benchmark [--manifest path/to/manifest.json] [filter...]
 //
 // Each filter is a substring match against benchmark names. If no filters
 // are given, all benchmarks are run.
@@ -35,9 +36,27 @@
 #endif
 
 #include <nlohmann/json.hpp>
+#ifdef SAFERE_PCRE2_JIT
+#include "pcre2_re2_compat.h"
+#else
 #include "re2/re2.h"
+#endif
 
 using json = nlohmann::json;
+
+#ifdef SAFERE_PCRE2_JIT
+constexpr const char* kEngineId = "pcre2_jit";
+constexpr const char* kPatternProfileId = "pcre2";
+constexpr const char* kReplacementProfileId = "pcre2";
+constexpr bool kSupportsLinearTimeWorkloads = false;
+constexpr bool kSupportsMeasuredReplacementWorkloads = false;
+#else
+constexpr const char* kEngineId = "re2_cpp";
+constexpr const char* kPatternProfileId = "re2";
+constexpr const char* kReplacementProfileId = "re2-cpp";
+constexpr bool kSupportsLinearTimeWorkloads = true;
+constexpr bool kSupportsMeasuredReplacementWorkloads = true;
+#endif
 
 json benchmark_input_manifest;
 std::filesystem::path benchmark_input_directory;
@@ -223,18 +242,18 @@ BenchResult measure(const std::string& name,
 }
 
 void print_json(const BenchResult& r) {
-  printf("{\"engine\":\"re2_cpp\",\"benchmark\":\"%s\","
+  printf("{\"engine\":\"%s\",\"benchmark\":\"%s\","
          "\"score\":%.3f,\"error\":%.3f,\"unit\":\"%s\"}\n",
-         r.name.c_str(), r.ns_per_op, r.error, r.unit.c_str());
+         kEngineId, r.name.c_str(), r.ns_per_op, r.error, r.unit.c_str());
   fflush(stdout);
 }
 
 // Print a memory measurement result as JSON.
 void print_memory_json(const std::string& name, long bytes,
                        const std::string& unit = "bytes") {
-  printf("{\"engine\":\"re2_cpp\",\"benchmark\":\"%s\","
+  printf("{\"engine\":\"%s\",\"benchmark\":\"%s\","
          "\"score\":%ld,\"error\":0,\"unit\":\"%s\"}\n",
-         name.c_str(), bytes, unit.c_str());
+         kEngineId, name.c_str(), bytes, unit.c_str());
   fflush(stdout);
 }
 
@@ -275,8 +294,8 @@ json load_benchmark_manifest(const std::string& manifest_path_string) {
   json benchmark_data = manifest.at("benchmarkData");
   if (benchmark_data.contains("patternProfiles")) {
     const auto& profiles = benchmark_data.at("patternProfiles");
-    if (profiles.contains("re2")) {
-      for (const auto& entry : profiles.at("re2")) {
+    if (profiles.contains(kPatternProfileId)) {
+      for (const auto& entry : profiles.at(kPatternProfileId)) {
         benchmark_pattern_profile.emplace(
             entry.at("java").get<std::string>(),
             entry.at("alternate").get<std::string>());
@@ -285,8 +304,8 @@ json load_benchmark_manifest(const std::string& manifest_path_string) {
   }
   if (benchmark_data.contains("replacementProfiles")) {
     const auto& profiles = benchmark_data.at("replacementProfiles");
-    if (profiles.contains("re2-cpp")) {
-      for (const auto& entry : profiles.at("re2-cpp")) {
+    if (profiles.contains(kReplacementProfileId)) {
+      for (const auto& entry : profiles.at(kReplacementProfileId)) {
         benchmark_replacement_profile.emplace(
             entry.at("java").get<std::string>(),
             entry.at("alternate").get<std::string>());
@@ -308,6 +327,18 @@ std::string select_replacement(const std::string& java_replacement) {
   return alternate == benchmark_replacement_profile.end()
              ? java_replacement
              : alternate->second;
+}
+
+void validate_pattern_profile() {
+  for (const auto& [java_pattern, alternate] : benchmark_pattern_profile) {
+    RE2 pattern(alternate);
+    if (!pattern.ok()) {
+      fprintf(
+          stderr, "ERROR: %s pattern alternate for %s does not compile\n",
+          kPatternProfileId, java_pattern.c_str());
+      exit(1);
+    }
+  }
 }
 
 std::string load_benchmark_input(const std::string& key) {
@@ -546,6 +577,10 @@ void run_application_benchmarks(const json& data,
               app_case.name.c_str());
       exit(1);
     }
+    if (app_case.op == "replaceAll" &&
+        !kSupportsMeasuredReplacementWorkloads) {
+      continue;
+    }
     if (app_case.op.rfind("findAll", 0) == 0 &&
         RE2::PartialMatch("", app_case.re)) {
       fprintf(stderr, "ERROR: empty-width find-all application pattern: %s\n",
@@ -570,6 +605,10 @@ void run_application_benchmarks(const json& data,
 
   for (const auto& app_case_ptr : cases) {
     const AppCase& app_case = *app_case_ptr;
+    if (app_case.op == "replaceAll" &&
+        !kSupportsMeasuredReplacementWorkloads) {
+      continue;
+    }
     run("ApplicationBenchmark." + app_case.name, [&]() {
       if (app_case.op == "replaceAll") {
         do_not_optimize(run_string(app_case));
@@ -624,6 +663,10 @@ void run_real_world_regex_benchmarks(
 
   for (const auto& case_ptr : cases) {
     const RealWorldCase& c = *case_ptr;
+    if (c.op.rfind("replaceAll", 0) == 0 &&
+        !kSupportsMeasuredReplacementWorkloads) {
+      continue;
+    }
     for (bool match : {true, false}) {
       std::string match_label = match ? "match" : "noMatch";
       for (int size : sizes) {
@@ -1090,6 +1133,7 @@ void run_memory_benchmarks(const json& data,
     print_memory_json(pi.name + ".heapBytes", heap_delta);
 #endif
 
+#ifndef SAFERE_PCRE2_JIT
     // Report RE2's program size (number of bytecode instructions).
     if (re->ok()) {
       print_memory_json(pi.name + ".programSize",
@@ -1097,6 +1141,7 @@ void run_memory_benchmarks(const json& data,
       print_memory_json(pi.name + ".reverseProgramSize",
                         re->ReverseProgramSize(), "instructions");
     }
+#endif
   }
 }
 
@@ -1107,6 +1152,44 @@ void run_memory_benchmarks(const json& data,
 int main(int argc, char* argv[]) {
   if (argc == 2 && std::string_view(argv[1]) == "--sha256-self-test") {
     return run_sha256_self_test() ? 0 : 1;
+  }
+  if (argc == 2 && std::string_view(argv[1]) == "--engine-self-test") {
+    RE2 pattern("(a+)-(b+)");
+    if (!pattern.ok()) {
+      fprintf(stderr, "%s self-test failed to compile\n", kEngineId);
+      return 1;
+    }
+#ifdef SAFERE_PCRE2_JIT
+    if (pattern.jit_size() == 0) {
+      fprintf(stderr, "PCRE2 JIT self-test did not generate JIT code\n");
+      return 1;
+    }
+#endif
+    std::string first;
+    std::string second;
+    if (!RE2::FullMatch("aaa-bb", pattern, &first, &second) ||
+        first != "aaa" || second != "bb") {
+      fprintf(stderr, "%s self-test failed to match captures\n", kEngineId);
+      return 1;
+    }
+    RE2 alternative("a|ab");
+    if (!RE2::FullMatch("ab", alternative)) {
+      fprintf(stderr, "%s self-test failed to end-anchor alternatives\n",
+              kEngineId);
+      return 1;
+    }
+    std::string replaced = "aaa-bb a-b";
+#ifdef SAFERE_PCRE2_JIT
+    const std::string replacement = "$2:$1";
+#else
+    const std::string replacement = "\\2:\\1";
+#endif
+    if (RE2::GlobalReplace(&replaced, pattern, replacement) != 2 ||
+        replaced != "bb:aaa b:a") {
+      fprintf(stderr, "%s self-test failed to replace captures\n", kEngineId);
+      return 1;
+    }
+    return 0;
   }
 
   std::string manifest_path = "../../target/benchmark-corpus/manifest.json";
@@ -1122,6 +1205,7 @@ int main(int argc, char* argv[]) {
   }
 
   json data = load_benchmark_manifest(manifest_path);
+  validate_pattern_profile();
 
   run_regex_benchmarks(data, filters);
   run_application_benchmarks(data, filters);
@@ -1131,8 +1215,12 @@ int main(int argc, char* argv[]) {
   run_issue481_scaling_benchmarks(data, filters);
   run_capture_scaling_benchmarks(data, filters);
   run_http_benchmarks(data, filters);
-  run_replace_benchmarks(data, filters);
-  run_pathological_benchmarks(data, filters);
+  if (kSupportsMeasuredReplacementWorkloads) {
+    run_replace_benchmarks(data, filters);
+  }
+  if (kSupportsLinearTimeWorkloads) {
+    run_pathological_benchmarks(data, filters);
+  }
   run_fanout_benchmarks(data, filters);
   run_memory_benchmarks(data, filters);
 

--- a/safere-benchmarks/cpp/pcre2_re2_compat.h
+++ b/safere-benchmarks/cpp/pcre2_re2_compat.h
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
+// See LICENSE file in the project root for details.
+//
+// Small RE2-shaped adapter used to run the shared native benchmark harness
+// against PCRE2's 8-bit JIT API.
+
+#ifndef SAFERE_BENCHMARKS_CPP_PCRE2_RE2_COMPAT_H_
+#define SAFERE_BENCHMARKS_CPP_PCRE2_RE2_COMPAT_H_
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace re2 {
+
+class StringPiece {
+ public:
+  StringPiece() = default;
+  StringPiece(const std::string& value)
+      : data_(value.data()), size_(value.size()) {}
+  StringPiece(const char* data, size_t size) : data_(data), size_(size) {}
+
+  const char* data() const { return data_; }
+  size_t size() const { return size_; }
+  bool empty() const { return size_ == 0; }
+
+  void remove_prefix(size_t count) {
+    count = std::min(count, size_);
+    data_ += count;
+    size_ -= count;
+  }
+
+  void set(const char* data, size_t size) {
+    data_ = data;
+    size_ = size;
+  }
+
+ private:
+  const char* data_ = nullptr;
+  size_t size_ = 0;
+};
+
+}  // namespace re2
+
+class RE2 {
+ public:
+  enum Anchor {
+    UNANCHORED,
+    ANCHOR_START,
+    ANCHOR_BOTH,
+  };
+
+  explicit RE2(const std::string& pattern) : pattern_(pattern) {
+    int error_code = 0;
+    PCRE2_SIZE error_offset = 0;
+    code_ = pcre2_compile(
+        reinterpret_cast<PCRE2_SPTR>(pattern.data()), pattern.size(),
+        PCRE2_UTF, &error_code, &error_offset, nullptr);
+    if (code_ == nullptr) {
+      fail_compile("compilation", error_code, error_offset);
+    }
+    int jit_result = pcre2_jit_compile(code_, PCRE2_JIT_COMPLETE);
+    if (jit_result != 0) {
+      fail_compile("JIT compilation", jit_result, 0);
+    }
+    PCRE2_SIZE jit_size = 0;
+    if (pcre2_pattern_info(code_, PCRE2_INFO_JITSIZE, &jit_size) != 0 ||
+        jit_size == 0) {
+      fail_compile("JIT code generation", PCRE2_ERROR_JIT_UNSUPPORTED, 0);
+    }
+    jit_size_ = jit_size;
+    match_data_ = pcre2_match_data_create_from_pattern(code_, nullptr);
+    if (match_data_ == nullptr) {
+      fail_compile("match-data allocation", PCRE2_ERROR_NOMEMORY, 0);
+    }
+  }
+
+  ~RE2() {
+    pcre2_match_data_free(end_anchored_match_data_);
+    pcre2_code_free(end_anchored_code_);
+    pcre2_match_data_free(match_data_);
+    pcre2_code_free(code_);
+  }
+
+  RE2(const RE2&) = delete;
+  RE2& operator=(const RE2&) = delete;
+  RE2(RE2&&) = delete;
+  RE2& operator=(RE2&&) = delete;
+
+  bool ok() const { return code_ != nullptr && match_data_ != nullptr; }
+  size_t jit_size() const { return jit_size_; }
+
+  bool Match(const std::string& text, size_t start, size_t end,
+             Anchor anchor, re2::StringPiece* matches, int match_count) const {
+    if (!ok() || start > end || end > text.size()) {
+      return false;
+    }
+    pcre2_code* code = code_;
+    pcre2_match_data* match_data = match_data_;
+    if (anchor == ANCHOR_BOTH) {
+      ensure_end_anchored_code();
+      code = end_anchored_code_;
+      match_data = end_anchored_match_data_;
+    }
+    uint32_t options = anchor == UNANCHORED ? 0 : PCRE2_ANCHORED;
+    int result = pcre2_jit_match(
+        code, reinterpret_cast<PCRE2_SPTR>(text.data()), end, start,
+        options, match_data, nullptr);
+    if (result < 0) {
+      return handle_match_failure(result);
+    }
+    PCRE2_SIZE* offsets = pcre2_get_ovector_pointer(match_data);
+    if (anchor == ANCHOR_BOTH && offsets[1] != end) {
+      return false;
+    }
+    fill_matches(text.data(), matches, match_count, result, offsets);
+    return true;
+  }
+
+  static bool FullMatch(const std::string& text, const RE2& pattern) {
+    return pattern.Match(text, 0, text.size(), ANCHOR_BOTH, nullptr, 0);
+  }
+
+  template <typename... Captures>
+  static bool FullMatch(const std::string& text, const RE2& pattern,
+                        Captures*... captures) {
+    constexpr int capture_count = sizeof...(Captures);
+    std::array<re2::StringPiece, capture_count + 1> matches;
+    if (!pattern.Match(
+            text, 0, text.size(), ANCHOR_BOTH, matches.data(), matches.size())) {
+      return false;
+    }
+    assign_captures(matches, 1, captures...);
+    return true;
+  }
+
+  static bool PartialMatch(const std::string& text, const RE2& pattern) {
+    return pattern.Match(text, 0, text.size(), UNANCHORED, nullptr, 0);
+  }
+
+  template <typename... Captures>
+  static bool PartialMatch(const std::string& text, const RE2& pattern,
+                           Captures*... captures) {
+    constexpr int capture_count = sizeof...(Captures);
+    std::array<re2::StringPiece, capture_count + 1> matches;
+    if (!pattern.Match(
+            text, 0, text.size(), UNANCHORED, matches.data(), matches.size())) {
+      return false;
+    }
+    assign_captures(matches, 1, captures...);
+    return true;
+  }
+
+  static bool FindAndConsume(
+      re2::StringPiece* input, const RE2& pattern, std::string* capture) {
+    if (input == nullptr) {
+      return false;
+    }
+    std::string_view subject(input->data(), input->size());
+    int result = pattern.match(subject, 0, false);
+    if (result < 0) {
+      return handle_match_failure(result);
+    }
+    PCRE2_SIZE* offsets = pcre2_get_ovector_pointer(pattern.match_data_);
+    int selected = result > 1 ? 1 : 0;
+    if (capture != nullptr) {
+      if (offsets[2 * selected] == PCRE2_UNSET) {
+        capture->clear();
+      } else {
+        capture->assign(
+            subject.data() + offsets[2 * selected],
+            offsets[2 * selected + 1] - offsets[2 * selected]);
+      }
+    }
+    input->remove_prefix(offsets[1]);
+    return true;
+  }
+
+  static bool Replace(
+      std::string* text, const RE2& pattern, const std::string& replacement) {
+    return replace(text, pattern, replacement, false) > 0;
+  }
+
+  static int GlobalReplace(
+      std::string* text, const RE2& pattern, const std::string& replacement) {
+    return replace(text, pattern, replacement, true);
+  }
+
+ private:
+  [[noreturn]] static void fail_compile(
+      const char* stage, int error_code, PCRE2_SIZE error_offset) {
+    PCRE2_UCHAR message[256];
+    int message_result =
+        pcre2_get_error_message(error_code, message, sizeof(message));
+    if (message_result >= 0) {
+      fprintf(
+          stderr, "ERROR: PCRE2 %s failed at offset %zu: %s (%d)\n",
+          stage, static_cast<size_t>(error_offset),
+          reinterpret_cast<const char*>(message), error_code);
+    } else {
+      fprintf(
+          stderr, "ERROR: PCRE2 %s failed at offset %zu: %d\n",
+          stage, static_cast<size_t>(error_offset), error_code);
+    }
+    exit(1);
+  }
+
+  int match(std::string_view text, size_t start, bool anchored) const {
+    if (!ok() || start > text.size()) {
+      return PCRE2_ERROR_NOMATCH;
+    }
+    return pcre2_jit_match(
+        code_, reinterpret_cast<PCRE2_SPTR>(text.data()), text.size(), start,
+        anchored ? PCRE2_ANCHORED : 0, match_data_, nullptr);
+  }
+
+  void ensure_end_anchored_code() const {
+    if (end_anchored_code_ != nullptr) {
+      return;
+    }
+    int error_code = 0;
+    PCRE2_SIZE error_offset = 0;
+    end_anchored_code_ = pcre2_compile(
+        reinterpret_cast<PCRE2_SPTR>(pattern_.data()), pattern_.size(),
+        PCRE2_UTF | PCRE2_ENDANCHORED, &error_code, &error_offset, nullptr);
+    if (end_anchored_code_ == nullptr) {
+      fail_compile("end-anchored compilation", error_code, error_offset);
+    }
+    int jit_result =
+        pcre2_jit_compile(end_anchored_code_, PCRE2_JIT_COMPLETE);
+    if (jit_result != 0) {
+      fail_compile("end-anchored JIT compilation", jit_result, 0);
+    }
+    PCRE2_SIZE jit_size = 0;
+    if (pcre2_pattern_info(
+            end_anchored_code_, PCRE2_INFO_JITSIZE, &jit_size) != 0 ||
+        jit_size == 0) {
+      fail_compile(
+          "end-anchored JIT code generation",
+          PCRE2_ERROR_JIT_UNSUPPORTED, 0);
+    }
+    end_anchored_match_data_ =
+        pcre2_match_data_create_from_pattern(end_anchored_code_, nullptr);
+    if (end_anchored_match_data_ == nullptr) {
+      fail_compile(
+          "end-anchored match-data allocation", PCRE2_ERROR_NOMEMORY, 0);
+    }
+  }
+
+  static bool handle_match_failure(int result) {
+    if (result == PCRE2_ERROR_NOMATCH) {
+      return false;
+    }
+    PCRE2_UCHAR message[256];
+    int message_result =
+        pcre2_get_error_message(result, message, sizeof(message));
+    if (message_result >= 0) {
+      fprintf(
+          stderr, "ERROR: PCRE2 JIT matching failed: %s (%d)\n",
+          reinterpret_cast<const char*>(message), result);
+    } else {
+      fprintf(stderr, "ERROR: PCRE2 JIT matching failed: %d\n", result);
+    }
+    exit(1);
+  }
+
+  static void fill_matches(
+      const char* text, re2::StringPiece* matches, int match_count,
+      int result, const PCRE2_SIZE* offsets) {
+    if (matches == nullptr) {
+      return;
+    }
+    for (int index = 0; index < match_count; ++index) {
+      if (index >= result || offsets[2 * index] == PCRE2_UNSET) {
+        matches[index].set(nullptr, 0);
+      } else {
+        matches[index].set(
+            text + offsets[2 * index],
+            offsets[2 * index + 1] - offsets[2 * index]);
+      }
+    }
+  }
+
+  template <size_t Size>
+  static void assign_captures(
+      const std::array<re2::StringPiece, Size>&, size_t) {}
+
+  template <size_t Size, typename... Remaining>
+  static void assign_captures(
+      const std::array<re2::StringPiece, Size>& matches, size_t index,
+      std::string* capture, Remaining*... remaining) {
+    if (capture != nullptr) {
+      const re2::StringPiece& match = matches[index];
+      if (match.data() == nullptr) {
+        capture->clear();
+      } else {
+        capture->assign(match.data(), match.size());
+      }
+    }
+    assign_captures(matches, index + 1, remaining...);
+  }
+
+  static int replace(
+      std::string* text, const RE2& pattern, const std::string& replacement,
+      bool global) {
+    if (text == nullptr || !pattern.ok()) {
+      return 0;
+    }
+    uint32_t options =
+        PCRE2_SUBSTITUTE_OVERFLOW_LENGTH |
+        (global ? PCRE2_SUBSTITUTE_GLOBAL : 0);
+    PCRE2_SIZE output_length =
+        text->size() * 2 + replacement.size() + 1;
+    std::vector<PCRE2_UCHAR> output(output_length);
+    int result = pcre2_substitute(
+        pattern.code_, reinterpret_cast<PCRE2_SPTR>(text->data()),
+        text->size(), 0, options, pattern.match_data_, nullptr,
+        reinterpret_cast<PCRE2_SPTR>(replacement.data()), replacement.size(),
+        output.data(), &output_length);
+    if (result == PCRE2_ERROR_NOMEMORY) {
+      output.resize(output_length);
+      result = pcre2_substitute(
+          pattern.code_, reinterpret_cast<PCRE2_SPTR>(text->data()),
+          text->size(), 0, options, pattern.match_data_, nullptr,
+          reinterpret_cast<PCRE2_SPTR>(replacement.data()), replacement.size(),
+          output.data(), &output_length);
+    }
+    if (result < 0) {
+      handle_match_failure(result);
+    }
+    text->assign(reinterpret_cast<const char*>(output.data()), output_length);
+    return result;
+  }
+
+  pcre2_code* code_ = nullptr;
+  pcre2_match_data* match_data_ = nullptr;
+  std::string pattern_;
+  mutable pcre2_code* end_anchored_code_ = nullptr;
+  mutable pcre2_match_data* end_anchored_match_data_ = nullptr;
+  size_t jit_size_ = 0;
+};
+
+#endif  // SAFERE_BENCHMARKS_CPP_PCRE2_RE2_COMPAT_H_

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -198,6 +198,11 @@ class PatternProfilesTest {
     assertThat(patterns.select("re2", "\\p{script=Latin}+")).isEqualTo("\\p{Latin}+");
     assertThat(patterns.select("re2", "[\\p{L}&&[^\\p{Lu}]]+"))
         .isEqualTo("[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+");
+    assertThat(patterns.select("pcre2", "\\p{block=BasicLatin}+")).isEqualTo("[\\x{0}-\\x{7F}]+");
+    assertThat(patterns.select("pcre2", "[\\p{L}&&[^\\p{Lu}]]+"))
+        .isEqualTo("[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+");
+    assertThat(patterns.select("pcre2", "\\p{javaLetter}")).isEqualTo("\\p{L}");
+    assertThat(patterns.select("pcre2", "\\p{script=Latin}+")).isEqualTo("\\p{script=Latin}+");
     assertThat(patterns.select("re2", "\\p{IsAlphabetic}+")).isEqualTo("\\p{IsAlphabetic}+");
     assertThat(patterns.select("re2", "\\p{IsIdeographic}+")).isEqualTo("\\p{IsIdeographic}+");
     assertThat(patterns.select("rust-regex", "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$"))
@@ -214,6 +219,7 @@ class PatternProfilesTest {
     assertThat(replacements.select("re2-cpp", "$1=REDACTED")).isEqualTo("\\1=REDACTED");
     assertThat(replacements.select("re2-cpp", "$1")).isEqualTo("\\1");
     assertThat(replacements.select("go-regexp", "$2$1ay")).isEqualTo("${2}${1}ay");
+    assertThat(replacements.select("pcre2", "$1")).isEqualTo("$1");
     assertThat(replacements.select("rust-regex", "$2$1ay")).isEqualTo("${2}${1}ay");
     for (String profileType : List.of("patternProfiles", "replacementProfiles")) {
       for (JsonElement profile : normalized.getAsJsonObject(profileType).asMap().values()) {


### PR DESCRIPTION
## Summary

- build pinned PCRE2 10.47 with 8-bit JIT support in the native C++ benchmark build
- run the shared native C++ workload harness through a PCRE2 JIT adapter, with explicit capability
  handling for linear-time-only and measured-replacement workloads
- select a dedicated `pcre2` pattern profile and declare exact alternates for Java Unicode blocks,
  `javaLetter`, and Java character-class intersection
- build on #639's explicit, conversion-free pattern and replacement profile selection
- use PCRE2's native substitution API for unchanged Java `$N` and `${name}` templates
- validate every selected native pattern alternate before benchmark measurement
- provide per-engine native runner selection and matching/capture/replacement self-tests
- add explicit Linux and macOS PCRE2 JIT benchmark smoke coverage, plus Linux memory smoke coverage
- add `pcre2_jit` results to cross-language collection and comparison tables
- document each cross-runtime engine's workload coverage, toolchain and installation links,
  per-engine commands, JIT requirements, memory-platform limits, and smoke tests

This PR is stacked on #639, which owns the shared replacement-profile migration and implicit
conversion cleanup.

Fixes #627

## Verification

Ran after rebasing onto #639:

- `mvn -pl safere-benchmarks test -q`
- `go test ./...`
- `cargo test --locked --manifest-path safere-benchmarks/rust/Cargo.toml`
- `cmake -S safere-benchmarks/cpp -B safere-benchmarks/cpp/build`
- `cmake --build safere-benchmarks/cpp/build --parallel`
- `ctest --test-dir safere-benchmarks/cpp/build --output-on-failure`
- `safere-benchmarks/cpp/build/re2_benchmark --engine-self-test`
- `safere-benchmarks/cpp/build/pcre2_jit_benchmark --engine-self-test`

Previously ran on the same PCRE2 implementation before the stack rebase:

- `mvn -pl safere-benchmarks -am test -q`
- `mvn -pl safere-benchmarks -Dtest=PatternProfilesTest,BenchmarkInputMaterializerTest test -q`
- `bash -n run-cpp-benchmarks.sh collect-benchmark-results.sh`
- `python3 -m json.tool safere-benchmarks/benchmark-data.json`
- `./run-cpp-benchmarks.sh --engine re2 ApplicationBenchmark.secretRedaction`
- `./run-cpp-benchmarks.sh --engine pcre2-jit ApplicationBenchmark.secretRedaction`

A full benchmark collection and the external OpenJDK-derived benchmark suite were not run.
