### PR TITLE
Fix diagnostics for UTF-8 matchers

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -143,6 +143,7 @@
                         <exclude name="UnicodeJdkConsistencyTest.java"/>
                         <exclude name="UnicodeTablesTest.java"/>
                         <exclude name="Utf8AllocationScalingTest.java"/>
+                        <exclude name="Utf8DiagnosticsTest.java"/>
                         <exclude name="Utf8EnginePathEquivalenceTest.java"/>
                         <exclude name="Utf8InputScannerTest.java"/>
                         <exclude name="Utf8InputTest.java"/>

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -141,7 +141,11 @@ public final class Matcher implements MatchResult {
     }
     OperationDiagnostics event =
         accumulator.toEvent(
-            parentPattern.descriptor(), operation.operation(), outcome, captureMode, text.length());
+            parentPattern.descriptor(),
+            operation.operation(),
+            outcome,
+            captureMode,
+            getTextLength());
     diagnosticOperation = null;
     operation.listener().onOperationCompleted(event);
   }

--- a/safere/src/main/java/org/safere/OperationDiagnostics.java
+++ b/safere/src/main/java/org/safere/OperationDiagnostics.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * budget. Replacement operations aggregate searches across all matches into their single event.
  *
  * @param inputLength input length in UTF-16 code units for {@link Matcher} operations or UTF-8
- *     bytes for {@link Utf8Matcher} operations
+ *     bytes for {@link Utf8Matcher} and {@link Pattern#find(Utf8Input)} operations
  */
 public record OperationDiagnostics(
     PatternDescriptor pattern,

--- a/safere/src/main/java/org/safere/OperationDiagnostics.java
+++ b/safere/src/main/java/org/safere/OperationDiagnostics.java
@@ -14,6 +14,9 @@ import java.util.Set;
  *
  * <p>DFA search counts include every attempted search, including attempts that exceed the DFA state
  * budget. Replacement operations aggregate searches across all matches into their single event.
+ *
+ * @param inputLength input length in UTF-16 code units for {@link Matcher} operations or UTF-8
+ *     bytes for {@link Utf8Matcher} operations
  */
 public record OperationDiagnostics(
     PatternDescriptor pattern,

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -59,10 +59,8 @@ public final class Pattern implements Serializable {
       MethodType.methodType(boolean.class, Pattern.class, Utf8InputScanner.class);
   private static final MutableCallSite UTF8_FIND_SITE = new MutableCallSite(UTF8_FIND_TYPE);
   private static final MethodHandle UTF8_FIND_INVOKER = UTF8_FIND_SITE.dynamicInvoker();
-  private static final MethodHandle UTF8_FIND_DISABLED =
-      findUtf8Handle("findWithoutDiagnostics");
-  private static final MethodHandle UTF8_FIND_ENABLED =
-      findUtf8Handle("findWithDiagnostics");
+  private static final MethodHandle UTF8_FIND_DISABLED = findUtf8Handle("findWithoutDiagnostics");
+  private static final MethodHandle UTF8_FIND_ENABLED = findUtf8Handle("findWithDiagnostics");
 
   static {
     setDiagnosticsTarget(SafeReMatchDiagnostics.NONE);
@@ -691,8 +689,7 @@ public final class Pattern implements Serializable {
         != null;
   }
 
-  private boolean findWithDiagnostics(
-      Utf8InputScanner scanner, DiagnosticAccumulator diagnostics) {
+  private boolean findWithDiagnostics(Utf8InputScanner scanner, DiagnosticAccumulator diagnostics) {
     int length = scanner.length();
     if (literalMatchUtf8 != null && !prefixFoldCase) {
       boolean matched =
@@ -745,9 +742,7 @@ public final class Pattern implements Serializable {
         return result.matched();
       }
       diagnostics.decision(
-          MatchStrategy.DFA,
-          StrategyDisposition.FALLBACK,
-          StrategyReason.DFA_BUDGET_EXCEEDED);
+          MatchStrategy.DFA, StrategyDisposition.FALLBACK, StrategyReason.DFA_BUDGET_EXCEEDED);
     }
     boolean matched =
         Nfa.search(

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -594,15 +594,44 @@ public final class Pattern implements Serializable {
   public boolean find(Utf8Input input) {
     ArrayUtf8Input arrayInput = (ArrayUtf8Input) Objects.requireNonNull(input, "input");
     Utf8InputScanner scanner = arrayInput.scanner();
+    SafeReMatchDiagnostics listener = diagnostics();
+    DiagnosticAccumulator accumulator =
+        SafeReMatchDiagnostics.isEnabled(listener) ? new DiagnosticAccumulator() : null;
+    boolean matched = find(scanner, accumulator);
+    if (accumulator != null) {
+      accumulator.matchCount(matched ? 1 : 0);
+      MatchOutcome outcome = matched ? MatchOutcome.MATCH : MatchOutcome.NO_MATCH;
+      OperationDiagnostics event =
+          accumulator.toEvent(
+              descriptor(),
+              MatchOperation.FIND,
+              outcome,
+              CaptureMode.NONE,
+              scanner.length());
+      listener.onOperationCompleted(event);
+    }
+    return matched;
+  }
+
+  private boolean find(Utf8InputScanner scanner, DiagnosticAccumulator diagnostics) {
     int length = scanner.length();
     if (literalMatchUtf8 != null && !prefixFoldCase) {
-      return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
+      boolean matched =
+          scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
+      if (diagnostics != null) {
+        diagnostics.boundary(MatchStrategy.LITERAL);
+      }
+      return matched;
     }
     if (enginePathOptions.literalFastPaths()
         && requiredLiteralUtf8 != null
         && prefixUtf8 == null
         && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
             < 0) {
+      if (diagnostics != null) {
+        diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
+        diagnostics.boundary(MatchStrategy.LITERAL);
+      }
       return false;
     }
     if (enginePathOptions.charClassMatchFastPaths()
@@ -612,38 +641,72 @@ public final class Pattern implements Serializable {
         && scanner.indexOfCodePointClass(
                 requiredMatchClassRanges, requiredMatchClassBitmap0, requiredMatchClassBitmap1, 0)
             < 0) {
+      if (diagnostics != null) {
+        diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
+        diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
+      }
       return false;
     }
     int searchStart = 0;
     if (prefixUtf8 != null && !prefixFoldCase) {
+      if (diagnostics != null) {
+        diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
+      }
       searchStart = scanner.indexOf(prefixUtf8, prefixUtf8Failure, prefixUtf8Shifts);
       if (searchStart < 0) {
+        if (diagnostics != null) {
+          diagnostics.boundary(MatchStrategy.LITERAL);
+        }
         return false;
       }
     } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
+      if (diagnostics != null) {
+        diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
+      }
       searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
       if (searchStart < 0) {
+        if (diagnostics != null) {
+          diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
+        }
         return false;
       }
     }
     if (!prog.anchorEnd() && !prog.hasGraphemeSemantics() && prog.numLoopRegs() == 0) {
+      if (diagnostics != null) {
+        diagnostics.participate(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
+        diagnostics.incrementForwardDfaSearchCount();
+      }
       Dfa.SearchResult result = forwardFirstMatchDfa().doSearch(scanner, searchStart, false, false);
       if (result != null) {
+        if (diagnostics != null) {
+          diagnostics.boundary(MatchStrategy.DFA);
+        }
         return result.matched();
       }
+      if (diagnostics != null) {
+        diagnostics.decision(
+            MatchStrategy.DFA,
+            StrategyDisposition.FALLBACK,
+            StrategyReason.DFA_BUDGET_EXCEEDED);
+      }
     }
-    return Nfa.search(
-            prog,
-            scanner,
-            searchStart,
-            length,
-            length,
-            0,
-            Nfa.Anchor.UNANCHORED,
-            Nfa.MatchKind.FIRST_MATCH,
-            0,
-            null)
-        != null;
+    boolean matched =
+        Nfa.search(
+                prog,
+                scanner,
+                searchStart,
+                length,
+                length,
+                0,
+                Nfa.Anchor.UNANCHORED,
+                Nfa.MatchKind.FIRST_MATCH,
+                0,
+                null)
+            != null;
+    if (diagnostics != null) {
+      diagnostics.boundary(MatchStrategy.NFA);
+    }
+    return matched;
   }
 
   private static int[] literalFailure(byte[] literal) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -55,9 +55,29 @@ public final class Pattern implements Serializable {
       MethodType.methodType(SafeReMatchDiagnostics.class);
   private static final MutableCallSite DIAGNOSTICS_SITE = new MutableCallSite(DIAGNOSTICS_TYPE);
   private static final MethodHandle DIAGNOSTICS_INVOKER = DIAGNOSTICS_SITE.dynamicInvoker();
+  private static final MethodType UTF8_FIND_TYPE =
+      MethodType.methodType(boolean.class, Pattern.class, Utf8InputScanner.class);
+  private static final MutableCallSite UTF8_FIND_SITE = new MutableCallSite(UTF8_FIND_TYPE);
+  private static final MethodHandle UTF8_FIND_INVOKER = UTF8_FIND_SITE.dynamicInvoker();
+  private static final MethodHandle UTF8_FIND_DISABLED =
+      findUtf8Handle("findWithoutDiagnostics");
+  private static final MethodHandle UTF8_FIND_ENABLED =
+      findUtf8Handle("findWithDiagnostics");
 
   static {
     setDiagnosticsTarget(SafeReMatchDiagnostics.NONE);
+  }
+
+  private static MethodHandle findUtf8Handle(String methodName) {
+    try {
+      return MethodHandles.lookup()
+          .findVirtual(
+              Pattern.class,
+              methodName,
+              MethodType.methodType(boolean.class, Utf8InputScanner.class));
+    } catch (NoSuchMethodException | IllegalAccessException impossible) {
+      throw new ExceptionInInitializerError(impossible);
+    }
   }
 
   /**
@@ -391,7 +411,7 @@ public final class Pattern implements Serializable {
    */
   public static void setDiagnostics(SafeReMatchDiagnostics listener) {
     setDiagnosticsTarget(Objects.requireNonNull(listener, "listener"));
-    MutableCallSite.syncAll(new MutableCallSite[] {DIAGNOSTICS_SITE});
+    MutableCallSite.syncAll(new MutableCallSite[] {DIAGNOSTICS_SITE, UTF8_FIND_SITE});
   }
 
   /**
@@ -409,6 +429,8 @@ public final class Pattern implements Serializable {
 
   private static void setDiagnosticsTarget(SafeReMatchDiagnostics listener) {
     DIAGNOSTICS_SITE.setTarget(MethodHandles.constant(SafeReMatchDiagnostics.class, listener));
+    UTF8_FIND_SITE.setTarget(
+        SafeReMatchDiagnostics.isEnabled(listener) ? UTF8_FIND_ENABLED : UTF8_FIND_DISABLED);
   }
 
   /**
@@ -594,44 +616,38 @@ public final class Pattern implements Serializable {
   public boolean find(Utf8Input input) {
     ArrayUtf8Input arrayInput = (ArrayUtf8Input) Objects.requireNonNull(input, "input");
     Utf8InputScanner scanner = arrayInput.scanner();
-    SafeReMatchDiagnostics listener = diagnostics();
-    DiagnosticAccumulator accumulator =
-        SafeReMatchDiagnostics.isEnabled(listener) ? new DiagnosticAccumulator() : null;
-    boolean matched = find(scanner, accumulator);
-    if (accumulator != null) {
-      accumulator.matchCount(matched ? 1 : 0);
-      MatchOutcome outcome = matched ? MatchOutcome.MATCH : MatchOutcome.NO_MATCH;
-      OperationDiagnostics event =
-          accumulator.toEvent(
-              descriptor(),
-              MatchOperation.FIND,
-              outcome,
-              CaptureMode.NONE,
-              scanner.length());
-      listener.onOperationCompleted(event);
+    try {
+      return (boolean) UTF8_FIND_INVOKER.invokeExact(this, scanner);
+    } catch (RuntimeException | Error e) {
+      throw e;
+    } catch (Throwable impossible) {
+      throw new AssertionError(impossible);
     }
+  }
+
+  boolean findWithDiagnostics(Utf8InputScanner scanner) {
+    SafeReMatchDiagnostics listener = diagnostics();
+    DiagnosticAccumulator accumulator = new DiagnosticAccumulator();
+    boolean matched = findWithDiagnostics(scanner, accumulator);
+    accumulator.matchCount(matched ? 1 : 0);
+    MatchOutcome outcome = matched ? MatchOutcome.MATCH : MatchOutcome.NO_MATCH;
+    OperationDiagnostics event =
+        accumulator.toEvent(
+            descriptor(), MatchOperation.FIND, outcome, CaptureMode.NONE, scanner.length());
+    listener.onOperationCompleted(event);
     return matched;
   }
 
-  private boolean find(Utf8InputScanner scanner, DiagnosticAccumulator diagnostics) {
+  boolean findWithoutDiagnostics(Utf8InputScanner scanner) {
     int length = scanner.length();
     if (literalMatchUtf8 != null && !prefixFoldCase) {
-      boolean matched =
-          scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
-      if (diagnostics != null) {
-        diagnostics.boundary(MatchStrategy.LITERAL);
-      }
-      return matched;
+      return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
     }
     if (enginePathOptions.literalFastPaths()
         && requiredLiteralUtf8 != null
         && prefixUtf8 == null
         && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
             < 0) {
-      if (diagnostics != null) {
-        diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
-        diagnostics.boundary(MatchStrategy.LITERAL);
-      }
       return false;
     }
     if (enginePathOptions.charClassMatchFastPaths()
@@ -641,54 +657,97 @@ public final class Pattern implements Serializable {
         && scanner.indexOfCodePointClass(
                 requiredMatchClassRanges, requiredMatchClassBitmap0, requiredMatchClassBitmap1, 0)
             < 0) {
-      if (diagnostics != null) {
-        diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
-        diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
-      }
       return false;
     }
     int searchStart = 0;
     if (prefixUtf8 != null && !prefixFoldCase) {
-      if (diagnostics != null) {
-        diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
-      }
       searchStart = scanner.indexOf(prefixUtf8, prefixUtf8Failure, prefixUtf8Shifts);
       if (searchStart < 0) {
-        if (diagnostics != null) {
-          diagnostics.boundary(MatchStrategy.LITERAL);
-        }
         return false;
       }
     } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
-      if (diagnostics != null) {
-        diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
-      }
       searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
       if (searchStart < 0) {
-        if (diagnostics != null) {
-          diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
-        }
         return false;
       }
     }
     if (!prog.anchorEnd() && !prog.hasGraphemeSemantics() && prog.numLoopRegs() == 0) {
-      if (diagnostics != null) {
-        diagnostics.participate(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
-        diagnostics.incrementForwardDfaSearchCount();
-      }
       Dfa.SearchResult result = forwardFirstMatchDfa().doSearch(scanner, searchStart, false, false);
       if (result != null) {
-        if (diagnostics != null) {
-          diagnostics.boundary(MatchStrategy.DFA);
-        }
         return result.matched();
       }
-      if (diagnostics != null) {
-        diagnostics.decision(
-            MatchStrategy.DFA,
-            StrategyDisposition.FALLBACK,
-            StrategyReason.DFA_BUDGET_EXCEEDED);
+    }
+    return Nfa.search(
+            prog,
+            scanner,
+            searchStart,
+            length,
+            length,
+            0,
+            Nfa.Anchor.UNANCHORED,
+            Nfa.MatchKind.FIRST_MATCH,
+            0,
+            null)
+        != null;
+  }
+
+  private boolean findWithDiagnostics(
+      Utf8InputScanner scanner, DiagnosticAccumulator diagnostics) {
+    int length = scanner.length();
+    if (literalMatchUtf8 != null && !prefixFoldCase) {
+      boolean matched =
+          scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
+      diagnostics.boundary(MatchStrategy.LITERAL);
+      return matched;
+    }
+    if (enginePathOptions.literalFastPaths()
+        && requiredLiteralUtf8 != null
+        && prefixUtf8 == null
+        && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
+            < 0) {
+      diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
+      diagnostics.boundary(MatchStrategy.LITERAL);
+      return false;
+    }
+    if (enginePathOptions.charClassMatchFastPaths()
+        && requiredMatchClassRanges != null
+        && prefixUtf8 == null
+        && charClassPrefixAscii == null
+        && scanner.indexOfCodePointClass(
+                requiredMatchClassRanges, requiredMatchClassBitmap0, requiredMatchClassBitmap1, 0)
+            < 0) {
+      diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
+      diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
+      return false;
+    }
+    int searchStart = 0;
+    if (prefixUtf8 != null && !prefixFoldCase) {
+      diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
+      searchStart = scanner.indexOf(prefixUtf8, prefixUtf8Failure, prefixUtf8Shifts);
+      if (searchStart < 0) {
+        diagnostics.boundary(MatchStrategy.LITERAL);
+        return false;
       }
+    } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
+      diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
+      searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
+      if (searchStart < 0) {
+        diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
+        return false;
+      }
+    }
+    if (!prog.anchorEnd() && !prog.hasGraphemeSemantics() && prog.numLoopRegs() == 0) {
+      diagnostics.participate(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
+      diagnostics.incrementForwardDfaSearchCount();
+      Dfa.SearchResult result = forwardFirstMatchDfa().doSearch(scanner, searchStart, false, false);
+      if (result != null) {
+        diagnostics.boundary(MatchStrategy.DFA);
+        return result.matched();
+      }
+      diagnostics.decision(
+          MatchStrategy.DFA,
+          StrategyDisposition.FALLBACK,
+          StrategyReason.DFA_BUDGET_EXCEEDED);
     }
     boolean matched =
         Nfa.search(
@@ -703,9 +762,7 @@ public final class Pattern implements Serializable {
                 0,
                 null)
             != null;
-    if (diagnostics != null) {
-      diagnostics.boundary(MatchStrategy.NFA);
-    }
+    diagnostics.boundary(MatchStrategy.NFA);
     return matched;
   }
 

--- a/safere/src/main/java/org/safere/SafeReMatchDiagnostics.java
+++ b/safere/src/main/java/org/safere/SafeReMatchDiagnostics.java
@@ -15,6 +15,10 @@ package org.safere;
  * <p>When {@link #NONE} is installed, matching allocates no diagnostics objects. Enabled listeners
  * receive one bounded event per supported public operation, irrespective of internal engine passes
  * or replacement match count.
+ *
+ * <p>Supported operations are {@link Matcher#matches()}, {@link Matcher#lookingAt()}, {@link
+ * Matcher#find()}, the {@link Matcher} replacement operations, the corresponding matching
+ * operations on {@link Utf8Matcher}, and {@link Pattern#find(Utf8Input)}.
  */
 public class SafeReMatchDiagnostics {
   /** Listener used when match diagnostics are disabled. */

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 @Isolated
 @Execution(ExecutionMode.SAME_THREAD)
@@ -443,6 +446,35 @@ class DiagnosticsTest {
     assertThat(PatternDescriptor.class.getRecordComponents())
         .noneMatch(component -> component.getType() == String.class);
     assertThat(event.inputLength()).isEqualTo(inputSecret.length());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = MatchOperation.class,
+      names = {"MATCHES", "LOOKING_AT", "FIND"})
+  void utf8OperationsReportDiagnosticsWithByteInputLength(MatchOperation operation) {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile(".*é.*");
+    byte[] inputBytes = "xéy".getBytes(UTF_8);
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.trusted(inputBytes, 0, inputBytes.length));
+
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+          case FIND -> matcher.find();
+          default -> throw new AssertionError("Unexpected operation: " + operation);
+        };
+
+    assertThat(matched).isTrue();
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(operation);
+              assertThat(event.outcome()).isEqualTo(MatchOutcome.MATCH);
+              assertThat(event.inputLength()).isEqualTo(inputBytes.length);
+            });
   }
 
   @Test

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -5,7 +5,6 @@
 
 package org.safere;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -23,8 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 @Isolated
 @Execution(ExecutionMode.SAME_THREAD)
@@ -446,35 +443,6 @@ class DiagnosticsTest {
     assertThat(PatternDescriptor.class.getRecordComponents())
         .noneMatch(component -> component.getType() == String.class);
     assertThat(event.inputLength()).isEqualTo(inputSecret.length());
-  }
-
-  @ParameterizedTest
-  @EnumSource(
-      value = MatchOperation.class,
-      names = {"MATCHES", "LOOKING_AT", "FIND"})
-  void utf8OperationsReportDiagnosticsWithByteInputLength(MatchOperation operation) {
-    Pattern.setDiagnostics(diagnostics);
-    Pattern pattern = Pattern.compile(".*é.*");
-    byte[] inputBytes = "xéy".getBytes(UTF_8);
-    Utf8Matcher matcher = pattern.matcher(Utf8Input.trusted(inputBytes, 0, inputBytes.length));
-
-    boolean matched =
-        switch (operation) {
-          case MATCHES -> matcher.matches();
-          case LOOKING_AT -> matcher.lookingAt();
-          case FIND -> matcher.find();
-          default -> throw new AssertionError("Unexpected operation: " + operation);
-        };
-
-    assertThat(matched).isTrue();
-    assertThat(operationsFor(pattern))
-        .singleElement()
-        .satisfies(
-            event -> {
-              assertThat(event.operation()).isEqualTo(operation);
-              assertThat(event.outcome()).isEqualTo(MatchOutcome.MATCH);
-              assertThat(event.inputLength()).isEqualTo(inputBytes.length);
-            });
   }
 
   @Test

--- a/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
@@ -1,0 +1,388 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+@DisabledForCrosscheck("UTF-8 match diagnostics are a SafeRE-specific public API")
+class Utf8DiagnosticsTest {
+  private final RecordingDiagnostics diagnostics = new RecordingDiagnostics();
+
+  @AfterEach
+  void disableDiagnostics() {
+    Pattern.setDiagnostics(SafeReMatchDiagnostics.NONE);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = MatchOperation.class,
+      names = {"MATCHES", "LOOKING_AT", "FIND"})
+  void operationsReportDiagnosticsWithSlicedByteInputLength(MatchOperation operation) {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile(".*é.*");
+    byte[] logicalInput = "xéy".getBytes(UTF_8);
+    byte[] storage = new byte[logicalInput.length + 5];
+    System.arraycopy(logicalInput, 0, storage, 2, logicalInput.length);
+    Utf8Matcher matcher =
+        pattern.matcher(Utf8Input.trusted(storage, 2, logicalInput.length));
+
+    boolean matched =
+        switch (operation) {
+          case MATCHES -> matcher.matches();
+          case LOOKING_AT -> matcher.lookingAt();
+          case FIND -> matcher.find();
+          default -> throw new AssertionError("Unexpected operation: " + operation);
+        };
+
+    assertThat(matched).isTrue();
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(operation);
+              assertThat(event.outcome()).isEqualTo(MatchOutcome.MATCH);
+              assertThat(event.inputLength()).isEqualTo(logicalInput.length);
+              assertThat(event.matchCount()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void onePassReportsDescriptorAndEagerCaptures() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("^GET ([^ ]+)");
+
+    assertThat(matcher(pattern, "GET /café").lookingAt()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.pattern()).isSameAs(pattern.descriptor());
+              assertThat(event.operation()).isEqualTo(MatchOperation.LOOKING_AT);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.ONE_PASS);
+              assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.ONE_PASS);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.EAGER);
+            });
+  }
+
+  @Test
+  void literalFindReportsUtf8FastPath() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("é");
+
+    assertThat(matcher(pattern, "xéy").find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+              assertThat(event.forwardDfaSearchCount()).isZero();
+              assertThat(event.reverseDfaSearchCount()).isZero();
+            });
+  }
+
+  @Test
+  void patternBooleanFindReportsUtf8FastPath() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("é");
+    Utf8Input input = Utf8Input.validated("xéy".getBytes(UTF_8));
+
+    assertThat(pattern.find(input)).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.operation()).isEqualTo(MatchOperation.FIND);
+              assertThat(event.outcome()).isEqualTo(MatchOutcome.MATCH);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+              assertThat(event.inputLength()).isEqualTo(4);
+              assertThat(event.matchCount()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void patternBooleanFindReportsAccelerationAndDfaSearch() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("é[ab]+c");
+
+    assertThat(pattern.find(input("xxéabc"))).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.forwardDfaSearchCount()).isEqualTo(1);
+              assertThat(event.reverseDfaSearchCount()).isZero();
+              assertThat(event.auxiliaryStrategies())
+                  .containsExactly(
+                      new StrategyParticipation(
+                          MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION),
+                      new StrategyParticipation(
+                          MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER));
+            });
+  }
+
+  @Test
+  void patternBooleanFindReportsNfaForGraphemeSemantics() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("\\Xz");
+
+    assertThat(pattern.find(input("a\u0301z"))).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+              assertThat(event.forwardDfaSearchCount()).isZero();
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.NONE);
+            });
+  }
+
+  @Test
+  void patternBooleanFindReportsAcceleratedRejection() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("é[ab]+c");
+
+    assertThat(pattern.find(input("ordinary ASCII text"))).isFalse();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.outcome()).isEqualTo(MatchOutcome.NO_MATCH);
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+              assertThat(event.auxiliaryStrategies())
+                  .containsExactly(
+                      new StrategyParticipation(
+                          MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION));
+              assertThat(event.matchCount()).isZero();
+            });
+  }
+
+  @Test
+  void literalPrefixCandidateReportsAccelerationAndVerification() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("é[ab]+c");
+
+    assertThat(matcher(pattern, "xxéabc").find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.forwardDfaSearchCount()).isEqualTo(2);
+              assertThat(event.reverseDfaSearchCount()).isZero();
+              assertThat(event.auxiliaryStrategies())
+                  .containsExactly(
+                      new StrategyParticipation(
+                          MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION),
+                      new StrategyParticipation(
+                          MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER),
+                      new StrategyParticipation(
+                          MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION));
+            });
+  }
+
+  @Test
+  void dfaSandwichReportsForwardAndReverseSearchCounts() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("[ab]+é");
+
+    assertThat(matcher(pattern, "xxabé").find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.forwardDfaSearchCount()).isEqualTo(1);
+              assertThat(event.reverseDfaSearchCount()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  void forcedBitStateAndNfaReportTheExactEngine() {
+    Pattern.setDiagnostics(diagnostics);
+    EnginePathOptions bitStateOnly = exactEngineOptions(true);
+    Pattern bitState = Pattern.compile("(?:é)+", 0, bitStateOnly);
+
+    assertThat(matcher(bitState, "xéé").find()).isTrue();
+    assertThat(operationsFor(bitState).getLast().boundaryStrategy())
+        .isEqualTo(MatchStrategy.BIT_STATE);
+
+    EnginePathOptions nfaOnly = exactEngineOptions(false);
+    Pattern nfa = Pattern.compile("(?:é)+", 0, nfaOnly);
+
+    assertThat(matcher(nfa, "xéé").find()).isTrue();
+    assertThat(operationsFor(nfa).getLast().boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+  }
+
+  @Test
+  void dfaBoundsCanLeaveCapturesDeferred() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("(é+)x");
+    Utf8Matcher matcher = matcher(pattern, "zzééx");
+
+    assertThat(matcher.find()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.NONE);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.DEFERRED);
+            });
+    assertThat(matcher.start(1)).isEqualTo(2);
+    assertThat(matcher.end(1)).isEqualTo(6);
+    assertThat(operationsFor(pattern)).hasSize(1);
+  }
+
+  @Test
+  void failedMatchReportsNoMatchWithoutCaptures() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("(é)+");
+
+    assertThat(matcher(pattern, "abc").find()).isFalse();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.outcome()).isEqualTo(MatchOutcome.NO_MATCH);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.NONE);
+              assertThat(event.matchCount()).isZero();
+            });
+  }
+
+  @Test
+  void largeInputReportsBitStateBypassAndNfaFallback() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("a+b", 0, exactEngineOptions(true));
+
+    assertThat(matcher(pattern, "a".repeat(100_000) + "b").matches()).isTrue();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+              assertThat(event.strategyDecisions())
+                  .contains(
+                      new StrategyDecision(
+                          MatchStrategy.BIT_STATE,
+                          StrategyDisposition.BYPASSED,
+                          StrategyReason.INPUT_TOO_LARGE));
+            });
+  }
+
+  @Test
+  void graphemeSemanticsReportNfaFallback() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("\\X");
+
+    assertThat(matcher(pattern, "a\u0301").matches()).isTrue();
+
+    assertThat(operationsFor(pattern).getFirst().boundaryStrategy()).isEqualTo(MatchStrategy.NFA);
+  }
+
+  @Test
+  void listenerFailurePropagatesAfterMatcherStateIsFinalized() {
+    Pattern pattern = Pattern.compile("é");
+    Utf8Matcher matcher = matcher(pattern, "é");
+    Pattern.setDiagnostics(
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            throw new IllegalStateException("listener failed");
+          }
+        });
+
+    assertThatThrownBy(matcher::matches)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("listener failed");
+    assertThat(matcher.start()).isZero();
+    assertThat(matcher.end()).isEqualTo(2);
+  }
+
+  @Test
+  void listenerCanAggregateOperationsFromMultipleThreads() {
+    Pattern pattern = Pattern.compile("é");
+    ConcurrentLinkedQueue<OperationDiagnostics> events = new ConcurrentLinkedQueue<>();
+    Pattern.setDiagnostics(
+        new SafeReMatchDiagnostics() {
+          @Override
+          public void onOperationCompleted(OperationDiagnostics event) {
+            events.add(event);
+          }
+        });
+
+    IntStream.range(0, 32)
+        .parallel()
+        .forEach(ignored -> assertThat(matcher(pattern, "é").matches()).isTrue());
+
+    assertThat(events)
+        .filteredOn(event -> event.pattern().patternId() == pattern.descriptor().patternId())
+        .hasSize(32);
+  }
+
+  private static EnginePathOptions exactEngineOptions(boolean bitState) {
+    return EnginePathOptions.builder()
+        .literalFastPaths(false)
+        .charClassMatchFastPaths(false)
+        .keywordAlternationFastPath(false)
+        .startAcceleration(false)
+        .onePass(false)
+        .dfa(false)
+        .bitState(bitState)
+        .build();
+  }
+
+  private static Utf8Matcher matcher(Pattern pattern, String input) {
+    return pattern.matcher(input(input));
+  }
+
+  private static Utf8Input input(String input) {
+    return Utf8Input.validated(input.getBytes(UTF_8));
+  }
+
+  private List<OperationDiagnostics> operationsFor(Pattern pattern) {
+    long patternId = pattern.descriptor().patternId();
+    return diagnostics.operations.stream()
+        .filter(event -> event.pattern().patternId() == patternId)
+        .toList();
+  }
+
+  private static final class RecordingDiagnostics extends SafeReMatchDiagnostics {
+    final List<OperationDiagnostics> operations = new ArrayList<>();
+
+    @Override
+    public void onOperationCompleted(OperationDiagnostics event) {
+      operations.add(event);
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
@@ -13,13 +13,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Isolated
 @Execution(ExecutionMode.SAME_THREAD)
@@ -180,6 +183,34 @@ class Utf8DiagnosticsTest {
                           MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION));
               assertThat(event.matchCount()).isZero();
             });
+  }
+
+  @ParameterizedTest
+  @MethodSource("patternBooleanFindScenarios")
+  void patternBooleanFindDiagnosticsPreserveResults(
+      String regex, String text, boolean expectedResult) {
+    Pattern pattern = Pattern.compile(regex);
+    Utf8Input input = input(text);
+
+    Pattern.setDiagnostics(SafeReMatchDiagnostics.NONE);
+    assertThat(pattern.find(input)).isEqualTo(expectedResult);
+
+    Pattern.setDiagnostics(diagnostics);
+    assertThat(pattern.find(input)).isEqualTo(expectedResult);
+    assertThat(operationsFor(pattern)).hasSize(1);
+  }
+
+  private static Stream<Arguments> patternBooleanFindScenarios() {
+    return Stream.of(
+        Arguments.of("é", "xéy", true),
+        Arguments.of("é", "xyz", false),
+        Arguments.of("é[ab]+c", "xxéabc", true),
+        Arguments.of("é[ab]+c", "xxézz", false),
+        Arguments.of("[ab]+é", "xxabé", true),
+        Arguments.of("[一-龥]{3,}", "ordinary ASCII text", false),
+        Arguments.of("\\Xz", "a\u0301z", true),
+        Arguments.of(".*z$", "abc", false),
+        Arguments.of("(a?)*X", "aaaaX", true));
   }
 
   @Test

--- a/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
@@ -45,8 +45,7 @@ class Utf8DiagnosticsTest {
     byte[] logicalInput = "xéy".getBytes(UTF_8);
     byte[] storage = new byte[logicalInput.length + 5];
     System.arraycopy(logicalInput, 0, storage, 2, logicalInput.length);
-    Utf8Matcher matcher =
-        pattern.matcher(Utf8Input.trusted(storage, 2, logicalInput.length));
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.trusted(storage, 2, logicalInput.length));
 
     boolean matched =
         switch (operation) {
@@ -142,8 +141,7 @@ class Utf8DiagnosticsTest {
                   .containsExactly(
                       new StrategyParticipation(
                           MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION),
-                      new StrategyParticipation(
-                          MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER));
+                      new StrategyParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER));
             });
   }
 
@@ -231,8 +229,7 @@ class Utf8DiagnosticsTest {
                   .containsExactly(
                       new StrategyParticipation(
                           MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION),
-                      new StrategyParticipation(
-                          MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER),
+                      new StrategyParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER),
                       new StrategyParticipation(
                           MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION));
             });


### PR DESCRIPTION
## Summary

- use the representation-neutral matcher input length when completing diagnostics
- report UTF-8 matcher input lengths in bytes, consistent with the UTF-8 API's offsets
- emit diagnostics for the optimized `Pattern.find(Utf8Input)` path
- dispatch one-shot UTF-8 finds directly to separate enabled and disabled implementations so
  disabled diagnostics retain the original allocation and inlining behavior
- document the supported diagnostics operations and their input-length units
- add dedicated UTF-8 diagnostics coverage across match operations, engine strategies, counters,
  participation, decisions, capture modes, sliced inputs, listener failure, and concurrency

Fixes #635

## Verification

- `mvn -pl safere -Dtest=DiagnosticsTest,Utf8DiagnosticsTest test -q`
- `mvn -pl safere test -q`
- `git diff --check`

## Disabled-diagnostics performance

Measured the most overhead-sensitive existing one-shot UTF-8 workload,
`Utf8MatchingBenchmark.captureFreeBytes.asciiEarly@safere-utf8`, with diagnostics disabled and GC
profiling. Both measurements used the benchmark script's long configuration.

| Revision | Average time | Allocation |
|---|---:|---:|
| Before one-shot diagnostics (`685edfc`) | 4.428 ± 0.008 ns/op | ≈ 10^-5 B/op |
| This PR (`fa3a7a5`) | 4.401 ± 0.075 ns/op | ≈ 10^-5 B/op |

The result is statistically indistinguishable from baseline (nominally 0.6% faster), with unchanged
effectively-zero allocation.
