### PR TITLE
Add Java-canonical benchmark pattern profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,8 +591,17 @@ explicitly only when optimizing crosscheck:
 ### C++ RE2 and Go Benchmarks
 
 The benchmark suite includes C++ RE2 and Go `regexp` harnesses for
-cross-language comparison. Prerequisites: CMake ≥ 3.14 + C++17 compiler
-(for C++), Go ≥ 1.21 (for Go). Dependencies are fetched automatically.
+cross-language comparison. Prerequisites are
+[CMake ≥ 3.14](https://cmake.org/download/) with a C++17 compiler,
+[Go ≥ 1.21](https://go.dev/doc/install). Dependencies are fetched
+automatically.
+
+Benchmark patterns are written in Java syntax. A pattern that needs different
+syntax in another regex dialect declares exact alternatives beside its
+Java-canonical definition in `safere-benchmarks/benchmark-data.json`; a missing
+alternate means that the Java pattern is used unchanged. See the
+[pattern-profile schema](safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles)
+for profile mappings and validation rules.
 
 ```bash
 # C++ RE2 benchmarks

--- a/safere-benchmarks/BENCHMARK_INPUTS.md
+++ b/safere-benchmarks/BENCHMARK_INPUTS.md
@@ -9,11 +9,17 @@ parameters, expected results, and deterministic input recipes.
 
 Before execution, each benchmark runner invokes the central materializer. It
 writes a resolved manifest and exact UTF-8 inputs under
-`target/benchmark-corpus/`. Java, C++, Go, and future harnesses read only those
-generated artifacts; they do not read or interpret `benchmark-data.json`.
+`target/benchmark-corpus/`. Java, C++, Go, and future harnesses read only
+those generated artifacts; they do not read or interpret `benchmark-data.json`.
 Java string engines decode input files as UTF-8 during benchmark setup, while
 byte-oriented engines use the bytes directly. Materialization and decoding are
 outside the timed operation.
+
+Patterns remain Java-canonical in `benchmark-data.json`. Explicit
+engine-dialect alternatives live beside the pattern that needs them. The
+materializer collects those inline definitions into the resolved manifest;
+runners select their profile there and otherwise use the Java string unchanged.
+See [DECLARATIVE_BENCHMARK_PLAN.md](DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles).
 
 The normal runner scripts materialize automatically. To prepare the corpus
 without starting a benchmark, run from the repository root:

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -76,6 +76,42 @@ A materially changed operation, input, result-consumption rule, lifecycle, or
 timing boundary requires a new workload ID. Reordering JSON or changing a
 display label does not.
 
+## Pattern profiles
+
+All workload patterns use Java regex syntax as their canonical representation.
+When another regex dialect needs different syntax for the same semantics,
+the pattern definition declares an exact alternate inline:
+
+```json
+{
+  "patterns": [
+    {
+      "java": "\\p{script=Latin}+",
+      "alternates": {
+        "re2": {
+          "pattern": "\\p{Latin}+",
+          "reason": "RE2 uses bare Unicode script names"
+        }
+      }
+    }
+  ]
+}
+```
+
+An engine adapter selects one syntax-family profile. SafeRE and JDK select
+`java`; RE2/J, RE2-FFM, native C++ RE2, and Go select `re2`. If the selected
+profile has no entry for a Java pattern, the adapter uses the Java pattern
+unchanged.
+
+Alternates are exact reviewed strings. Runners must not rewrite regex syntax
+automatically. The required nonblank `reason` records why the alternate is
+necessary. The materializer replaces inline definitions with their Java strings
+and emits a resolved profile lookup in the generated manifest. Conflicting
+alternates for the same Java pattern and profile, malformed profile IDs, blank
+fields, and unknown fields are rejected during materialization.
+Pattern selection and compilation happen outside timed matching operations;
+compile benchmarks select the alternate before starting the timed compilation.
+
 ## Bounded input recipes
 
 Recipes describe data and deterministic generation; they cannot invoke Java

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -6438,11 +6438,27 @@
           },
           {
             "id": "alphabetic",
-            "value": "\\p{IsAlphabetic}+"
+            "value": {
+              "java": "\\p{IsAlphabetic}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{L}+",
+                  "reason": "RE2 uses Unicode general-category names rather than Java Is properties"
+                }
+              }
+            }
           },
           {
             "id": "ideographic",
-            "value": "\\p{IsIdeographic}+"
+            "value": {
+              "java": "\\p{IsIdeographic}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{Han}+",
+                  "reason": "RE2 exposes the Han script rather than Java's IsIdeographic property"
+                }
+              }
+            }
           },
           {
             "id": "emoji",
@@ -6454,19 +6470,51 @@
           },
           {
             "id": "scriptLatin",
-            "value": "\\p{script=Latin}+"
+            "value": {
+              "java": "\\p{script=Latin}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{Latin}+",
+                  "reason": "RE2 uses bare Unicode script names"
+                }
+              }
+            }
           },
           {
             "id": "scriptHan",
-            "value": "\\p{script=Han}+"
+            "value": {
+              "java": "\\p{script=Han}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{Han}+",
+                  "reason": "RE2 uses bare Unicode script names"
+                }
+              }
+            }
           },
           {
             "id": "blockBasicLatin",
-            "value": "\\p{block=BasicLatin}+"
+            "value": {
+              "java": "\\p{block=BasicLatin}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "[\\x{0}-\\x{7F}]+",
+                  "reason": "RE2 does not expose Java Unicode block names"
+                }
+              }
+            }
           },
           {
             "id": "blockCjk",
-            "value": "\\p{block=CJK_Unified_Ideographs}+"
+            "value": {
+              "java": "\\p{block=CJK_Unified_Ideographs}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "[\\x{4E00}-\\x{9FFF}]+",
+                  "reason": "RE2 does not expose Java Unicode block names"
+                }
+              }
+            }
           },
           {
             "id": "word",
@@ -6490,7 +6538,15 @@
           },
           {
             "id": "letterIntersection",
-            "value": "[\\p{L}&&[^\\p{Lu}]]+"
+            "value": {
+              "java": "[\\p{L}&&[^\\p{Lu}]]+",
+              "alternates": {
+                "re2": {
+                  "pattern": "[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+",
+                  "reason": "RE2 does not support Java character-class intersection"
+                }
+              }
+            }
           },
           {
             "id": "identifier",
@@ -6537,7 +6593,15 @@
           },
           {
             "id": "alphabetic",
-            "value": "\\p{IsAlphabetic}+"
+            "value": {
+              "java": "\\p{IsAlphabetic}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{L}+",
+                  "reason": "RE2 uses Unicode general-category names rather than Java Is properties"
+                }
+              }
+            }
           },
           {
             "id": "emoji",
@@ -6549,15 +6613,39 @@
           },
           {
             "id": "scriptLatin",
-            "value": "\\p{script=Latin}+"
+            "value": {
+              "java": "\\p{script=Latin}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{Latin}+",
+                  "reason": "RE2 uses bare Unicode script names"
+                }
+              }
+            }
           },
           {
             "id": "scriptHan",
-            "value": "\\p{script=Han}+"
+            "value": {
+              "java": "\\p{script=Han}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "\\p{Han}+",
+                  "reason": "RE2 uses bare Unicode script names"
+                }
+              }
+            }
           },
           {
             "id": "blockBasicLatin",
-            "value": "\\p{block=BasicLatin}+"
+            "value": {
+              "java": "\\p{block=BasicLatin}+",
+              "alternates": {
+                "re2": {
+                  "pattern": "[\\x{0}-\\x{7F}]+",
+                  "reason": "RE2 does not expose Java Unicode block names"
+                }
+              }
+            }
           },
           {
             "id": "word",
@@ -8257,7 +8345,15 @@
       "id": "JavaCharacterClassBenchmark.compileAndFindJavaLetter",
       "operation": "compileAndFindRotatingUtf16",
       "patterns": [
-        "\\p{javaLetter}"
+        {
+          "java": "\\p{javaLetter}",
+          "alternates": {
+            "re2": {
+              "pattern": "\\p{L}",
+              "reason": "RE2 uses the Unicode letter category rather than Java character properties"
+            }
+          }
+        }
       ],
       "arguments": {
         "seed": 95413077,
@@ -8279,7 +8375,15 @@
       "id": "JavaCharacterClassBenchmark.findJavaLetter",
       "operation": "findRotatingUtf16",
       "patterns": [
-        "\\p{javaLetter}"
+        {
+          "java": "\\p{javaLetter}",
+          "alternates": {
+            "re2": {
+              "pattern": "\\p{L}",
+              "reason": "RE2 uses the Unicode letter category rather than Java character properties"
+            }
+          }
+        }
       ],
       "arguments": {
         "seed": 95413077,

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -6438,27 +6438,11 @@
           },
           {
             "id": "alphabetic",
-            "value": {
-              "java": "\\p{IsAlphabetic}+",
-              "alternates": {
-                "re2": {
-                  "pattern": "\\p{L}+",
-                  "reason": "RE2 uses Unicode general-category names rather than Java Is properties"
-                }
-              }
-            }
+            "value": "\\p{IsAlphabetic}+"
           },
           {
             "id": "ideographic",
-            "value": {
-              "java": "\\p{IsIdeographic}+",
-              "alternates": {
-                "re2": {
-                  "pattern": "\\p{Han}+",
-                  "reason": "RE2 exposes the Han script rather than Java's IsIdeographic property"
-                }
-              }
-            }
+            "value": "\\p{IsIdeographic}+"
           },
           {
             "id": "emoji",
@@ -6593,15 +6577,7 @@
           },
           {
             "id": "alphabetic",
-            "value": {
-              "java": "\\p{IsAlphabetic}+",
-              "alternates": {
-                "re2": {
-                  "pattern": "\\p{L}+",
-                  "reason": "RE2 uses Unicode general-category names rather than Java Is properties"
-                }
-              }
-            }
+            "value": "\\p{IsAlphabetic}+"
           },
           {
             "id": "emoji",
@@ -8359,9 +8335,6 @@
         "seed": 95413077,
         "count": 4096
       },
-      "requirements": [
-        "javaCharacterClass"
-      ],
       "inputRepresentations": [
         "javaString"
       ],
@@ -8389,9 +8362,6 @@
         "seed": 95413077,
         "count": 4096
       },
-      "requirements": [
-        "javaCharacterClass"
-      ],
       "inputRepresentations": [
         "javaString"
       ],

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #ifdef SAFERE_HAVE_MALLINFO2
@@ -41,6 +42,7 @@ using json = nlohmann::json;
 
 json benchmark_input_manifest;
 std::filesystem::path benchmark_input_directory;
+std::unordered_map<std::string, std::string> benchmark_pattern_profile;
 
 std::string sha256_hex(std::string_view input) {
   static constexpr std::array<uint32_t, 64> kRoundConstants = {
@@ -270,7 +272,25 @@ json load_benchmark_manifest(const std::string& manifest_path_string) {
     exit(1);
   }
   benchmark_input_manifest = manifest.at("inputs");
-  return manifest.at("benchmarkData");
+  json benchmark_data = manifest.at("benchmarkData");
+  if (benchmark_data.contains("patternProfiles")) {
+    const auto& profiles = benchmark_data.at("patternProfiles");
+    if (profiles.contains("re2")) {
+      for (const auto& entry : profiles.at("re2")) {
+        benchmark_pattern_profile.emplace(
+            entry.at("java").get<std::string>(),
+            entry.at("alternate").get<std::string>());
+      }
+    }
+  }
+  return benchmark_data;
+}
+
+std::string select_pattern(const std::string& java_pattern) {
+  auto alternate = benchmark_pattern_profile.find(java_pattern);
+  return alternate == benchmark_pattern_profile.end()
+             ? java_pattern
+             : alternate->second;
 }
 
 std::string load_benchmark_input(const std::string& key) {
@@ -339,12 +359,12 @@ void run_regex_benchmarks(const json& data,
                           const std::vector<std::string>& filters) {
   const auto& sec = data["regex"];
 
-  RE2 hello(sec["literalMatch"]["pattern"].get<std::string>());
-  RE2 alpha(sec["charClassMatch"]["pattern"].get<std::string>());
-  RE2 alt(sec["alternationFind"]["pattern"].get<std::string>());
-  RE2 date(sec["captureGroups"]["pattern"].get<std::string>());
-  RE2 find_ing(sec["findInText"]["pattern"].get<std::string>());
-  RE2 email(sec["emailFind"]["pattern"].get<std::string>());
+  RE2 hello(select_pattern(sec["literalMatch"]["pattern"].get<std::string>()));
+  RE2 alpha(select_pattern(sec["charClassMatch"]["pattern"].get<std::string>()));
+  RE2 alt(select_pattern(sec["alternationFind"]["pattern"].get<std::string>()));
+  RE2 date(select_pattern(sec["captureGroups"]["pattern"].get<std::string>()));
+  RE2 find_ing(select_pattern(sec["findInText"]["pattern"].get<std::string>()));
+  RE2 email(select_pattern(sec["emailFind"]["pattern"].get<std::string>()));
 
   std::string hello_text = sec["literalMatch"]["text"];
   std::string alpha_text = sec["charClassMatch"]["text"];
@@ -416,7 +436,7 @@ void run_application_benchmarks(const json& data,
     explicit AppCase(const json& item)
         : name(item.at("name").get<std::string>()),
           op(item.at("op").get<std::string>()),
-          pattern(item.at("pattern").get<std::string>()),
+          pattern(select_pattern(item.at("pattern").get<std::string>())),
           texts(item.contains("texts")
                     ? item.at("texts").get<std::vector<std::string>>()
                     : std::vector<std::string>()),
@@ -578,7 +598,7 @@ void run_real_world_regex_benchmarks(
     explicit RealWorldCase(const json& item)
         : name(item.at("name").get<std::string>()),
           op(item.at("op").get<std::string>()),
-          pattern(item.at("pattern").get<std::string>()),
+          pattern(select_pattern(item.at("pattern").get<std::string>())),
           re(pattern) {}
   };
 
@@ -650,10 +670,14 @@ void run_compile_benchmarks(const json& data,
                             const std::vector<std::string>& filters) {
   const auto& sec = data["compile"];
 
-  std::string simple = sec["simple"]["pattern"];
-  std::string medium = sec["medium"]["pattern"];
-  std::string complex_pat = sec["complex"]["pattern"];
-  std::string alternation = sec["alternation"]["pattern"];
+  std::string simple =
+      select_pattern(sec["simple"]["pattern"].get<std::string>());
+  std::string medium =
+      select_pattern(sec["medium"]["pattern"].get<std::string>());
+  std::string complex_pat =
+      select_pattern(sec["complex"]["pattern"].get<std::string>());
+  std::string alternation =
+      select_pattern(sec["alternation"]["pattern"].get<std::string>());
 
   auto run = [&](const std::string& name, const std::string& pattern) {
     if (matches_filter(name, filters)) {
@@ -675,10 +699,10 @@ void run_search_scaling_benchmarks(const json& data,
   const auto& sec = data["searchScaling"];
   std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
 
-  RE2 easy(sec["patterns"]["easy"].get<std::string>());
-  RE2 medium(sec["patterns"]["medium"].get<std::string>());
-  RE2 hard(sec["patterns"]["hard"].get<std::string>());
-  RE2 find_ing(sec["findIngPattern"].get<std::string>());
+  RE2 easy(select_pattern(sec["patterns"]["easy"].get<std::string>()));
+  RE2 medium(select_pattern(sec["patterns"]["medium"].get<std::string>()));
+  RE2 hard(select_pattern(sec["patterns"]["hard"].get<std::string>()));
+  RE2 find_ing(select_pattern(sec["findIngPattern"].get<std::string>()));
 
   for (int size : sizes) {
     std::string size_string = std::to_string(size);
@@ -725,10 +749,10 @@ void run_issue481_scaling_benchmarks(const json& data,
   const auto& sec = data["issue481Scaling"];
   std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
 
-  RE2 split_w(sec["splitW"]["pattern"].get<std::string>());
-  RE2 block(sec["block"]["pattern"].get<std::string>());
-  RE2 tag(sec["tag"]["pattern"].get<std::string>());
-  RE2 scheme(sec["scheme"]["pattern"].get<std::string>());
+  RE2 split_w(select_pattern(sec["splitW"]["pattern"].get<std::string>()));
+  RE2 block(select_pattern(sec["block"]["pattern"].get<std::string>()));
+  RE2 tag(select_pattern(sec["tag"]["pattern"].get<std::string>()));
+  RE2 scheme(select_pattern(sec["scheme"]["pattern"].get<std::string>()));
 
   auto split_length_sum = [](const std::string& text, RE2& re) {
     int sum = 0;
@@ -829,10 +853,10 @@ void run_capture_scaling_benchmarks(const json& data,
                                     const std::vector<std::string>& filters) {
   const auto& sec = data["captureScaling"];
 
-  RE2 pat0(sec["capture0"]["pattern"].get<std::string>());
-  RE2 pat1(sec["capture1"]["pattern"].get<std::string>());
-  RE2 pat3(sec["capture3"]["pattern"].get<std::string>());
-  RE2 pat10(sec["capture10"]["pattern"].get<std::string>());
+  RE2 pat0(select_pattern(sec["capture0"]["pattern"].get<std::string>()));
+  RE2 pat1(select_pattern(sec["capture1"]["pattern"].get<std::string>()));
+  RE2 pat3(select_pattern(sec["capture3"]["pattern"].get<std::string>()));
+  RE2 pat10(select_pattern(sec["capture10"]["pattern"].get<std::string>()));
 
   std::string text0 = sec["capture0"]["text"];
   std::string text1 = sec["capture1"]["text"];
@@ -881,7 +905,7 @@ void run_http_benchmarks(const json& data,
                          const std::vector<std::string>& filters) {
   const auto& sec = data["http"];
 
-  RE2 http(sec["pattern"].get<std::string>());
+  RE2 http(select_pattern(sec["pattern"].get<std::string>()));
   std::string full = sec["fullRequest"];
   std::string small = sec["smallRequest"];
 
@@ -924,7 +948,7 @@ void run_replace_benchmarks(const json& data,
   for (auto& [key, val] : sec.items()) {
     cases.push_back({
         key,
-        val["pattern"].get<std::string>(),
+        select_pattern(val["pattern"].get<std::string>()),
         val["text"].get<std::string>(),
         convert_replacement(val["replacement"].get<std::string>()),
         val["op"].get<std::string>()
@@ -967,7 +991,7 @@ void run_pathological_benchmarks(const json& data,
     std::string name =
         "PathologicalBenchmark.pathological." + std::to_string(n);
     if (matches_filter(name, filters)) {
-      RE2 re(regex);
+      RE2 re(select_pattern(regex));
       print_json(measure(name, [&]() {
         do_not_optimize(RE2::FullMatch(text, re));
       }, 2, 2.0, 10, 2.0, "us/op", 1000.0));
@@ -980,8 +1004,8 @@ void run_fanout_benchmarks(const json& data,
   const auto& sec = data["fanout"];
   std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
 
-  RE2 fanout(sec["unicodeFanout"]["pattern"].get<std::string>());
-  RE2 nested(sec["nestedQuantifier"]["pattern"].get<std::string>());
+  RE2 fanout(select_pattern(sec["unicodeFanout"]["pattern"].get<std::string>()));
+  RE2 nested(select_pattern(sec["nestedQuantifier"]["pattern"].get<std::string>()));
 
   for (int size : sizes) {
     std::string size_string = std::to_string(size);
@@ -1050,12 +1074,13 @@ void run_memory_benchmarks(const json& data,
 
   for (const auto& pi : patterns) {
     if (!matches_filter(pi.name, filters)) continue;
+    std::string pattern = select_pattern(pi.pattern);
 
 #ifdef SAFERE_HAVE_MALLINFO2
     // Measure heap delta around RE2 compilation using mallinfo2().
     struct mallinfo2 before = mallinfo2();
 #endif
-    auto re = std::make_unique<RE2>(pi.pattern);
+    auto re = std::make_unique<RE2>(pattern);
 #ifdef SAFERE_HAVE_MALLINFO2
     struct mallinfo2 after = mallinfo2();
 

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -135,6 +135,7 @@ type materializedInput struct {
 
 var benchmarkInputDirectory string
 var benchmarkInputs map[string]materializedInput
+var benchmarkPatternProfile map[string]string
 
 func loadBenchmarkManifest(manifestPath string) map[string]any {
 	benchmarkInputDirectory = filepath.Dir(manifestPath)
@@ -158,7 +159,36 @@ func loadBenchmarkManifest(manifestPath string) map[string]any {
 		os.Exit(1)
 	}
 	benchmarkInputs = manifest.Inputs
+	benchmarkPatternProfile = loadPatternProfile(manifest.BenchmarkData, "re2")
 	return manifest.BenchmarkData
+}
+
+func loadPatternProfile(data map[string]any, profileID string) map[string]string {
+	result := make(map[string]string)
+	profiles, ok := data["patternProfiles"].(map[string]any)
+	if !ok {
+		return result
+	}
+	entries, ok := profiles[profileID].([]any)
+	if !ok {
+		return result
+	}
+	for _, raw := range entries {
+		entry := raw.(map[string]any)
+		result[entry["java"].(string)] = entry["alternate"].(string)
+	}
+	return result
+}
+
+func mustCompile(javaPattern string) *regexp.Regexp {
+	return regexp.MustCompile(selectedPattern(javaPattern))
+}
+
+func selectedPattern(javaPattern string) string {
+	if alternate, ok := benchmarkPatternProfile[javaPattern]; ok {
+		return alternate
+	}
+	return javaPattern
 }
 
 func loadBenchmarkInput(key string) string {
@@ -256,12 +286,12 @@ func getStringSlice(data any, path string) []string {
 func runRegexBenchmarks(data map[string]any, filters []string) {
 	sec := data["regex"]
 
-	hello := regexp.MustCompile(getString(sec, "literalMatch.pattern"))
-	alpha := regexp.MustCompile(getString(sec, "charClassMatch.pattern"))
-	alt := regexp.MustCompile(getString(sec, "alternationFind.pattern"))
-	date := regexp.MustCompile(getString(sec, "captureGroups.pattern"))
-	findIng := regexp.MustCompile(getString(sec, "findInText.pattern"))
-	email := regexp.MustCompile(getString(sec, "emailFind.pattern"))
+	hello := mustCompile(getString(sec, "literalMatch.pattern"))
+	alpha := mustCompile(getString(sec, "charClassMatch.pattern"))
+	alt := mustCompile(getString(sec, "alternationFind.pattern"))
+	date := mustCompile(getString(sec, "captureGroups.pattern"))
+	findIng := mustCompile(getString(sec, "findInText.pattern"))
+	email := mustCompile(getString(sec, "emailFind.pattern"))
 
 	helloText := getString(sec, "literalMatch.text")
 	alphaText := getString(sec, "charClassMatch.text")
@@ -338,10 +368,10 @@ func runApplicationBenchmarks(data map[string]any, filters []string) {
 			groups:      getIntSlice(item, "groups"),
 			replacement: convertReplacement(getString(item, "replacement")),
 			expected:    item["expected"],
-			re:          regexp.MustCompile(pattern),
+			re:          mustCompile(pattern),
 		}
 		if strings.HasPrefix(c.op, "matches") {
-			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
+			c.fullRe = mustCompile("^(?:" + selectedPattern(pattern) + ")$")
 		}
 		cases = append(cases, c)
 	}
@@ -468,10 +498,10 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 		c := realWorldCase{
 			name: getString(item, "name"),
 			op:   op,
-			re:   regexp.MustCompile(pattern),
+			re:   mustCompile(pattern),
 		}
 		if op == "matches" {
-			c.fullRe = regexp.MustCompile("^(?:" + pattern + ")$")
+			c.fullRe = mustCompile("^(?:" + selectedPattern(pattern) + ")$")
 		}
 		cases = append(cases, c)
 	}
@@ -528,8 +558,9 @@ func runCompileBenchmarks(data map[string]any, filters []string) {
 
 	run := func(name string, pattern string) {
 		if matchesFilter(name, filters) {
+			selected := selectedPattern(pattern)
 			printJSON(measureUs(name, func() {
-				sink = regexp.MustCompile(pattern)
+				sink = regexp.MustCompile(selected)
 			}))
 		}
 	}
@@ -544,10 +575,10 @@ func runSearchScalingBenchmarks(data map[string]any, filters []string) {
 	sec := data["searchScaling"].(map[string]any)
 
 	sizes := getIntSlice(sec, "textSizes")
-	easy := regexp.MustCompile(getString(sec, "patterns.easy"))
-	medium := regexp.MustCompile(getString(sec, "patterns.medium"))
-	hard := regexp.MustCompile(getString(sec, "patterns.hard"))
-	findIng := regexp.MustCompile(getString(sec, "findIngPattern"))
+	easy := mustCompile(getString(sec, "patterns.easy"))
+	medium := mustCompile(getString(sec, "patterns.medium"))
+	hard := mustCompile(getString(sec, "patterns.hard"))
+	findIng := mustCompile(getString(sec, "findIngPattern"))
 
 	for _, size := range sizes {
 		randomText := loadBenchmarkInput(fmt.Sprintf("searchScaling.random.%d", size))
@@ -585,10 +616,10 @@ func runIssue481ScalingBenchmarks(data map[string]any, filters []string) {
 	sec := data["issue481Scaling"].(map[string]any)
 
 	sizes := getIntSlice(sec, "textSizes")
-	splitW := regexp.MustCompile(getString(sec, "splitW.pattern"))
-	block := regexp.MustCompile(getString(sec, "block.pattern"))
-	tag := regexp.MustCompile(getString(sec, "tag.pattern"))
-	scheme := regexp.MustCompile(getString(sec, "scheme.pattern"))
+	splitW := mustCompile(getString(sec, "splitW.pattern"))
+	block := mustCompile(getString(sec, "block.pattern"))
+	tag := mustCompile(getString(sec, "tag.pattern"))
+	scheme := mustCompile(getString(sec, "scheme.pattern"))
 
 	splitLengthSum := func(parts []string) int {
 		for len(parts) > 0 && parts[len(parts)-1] == "" {
@@ -656,10 +687,10 @@ func runIssue481ScalingBenchmarks(data map[string]any, filters []string) {
 func runCaptureScalingBenchmarks(data map[string]any, filters []string) {
 	sec := data["captureScaling"]
 
-	pat0 := regexp.MustCompile(getString(sec, "capture0.pattern"))
-	pat1 := regexp.MustCompile(getString(sec, "capture1.pattern"))
-	pat3 := regexp.MustCompile(getString(sec, "capture3.pattern"))
-	pat10 := regexp.MustCompile(getString(sec, "capture10.pattern"))
+	pat0 := mustCompile(getString(sec, "capture0.pattern"))
+	pat1 := mustCompile(getString(sec, "capture1.pattern"))
+	pat3 := mustCompile(getString(sec, "capture3.pattern"))
+	pat10 := mustCompile(getString(sec, "capture10.pattern"))
 
 	text0 := getString(sec, "capture0.text")
 	text1 := getString(sec, "capture1.text")
@@ -689,7 +720,7 @@ func runCaptureScalingBenchmarks(data map[string]any, filters []string) {
 func runHTTPBenchmarks(data map[string]any, filters []string) {
 	sec := data["http"]
 
-	http := regexp.MustCompile(getString(sec, "pattern"))
+	http := mustCompile(getString(sec, "pattern"))
 	full := getString(sec, "fullRequest")
 	small := getString(sec, "smallRequest")
 
@@ -723,7 +754,7 @@ func runReplaceBenchmarks(data map[string]any, filters []string) {
 		// Convert Java-style $N backreferences to Go-style ${N}
 		goReplacement := convertReplacement(replacement)
 
-		re := regexp.MustCompile(pattern)
+		re := mustCompile(pattern)
 		benchName := "ReplaceBenchmark." + key
 
 		if !matchesFilter(benchName, filters) {
@@ -779,7 +810,7 @@ func runPathologicalBenchmarks(data map[string]any, filters []string) {
 
 		name := fmt.Sprintf("PathologicalBenchmark.pathological.%d", n)
 		if matchesFilter(name, filters) {
-			re := regexp.MustCompile(pattern)
+			re := mustCompile(pattern)
 			printJSON(measureUs(name, func() {
 				sink = re.MatchString(text)
 			}))
@@ -791,8 +822,8 @@ func runFanoutBenchmarks(data map[string]any, filters []string) {
 	sec := data["fanout"].(map[string]any)
 	sizes := getIntSlice(sec, "textSizes")
 
-	fanout := regexp.MustCompile(getString(sec, "unicodeFanout.pattern"))
-	nested := regexp.MustCompile(getString(sec, "nestedQuantifier.pattern"))
+	fanout := mustCompile(getString(sec, "unicodeFanout.pattern"))
+	nested := mustCompile(getString(sec, "nestedQuantifier.pattern"))
 
 	for _, size := range sizes {
 		unicodeText := loadBenchmarkInput(fmt.Sprintf("fanout.unicode.%d", size))
@@ -887,7 +918,7 @@ func runMemoryBenchmarks(data map[string]any, filters []string) {
 		if !matchesFilter(pi.name, filters) {
 			continue
 		}
-		heapBytes := measureCompiledSize(pi.pattern)
+		heapBytes := measureCompiledSize(selectedPattern(pi.pattern))
 		printMemoryJSON(memoryResult{
 			Engine:    "go_regexp",
 			Benchmark: pi.name + ".heapBytes",

--- a/safere-benchmarks/go/regexp_benchmark_test.go
+++ b/safere-benchmarks/go/regexp_benchmark_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
+// See LICENSE file in the project root for details.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestCheckedInRE2PatternProfileCompiles(t *testing.T) {
+	contents, err := os.ReadFile("../benchmark-data.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(contents, &data); err != nil {
+		t.Fatal(err)
+	}
+	alternateCount := 0
+	var visit func(any)
+	visit = func(value any) {
+		switch current := value.(type) {
+		case map[string]any:
+			if javaPattern, ok := current["java"].(string); ok {
+				alternates := current["alternates"].(map[string]any)
+				if re2, ok := alternates["re2"].(map[string]any); ok {
+					alternate := re2["pattern"].(string)
+					alternateCount++
+					if _, err := regexp.Compile(alternate); err != nil {
+						t.Errorf(
+							"%q alternate for %q does not compile: %v",
+							alternate,
+							javaPattern,
+							err,
+						)
+					}
+				}
+				return
+			}
+			for _, child := range current {
+				visit(child)
+			}
+		case []any:
+			for _, child := range current {
+				visit(child)
+			}
+		}
+	}
+	visit(data)
+	if alternateCount == 0 {
+		t.Fatal("no inline re2 pattern alternates found")
+	}
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -32,6 +32,7 @@ public final class BenchmarkData {
   private final Path corpusDirectory;
   private final JsonObject root;
   private final JsonObject materializedInputs;
+  private final PatternProfiles patternProfiles;
   private final Map<String, byte[]> inputBytes = new ConcurrentHashMap<>();
   private final Map<String, String> inputStrings = new ConcurrentHashMap<>();
 
@@ -53,6 +54,7 @@ public final class BenchmarkData {
       }
       root = manifest.getAsJsonObject("benchmarkData");
       materializedInputs = manifest.getAsJsonObject("inputs");
+      patternProfiles = PatternProfiles.parse(root.get("patternProfiles"));
     } catch (Exception e) {
       throw new RuntimeException("Failed to load materialized benchmark data: " + manifestPath, e);
     }
@@ -108,6 +110,17 @@ public final class BenchmarkData {
    */
   public byte[] getInputBytes(String key) {
     return loadInputBytes(key).clone();
+  }
+
+  /**
+   * Selects an explicit profile alternative or returns the Java-canonical pattern unchanged.
+   *
+   * @param profileId pattern profile selected by an engine adapter
+   * @param javaPattern Java-canonical benchmark pattern
+   * @return exact pattern source for the selected profile
+   */
+  public String getPattern(String profileId, String javaPattern) {
+    return patternProfiles.select(profileId, javaPattern);
   }
 
   private byte[] loadInputBytes(String key) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -42,17 +42,19 @@ public final class BenchmarkInputMaterializer {
   private final Map<String, byte[]> inputs = new LinkedHashMap<>();
 
   private BenchmarkInputMaterializer(JsonObject data, String benchmarkDataSha256) {
-    this.data = data;
+    this.data = PatternProfiles.normalizeInline(data);
     this.benchmarkDataSha256 = benchmarkDataSha256;
-    if (!data.has("schemaVersion")
-        || data.get("schemaVersion").getAsInt() != DeclarativeBenchmarkPlan.SCHEMA_VERSION) {
+    if (!this.data.has("schemaVersion")
+        || this.data.get("schemaVersion").getAsInt() != DeclarativeBenchmarkPlan.SCHEMA_VERSION) {
       throw new IllegalArgumentException(
           "benchmark-data.json requires schemaVersion " + DeclarativeBenchmarkPlan.SCHEMA_VERSION);
     }
-    if (!data.has("inputs") || !data.get("inputs").isJsonArray()) {
+    if (!this.data.has("inputs") || !this.data.get("inputs").isJsonArray()) {
       throw new IllegalArgumentException("benchmark-data.json requires declarative inputs");
     }
-    declarations = DeclarativeBenchmarkPlan.parseInputDeclarations(data.getAsJsonArray("inputs"));
+    PatternProfiles.parse(this.data.get("patternProfiles"));
+    declarations =
+        DeclarativeBenchmarkPlan.parseInputDeclarations(this.data.getAsJsonArray("inputs"));
   }
 
   /**

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
@@ -60,10 +60,14 @@ final class CrossEngineTrialRunner implements AutoCloseable {
 
     List<RegexEngineVariant.RegexInput> inputs =
         trial.variant().prepareInputs(data, workload.inputKeys());
+    List<String> patternSources =
+        workload.patterns().stream()
+            .map(pattern -> data.getPattern(trial.variant().patternProfile(), pattern))
+            .toList();
     List<RegexEngineVariant.CompiledRegex> patterns = new ArrayList<>();
     try {
       if (workload.operation() != BenchmarkOperation.COMPILE) {
-        for (String pattern : workload.patterns()) {
+        for (String pattern : patternSources) {
           patterns.add(trial.variant().compile(pattern));
         }
       }
@@ -73,7 +77,7 @@ final class CrossEngineTrialRunner implements AutoCloseable {
                 .operation()
                 .execute(
                     trial.variant(),
-                    workload.patterns(),
+                    patternSources,
                     patterns,
                     inputs,
                     workload.groups(),
@@ -90,7 +94,7 @@ final class CrossEngineTrialRunner implements AutoCloseable {
               .operation()
               .bind(
                   trial.variant(),
-                  workload.patterns(),
+                  patternSources,
                   patterns,
                   inputs,
                   workload.groups(),

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
@@ -1,0 +1,218 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/** Explicit engine-profile alternatives for Java-canonical benchmark patterns. */
+final class PatternProfiles {
+  private static final Pattern PROFILE_ID = Pattern.compile("[a-z][a-z0-9-]*");
+
+  private final Map<String, Map<String, String>> profiles;
+
+  private PatternProfiles(Map<String, Map<String, String>> profiles) {
+    this.profiles = Collections.unmodifiableMap(new LinkedHashMap<>(profiles));
+  }
+
+  static JsonObject normalizeInline(JsonObject source) {
+    if (source.has("patternProfiles")) {
+      throw new IllegalArgumentException(
+          "benchmark-data.json must define pattern alternates next to their Java patterns");
+    }
+    JsonObject normalized = source.deepCopy();
+    Map<String, Map<String, Alternate>> profiles = new LinkedHashMap<>();
+    Deque<JsonElement> pending = new ArrayDeque<>();
+    pending.push(normalized);
+    while (!pending.isEmpty()) {
+      JsonElement element = pending.pop();
+      if (element.isJsonObject()) {
+        JsonObject object = element.getAsJsonObject();
+        for (Map.Entry<String, JsonElement> entry : List.copyOf(object.entrySet())) {
+          JsonElement child = entry.getValue();
+          if (isInlinePattern(child)) {
+            object.add(entry.getKey(), normalizePattern(child.getAsJsonObject(), profiles));
+          } else if (child.isJsonArray() || child.isJsonObject()) {
+            pending.push(child);
+          }
+        }
+      } else {
+        JsonArray array = element.getAsJsonArray();
+        for (int index = 0; index < array.size(); index++) {
+          JsonElement child = array.get(index);
+          if (isInlinePattern(child)) {
+            array.set(index, normalizePattern(child.getAsJsonObject(), profiles));
+          } else if (child.isJsonArray() || child.isJsonObject()) {
+            pending.push(child);
+          }
+        }
+      }
+    }
+    normalized.add("patternProfiles", profileJson(profiles));
+    return normalized;
+  }
+
+  private static boolean isInlinePattern(JsonElement element) {
+    return element.isJsonObject()
+        && (element.getAsJsonObject().has("java") || element.getAsJsonObject().has("alternates"));
+  }
+
+  private static JsonPrimitive normalizePattern(
+      JsonObject definition, Map<String, Map<String, Alternate>> profiles) {
+    for (String field : definition.keySet()) {
+      if (!field.equals("java") && !field.equals("alternates")) {
+        throw new IllegalArgumentException("Inline benchmark pattern has unknown field: " + field);
+      }
+    }
+    String javaPattern = requiredInlineString(definition, "java", "Inline benchmark pattern");
+    JsonElement alternatesElement = definition.get("alternates");
+    if (alternatesElement == null || !alternatesElement.isJsonObject()) {
+      throw new IllegalArgumentException("Inline benchmark pattern requires object: alternates");
+    }
+    JsonObject alternates = alternatesElement.getAsJsonObject();
+    if (alternates.isEmpty()) {
+      throw new IllegalArgumentException("Inline benchmark pattern alternates must not be empty");
+    }
+    for (Map.Entry<String, JsonElement> entry : alternates.entrySet()) {
+      String profileId = entry.getKey();
+      if (!PROFILE_ID.matcher(profileId).matches()) {
+        throw new IllegalArgumentException("Invalid benchmark pattern profile ID: " + profileId);
+      }
+      if (!entry.getValue().isJsonObject()) {
+        throw new IllegalArgumentException(
+            "Inline benchmark pattern alternate " + profileId + " must be an object");
+      }
+      JsonObject alternateObject = entry.getValue().getAsJsonObject();
+      for (String field : alternateObject.keySet()) {
+        if (!field.equals("pattern") && !field.equals("reason")) {
+          throw new IllegalArgumentException(
+              "Inline benchmark pattern alternate " + profileId + " has unknown field: " + field);
+        }
+      }
+      Alternate alternate =
+          new Alternate(
+              requiredInlineString(
+                  alternateObject, "pattern", "Inline benchmark pattern alternate " + profileId),
+              requiredInlineString(
+                  alternateObject, "reason", "Inline benchmark pattern alternate " + profileId));
+      Alternate previous =
+          profiles
+              .computeIfAbsent(profileId, unused -> new LinkedHashMap<>())
+              .putIfAbsent(javaPattern, alternate);
+      if (previous != null && !previous.equals(alternate)) {
+        throw new IllegalArgumentException(
+            "Conflicting " + profileId + " alternates for Java pattern: " + javaPattern);
+      }
+    }
+    return new JsonPrimitive(javaPattern);
+  }
+
+  private static String requiredInlineString(JsonObject object, String field, String description) {
+    JsonElement value = object.get(field);
+    if (value == null || !value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+      throw new IllegalArgumentException(description + " requires string: " + field);
+    }
+    String string = value.getAsString();
+    if (string.isBlank()) {
+      throw new IllegalArgumentException(description + " field must not be blank: " + field);
+    }
+    return string;
+  }
+
+  private static JsonObject profileJson(Map<String, Map<String, Alternate>> profiles) {
+    JsonObject result = new JsonObject();
+    for (Map.Entry<String, Map<String, Alternate>> profile : profiles.entrySet()) {
+      JsonArray entries = new JsonArray();
+      for (Map.Entry<String, Alternate> alternate : profile.getValue().entrySet()) {
+        JsonObject entry = new JsonObject();
+        entry.addProperty("java", alternate.getKey());
+        entry.addProperty("alternate", alternate.getValue().pattern());
+        entry.addProperty("reason", alternate.getValue().reason());
+        entries.add(entry);
+      }
+      result.add(profile.getKey(), entries);
+    }
+    return result;
+  }
+
+  static PatternProfiles parse(JsonElement element) {
+    if (element == null) {
+      return new PatternProfiles(Map.of());
+    }
+    if (!element.isJsonObject()) {
+      throw new IllegalArgumentException("patternProfiles must be an object");
+    }
+    Map<String, Map<String, String>> profiles = new LinkedHashMap<>();
+    for (Map.Entry<String, JsonElement> profileEntry : element.getAsJsonObject().entrySet()) {
+      String profileId = profileEntry.getKey();
+      if (!PROFILE_ID.matcher(profileId).matches()) {
+        throw new IllegalArgumentException("Invalid benchmark pattern profile ID: " + profileId);
+      }
+      if (!profileEntry.getValue().isJsonArray()) {
+        throw new IllegalArgumentException("Pattern profile " + profileId + " must be an array");
+      }
+      Map<String, String> alternatives =
+          parseProfile(profileId, profileEntry.getValue().getAsJsonArray());
+      profiles.put(profileId, Collections.unmodifiableMap(alternatives));
+    }
+    return new PatternProfiles(profiles);
+  }
+
+  private static Map<String, String> parseProfile(String profileId, JsonArray entries) {
+    Map<String, String> alternatives = new LinkedHashMap<>();
+    for (JsonElement element : entries) {
+      if (!element.isJsonObject()) {
+        throw new IllegalArgumentException(
+            "Pattern profile " + profileId + " entries must be objects");
+      }
+      JsonObject entry = element.getAsJsonObject();
+      for (String field : entry.keySet()) {
+        if (!field.equals("java") && !field.equals("alternate") && !field.equals("reason")) {
+          throw new IllegalArgumentException(
+              "Pattern profile " + profileId + " entry has unknown field: " + field);
+        }
+      }
+      String javaPattern = requiredString(entry, profileId, "java");
+      String alternate = requiredString(entry, profileId, "alternate");
+      requiredString(entry, profileId, "reason");
+      if (alternatives.put(javaPattern, alternate) != null) {
+        throw new IllegalArgumentException(
+            "Pattern profile " + profileId + " repeats Java pattern: " + javaPattern);
+      }
+    }
+    return alternatives;
+  }
+
+  private static String requiredString(JsonObject entry, String profileId, String field) {
+    JsonElement value = entry.get(field);
+    if (value == null || !value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+      throw new IllegalArgumentException(
+          "Pattern profile " + profileId + " entry requires string field: " + field);
+    }
+    String string = value.getAsString();
+    if (string.isBlank()) {
+      throw new IllegalArgumentException(
+          "Pattern profile " + profileId + " entry field must not be blank: " + field);
+    }
+    return string;
+  }
+
+  String select(String profileId, String javaPattern) {
+    Map<String, String> alternatives = profiles.get(profileId);
+    return alternatives == null ? javaPattern : alternatives.getOrDefault(javaPattern, javaPattern);
+  }
+
+  private record Alternate(String pattern, String reason) {}
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
@@ -13,7 +13,8 @@ import java.util.List;
 
 /** Java-side regex execution variants and their representation/timing boundaries. */
 enum RegexEngineVariant {
-  SAFERE_STRING("safere-string", "safere", InputRepresentation.JAVA_STRING, allCapabilities()) {
+  SAFERE_STRING(
+      "safere-string", "safere", "java", InputRepresentation.JAVA_STRING, allCapabilities()) {
     @Override
     CompiledRegex compile(String regex) {
       org.safere.Pattern pattern = org.safere.Pattern.compile(regex);
@@ -94,6 +95,7 @@ enum RegexEngineVariant {
   SAFERE_UTF8(
       "safere-utf8",
       "safere_utf8",
+      "java",
       InputRepresentation.PREEXISTING_UTF8,
       EnumSet.of(EngineCapability.FIND)) {
     @Override
@@ -118,7 +120,7 @@ enum RegexEngineVariant {
       };
     }
   },
-  JDK_STRING("jdk-string", "jdk", InputRepresentation.JAVA_STRING, allCapabilities()) {
+  JDK_STRING("jdk-string", "jdk", "java", InputRepresentation.JAVA_STRING, allCapabilities()) {
     @Override
     CompiledRegex compile(String regex) {
       java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regex);
@@ -196,7 +198,7 @@ enum RegexEngineVariant {
       };
     }
   },
-  RE2J_STRING("re2j-string", "re2j", InputRepresentation.JAVA_STRING, re2jCapabilities()) {
+  RE2J_STRING("re2j-string", "re2j", "re2", InputRepresentation.JAVA_STRING, re2jCapabilities()) {
     @Override
     CompiledRegex compile(String regex) {
       com.google.re2j.Pattern pattern = com.google.re2j.Pattern.compile(regex);
@@ -272,6 +274,7 @@ enum RegexEngineVariant {
   RE2_FFM_STRING_CONVERSION(
       "re2-ffm-string-conversion",
       "re2_ffm",
+      "re2",
       InputRepresentation.JAVA_STRING_WITH_TIMED_UTF8_CONVERSION,
       ffmCapabilities()) {
     @Override
@@ -334,16 +337,19 @@ enum RegexEngineVariant {
 
   private final String id;
   private final String reportEngine;
+  private final String patternProfile;
   private final InputRepresentation inputRepresentation;
   private final EnumSet<EngineCapability> capabilities;
 
   RegexEngineVariant(
       String id,
       String reportEngine,
+      String patternProfile,
       InputRepresentation inputRepresentation,
       EnumSet<EngineCapability> capabilities) {
     this.id = id;
     this.reportEngine = reportEngine;
+    this.patternProfile = patternProfile;
     this.inputRepresentation = inputRepresentation;
     this.capabilities = capabilities;
   }
@@ -354,6 +360,10 @@ enum RegexEngineVariant {
 
   String reportEngine() {
     return reportEngine;
+  }
+
+  String patternProfile() {
+    return patternProfile;
   }
 
   InputRepresentation inputRepresentation() {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -146,6 +146,27 @@ class BenchmarkInputMaterializerTest {
     assertThat(entry.get("unicodeScalars").getAsInt()).isEqualTo(5);
     assertThat(entry.get("sha256").getAsString())
         .isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    JsonObject resolvedData = manifest.getAsJsonObject("benchmarkData");
+    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(8);
+    assertThat(
+            resolvedData.getAsJsonArray("workloads").asList().stream()
+                .filter(
+                    workload ->
+                        workload
+                            .getAsJsonObject()
+                            .get("id")
+                            .getAsString()
+                            .equals("UnicodeCompileBenchmark.compile.{regex}.{flagSet}"))
+                .findFirst()
+                .orElseThrow()
+                .getAsJsonObject()
+                .getAsJsonObject("axes")
+                .getAsJsonArray("regex")
+                .get(4)
+                .getAsJsonObject()
+                .get("value")
+                .getAsString())
+        .isEqualTo("\\p{IsAlphabetic}+");
   }
 
   @Test

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -147,7 +147,7 @@ class BenchmarkInputMaterializerTest {
     assertThat(entry.get("sha256").getAsString())
         .isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
     JsonObject resolvedData = manifest.getAsJsonObject("benchmarkData");
-    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(8);
+    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(6);
     assertThat(
             resolvedData.getAsJsonArray("workloads").asList().stream()
                 .filter(

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -77,8 +77,8 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1404);
-    assertThat(plan.exclusions()).hasSize(636);
+    assertThat(allTrials).hasSize(1406);
+    assertThat(plan.exclusions()).hasSize(634);
     assertThat(accounted).hasSize(408 * RegexEngineVariant.values().length);
   }
 
@@ -100,7 +100,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(523);
+        .hasSize(525);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -157,6 +157,20 @@ class CrossEngineBenchmarkPlanTest {
   void re2BasedAdaptersShareARegexSyntaxProfile() {
     assertThat(RegexEngineVariant.RE2J_STRING.patternProfile()).isEqualTo("re2");
     assertThat(RegexEngineVariant.RE2_FFM_STRING_CONVERSION.patternProfile()).isEqualTo("re2");
+  }
+
+  @Test
+  void javaOnlyUnicodePropertyCompileWorkloadsRemainExcludedFromRe2Adapters() {
+    CrossEngineBenchmarkPlan plan = CrossEngineBenchmarkPlan.load();
+
+    assertThatThrownBy(
+            () -> plan.resolve("UnicodeCompileBenchmark.compile.alphabetic.0@re2j-string"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("engine lacks [flaggedCompile]");
+    assertThatThrownBy(
+            () -> plan.resolve("UnicodeCompileBenchmark.compile.ideographic.0@re2j-string"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("engine lacks [flaggedCompile]");
   }
 
   @Test
@@ -279,8 +293,10 @@ class CrossEngineBenchmarkPlanTest {
             "MatcherApiBenchmark.resetAndFind@re2j-string",
             "JavaCharacterClassBenchmark.compileAndFindJavaLetter@safere-string",
             "JavaCharacterClassBenchmark.compileAndFindJavaLetter@jdk-string",
+            "JavaCharacterClassBenchmark.compileAndFindJavaLetter@re2j-string",
             "JavaCharacterClassBenchmark.findJavaLetter@safere-string",
-            "JavaCharacterClassBenchmark.findJavaLetter@jdk-string");
+            "JavaCharacterClassBenchmark.findJavaLetter@jdk-string",
+            "JavaCharacterClassBenchmark.findJavaLetter@re2j-string");
     CrossEngineBenchmarkPlan plan = CrossEngineBenchmarkPlan.load();
 
     for (String trialId : trials) {
@@ -324,8 +340,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1443);
-    assertThat(plan.reportPlan().trials()).hasSize(1443);
+        .hasSize(1445);
+    assertThat(plan.reportPlan().trials()).hasSize(1445);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -154,6 +154,12 @@ class CrossEngineBenchmarkPlanTest {
   }
 
   @Test
+  void re2BasedAdaptersShareARegexSyntaxProfile() {
+    assertThat(RegexEngineVariant.RE2J_STRING.patternProfile()).isEqualTo("re2");
+    assertThat(RegexEngineVariant.RE2_FFM_STRING_CONVERSION.patternProfile()).isEqualTo("re2");
+  }
+
+  @Test
   void boundTaskReusesInputPreparedBeforeTimedInvocation() {
     RegexEngineVariant.RegexInput preparedInput =
         new RegexEngineVariant.StringRegexInput("materialized before binding");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -116,6 +116,8 @@ class PatternProfilesTest {
     assertThat(profiles.select("re2", "\\p{script=Latin}+")).isEqualTo("\\p{Latin}+");
     assertThat(profiles.select("re2", "[\\p{L}&&[^\\p{Lu}]]+"))
         .isEqualTo("[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+");
+    assertThat(profiles.select("re2", "\\p{IsAlphabetic}+")).isEqualTo("\\p{IsAlphabetic}+");
+    assertThat(profiles.select("re2", "\\p{IsIdeographic}+")).isEqualTo("\\p{IsIdeographic}+");
     for (JsonElement profile : normalized.getAsJsonObject("patternProfiles").asMap().values()) {
       for (JsonElement entry : profile.getAsJsonArray()) {
         String javaPattern = entry.getAsJsonObject().get("java").getAsString();

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -1,0 +1,152 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class PatternProfilesTest {
+  @Test
+  void selectsExplicitAlternateAndFallsBackToJava() {
+    PatternProfiles profiles =
+        PatternProfiles.parse(
+            JsonParser.parseString(
+                """
+                {
+                  "alternate-engine": [{
+                    "java": "\\\\Qfoo.bar\\\\E",
+                    "alternate": "foo\\\\.bar",
+                    "reason": "Alternate engine does not support Java quoted literals"
+                  }]
+                }
+                """));
+
+    assertThat(profiles.select("alternate-engine", "\\Qfoo.bar\\E")).isEqualTo("foo\\.bar");
+    assertThat(profiles.select("alternate-engine", "unchanged")).isEqualTo("unchanged");
+    assertThat(profiles.select("go-regexp", "\\Qfoo.bar\\E")).isEqualTo("\\Qfoo.bar\\E");
+  }
+
+  @Test
+  void rejectsMalformedAndDuplicateAlternates() {
+    assertThatThrownBy(
+            () ->
+                PatternProfiles.parse(
+                    JsonParser.parseString(
+                        """
+                        {"Rust": []}
+                        """)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid benchmark pattern profile ID: Rust");
+
+    assertThatThrownBy(
+            () ->
+                PatternProfiles.parse(
+                    JsonParser.parseString(
+                        """
+                        {
+                          "alternate-engine": [
+                            {"java": "x", "alternate": "y", "reason": "first"},
+                            {"java": "x", "alternate": "z", "reason": "second"}
+                          ]
+                        }
+                        """)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Pattern profile alternate-engine repeats Java pattern: x");
+  }
+
+  @Test
+  void rejectsTopLevelAndConflictingInlineAlternates() {
+    assertThatThrownBy(
+            () ->
+                PatternProfiles.normalizeInline(
+                    JsonParser.parseString(
+                            """
+                            {"patternProfiles": {}}
+                            """)
+                        .getAsJsonObject()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "benchmark-data.json must define pattern alternates next to their Java patterns");
+
+    assertThatThrownBy(
+            () ->
+                PatternProfiles.normalizeInline(
+                    JsonParser.parseString(
+                            """
+                            {
+                              "first": {
+                                "java": "x",
+                                "alternates": {
+                                  "re2": {"pattern": "y", "reason": "first"}
+                                }
+                              },
+                              "second": {
+                                "java": "x",
+                                "alternates": {
+                                  "re2": {"pattern": "z", "reason": "second"}
+                                }
+                              }
+                            }
+                            """)
+                        .getAsJsonObject()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Conflicting re2 alternates for Java pattern: x");
+  }
+
+  @Test
+  void checkedInProfilesContainReviewedDialectAlternates() throws Exception {
+    Path benchmarkData =
+        Files.exists(Path.of("benchmark-data.json"))
+            ? Path.of("benchmark-data.json")
+            : Path.of("safere-benchmarks", "benchmark-data.json");
+    JsonObject root = JsonParser.parseString(Files.readString(benchmarkData)).getAsJsonObject();
+    JsonObject normalized = PatternProfiles.normalizeInline(root);
+    PatternProfiles profiles = PatternProfiles.parse(normalized.get("patternProfiles"));
+
+    assertThat(profiles.select("re2", "\\p{script=Latin}+")).isEqualTo("\\p{Latin}+");
+    assertThat(profiles.select("re2", "[\\p{L}&&[^\\p{Lu}]]+"))
+        .isEqualTo("[\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}]+");
+    for (JsonElement profile : normalized.getAsJsonObject("patternProfiles").asMap().values()) {
+      for (JsonElement entry : profile.getAsJsonArray()) {
+        String javaPattern = entry.getAsJsonObject().get("java").getAsString();
+        assertThat(containsString(root.getAsJsonArray("workloads"), javaPattern))
+            .as("checked-in workload uses canonical pattern %s", javaPattern)
+            .isTrue();
+      }
+    }
+    for (JsonElement entry : normalized.getAsJsonObject("patternProfiles").getAsJsonArray("re2")) {
+      String alternate = entry.getAsJsonObject().get("alternate").getAsString();
+      assertThat(com.google.re2j.Pattern.compile(alternate)).isNotNull();
+    }
+  }
+
+  private static boolean containsString(JsonElement element, String expected) {
+    if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
+      return element.getAsString().equals(expected);
+    }
+    if (element.isJsonArray()) {
+      for (JsonElement child : element.getAsJsonArray()) {
+        if (containsString(child, expected)) {
+          return true;
+        }
+      }
+    } else if (element.isJsonObject()) {
+      for (JsonElement child : element.getAsJsonObject().asMap().values()) {
+        if (containsString(child, expected)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- make Java regex syntax the canonical representation for benchmark patterns
- colocate exact, reviewed dialect alternatives with the Java-canonical pattern that needs them
- include checked-in RE2-family alternatives for Java Unicode property names, Unicode blocks, and character-class intersection
- use a shared `re2` syntax profile for RE2/J, RE2-FFM, native C++ RE2, and Go `regexp`
- normalize inline definitions into canonical strings and a generated manifest lookup for runners
- select profile-specific patterns in Java, C++ RE2, and Go adapters, with unchanged Java syntax as the fallback
- validate profile IDs, fields, duplicate mappings, nonblank values, real workload references, and RE2 alternate compilation
- keep profile selection outside timed compilation and matching operations
- document the schema and syntax-family assignments

This is the syntax-adaptation foundation for adding more engines to the benchmark matrix. It intentionally does not add the Rust benchmark harness.

Refs #625

## Pattern audit

Reviewed all 226 declarations, which expand to 485 concrete benchmark cases and 172 unique patterns. Compiler checks covered the 97 unique patterns in the ordinary cross-engine matrix with JDK, SafeRE, RE2/J, C++ RE2, and Go `regexp`.

The checked-in alternatives cover the exact syntax differences found. RE2 has no reasonable equivalent for Java's Alphabetic, Ideographic, Emoji, and Extended_Pictographic properties, so those remain capability exclusions rather than inaccurate substitutions. ASCII shorthands, case folding, anchors, and named captures were also reviewed; they are either equivalent for the current benchmark inputs or belong to operations those adapters do not expose.

## Verification

Ran:

- `mvn -pl safere-benchmarks test -q -Dpmd.skip=true -Dcheckstyle.skip=true`
- `mvn -pl safere-benchmarks spotless:check -q`
- `go test ./...` in `safere-benchmarks/go`
- CMake build of `safere-benchmarks/cpp`
- `./collect-benchmark-results.sh --smoke --cross-language --skip-openjdk-regex --output-dir benchmark-results/issue-625-pattern-profiles-smoke`
- direct canonical-pattern compiler audits for JDK, SafeRE, RE2/J, C++ RE2, and Go `regexp`
- Codex review-fix loop through a final pass with no actionable correctness findings

Not run:

- full non-smoke benchmark collection
- external OpenJDK-derived benchmark suite
