### PR TITLE
Eliminate implicit benchmark syntax conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,10 +599,12 @@ for cross-language comparison. Prerequisites are
 [Rust ≥ 1.85 with Cargo](https://rust-lang.org/tools/install/). Dependencies
 are fetched automatically.
 
-Benchmark patterns are written in Java syntax. A pattern that needs different
-syntax in another regex dialect declares exact alternatives beside its
-Java-canonical definition in `safere-benchmarks/benchmark-data.json`; a missing
-alternate means that the Java pattern is used unchanged. See the
+Benchmark patterns and replacement templates are written in Java syntax. A
+value that needs different syntax in another regex dialect declares exact
+alternatives beside its Java-canonical definition in
+`safere-benchmarks/benchmark-data.json`; a missing alternate means that the Java
+value is used unchanged. Harnesses do not translate syntax or infer replacement
+templates from operation names. See the
 [pattern-profile schema](safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles)
 for profile mappings and validation rules.
 

--- a/safere-benchmarks/BENCHMARK_INPUTS.md
+++ b/safere-benchmarks/BENCHMARK_INPUTS.md
@@ -15,11 +15,12 @@ Java string engines decode input files as UTF-8 during benchmark setup, while
 byte-oriented engines use the bytes directly. Materialization and decoding are
 outside the timed operation.
 
-Patterns remain Java-canonical in `benchmark-data.json`. Explicit
-engine-dialect alternatives live beside the pattern that needs them. The
-materializer collects those inline definitions into the resolved manifest;
-runners select their profile there and otherwise use the Java string unchanged.
-See [DECLARATIVE_BENCHMARK_PLAN.md](DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles).
+Regex patterns and replacement templates remain Java-canonical in
+`benchmark-data.json`. Explicit engine-dialect alternatives live beside the
+value that needs them. The materializer collects those inline definitions into
+separate resolved pattern and replacement profiles; runners select exact values
+there and otherwise use the Java string unchanged. See
+[DECLARATIVE_BENCHMARK_PLAN.md](DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles).
 
 The normal runner scripts materialize automatically. To prepare the corpus
 without starting a benchmark, run from the repository root:

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -113,9 +113,10 @@ with a `replacement` field instead of `pattern`:
 An engine adapter selects one profile for each syntax kind. SafeRE and JDK use
 the Java values directly. RE2/J and RE2-FFM select the `re2` pattern profile;
 native C++ RE2 selects `re2` patterns and `re2-cpp` replacements; Go selects
-`re2` patterns and `go-regexp` replacements; and Rust `regex` selects
-`rust-regex` for both kinds. If the selected profile has no entry for a Java
-syntax value, the adapter uses the Java value unchanged.
+`re2` patterns and `go-regexp` replacements where adjacent text makes a Java
+capture reference ambiguous; and Rust `regex` selects `rust-regex` for both
+kinds. If the selected profile has no entry for a Java syntax value, the adapter
+uses the Java value unchanged.
 
 Alternates are exact reviewed strings. Runners must not rewrite regex or
 replacement syntax automatically or derive replacement templates from operation

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -110,19 +110,22 @@ with a `replacement` field instead of `pattern`:
 }
 ```
 
-An engine adapter selects one syntax-family profile. SafeRE and JDK select
-`java`; RE2/J, RE2-FFM, native C++ RE2, and Go select `re2`; and Rust
-`regex` selects `rust-regex`. If the selected profile has no entry for a Java
+An engine adapter selects one profile for each syntax kind. SafeRE and JDK use
+the Java values directly. RE2/J and RE2-FFM select the `re2` pattern profile;
+native C++ RE2 selects `re2` patterns and `re2-cpp` replacements; Go selects
+`re2` patterns and `go-regexp` replacements; and Rust `regex` selects
+`rust-regex` for both kinds. If the selected profile has no entry for a Java
 syntax value, the adapter uses the Java value unchanged.
 
-Alternates are exact reviewed strings. Runners must not rewrite regex syntax
-automatically. The required nonblank `reason` records why the alternate is
-necessary. The materializer replaces inline definitions with their Java strings
-and emits separate resolved pattern and replacement profile lookups in the
-generated manifest. Keeping the namespaces separate prevents the same Java
-string from selecting a pattern alternate when it is used as a replacement, or
-vice versa. Conflicting alternates for the same Java value, kind, and profile,
-malformed profile IDs, blank fields, and unknown fields are rejected during
+Alternates are exact reviewed strings. Runners must not rewrite regex or
+replacement syntax automatically or derive replacement templates from operation
+names. The required nonblank `reason` records why the alternate is necessary.
+The materializer replaces inline definitions with their Java strings and emits
+separate resolved pattern and replacement profile lookups in the generated
+manifest. Keeping the namespaces separate prevents the same Java string from
+selecting a pattern alternate when it is used as a replacement, or vice versa.
+Conflicting alternates for the same Java value, kind, and profile, malformed
+profile IDs, blank fields, and unknown fields are rejected during
 materialization.
 Pattern selection and compilation happen outside timed matching operations;
 compile benchmarks select the alternate before starting the timed compilation.

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4855,6 +4855,10 @@
         "replacement": {
           "java": "$2$1ay",
           "alternates": {
+            "go-regexp": {
+              "replacement": "${2}${1}ay",
+              "reason": "Go replacement references need braces before adjacent letters"
+            },
             "rust-regex": {
               "replacement": "${2}${1}ay",
               "reason": "Rust replacement references need braces before adjacent letters"
@@ -4929,6 +4933,10 @@
         "replacement": {
           "java": "$2$1ay",
           "alternates": {
+            "go-regexp": {
+              "replacement": "${2}${1}ay",
+              "reason": "Go replacement references need braces before adjacent letters"
+            },
             "rust-regex": {
               "replacement": "${2}${1}ay",
               "reason": "Rust replacement references need braces before adjacent letters"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1966,12 +1966,28 @@
       "numbered": {
         "pattern": "([A-Za-z]+)=([^&]+)",
         "text": "city=東京&name=Renée",
-        "replacement": "$1=[$2]"
+        "replacement": {
+          "java": "$1=[$2]",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1=[\\2]",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        }
       },
       "named": {
         "pattern": "(?<key>[A-Za-z]+)=(?<value>[^&]+)",
         "text": "city=東京&name=Renée",
-        "replacement": "${key}=[${value}]"
+        "replacement": {
+          "java": "${key}=[${value}]",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1=[\\2]",
+              "reason": "C++ RE2 replacements reference named captures by number"
+            }
+          }
+        }
       }
     },
     "window": {
@@ -2107,7 +2123,15 @@
     },
     "altCapture": {
       "pattern": "(^|[^#])(#!customTag)",
-      "replacement": "$1<tag type=\"custom\"",
+      "replacement": {
+        "java": "$1<tag type=\"custom\"",
+        "alternates": {
+          "re2-cpp": {
+            "replacement": "\\1<tag type=\"custom\"",
+            "reason": "C++ RE2 uses backslash-number capture references"
+          }
+        }
+      },
       "hitUnit": "This is some sample prose text that contains a tag marker #!customTag and more text here. ",
       "missUnit": "This is some sample prose text that contains a tag marker #customTag and more text here. ",
       "hitInterval": 5
@@ -2153,6 +2177,10 @@
     "fullRequest": "GET /asdfhjasdhfasdlfhasdflkjasdfkljasdhflaskdjhflkajsdhflkajshfklasjdhfklasjdhfklashdflka HTTP/1.1",
     "smallRequest": "GET /abc HTTP/1.1"
   },
+  "crosscheckOverhead": {
+    "pattern": "([a-z]+)(\\d+)",
+    "replacement": "$2:$1"
+  },
   "replace": {
     "literalReplaceFirst": {
       "pattern": "b",
@@ -2178,6 +2206,14 @@
       "replacement": {
         "java": "$2$1ay",
         "alternates": {
+          "go-regexp": {
+            "replacement": "${2}${1}ay",
+            "reason": "Go replacement references need braces before adjacent letters"
+          },
+          "re2-cpp": {
+            "replacement": "\\2\\1ay",
+            "reason": "C++ RE2 uses backslash-number capture references"
+          },
           "rust-regex": {
             "replacement": "${2}${1}ay",
             "reason": "Rust replacement references need braces before adjacent letters"
@@ -2244,6 +2280,7 @@
         "name": "markupImageLink",
         "pattern": "<<!(image|media|link)(\\([^\\)]*\\))?/?>?>",
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "<<!image(src=\"http://image.png\")>>",
         "nonMatch": "<<!image"
       },
@@ -2260,6 +2297,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "[1.2.3, 4.5.6]",
         "nonMatch": "[1.2.3,"
       },
@@ -2268,6 +2306,7 @@
         "name": "malformedEntity",
         "pattern": "<[^>]*entity[^>]*>{1,2}",
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "<entity id=\"123\">",
         "nonMatch": "<ent id=\"123\">"
       },
@@ -2308,6 +2347,7 @@
         "name": "metadataBlock",
         "pattern": "(?s)<meta_start>.*?<meta_end>",
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "<meta_start>Thinking process: analyzing query...<meta_end>",
         "nonMatch": "<meta_start>Thinking process: analyzing query..."
       },
@@ -2324,6 +2364,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "```code_block\n# tags_identified: shopping\n```",
         "nonMatch": "```code_block\n# tags: shopping\n```"
       },
@@ -2340,6 +2381,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "<container>\n# topic_identified: sports\n</container>",
         "nonMatch": "<container>\n# topic: sports\n</container>"
       },
@@ -2356,6 +2398,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "https://www.example.com/search?q=testing&hl=en",
         "nonMatch": "some-random-domain-name"
       },
@@ -2364,6 +2407,7 @@
         "name": "caseInsensitiveKeyword",
         "pattern": "(?i)keyword_to_find",
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "KEYWORD_TO_FIND",
         "nonMatch": "other_random_words"
       },
@@ -2380,6 +2424,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "first name value",
         "nonMatch": "first name other_value"
       },
@@ -2396,6 +2441,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "<template name>content to match</template",
         "nonMatch": "plain text without template tag"
       },
@@ -2412,6 +2458,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "https://www.example.com/search?q=testing&hl=en",
         "nonMatch": "some-random-domain-name",
         "matchInput": {
@@ -2453,6 +2500,15 @@
           }
         },
         "op": "replaceAllGroup1",
+        "replacement": {
+          "java": "$1",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        },
         "match": "Here are the apples to show for banana in this session.",
         "nonMatch": "Orange lemon melon peach pear plum.",
         "matchInput": {
@@ -2467,6 +2523,15 @@
         "name": "fruitMarkupTag",
         "pattern": "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$",
         "op": "replaceAllGroup1",
+        "replacement": {
+          "java": "$1",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        },
         "match": "  <Banana>  ",
         "nonMatch": "  <Orange>  ",
         "matchInput": {
@@ -2491,6 +2556,15 @@
           }
         },
         "op": "replaceAllGroup1",
+        "replacement": {
+          "java": "$1",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        },
         "match": "{\n  \"key1\": \"value1\",\n  \"key2\": \"value2\",\n  \"key3\": \"value3\"\n}",
         "nonMatch": "some non-matching string containing no braces",
         "matchInput": {
@@ -2509,6 +2583,7 @@
         "name": "charReplace",
         "pattern": "a",
         "op": "replaceAllLiteral",
+        "replacement": "xyz",
         "match": "a",
         "nonMatch": "b",
         "matchInput": {
@@ -2545,6 +2620,7 @@
           }
         },
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "<block>\n  # category_defined: alpha, beta\n  entry: apple\n  entry: banana\n</block>\n",
         "nonMatch": "<block>\n  # comment but not defined tag\n  entry: orange\n</block>\n",
         "matchInput": {
@@ -2558,6 +2634,7 @@
         "name": "turnTitleWhitespaceCjk",
         "pattern": "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+",
         "op": "replaceAllEmpty",
+        "replacement": "",
         "match": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
         "nonMatch": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
         "matchInput": {
@@ -2724,7 +2801,15 @@
         }
       },
       "text": "user=service password=hunter2 token=abc123XYZ path=/api secret=prod-key-9 debug=true",
-      "replacement": "$1=REDACTED",
+      "replacement": {
+        "java": "$1=REDACTED",
+        "alternates": {
+          "re2-cpp": {
+            "replacement": "\\1=REDACTED",
+            "reason": "C++ RE2 uses backslash-number capture references"
+          }
+        }
+      },
       "expected": "user=service password=REDACTED token=REDACTED path=/api secret=REDACTED debug=true"
     }
   ],

--- a/safere-benchmarks/cpp/re2_benchmark.cc
+++ b/safere-benchmarks/cpp/re2_benchmark.cc
@@ -16,7 +16,6 @@
 // are given, all benchmarks are run.
 
 #include <array>
-#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -43,6 +42,7 @@ using json = nlohmann::json;
 json benchmark_input_manifest;
 std::filesystem::path benchmark_input_directory;
 std::unordered_map<std::string, std::string> benchmark_pattern_profile;
+std::unordered_map<std::string, std::string> benchmark_replacement_profile;
 
 std::string sha256_hex(std::string_view input) {
   static constexpr std::array<uint32_t, 64> kRoundConstants = {
@@ -283,6 +283,16 @@ json load_benchmark_manifest(const std::string& manifest_path_string) {
       }
     }
   }
+  if (benchmark_data.contains("replacementProfiles")) {
+    const auto& profiles = benchmark_data.at("replacementProfiles");
+    if (profiles.contains("re2-cpp")) {
+      for (const auto& entry : profiles.at("re2-cpp")) {
+        benchmark_replacement_profile.emplace(
+            entry.at("java").get<std::string>(),
+            entry.at("alternate").get<std::string>());
+      }
+    }
+  }
   return benchmark_data;
 }
 
@@ -290,6 +300,13 @@ std::string select_pattern(const std::string& java_pattern) {
   auto alternate = benchmark_pattern_profile.find(java_pattern);
   return alternate == benchmark_pattern_profile.end()
              ? java_pattern
+             : alternate->second;
+}
+
+std::string select_replacement(const std::string& java_replacement) {
+  auto alternate = benchmark_replacement_profile.find(java_replacement);
+  return alternate == benchmark_replacement_profile.end()
+             ? java_replacement
              : alternate->second;
 }
 
@@ -328,27 +345,6 @@ std::string load_benchmark_input(const std::string& key) {
     exit(1);
   }
   return text;
-}
-
-// Convert Java-style replacement references ($N) to RE2 C++ style (\\N).
-std::string convert_replacement(const std::string& repl) {
-  std::string result;
-  for (size_t i = 0; i < repl.size(); ++i) {
-    if (repl[i] == '$' && i + 1 < repl.size() &&
-        std::isdigit(static_cast<unsigned char>(repl[i + 1]))) {
-      result += '\\';
-      ++i;
-      while (i < repl.size() &&
-             std::isdigit(static_cast<unsigned char>(repl[i]))) {
-        result += repl[i];
-        ++i;
-      }
-      --i;
-    } else {
-      result += repl[i];
-    }
-  }
-  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -444,7 +440,7 @@ void run_application_benchmarks(const json& data,
           groups(item.contains("groups") ? item.at("groups").get<std::vector<int>>()
                                          : std::vector<int>()),
           replacement(item.contains("replacement")
-                          ? convert_replacement(item.at("replacement").get<std::string>())
+                          ? select_replacement(item.at("replacement").get<std::string>())
                           : ""),
           expected(item.at("expected")),
           re(pattern) {}
@@ -593,12 +589,17 @@ void run_real_world_regex_benchmarks(
     std::string name;
     std::string op;
     std::string pattern;
+    std::string replacement;
     RE2 re;
 
     explicit RealWorldCase(const json& item)
         : name(item.at("name").get<std::string>()),
           op(item.at("op").get<std::string>()),
           pattern(select_pattern(item.at("pattern").get<std::string>())),
+          replacement(item.contains("replacement")
+                          ? select_replacement(
+                                item.at("replacement").get<std::string>())
+                          : ""),
           re(pattern) {}
   };
 
@@ -645,19 +646,19 @@ void run_real_world_regex_benchmarks(
         } else if (c.op == "replaceAllEmpty") {
           print_json(measure(name, [&]() {
             std::string replaced = text;
-            RE2::GlobalReplace(&replaced, c.re, "");
+            RE2::GlobalReplace(&replaced, c.re, c.replacement);
             do_not_optimize(replaced);
           }));
         } else if (c.op == "replaceAllGroup1") {
           print_json(measure(name, [&]() {
             std::string replaced = text;
-            RE2::GlobalReplace(&replaced, c.re, "\\1");
+            RE2::GlobalReplace(&replaced, c.re, c.replacement);
             do_not_optimize(replaced);
           }));
         } else if (c.op == "replaceAllLiteral") {
           print_json(measure(name, [&]() {
             std::string replaced = text;
-            RE2::GlobalReplace(&replaced, c.re, "xyz");
+            RE2::GlobalReplace(&replaced, c.re, c.replacement);
             do_not_optimize(replaced);
           }));
         }
@@ -950,7 +951,7 @@ void run_replace_benchmarks(const json& data,
         key,
         select_pattern(val["pattern"].get<std::string>()),
         val["text"].get<std::string>(),
-        convert_replacement(val["replacement"].get<std::string>()),
+        select_replacement(val["replacement"].get<std::string>()),
         val["op"].get<std::string>()
     });
   }

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -136,6 +136,7 @@ type materializedInput struct {
 var benchmarkInputDirectory string
 var benchmarkInputs map[string]materializedInput
 var benchmarkPatternProfile map[string]string
+var benchmarkReplacementProfile map[string]string
 
 func loadBenchmarkManifest(manifestPath string) map[string]any {
 	benchmarkInputDirectory = filepath.Dir(manifestPath)
@@ -159,13 +160,15 @@ func loadBenchmarkManifest(manifestPath string) map[string]any {
 		os.Exit(1)
 	}
 	benchmarkInputs = manifest.Inputs
-	benchmarkPatternProfile = loadPatternProfile(manifest.BenchmarkData, "re2")
+	benchmarkPatternProfile = loadProfile(manifest.BenchmarkData, "patternProfiles", "re2")
+	benchmarkReplacementProfile =
+		loadProfile(manifest.BenchmarkData, "replacementProfiles", "go-regexp")
 	return manifest.BenchmarkData
 }
 
-func loadPatternProfile(data map[string]any, profileID string) map[string]string {
+func loadProfile(data map[string]any, registry string, profileID string) map[string]string {
 	result := make(map[string]string)
-	profiles, ok := data["patternProfiles"].(map[string]any)
+	profiles, ok := data[registry].(map[string]any)
 	if !ok {
 		return result
 	}
@@ -185,10 +188,18 @@ func mustCompile(javaPattern string) *regexp.Regexp {
 }
 
 func selectedPattern(javaPattern string) string {
-	if alternate, ok := benchmarkPatternProfile[javaPattern]; ok {
+	return selectedProfileValue(benchmarkPatternProfile, javaPattern)
+}
+
+func selectedReplacement(javaReplacement string) string {
+	return selectedProfileValue(benchmarkReplacementProfile, javaReplacement)
+}
+
+func selectedProfileValue(profile map[string]string, javaValue string) string {
+	if alternate, ok := profile[javaValue]; ok {
 		return alternate
 	}
-	return javaPattern
+	return javaValue
 }
 
 func loadBenchmarkInput(key string) string {
@@ -366,7 +377,7 @@ func runApplicationBenchmarks(data map[string]any, filters []string) {
 			texts:       getStringSlice(item, "texts"),
 			text:        getString(item, "text"),
 			groups:      getIntSlice(item, "groups"),
-			replacement: convertReplacement(getString(item, "replacement")),
+			replacement: selectedReplacement(getString(item, "replacement")),
 			expected:    item["expected"],
 			re:          mustCompile(pattern),
 		}
@@ -471,10 +482,11 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 	}
 	sizes := getIntSlice(sec, "textSizes")
 	type realWorldCase struct {
-		name   string
-		op     string
-		re     *regexp.Regexp
-		fullRe *regexp.Regexp
+		name        string
+		op          string
+		replacement string
+		re          *regexp.Regexp
+		fullRe      *regexp.Regexp
 	}
 
 	rawCases, ok := sec["cases"].([]any)
@@ -496,9 +508,10 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 		}
 		pattern := getString(item, "pattern")
 		c := realWorldCase{
-			name: getString(item, "name"),
-			op:   op,
-			re:   mustCompile(pattern),
+			name:        getString(item, "name"),
+			op:          op,
+			replacement: selectedReplacement(getString(item, "replacement")),
+			re:          mustCompile(pattern),
 		}
 		if op == "matches" {
 			c.fullRe = mustCompile("^(?:" + selectedPattern(pattern) + ")$")
@@ -532,15 +545,15 @@ func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
 					}))
 				} else if c.op == "replaceAllEmpty" {
 					printJSON(measureNs(name, func() {
-						sink = c.re.ReplaceAllString(text, "")
+						sink = c.re.ReplaceAllString(text, c.replacement)
 					}))
 				} else if c.op == "replaceAllGroup1" {
 					printJSON(measureNs(name, func() {
-						sink = c.re.ReplaceAllString(text, "$1")
+						sink = c.re.ReplaceAllString(text, c.replacement)
 					}))
 				} else if c.op == "replaceAllLiteral" {
 					printJSON(measureNs(name, func() {
-						sink = c.re.ReplaceAllString(text, "xyz")
+						sink = c.re.ReplaceAllString(text, c.replacement)
 					}))
 				}
 			}
@@ -748,11 +761,8 @@ func runReplaceBenchmarks(data map[string]any, filters []string) {
 		entry := val.(map[string]any)
 		pattern := entry["pattern"].(string)
 		text := entry["text"].(string)
-		replacement := entry["replacement"].(string)
+		replacement := selectedReplacement(entry["replacement"].(string))
 		op := entry["op"].(string)
-
-		// Convert Java-style $N backreferences to Go-style ${N}
-		goReplacement := convertReplacement(replacement)
 
 		re := mustCompile(pattern)
 		benchName := "ReplaceBenchmark." + key
@@ -768,37 +778,17 @@ func runReplaceBenchmarks(data map[string]any, filters []string) {
 				sink = re.ReplaceAllStringFunc(text, func(match string) string {
 					if !replaced {
 						replaced = true
-						return re.ReplaceAllString(match, goReplacement)
+						return re.ReplaceAllString(match, replacement)
 					}
 					return match
 				})
 			}))
 		} else {
 			printJSON(measureNs(benchName, func() {
-				sink = re.ReplaceAllString(text, goReplacement)
+				sink = re.ReplaceAllString(text, replacement)
 			}))
 		}
 	}
-}
-
-// convertReplacement translates Java-style $N to Go-style ${N}.
-func convertReplacement(repl string) string {
-	var b strings.Builder
-	for i := 0; i < len(repl); i++ {
-		if repl[i] == '$' && i+1 < len(repl) && repl[i+1] >= '0' && repl[i+1] <= '9' {
-			b.WriteString("${")
-			i++
-			for i < len(repl) && repl[i] >= '0' && repl[i] <= '9' {
-				b.WriteByte(repl[i])
-				i++
-			}
-			b.WriteByte('}')
-			i--
-		} else {
-			b.WriteByte(repl[i])
-		}
-	}
-	return b.String()
 }
 
 func runPathologicalBenchmarks(data map[string]any, filters []string) {

--- a/safere-benchmarks/go/regexp_benchmark_test.go
+++ b/safere-benchmarks/go/regexp_benchmark_test.go
@@ -55,7 +55,7 @@ func TestCheckedInRE2PatternProfileCompiles(t *testing.T) {
 	}
 }
 
-func TestExplicitProfileAlternateIsSelectedWithJavaFallback(t *testing.T) {
+func TestReplacementProfileSelectsExactAlternateWithJavaFallback(t *testing.T) {
 	data := map[string]any{
 		"replacementProfiles": map[string]any{
 			"go-regexp": []any{
@@ -67,12 +67,19 @@ func TestExplicitProfileAlternateIsSelectedWithJavaFallback(t *testing.T) {
 		},
 	}
 
-	profile := loadProfile(data, "replacementProfiles", "go-regexp")
+	benchmarkReplacementProfile = loadProfile(data, "replacementProfiles", "go-regexp")
+	t.Cleanup(func() {
+		benchmarkReplacementProfile = nil
+	})
 
-	if got := selectedProfileValue(profile, "$2$1ay"); got != "${2}${1}ay" {
-		t.Fatalf("selected alternate = %q, want %q", got, "${2}${1}ay")
+	if actual := selectedReplacement("$2$1ay"); actual != "${2}${1}ay" {
+		t.Fatalf("selected replacement %q, want %q", actual, "${2}${1}ay")
 	}
-	if got := selectedProfileValue(profile, "$1=[$2]"); got != "$1=[$2]" {
-		t.Fatalf("fallback = %q, want unchanged Java value", got)
+	if actual := selectedReplacement("$1=REDACTED"); actual != "$1=REDACTED" {
+		t.Fatalf("fallback replacement %q, want unchanged Java value", actual)
+	}
+	re := regexp.MustCompile("(qu|[b-df-hj-np-tv-z]*)([a-z]+)")
+	if actual := re.ReplaceAllString("the", selectedReplacement("$2$1ay")); actual != "ethay" {
+		t.Fatalf("replacement result %q, want %q", actual, "ethay")
 	}
 }

--- a/safere-benchmarks/go/regexp_benchmark_test.go
+++ b/safere-benchmarks/go/regexp_benchmark_test.go
@@ -54,3 +54,25 @@ func TestCheckedInRE2PatternProfileCompiles(t *testing.T) {
 		t.Fatal("no inline re2 pattern alternates found")
 	}
 }
+
+func TestExplicitProfileAlternateIsSelectedWithJavaFallback(t *testing.T) {
+	data := map[string]any{
+		"replacementProfiles": map[string]any{
+			"go-regexp": []any{
+				map[string]any{
+					"java":      "$2$1ay",
+					"alternate": "${2}${1}ay",
+				},
+			},
+		},
+	}
+
+	profile := loadProfile(data, "replacementProfiles", "go-regexp")
+
+	if got := selectedProfileValue(profile, "$2$1ay"); got != "${2}${1}ay" {
+		t.Fatalf("selected alternate = %q, want %q", got, "${2}${1}ay")
+	}
+	if got := selectedProfileValue(profile, "$1=[$2]"); got != "$1=[$2]" {
+		t.Fatalf("fallback = %q, want unchanged Java value", got)
+	}
+}

--- a/safere-benchmarks/rust/src/main.rs
+++ b/safere-benchmarks/rust/src/main.rs
@@ -469,10 +469,9 @@ fn run_real_world_benchmarks(corpus: &Corpus, filters: &[String]) {
         let case_name = required_string(item, "name");
         let operation = required_string(item, "op");
         let pattern = required_string(item, "pattern");
-        let replacement = item
-            .get("replacement")
-            .map(|_| selected_replacement(&required_string(item, "replacement")))
-            .unwrap_or_default();
+        let replacement = operation
+            .starts_with("replaceAll")
+            .then(|| selected_replacement(&required_string(item, "replacement")));
         let regex = compile(&pattern);
         let full_regex = (operation == "matches").then(|| compile_full(&pattern));
         for matches in [true, false] {
@@ -491,13 +490,19 @@ fn run_real_world_benchmarks(corpus: &Corpus, filters: &[String]) {
                         black_box(full_regex.as_ref().unwrap().is_match(black_box(&text)));
                     }),
                     "replaceAllEmpty" => run_ns(&name, filters, || {
-                        black_box(regex.replace_all(black_box(&text), replacement.as_str()));
+                        black_box(
+                            regex.replace_all(black_box(&text), replacement.as_deref().unwrap()),
+                        );
                     }),
                     "replaceAllGroup1" => run_ns(&name, filters, || {
-                        black_box(regex.replace_all(black_box(&text), replacement.as_str()));
+                        black_box(
+                            regex.replace_all(black_box(&text), replacement.as_deref().unwrap()),
+                        );
                     }),
                     "replaceAllLiteral" => run_ns(&name, filters, || {
-                        black_box(regex.replace_all(black_box(&text), replacement.as_str()));
+                        black_box(
+                            regex.replace_all(black_box(&text), replacement.as_deref().unwrap()),
+                        );
                     }),
                     _ => panic!("invalid realWorldRegex op: {operation}"),
                 }

--- a/safere-benchmarks/rust/src/main.rs
+++ b/safere-benchmarks/rust/src/main.rs
@@ -4,7 +4,7 @@
 // Rust regex benchmark harness. Runs the same patterns and inputs as the Java,
 // C++, and Go benchmarks and outputs JSON lines for cross-language comparison.
 
-use regex::{NoExpand, Regex};
+use regex::Regex;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 #[cfg(feature = "memory-tracking")]
@@ -469,6 +469,10 @@ fn run_real_world_benchmarks(corpus: &Corpus, filters: &[String]) {
         let case_name = required_string(item, "name");
         let operation = required_string(item, "op");
         let pattern = required_string(item, "pattern");
+        let replacement = item
+            .get("replacement")
+            .map(|_| selected_replacement(&required_string(item, "replacement")))
+            .unwrap_or_default();
         let regex = compile(&pattern);
         let full_regex = (operation == "matches").then(|| compile_full(&pattern));
         for matches in [true, false] {
@@ -487,13 +491,13 @@ fn run_real_world_benchmarks(corpus: &Corpus, filters: &[String]) {
                         black_box(full_regex.as_ref().unwrap().is_match(black_box(&text)));
                     }),
                     "replaceAllEmpty" => run_ns(&name, filters, || {
-                        black_box(regex.replace_all(black_box(&text), NoExpand("")));
+                        black_box(regex.replace_all(black_box(&text), replacement.as_str()));
                     }),
                     "replaceAllGroup1" => run_ns(&name, filters, || {
-                        black_box(regex.replace_all(black_box(&text), "$1"));
+                        black_box(regex.replace_all(black_box(&text), replacement.as_str()));
                     }),
                     "replaceAllLiteral" => run_ns(&name, filters, || {
-                        black_box(regex.replace_all(black_box(&text), NoExpand("xyz")));
+                        black_box(regex.replace_all(black_box(&text), replacement.as_str()));
                     }),
                     _ => panic!("invalid realWorldRegex op: {operation}"),
                 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -73,6 +73,24 @@ public final class BenchmarkData {
     return plan;
   }
 
+  /**
+   * Gets a string value by dot-separated path.
+   *
+   * @param path path within the resolved benchmark data
+   * @return exact configured string
+   */
+  public String getString(String path) {
+    String[] parts = path.split("\\.");
+    JsonElement element = root;
+    for (String part : parts) {
+      element = element.getAsJsonObject().get(part);
+      if (element == null) {
+        throw new IllegalArgumentException("No value at path: " + path);
+      }
+    }
+    return element.getAsString();
+  }
+
   /** Get a string array by dot-separated path. */
   public List<String> getStringList(String path) {
     String[] parts = path.split("\\.");

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrosscheckOverheadBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrosscheckOverheadBenchmark.java
@@ -43,9 +43,10 @@ public class CrosscheckOverheadBenchmark {
       sb.append("item").append(i).append(';');
     }
     text = sb.toString();
-    replacement = "$2:$1";
+    BenchmarkData data = BenchmarkData.get();
+    replacement = data.getString("crosscheckOverhead.replacement");
 
-    String regex = "([a-z]+)(\\d+)";
+    String regex = data.getString("crosscheckOverhead.pattern");
     saferePattern = org.safere.Pattern.compile(regex);
     jdkPattern = java.util.regex.Pattern.compile(regex);
     crosscheckPattern = org.safere.crosscheck.Pattern.compile(regex);

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -150,6 +150,10 @@ class BenchmarkInputMaterializerTest {
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(6);
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("rust-regex"))
         .hasSize(26);
+    assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("go-regexp"))
+        .hasSize(1);
+    assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("re2-cpp"))
+        .hasSize(6);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("rust-regex"))
         .hasSize(1);
     assertThat(

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -206,6 +206,14 @@ class PatternProfilesTest {
         .isEqualTo("([0-9]{4})-([0-9]{2})-([0-9]{2})");
     assertThat(patterns.select("rust-regex", "\\b\\w+ing\\b"))
         .isEqualTo("(?-u:\\b)[A-Za-z0-9_]+ing(?-u:\\b)");
+    assertThat(replacements.select("re2-cpp", "$1=[$2]")).isEqualTo("\\1=[\\2]");
+    assertThat(replacements.select("re2-cpp", "${key}=[${value}]")).isEqualTo("\\1=[\\2]");
+    assertThat(replacements.select("re2-cpp", "$1<tag type=\"custom\""))
+        .isEqualTo("\\1<tag type=\"custom\"");
+    assertThat(replacements.select("re2-cpp", "$2$1ay")).isEqualTo("\\2\\1ay");
+    assertThat(replacements.select("re2-cpp", "$1=REDACTED")).isEqualTo("\\1=REDACTED");
+    assertThat(replacements.select("re2-cpp", "$1")).isEqualTo("\\1");
+    assertThat(replacements.select("go-regexp", "$2$1ay")).isEqualTo("${2}${1}ay");
     assertThat(replacements.select("rust-regex", "$2$1ay")).isEqualTo("${2}${1}ay");
     for (String profileType : List.of("patternProfiles", "replacementProfiles")) {
       for (JsonElement profile : normalized.getAsJsonObject(profileType).asMap().values()) {


### PR DESCRIPTION
## Summary

- declare exact `re2-cpp` and `go-regexp` replacement alternates in
  `benchmark-data.json`
- remove the C++ and Go Java-replacement conversion helpers
- make C++, Go, and Rust real-world replacement workloads consume the resolved
  manifest replacement instead of deriving it from the operation name
- move the Java crosscheck diagnostic benchmark's regex and replacement into
  `benchmark-data.json`
- test exact alternate selection, unchanged fallback, and resolved profile
  contents
- document the zero-implicit-conversion rule and per-syntax profile mappings

## Harness audit

- C++ RE2: removed `convert_replacement`; application and replacement
  workloads now select `re2-cpp`, and real-world workloads read the manifest
  replacement.
- Go `regexp`: removed `convertReplacement`; application and replacement
  workloads now select `go-regexp`, and real-world workloads read the manifest
  replacement.
- Rust `regex`: existing `rust-regex` exact profile selection and unchanged
  fallback remain; real-world workloads now read the manifest replacement.
- Java: declarative workloads already pass exact materialized pattern and
  replacement arguments to engine adapters. `CrosscheckOverheadBenchmark` was
  the remaining measured workload with hardcoded syntax and now loads both
  values from the manifest.
- Python: comparison scripts normalize benchmark and engine identifiers only;
  they do not inspect or transform regex or replacement syntax.
- Shell: runner and collection scripts materialize the shared corpus and
  forward filters/options; they do not inspect or transform regex or
  replacement syntax.

The remaining pattern construction in Java/Go/Rust implements workload
semantics such as parameter substitution and full-match anchoring. Native
engine self-test patterns and replacements validate adapter behavior and are
not measured workload syntax.

Fixes #638

## Verification

Ran:

- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere-benchmarks spotless:check -q`
- `go test ./...`
- `go vet ./...`
- `cargo fmt --check --manifest-path safere-benchmarks/rust/Cargo.toml`
- `cargo test --locked --manifest-path safere-benchmarks/rust/Cargo.toml`
- `cargo clippy --locked --all-targets --manifest-path safere-benchmarks/rust/Cargo.toml -- -D warnings`
- `cmake -S safere-benchmarks/cpp -B safere-benchmarks/cpp/build`
- `cmake --build safere-benchmarks/cpp/build --parallel`
- `./run-cpp-benchmarks.sh ReplaceBenchmark.pigLatinReplaceAll`
- `./run-go-benchmarks.sh ReplaceBenchmark.pigLatinReplaceAll`
- `./run-rust-benchmarks.sh ReplaceBenchmark.pigLatinReplaceAll`
- `./run-java-benchmarks.sh --smoke '^org\.safere\.benchmark\.CrosscheckOverheadBenchmark\.appendReplacement_safere$'`
- source audit confirming no C++ or Go replacement-conversion helper remains
  and all native real-world replacement calls use the manifest value

Not run:

- full benchmark collection
- external OpenJDK-derived benchmark suite
