### PR TITLE
Materialize shared benchmark execution plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,24 +177,26 @@ jobs:
       - name: Smoke test C++ RE2 benchmarks
         run: |
           safere-benchmarks/cpp/build/re2_benchmark \
-            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json \
+            --smoke RegexBenchmark.literalMatch
 
-      - name: Smoke test C++ RE2 memory benchmarks
-        if: matrix.os == 'ubuntu-latest'
+      - name: Check C++ RE2 planned exclusions
         run: |
           safere-benchmarks/cpp/build/re2_benchmark \
-            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json \
+            --list-exclusions MemoryBenchmark.compileSimple
 
       - name: Smoke test PCRE2 JIT benchmarks
         run: |
           safere-benchmarks/cpp/build/pcre2_jit_benchmark \
-            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json \
+            --smoke RegexBenchmark.literalMatch
 
-      - name: Smoke test PCRE2 JIT memory benchmarks
-        if: matrix.os == 'ubuntu-latest'
+      - name: Check PCRE2 JIT planned exclusions
         run: |
           safere-benchmarks/cpp/build/pcre2_jit_benchmark \
-            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json \
+            --list-exclusions ReplaceBenchmark
 
   benchmark-smoke-test-go:
     needs: changes
@@ -226,12 +228,14 @@ jobs:
       - name: Smoke test Go benchmarks
         run: |
           safere-benchmarks/go/regexp_benchmark \
-            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json literalMatch
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json \
+            --smoke RegexBenchmark.literalMatch
 
-      - name: Smoke test Go memory benchmarks
+      - name: Check Go planned exclusions
         run: |
           safere-benchmarks/go/regexp_benchmark \
-            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json MemoryBenchmark
+            --manifest safere-benchmarks/target/benchmark-corpus/manifest.json \
+            --list-exclusions UnicodeCompileBenchmark
 
   benchmark-smoke-test-rust:
     needs: changes
@@ -265,7 +269,7 @@ jobs:
             --manifest-path safere-benchmarks/rust/Cargo.toml -- -D warnings
 
       - name: Smoke test Rust regex benchmarks
-        run: ./run-rust-benchmarks.sh RegexBenchmark.literalMatch
+        run: ./run-rust-benchmarks.sh --smoke RegexBenchmark.literalMatch
 
   benchmark-smoke-test-dotnet:
     needs: changes
@@ -288,3 +292,6 @@ jobs:
 
       - name: Smoke test .NET non-backtracking benchmarks
         run: ./run-dotnet-benchmarks.sh --smoke RegexBenchmark.literalMatch
+
+      - name: Check .NET planned exclusions
+        run: ./run-dotnet-benchmarks.sh --list-exclusions UnicodeCompileBenchmark

--- a/safere-benchmarks/BENCHMARK_INPUTS.md
+++ b/safere-benchmarks/BENCHMARK_INPUTS.md
@@ -17,10 +17,10 @@ byte-oriented engines use the bytes directly. Materialization and decoding are
 outside the timed operation.
 
 Regex patterns and replacement templates remain Java-canonical in
-`benchmark-data.json`. Explicit engine-dialect alternatives live beside the
-value that needs them. The materializer collects those inline definitions into
-separate resolved pattern and replacement profiles; runners select exact values
-there and otherwise use the Java string unchanged. See
+`benchmark-data.json`. Explicit engine-dialect alternatives and unsupported
+syntax declarations live beside the value that needs them. The materializer
+selects those values while building the execution plan; runners receive only
+the exact syntax selected for their engine. See
 [DECLARATIVE_BENCHMARK_PLAN.md](DECLARATIVE_BENCHMARK_PLAN.md#pattern-profiles).
 
 The normal runner scripts materialize automatically. To prepare the corpus
@@ -32,9 +32,12 @@ without starting a benchmark, run from the repository root:
 
 The manifest records each input's UTF-8 byte length, UTF-16 code-unit length,
 Unicode scalar count, and SHA-256 digest, along with the normalized benchmark
-configuration and a `resolvedWorkloads` array containing every expanded
-workload identity. Native runners can therefore consume the same axis
-expansion as the Java planner. The generated directory is ignored and is
+configuration and a versioned `executionPlan`. Its entries are the complete
+Cartesian product of expanded workloads and declared engines. Every entry is
+either runnable, with exact patterns, inputs, arguments, options, lifecycle,
+and measurement boundaries, or excluded with a durable kind and reason. Java
+and native runners consume this same join and do not repeat capability or
+syntax selection. The generated directory is ignored and is
 replaced on every materialization, so there is no second checked-in
 representation to update.
 

--- a/safere-benchmarks/CROSS_RUNTIME_ENGINES.md
+++ b/safere-benchmarks/CROSS_RUNTIME_ENGINES.md
@@ -3,7 +3,8 @@
 The cross-runtime matrix contains native C++ RE2, PCRE2 JIT, Go `regexp`, Rust
 `regex`, and .NET non-backtracking. All runners read materialized inputs,
 Java-canonical patterns and replacement templates, and stable workload
-identities derived from `benchmark-data.json`.
+identities derived from `benchmark-data.json`. Every runner consumes its rows
+from the same versioned materialized execution plan.
 
 ## Workload coverage
 
@@ -16,10 +17,10 @@ interpreted matching rather than JIT matching; reporting those measurements
 under the `pcre2_jit` engine ID would be misleading. Filters are forwarded
 unchanged to the selected engines.
 
-Go `regexp` and Rust `regex` run every workload implemented by their respective
-harnesses. .NET consumes the expanded workload plan and reports an explicit
-reason for every workload it cannot execute. Engine-specific syntax is selected
-through declared pattern and replacement profiles; unsupported syntax is not
+Go `regexp`, Rust `regex`, and .NET non-backtracking run every entry declared
+runnable for that engine. Every harness can list the plan's explicit
+exclusions with `--list-exclusions`. Engine-specific syntax and compatibility
+are resolved during materialization; unsupported syntax is never inferred or
 rewritten by a runner.
 
 These measurements are cross-runtime context rather than controlled same-JVM
@@ -84,9 +85,8 @@ the declared linear-time behavior. Replacement workloads are also absent
 because PCRE2 does not expose a JIT substitution operation. The engine
 self-test still checks substitution correctness outside benchmark measurement.
 
-On platforms with `mallinfo2`, both C++ engines also emit native heap deltas
-for memory workloads. Other platforms still run timing workloads and the
-engine self-tests, but do not emit that platform-specific heap measurement.
+C++ retained-memory rows are explicitly excluded because no portable,
+comparable retained-heap measurement is available across supported hosts.
 
 ## Go `regexp`
 

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -130,6 +130,10 @@ entry for a Java syntax value, the materializer uses the Java value unchanged.
 An alternate may instead declare `unsupported: true` and a reason when the
 same semantics cannot be expressed in that dialect; the corresponding
 workload/engine entry is then an explicit `unsupportedSyntax` exclusion.
+An optional nonempty `flagSets` array restricts an alternate to the listed
+exact Java flag-set IDs. For other flag sets, the materializer retains the
+canonical Java value. This represents cases such as .NET's Unicode shorthand
+defaults without making runners infer or rewrite syntax from flags.
 
 Alternates are exact reviewed strings. Runners must not rewrite regex or
 replacement syntax automatically or derive replacement templates from operation

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -110,7 +110,7 @@ with a `replacement` field instead of `pattern`:
 }
 ```
 
-An engine adapter selects one profile for each syntax kind. SafeRE and JDK use
+The execution-plan materializer selects one profile for each engine and syntax kind. SafeRE and JDK use
 the Java values directly. RE2/J and RE2-FFM select the `re2` pattern profile;
 native C++ RE2 selects `re2` patterns and `re2-cpp` replacements; Go selects
 `re2` patterns and `go-regexp` replacements where adjacent text makes a Java
@@ -118,20 +118,40 @@ capture reference ambiguous; and Rust `regex` selects `rust-regex` for both
 kinds. PCRE2 JIT selects `pcre2` for both kinds; this remains separate from
 `re2` because PCRE2 accepts some Java-canonical forms that RE2 does not, while
 other forms need PCRE2-specific equivalents. If the selected profile has no
-entry for a Java syntax value, the adapter uses the Java value unchanged.
+entry for a Java syntax value, the materializer uses the Java value unchanged.
+An alternate may instead declare `unsupported: true` and a reason when the
+same semantics cannot be expressed in that dialect; the corresponding
+workload/engine entry is then an explicit `unsupportedSyntax` exclusion.
 
 Alternates are exact reviewed strings. Runners must not rewrite regex or
 replacement syntax automatically or derive replacement templates from operation
 names. The required nonblank `reason` records why the alternate is necessary.
-The materializer replaces inline definitions with their Java strings and emits
-separate resolved pattern and replacement profile lookups in the generated
-manifest. Keeping the namespaces separate prevents the same Java string from
+The materializer replaces inline definitions with their Java strings, keeps
+pattern and replacement namespaces separate, and writes only the selected
+values into runnable execution-plan entries. Keeping the namespaces separate prevents the same Java string from
 selecting a pattern alternate when it is used as a replacement, or vice versa.
 Conflicting alternates for the same Java value, kind, and profile, malformed
 profile IDs, blank fields, and unknown fields are rejected during
 materialization.
-Pattern selection and compilation happen outside timed matching operations;
-compile benchmarks select the alternate before starting the timed compilation.
+Pattern selection happens before any runner starts. Compilation happens outside
+timed matching operations; compile benchmarks receive the selected pattern
+before starting timed compilation.
+
+## Materialized execution plan
+
+The generated manifest's `executionPlan.version` is independent of
+`schemaVersion`, so the runner contract can evolve explicitly. Version 1
+declares the engine catalog, workload and engine counts, and an `entries`
+array containing exactly one entry for every expanded workload and engine.
+Consumers reject unknown versions and incomplete joins.
+
+Runnable entries contain engine-selected `patterns`, materialized input IDs,
+resolved `arguments`, `options`, `inputRepresentation`, `resultConsumption`,
+`measurement`, and optional expected results and lifecycle. Excluded entries
+contain an `exclusion` object with a stable kind and explanatory reason.
+Runners may implement generic regex operations only; an entry declared
+runnable that cannot be prepared is an error rather than a new runtime
+exclusion.
 
 ## Bounded input recipes
 

--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -6,6 +6,14 @@ declarations are authoritative for materialized inputs and ordinary/scaling
 cross-engine workloads, specialized modes, collection, and reporting. The
 schema preserves the established benchmark timing boundaries.
 
+The complete checked-in document is validated before materialization. Its only
+top-level fields are `schemaVersion`, `configuration`, `inputs`, and
+`workloads`. `configuration` holds typed non-workload settings for collection
+and the crosscheck instrumentation diagnostic; workload-family data is not
+allowed there. Syntax normalization visits only authoritative `workloads`, and
+rejects any engine-specific profile whose canonical value is not referenced by
+an expanded workload.
+
 The normalized plan has this shape:
 
 ```json

--- a/safere-benchmarks/DECLARATIVE_COLLECTION.md
+++ b/safere-benchmarks/DECLARATIVE_COLLECTION.md
@@ -17,7 +17,7 @@ BenchmarkCollectionPlan report-plan [--smoke]
 `runners` emits tab-separated execution profile, JMH entry point, parameter name, and planned trial
 IDs. `run-java-benchmarks.sh --declared` consumes those rows sequentially and applies standard,
 no-fork, or fresh-process settings from the selected profile. `allocation-runners` uses the
-declarative `collection.allocationWorkloadPrefixes` selection and is consumed by
+declarative `configuration.collection.allocationWorkloadPrefixes` selection and is consumed by
 `run-java-memory-benchmarks.sh --declared`.
 
 `report-plan` emits JSON containing every scheduled workload/variant pair and every declared

--- a/safere-benchmarks/DECLARATIVE_COLLECTION.md
+++ b/safere-benchmarks/DECLARATIVE_COLLECTION.md
@@ -35,9 +35,11 @@ representation and timed conversion boundaries are not erased.
 
 C++ RE2, PCRE2 JIT, Go `regexp`, Rust `regex`, and .NET non-backtracking harnesses run outside the
 JVM and emit JSONL with the same stable workload identities. RE2 and PCRE2 JIT share one C++
-workload harness but emit distinct engine IDs. The materialized manifest includes the fully expanded
-`resolvedWorkloads` plan for native consumers. The .NET runner accounts for every entry by either
-executing it or making an explicit capability exclusion available through `--list-exclusions`.
-Cross-runtime results are not treated as missing or excluded Java execution variants. Per-engine
+workload harness but emit distinct engine IDs. The materialized manifest includes one versioned
+`executionPlan` for Java and native consumers. It contains the complete workload-by-engine join;
+each entry is runnable with exact engine-selected syntax and arguments, or excluded with a durable
+reason. Native runners implement generic operations and expose planned exclusions through
+`--list-exclusions`; they do not select profiles, dispatch workload families, or infer
+capabilities. Cross-runtime results are not treated as missing or excluded Java execution variants. Per-engine
 workload, toolchain, and smoke-test details are documented in
 [`CROSS_RUNTIME_ENGINES.md`](CROSS_RUNTIME_ENGINES.md).

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1843,6 +1843,10 @@
           "rust-regex": {
             "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})",
             "reason": "Rust regex gives \\d Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})",
+            "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
           }
         }
       },
@@ -1858,6 +1862,10 @@
           "rust-regex": {
             "pattern": "(?-u:\\b)[A-Za-z0-9_]+ing(?-u:\\b)",
             "reason": "Rust regex gives word classes and boundaries Unicode semantics"
+          },
+          "dotnet": {
+            "unsupported": true,
+            "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
           }
         }
       },
@@ -1873,7 +1881,15 @@
   },
   "matcherApi": {
     "lookingAt": {
-      "pattern": "[A-Za-z]+:\\s+\\d+",
+      "pattern": {
+        "java": "[A-Za-z]+:\\s+\\d+",
+        "alternates": {
+          "dotnet": {
+            "pattern": "[A-Za-z]+:[ \\t\\n\\x0B\\f\\r]+[0-9]+",
+            "reason": ".NET gives \\s and \\d Unicode semantics while Java defaults to ASCII"
+          }
+        }
+      },
       "text": "requests: 1234 completed"
     },
     "regionFind": {
@@ -2022,6 +2038,10 @@
           "rust-regex": {
             "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})",
             "reason": "Rust regex gives \\d Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})",
+            "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
           }
         }
       }
@@ -2053,6 +2073,10 @@
         "rust-regex": {
           "pattern": "(?-u:\\b)[A-Za-z0-9_]+ing(?-u:\\b)",
           "reason": "Rust regex gives word classes and boundaries Unicode semantics"
+        },
+        "dotnet": {
+          "unsupported": true,
+          "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
         }
       }
     },
@@ -2083,6 +2107,10 @@
           "rust-regex": {
             "pattern": "[^A-Za-z0-9_]+",
             "reason": "Rust regex gives \\W Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "[^A-Za-z0-9_]+",
+            "reason": ".NET gives \\W Unicode semantics while Java defaults to ASCII"
           }
         }
       },
@@ -2115,7 +2143,15 @@
       100000
     ],
     "lazyAlt": {
-      "pattern": "(?i)(?s)\\s*\\n*(?:<block>|\\[block\\])\\s*\\n?renderElement\\(.*?\\)\\s*\\n?(?:</block>|\\[/block\\])",
+      "pattern": {
+        "java": "(?i)(?s)\\s*\\n*(?:<block>|\\[block\\])\\s*\\n?renderElement\\(.*?\\)\\s*\\n?(?:</block>|\\[/block\\])",
+        "alternates": {
+          "dotnet": {
+            "unsupported": true,
+            "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+          }
+        }
+      },
       "replacement": "",
       "prefixUnit": "Some prefix text preceding the render block element. ",
       "match": "\n<block>\nrenderElement(id=\"el-42\", width=100, height=200, label=\"hello world\")\n</block>\n",
@@ -2160,6 +2196,10 @@
           "rust-regex": {
             "pattern": "([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+)",
             "reason": "Rust regex gives \\w Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+)",
+            "reason": ".NET gives \\w Unicode semantics while Java defaults to ASCII"
           }
         }
       },
@@ -2229,6 +2269,10 @@
           "rust-regex": {
             "pattern": "[0-9]+",
             "reason": "Rust regex gives \\d Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "[0-9]+",
+            "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
           }
         }
       },
@@ -2268,6 +2312,10 @@
             "rust-regex": {
               "pattern": "([^\\x20\\t\\n\\x0B\\f\\r]+)(?-u:\\b)\\[(.+)\\]",
               "reason": "Rust regex gives \\S and word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
             }
           }
         },
@@ -2293,6 +2341,10 @@
             "rust-regex": {
               "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
               "reason": "Rust regex gives \\d Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
             }
           }
         },
@@ -2335,6 +2387,10 @@
             "rust-regex": {
               "pattern": "(?is).*(?-u:\\b)(you|your)(?-u:\\b).*",
               "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
             }
           }
         },
@@ -2360,6 +2416,10 @@
             "rust-regex": {
               "pattern": "```code_block\\n((?-u:\\s))*# (topic|tags)_identified:.*?\\n```",
               "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "```code_block\\n([ \\t\\n\\x0B\\f\\r])*# (topic|tags)_identified:.*?\\n```",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
             }
           }
         },
@@ -2377,6 +2437,10 @@
             "rust-regex": {
               "pattern": "<container>\\n((?-u:\\s))*# (topic|tags)_identified:.*?\\n</container>",
               "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "<container>\\n([ \\t\\n\\x0B\\f\\r])*# (topic|tags)_identified:.*?\\n</container>",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
             }
           }
         },
@@ -2394,6 +2458,10 @@
             "rust-regex": {
               "pattern": "(?i)(?-u:\\b)(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
               "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
             }
           }
         },
@@ -2405,7 +2473,15 @@
       {
         "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeyword",
         "name": "caseInsensitiveKeyword",
-        "pattern": "(?i)keyword_to_find",
+        "pattern": {
+          "java": "(?i)keyword_to_find",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        },
         "op": "replaceAllEmpty",
         "replacement": "",
         "match": "KEYWORD_TO_FIND",
@@ -2437,6 +2513,10 @@
             "rust-regex": {
               "pattern": "(?s)(<template(?-u:\\s)+name(?-u:\\s)*>.*?<(?-u:\\s)*/(?-u:\\s)*template[ \\t]*)([^>]|$)",
               "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "(?s)(<template[ \\t\\n\\x0B\\f\\r]+name[ \\t\\n\\x0B\\f\\r]*>.*?<[ \\t\\n\\x0B\\f\\r]*/[ \\t\\n\\x0B\\f\\r]*template[ \\t]*)([^>]|$)",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
             }
           }
         },
@@ -2454,6 +2534,10 @@
             "rust-regex": {
               "pattern": "(?i)(?-u:\\b)(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
               "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
             }
           }
         },
@@ -2496,6 +2580,10 @@
             "rust-regex": {
               "pattern": "(?is).*(?-u:\\b)(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)(?-u:\\b).*",
               "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
             }
           }
         },
@@ -2529,8 +2617,8 @@
               "reason": "Rust regex lacks Java quoted literals and gives \\s Unicode semantics"
             },
             "dotnet": {
-              "pattern": "^\\s*<(Apple|Banana|Cherry)>\\s*$",
-              "reason": ".NET does not support Java quoted literals with \\Q and \\E"
+              "pattern": "^[ \\t\\n\\x0B\\f\\r]*<(Apple|Banana|Cherry)>[ \\t\\n\\x0B\\f\\r]*$",
+              "reason": ".NET lacks Java quoted literals and gives \\s Unicode semantics"
             }
           }
         },
@@ -2628,6 +2716,10 @@
             "rust-regex": {
               "pattern": "(?s)<block>\\n((?-u:\\s))*# (category|group)_defined:.*?\\n</block>",
               "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "(?s)<block>\\n([ \\t\\n\\x0B\\f\\r])*# (category|group)_defined:.*?\\n</block>",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
             }
           }
         },
@@ -2728,6 +2820,10 @@
           "rust-regex": {
             "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)(?-u:\\s)+(INFO|WARN|ERROR)(?-u:\\s)+([A-Za-z0-9_.-]+)(?-u:\\s)+-(?-u:\\s)+(.+)$",
             "reason": "Rust regex gives \\d and \\s Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)[ \\t\\n\\x0B\\f\\r]+(INFO|WARN|ERROR)[ \\t\\n\\x0B\\f\\r]+([A-Za-z0-9_.-]+)[ \\t\\n\\x0B\\f\\r]+-[ \\t\\n\\x0B\\f\\r]+(.+)$",
+            "reason": ".NET gives \\d and \\s Unicode semantics while Java defaults to ASCII"
           }
         }
       },
@@ -2773,6 +2869,10 @@
           "rust-regex": {
             "pattern": "(?m)^(?-u:\\s)+at(?-u:\\s)+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):([0-9]+)\\)$",
             "reason": "Rust regex gives \\d and \\s Unicode semantics"
+          },
+          "dotnet": {
+            "pattern": "(?m)^[ \\t\\n\\x0B\\f\\r]+at[ \\t\\n\\x0B\\f\\r]+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):([0-9]+)\\)$",
+            "reason": ".NET gives \\d and \\s Unicode semantics while Java defaults to ASCII"
           }
         }
       },
@@ -2793,6 +2893,10 @@
           "rust-regex": {
             "pattern": "(?i)(?-u:\\b)(error|warning|timeout|failed)(?-u:\\b)",
             "reason": "Rust regex gives word boundaries Unicode semantics"
+          },
+          "dotnet": {
+            "unsupported": true,
+            "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
           }
         }
       },
@@ -2825,6 +2929,10 @@
           "rust-regex": {
             "pattern": "(?i)(?-u:\\b)(password|token|secret)=([^\\x20\\t\\n\\x0B\\f\\r&]+)",
             "reason": "Rust regex gives \\s and word boundaries Unicode semantics"
+          },
+          "dotnet": {
+            "unsupported": true,
+            "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
           }
         }
       },
@@ -3833,8 +3941,8 @@
               "reason": "Rust regex lacks Java quoted literals and gives \\s Unicode semantics"
             },
             "dotnet": {
-              "pattern": "^\\s*<(Apple|Banana|Cherry)>\\s*$",
-              "reason": ".NET does not support Java quoted literals with \\Q and \\E"
+              "pattern": "^[ \\t\\n\\x0B\\f\\r]*<(Apple|Banana|Cherry)>[ \\t\\n\\x0B\\f\\r]*$",
+              "reason": ".NET lacks Java quoted literals and gives \\s Unicode semantics"
             }
           }
         }
@@ -6235,19 +6343,51 @@
           },
           {
             "id": "alphabetic",
-            "value": "\\p{IsAlphabetic}+"
+            "value": {
+              "java": "\\p{IsAlphabetic}+",
+              "alternates": {
+                "dotnet": {
+                  "unsupported": true,
+                  "reason": ".NET does not expose Java's IsAlphabetic Unicode property"
+                }
+              }
+            }
           },
           {
             "id": "ideographic",
-            "value": "\\p{IsIdeographic}+"
+            "value": {
+              "java": "\\p{IsIdeographic}+",
+              "alternates": {
+                "dotnet": {
+                  "unsupported": true,
+                  "reason": ".NET does not expose Java's IsIdeographic Unicode property"
+                }
+              }
+            }
           },
           {
             "id": "emoji",
-            "value": "\\p{IsEmoji}+"
+            "value": {
+              "java": "\\p{IsEmoji}+",
+              "alternates": {
+                "dotnet": {
+                  "unsupported": true,
+                  "reason": ".NET does not expose Java's IsEmoji Unicode property"
+                }
+              }
+            }
           },
           {
             "id": "extendedPictographic",
-            "value": "\\p{IsExtended_Pictographic}+"
+            "value": {
+              "java": "\\p{IsExtended_Pictographic}+",
+              "alternates": {
+                "dotnet": {
+                  "unsupported": true,
+                  "reason": ".NET does not expose Java's IsExtended_Pictographic Unicode property"
+                }
+              }
+            }
           },
           {
             "id": "scriptLatin",
@@ -6257,6 +6397,10 @@
                 "re2": {
                   "pattern": "\\p{Latin}+",
                   "reason": "RE2 uses bare Unicode script names"
+                },
+                "dotnet": {
+                  "unsupported": true,
+                  "reason": ".NET does not expose Java Unicode script properties"
                 }
               }
             }
@@ -6269,6 +6413,10 @@
                 "re2": {
                   "pattern": "\\p{Han}+",
                   "reason": "RE2 uses bare Unicode script names"
+                },
+                "dotnet": {
+                  "unsupported": true,
+                  "reason": ".NET does not expose Java Unicode script properties"
                 }
               }
             }
@@ -6323,15 +6471,39 @@
           },
           {
             "id": "word",
-            "value": "\\w+"
+            "value": {
+              "java": "\\w+",
+              "alternates": {
+                "dotnet": {
+                  "pattern": "[A-Za-z0-9_]+",
+                  "reason": ".NET gives \\w Unicode semantics while Java defaults to ASCII"
+                }
+              }
+            }
           },
           {
             "id": "digit",
-            "value": "\\d+"
+            "value": {
+              "java": "\\d+",
+              "alternates": {
+                "dotnet": {
+                  "pattern": "[0-9]+",
+                  "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+                }
+              }
+            }
           },
           {
             "id": "space",
-            "value": "\\s+"
+            "value": {
+              "java": "\\s+",
+              "alternates": {
+                "dotnet": {
+                  "pattern": "[ \\t\\n\\x0B\\f\\r]+",
+                  "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
+                }
+              }
+            }
           },
           {
             "id": "asciiLower",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1,10 +1,16 @@
 {
   "schemaVersion": 1,
-  "collection": {
-    "allocationWorkloadPrefixes": [
-      "RegexBenchmark.",
-      "SearchScalingBenchmark."
-    ]
+  "configuration": {
+    "collection": {
+      "allocationWorkloadPrefixes": [
+        "RegexBenchmark.",
+        "SearchScalingBenchmark."
+      ]
+    },
+    "crosscheckOverhead": {
+      "pattern": "([a-z]+)(\\d+)",
+      "replacement": "$2:$1"
+    }
   },
   "inputs": [
     {
@@ -1816,1271 +1822,6 @@
       }
     }
   ],
-  "regex": {
-    "literalMatch": {
-      "id": "RegexBenchmark.literalMatch",
-      "pattern": "hello",
-      "text": "hello",
-      "op": "matches"
-    },
-    "charClassMatch": {
-      "id": "RegexBenchmark.charClassMatch",
-      "pattern": "[a-zA-Z]+",
-      "text": "TheQuickBrownFoxJumpsOverTheLazyDog",
-      "op": "matches"
-    },
-    "alternationFind": {
-      "id": "RegexBenchmark.alternationFind",
-      "pattern": "foo|bar|baz|qux|quux|corge|grault|garply",
-      "text": "the garply went to the baz and met a quux",
-      "op": "findAllCount"
-    },
-    "captureGroups": {
-      "id": "RegexBenchmark.captureGroups",
-      "pattern": {
-        "java": "(\\d{4})-(\\d{2})-(\\d{2})",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})",
-            "reason": "Rust regex gives \\d Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})",
-            "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "text": "2025-12-25",
-      "op": "matchAndExtract",
-      "groups": 3
-    },
-    "findInText": {
-      "id": "RegexBenchmark.findInText",
-      "pattern": {
-        "java": "\\b\\w+ing\\b",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "(?-u:\\b)[A-Za-z0-9_]+ing(?-u:\\b)",
-            "reason": "Rust regex gives word classes and boundaries Unicode semantics"
-          },
-          "dotnet": {
-            "unsupported": true,
-            "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
-          }
-        }
-      },
-      "text": "The morning sun was shining brightly, casting long shadows across the rolling hills. Birds were singing their melodious songs while children were playing in the sprawling gardens. A gentle breeze was blowing through the swaying trees, carrying the scent of blooming flowers. People were walking along the winding paths, enjoying the refreshing air and the stunning views of the surrounding countryside. Everything was moving in perfect harmony.",
-      "op": "findAllCount"
-    },
-    "emailFind": {
-      "id": "RegexBenchmark.emailFind",
-      "pattern": "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}",
-      "text": "contact user.name+tag@example.co.uk for info",
-      "op": "find"
-    }
-  },
-  "matcherApi": {
-    "lookingAt": {
-      "pattern": {
-        "java": "[A-Za-z]+:\\s+\\d+",
-        "alternates": {
-          "dotnet": {
-            "pattern": "[A-Za-z]+:[ \\t\\n\\x0B\\f\\r]+[0-9]+",
-            "reason": ".NET gives \\s and \\d Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "text": "requests: 1234 completed"
-    },
-    "regionFind": {
-      "pattern": "\\b[A-Za-z]+ing\\b",
-      "text": "IGNORE morning shining IGNORE",
-      "start": 7,
-      "end": 22
-    },
-    "resetAndFind": {
-      "pattern": "[A-Za-z]+\\d+",
-      "text": "item1 item22 item333"
-    }
-  },
-  "utf8Matching": {
-    "literalScan": {
-      "seed": 20260721,
-      "textSize": 32768,
-      "alphabet": "abcdefghijklmnopqrstuvwxyz",
-      "patterns": {
-        "fourByte": "qjxv",
-        "shortWord": "literal",
-        "longWord": "coolfunctionname"
-      }
-    },
-    "captureFreeFind": {
-      "asciiEarly": {
-        "pattern": "ERROR",
-        "text": "ERROR request completed"
-      },
-      "asciiLate": {
-        "pattern": "ERROR",
-        "text": "request completed with ERROR"
-      },
-      "asciiNoMatch": {
-        "pattern": "ERROR",
-        "text": "request completed normally"
-      },
-      "multibyteEarly": {
-        "pattern": "错误",
-        "text": "错误：请求失败"
-      },
-      "multibyteLate": {
-        "pattern": "错误",
-        "text": "请求处理结束：错误"
-      },
-      "multibyteNoMatch": {
-        "pattern": "错误",
-        "text": "请求处理成功"
-      }
-    },
-    "requiredClassNonmatch": {
-      "pattern": "[一-龥]{3,}",
-      "unit": "This is a sentence containing only English characters. ",
-      "textSize": 10000
-    },
-    "repeatedFind": {
-      "ascii": {
-        "pattern": "[A-Za-z]+",
-        "text": "one two three four five"
-      },
-      "multibyte": {
-        "pattern": "\\p{L}+",
-        "text": "one café 東京 naïve"
-      }
-    },
-    "captureBounds": {
-      "numbered": {
-        "pattern": "([A-Za-z]+)=([^&]+)",
-        "text": "user=service&token=abc123"
-      },
-      "named": {
-        "pattern": "(?<key>[A-Za-z]+)=(?<value>[^&]+)",
-        "text": "city=東京&name=Renée"
-      },
-      "nonparticipating": {
-        "pattern": "(cat)|(dog)",
-        "text": "dog"
-      }
-    },
-    "emptyMatchIteration": {
-      "pattern": "",
-      "text": "a💰有"
-    },
-    "replacement": {
-      "literal": {
-        "pattern": "错误",
-        "text": "错误 then 错误",
-        "replacement": "OK"
-      },
-      "numbered": {
-        "pattern": "([A-Za-z]+)=([^&]+)",
-        "text": "city=東京&name=Renée",
-        "replacement": {
-          "java": "$1=[$2]",
-          "alternates": {
-            "re2-cpp": {
-              "replacement": "\\1=[\\2]",
-              "reason": "C++ RE2 uses backslash-number capture references"
-            }
-          }
-        }
-      },
-      "named": {
-        "pattern": "(?<key>[A-Za-z]+)=(?<value>[^&]+)",
-        "text": "city=東京&name=Renée",
-        "replacement": {
-          "java": "${key}=[${value}]",
-          "alternates": {
-            "re2-cpp": {
-              "replacement": "\\1=[\\2]",
-              "reason": "C++ RE2 replacements reference named captures by number"
-            }
-          }
-        }
-      }
-    },
-    "window": {
-      "prefix": "sentinel-before-",
-      "text": "city=東京&name=Renée",
-      "suffix": "-sentinel-after",
-      "pattern": "東京"
-    },
-    "hardFailure": {
-      "pattern": "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$",
-      "unit": "ordinary ASCII text without the required suffix ",
-      "textSizes": [
-        1024,
-        10240,
-        102400,
-        1048576
-      ]
-    },
-    "constructionModes": [
-      "trusted",
-      "validated"
-    ]
-  },
-  "compile": {
-    "simple": {
-      "pattern": "hello"
-    },
-    "medium": {
-      "pattern": {
-        "java": "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})",
-            "reason": "Rust regex gives \\d Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})",
-            "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      }
-    },
-    "complex": {
-      "pattern": "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
-    },
-    "alternation": {
-      "pattern": "foo|bar|baz|qux|quux|corge|grault|garply|waldo|fred|plugh|xyzzy"
-    }
-  },
-  "searchScaling": {
-    "workloadIds": {
-      "easyFail": "SearchScalingBenchmark.searchEasyFail",
-      "easySuccess": "SearchScalingBenchmark.searchEasySuccess",
-      "mediumFail": "SearchScalingBenchmark.searchMediumFail",
-      "hardFail": "SearchScalingBenchmark.searchHardFail",
-      "findIngScaled": "SearchScalingBenchmark.findIngScaled"
-    },
-    "patterns": {
-      "easy": "ABCDEFGHIJKLMNOPQRSTUVWXYZ$",
-      "medium": "[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$",
-      "hard": "[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$"
-    },
-    "matchSuffix": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    "findIngPattern": {
-      "java": "\\b\\w+ing\\b",
-      "alternates": {
-        "rust-regex": {
-          "pattern": "(?-u:\\b)[A-Za-z0-9_]+ing(?-u:\\b)",
-          "reason": "Rust regex gives word classes and boundaries Unicode semantics"
-        },
-        "dotnet": {
-          "unsupported": true,
-          "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
-        }
-      }
-    },
-    "textSizes": [
-      1024,
-      10240,
-      102400,
-      1048576
-    ],
-    "randomText": {
-      "alphabet": "abcdefghijklmnopqrstuvwxyz0123456789 \n",
-      "seed": 42
-    },
-    "proseUnit": "The morning sun was shining brightly casting long shadows across the rolling hills Birds were singing their melodious songs while children were playing in the sprawling gardens A gentle breeze was blowing through the swaying trees carrying the scent of blooming flowers People were walking along the winding paths enjoying the refreshing air and the stunning views "
-  },
-  "issue481Scaling": {
-    "textSizes": [
-      128,
-      1024,
-      10240,
-      102400,
-      1048576
-    ],
-    "splitW": {
-      "pattern": {
-        "java": "\\W+",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "[^A-Za-z0-9_]+",
-            "reason": "Rust regex gives \\W Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "[^A-Za-z0-9_]+",
-            "reason": ".NET gives \\W Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "unit": "This is a generic sentence containing words that will be used to test splitting routines. "
-    },
-    "block": {
-      "pattern": "(?s)<block>.*?</block>",
-      "prefix": "This is a <block>",
-      "unit": "content bytes here... blah blah blah ",
-      "suffix": "</block> transcript.",
-      "negativeSuffix": " transcript without a closing block tag."
-    },
-    "tag": {
-      "pattern": "<<tag.*?>>",
-      "prefixUnit": "plain text before the tagged value ",
-      "match": "Hello <<tag type=\"typeA\" value=\"valA\">>!",
-      "negativeMatch": "Hello <<notag type=\"typeA\" value=\"valA\">>!"
-    },
-    "scheme": {
-      "pattern": "\\[(.*?)]\\(customScheme://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)",
-      "prefixUnit": "ordinary prose without a custom scheme link ",
-      "match": "Check [this link](customScheme://<id_1>) or [another](customScheme://id_2).",
-      "negativeMatch": "Check [this link](https://example.test/id_1) or [another](otherScheme://id_2)."
-    }
-  },
-  "issue488ReplaceAll": {
-    "textSizes": [
-      1000,
-      10000,
-      100000
-    ],
-    "lazyAlt": {
-      "pattern": {
-        "java": "(?i)(?s)\\s*\\n*(?:<block>|\\[block\\])\\s*\\n?renderElement\\(.*?\\)\\s*\\n?(?:</block>|\\[/block\\])",
-        "alternates": {
-          "dotnet": {
-            "unsupported": true,
-            "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-          }
-        }
-      },
-      "replacement": "",
-      "prefixUnit": "Some prefix text preceding the render block element. ",
-      "match": "\n<block>\nrenderElement(id=\"el-42\", width=100, height=200, label=\"hello world\")\n</block>\n",
-      "suffixUnit": "Some suffix text following the render block element. "
-    },
-    "altCapture": {
-      "pattern": "(^|[^#])(#!customTag)",
-      "replacement": {
-        "java": "$1<tag type=\"custom\"",
-        "alternates": {
-          "re2-cpp": {
-            "replacement": "\\1<tag type=\"custom\"",
-            "reason": "C++ RE2 uses backslash-number capture references"
-          }
-        }
-      },
-      "hitUnit": "This is some sample prose text that contains a tag marker #!customTag and more text here. ",
-      "missUnit": "This is some sample prose text that contains a tag marker #customTag and more text here. ",
-      "hitInterval": 5
-    }
-  },
-  "captureScaling": {
-    "capture0": {
-      "pattern": "[0-9]+-[0-9]+-[0-9]+",
-      "text": "650-253-0001",
-      "groups": 0
-    },
-    "capture1": {
-      "pattern": "([0-9]+)-[0-9]+-[0-9]+",
-      "text": "650-253-0001",
-      "groups": 1
-    },
-    "capture3": {
-      "pattern": "([0-9]+)-([0-9]+)-([0-9]+)",
-      "text": "650-253-0001",
-      "groups": 3
-    },
-    "capture10": {
-      "pattern": {
-        "java": "(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+)",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+)",
-            "reason": "Rust regex gives \\w Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+)",
-            "reason": ".NET gives \\w Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "text": "a=1;b=2;c=3;d=4;e=5",
-      "groups": 10
-    }
-  },
-  "http": {
-    "workloadIds": {
-      "full": "HttpBenchmark.httpFull",
-      "small": "HttpBenchmark.httpSmall",
-      "extract": "HttpBenchmark.httpExtract"
-    },
-    "pattern": "^(?:GET|POST) +([^ ]+) HTTP",
-    "fullRequest": "GET /asdfhjasdhfasdlfhasdflkjasdfkljasdhflaskdjhflkajsdhflkajshfklasjdhfklasjdhfklashdflka HTTP/1.1",
-    "smallRequest": "GET /abc HTTP/1.1"
-  },
-  "crosscheckOverhead": {
-    "pattern": "([a-z]+)(\\d+)",
-    "replacement": "$2:$1"
-  },
-  "replace": {
-    "literalReplaceFirst": {
-      "pattern": "b",
-      "text": "ababababab",
-      "replacement": "bb",
-      "op": "replaceFirst"
-    },
-    "literalReplaceFirstNoMatch": {
-      "pattern": "authorization=",
-      "text": "INFO service=checkout method=GET path=/api/orders/123 status=200 latency_ms=17 trace_id=8f14e45fceea167a user=anonymous region=us-east-1 cache=hit; INFO service=checkout method=POST path=/api/orders status=201 latency_ms=42 trace_id=c9f0f895fb98ab91 user=anonymous region=us-east-1 cache=miss; INFO service=inventory method=GET path=/api/items/sku-481516 status=200 latency_ms=11 trace_id=45c48cce2e2d7fbdea1afc51c7c6ad26 user=anonymous region=us-west-2 cache=hit; INFO service=payments method=GET path=/api/charges/ch_123 status=404 latency_ms=23 trace_id=d3d9446802a44259755d38e6d163e820 user=anonymous region=us-east-2 cache=miss; INFO service=shipping method=PATCH path=/api/shipments/shp_987 status=202 latency_ms=36 trace_id=6512bd43d9caa6e02c990b0a82652dca user=anonymous region=us-west-1 cache=hit",
-      "replacement": "authorization=REDACTED",
-      "op": "replaceFirst"
-    },
-    "literalReplaceAll": {
-      "pattern": "b",
-      "text": "ababababab",
-      "replacement": "bb",
-      "op": "replaceAll"
-    },
-    "pigLatinReplaceAll": {
-      "pattern": "(qu|[b-df-hj-np-tv-z]*)([a-z]+)",
-      "text": "the quick brown fox jumps over the lazy dogs",
-      "replacement": {
-        "java": "$2$1ay",
-        "alternates": {
-          "go-regexp": {
-            "replacement": "${2}${1}ay",
-            "reason": "Go replacement references need braces before adjacent letters"
-          },
-          "re2-cpp": {
-            "replacement": "\\2\\1ay",
-            "reason": "C++ RE2 uses backslash-number capture references"
-          },
-          "rust-regex": {
-            "replacement": "${2}${1}ay",
-            "reason": "Rust replacement references need braces before adjacent letters"
-          }
-        }
-      },
-      "op": "replaceAll"
-    },
-    "digitReplaceAll": {
-      "pattern": {
-        "java": "\\d+",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "[0-9]+",
-            "reason": "Rust regex gives \\d Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "[0-9]+",
-            "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "text": "order 12345 shipped on 2025-03-22 tracking 9876543210 weight 42kg price $199",
-      "replacement": "NUM",
-      "op": "replaceAll"
-    },
-    "emptyReplaceAll": {
-      "pattern": "a*",
-      "text": "abc",
-      "replacement": "x",
-      "op": "replaceAll"
-    }
-  },
-  "scrubber": {
-    "repeatCount": 500,
-    "linePattern": "[^\\n]*\\bSCRUB:strip_line\\b[^\\n]*\\n?",
-    "blockPattern": "\\bSCRUB:begin_strip\\b(?s:.*?)\\bSCRUB:end_strip\\b",
-    "baseWithoutDirectives": "public class Foo {\n  // Some comment\n  public void bar() {\n    System.out.println(\"Hello, world!\");\n  }\n}\n",
-    "baseWithDirectives": "public class Foo {\n  // SCRUB:strip_line\n  public void bar() {\n    // SCRUB:begin_strip\n    System.out.println(\"Secret code\");\n    // SCRUB:end_strip\n  }\n}\n"
-  },
-  "realWorldRegex": {
-    "textSizes": [
-      1000,
-      10000,
-      100000
-    ],
-    "safeDelimiterAlphabet": " ",
-    "seed": 42,
-    "cases": [
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.mapFieldPath",
-        "name": "mapFieldPath",
-        "pattern": {
-          "java": "([\\S]+)\\b\\[(.+)\\]",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "([^\\x20\\t\\n\\x0B\\f\\r]+)(?-u:\\b)\\[(.+)\\]",
-              "reason": "Rust regex gives \\S and word boundaries Unicode semantics"
-            },
-            "dotnet": {
-              "unsupported": true,
-              "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
-            }
-          }
-        },
-        "op": "find",
-        "match": "config.overrides[some_value]",
-        "nonMatch": "config.overrides"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.markupImageLink",
-        "name": "markupImageLink",
-        "pattern": "<<!(image|media|link)(\\([^\\)]*\\))?/?>?>",
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "<<!image(src=\"http://image.png\")>>",
-        "nonMatch": "<<!image"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.versionList",
-        "name": "versionList",
-        "pattern": {
-          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
-          "alternates": {
-            "rust-regex": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
-              "reason": "Rust regex gives \\d Unicode semantics"
-            },
-            "dotnet": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
-              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "[1.2.3, 4.5.6]",
-        "nonMatch": "[1.2.3,"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.malformedEntity",
-        "name": "malformedEntity",
-        "pattern": "<[^>]*entity[^>]*>{1,2}",
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "<entity id=\"123\">",
-        "nonMatch": "<ent id=\"123\">"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.markupEntity",
-        "name": "markupEntity",
-        "pattern": "<<!entity.*?>>",
-        "op": "find",
-        "match": "<<!entity(id=\"123\")>>",
-        "nonMatch": "<<entity(id=\"123\")"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.customProtocolLink",
-        "name": "customProtocolLink",
-        "pattern": "\\[(.*?)]\\(customProtocol://((?:<[^>]*>|[^()]*|\\([^()]*\\))*)\\)",
-        "op": "find",
-        "match": "[Click here](customProtocol://<doc_1>)",
-        "nonMatch": "[Click here](http://google.com)"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.wildcardSearch",
-        "name": "wildcardSearch",
-        "pattern": {
-          "java": "(?is).*\\b(you|your)\\b.*",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?is).*(?-u:\\b)(you|your)(?-u:\\b).*",
-              "reason": "Rust regex gives word boundaries Unicode semantics"
-            },
-            "dotnet": {
-              "unsupported": true,
-              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-            }
-          }
-        },
-        "op": "find",
-        "match": "What can I do for you today?",
-        "nonMatch": "What is the capital of France?"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.metadataBlock",
-        "name": "metadataBlock",
-        "pattern": "(?s)<meta_start>.*?<meta_end>",
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "<meta_start>Thinking process: analyzing query...<meta_end>",
-        "nonMatch": "<meta_start>Thinking process: analyzing query..."
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.blockedTags1",
-        "name": "blockedTags1",
-        "pattern": {
-          "java": "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "```code_block\\n((?-u:\\s))*# (topic|tags)_identified:.*?\\n```",
-              "reason": "Rust regex gives \\s Unicode semantics"
-            },
-            "dotnet": {
-              "pattern": "```code_block\\n([ \\t\\n\\x0B\\f\\r])*# (topic|tags)_identified:.*?\\n```",
-              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "```code_block\n# tags_identified: shopping\n```",
-        "nonMatch": "```code_block\n# tags: shopping\n```"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.blockedTags2",
-        "name": "blockedTags2",
-        "pattern": {
-          "java": "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "<container>\\n((?-u:\\s))*# (topic|tags)_identified:.*?\\n</container>",
-              "reason": "Rust regex gives \\s Unicode semantics"
-            },
-            "dotnet": {
-              "pattern": "<container>\\n([ \\t\\n\\x0B\\f\\r])*# (topic|tags)_identified:.*?\\n</container>",
-              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "<container>\n# topic_identified: sports\n</container>",
-        "nonMatch": "<container>\n# topic: sports\n</container>"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.overlappingUrl",
-        "name": "overlappingUrl",
-        "pattern": {
-          "java": "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?i)(?-u:\\b)(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
-              "reason": "Rust regex gives word boundaries Unicode semantics"
-            },
-            "dotnet": {
-              "unsupported": true,
-              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "https://www.example.com/search?q=testing&hl=en",
-        "nonMatch": "some-random-domain-name"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeyword",
-        "name": "caseInsensitiveKeyword",
-        "pattern": {
-          "java": "(?i)keyword_to_find",
-          "alternates": {
-            "dotnet": {
-              "unsupported": true,
-              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "KEYWORD_TO_FIND",
-        "nonMatch": "other_random_words"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.boundedNameMatch",
-        "name": "boundedNameMatch",
-        "pattern": {
-          "java": "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?-u:\\b)[Ff]irst [Nn]ame ((?-u:\\b)value(?-u:\\b)|\\*\\*value\\*\\*)",
-              "reason": "Rust regex gives word boundaries Unicode semantics"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "first name value",
-        "nonMatch": "first name other_value"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.templateTagMatch",
-        "name": "templateTagMatch",
-        "pattern": {
-          "java": "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?s)(<template(?-u:\\s)+name(?-u:\\s)*>.*?<(?-u:\\s)*/(?-u:\\s)*template[ \\t]*)([^>]|$)",
-              "reason": "Rust regex gives \\s Unicode semantics"
-            },
-            "dotnet": {
-              "pattern": "(?s)(<template[ \\t\\n\\x0B\\f\\r]+name[ \\t\\n\\x0B\\f\\r]*>.*?<[ \\t\\n\\x0B\\f\\r]*/[ \\t\\n\\x0B\\f\\r]*template[ \\t]*)([^>]|$)",
-              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "<template name>content to match</template",
-        "nonMatch": "plain text without template tag"
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.sparseUrl",
-        "name": "sparseUrl",
-        "pattern": {
-          "java": "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?i)(?-u:\\b)(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
-              "reason": "Rust regex gives word boundaries Unicode semantics"
-            },
-            "dotnet": {
-              "unsupported": true,
-              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "https://www.example.com/search?q=testing&hl=en",
-        "nonMatch": "some-random-domain-name",
-        "matchInput": {
-          "kind": "sparseMatch",
-          "nonMatchRepeats": 20,
-          "delimiterAlphabet": "bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ0123456789"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.unprefixedWordBoundary",
-        "name": "unprefixedWordBoundary",
-        "pattern": {
-          "java": "\\b[a-zA-Z]{3,5}\\b",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?-u:\\b)[a-zA-Z]{3,5}(?-u:\\b)",
-              "reason": "Rust regex gives word boundaries Unicode semantics"
-            }
-          }
-        },
-        "op": "find",
-        "match": "hello",
-        "nonMatch": "12345",
-        "matchInput": {
-          "kind": "prefixedRepeat",
-          "prefix": "12345 "
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.fruitSearchQuery",
-        "name": "fruitSearchQuery",
-        "pattern": {
-          "java": "(?is).*\\b(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)\\b.*",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?is).*(?-u:\\b)(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)(?-u:\\b).*",
-              "reason": "Rust regex gives word boundaries Unicode semantics"
-            },
-            "dotnet": {
-              "unsupported": true,
-              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-            }
-          }
-        },
-        "op": "replaceAllGroup1",
-        "replacement": {
-          "java": "$1",
-          "alternates": {
-            "re2-cpp": {
-              "replacement": "\\1",
-              "reason": "C++ RE2 uses backslash-number capture references"
-            }
-          }
-        },
-        "match": "Here are the apples to show for banana in this session.",
-        "nonMatch": "Orange lemon melon peach pear plum.",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.fruitMarkupTag",
-        "name": "fruitMarkupTag",
-        "pattern": {
-          "java": "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "^[[:space:]]*<(Apple|Banana|Cherry)>[[:space:]]*$",
-              "reason": "Rust regex lacks Java quoted literals and gives \\s Unicode semantics"
-            },
-            "dotnet": {
-              "pattern": "^[ \\t\\n\\x0B\\f\\r]*<(Apple|Banana|Cherry)>[ \\t\\n\\x0B\\f\\r]*$",
-              "reason": ".NET lacks Java quoted literals and gives \\s Unicode semantics"
-            }
-          }
-        },
-        "op": "replaceAllGroup1",
-        "replacement": {
-          "java": "$1",
-          "alternates": {
-            "re2-cpp": {
-              "replacement": "\\1",
-              "reason": "C++ RE2 uses backslash-number capture references"
-            }
-          }
-        },
-        "match": "  <Banana>  ",
-        "nonMatch": "  <Orange>  ",
-        "matchInput": {
-          "kind": "surroundWithSpaces",
-          "body": "<Banana>"
-        },
-        "nonMatchInput": {
-          "kind": "surroundWithSpaces",
-          "body": "<Orange>"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.jsonBlock",
-        "name": "jsonBlock",
-        "pattern": {
-          "java": "(\\{[\\s\\S]*\\})",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(\\{(?s:.)*\\})",
-              "reason": "Rust regex gives \\s and \\S Unicode semantics"
-            }
-          }
-        },
-        "op": "replaceAllGroup1",
-        "replacement": {
-          "java": "$1",
-          "alternates": {
-            "re2-cpp": {
-              "replacement": "\\1",
-              "reason": "C++ RE2 uses backslash-number capture references"
-            }
-          }
-        },
-        "match": "{\n  \"key1\": \"value1\",\n  \"key2\": \"value2\",\n  \"key3\": \"value3\"\n}",
-        "nonMatch": "some non-matching string containing no braces",
-        "matchInput": {
-          "kind": "scaledSurroundWithSpaces",
-          "bodyPrefix": "{ \"key\": \"value\", \"padding\": \"",
-          "bodyFill": "a",
-          "bodySuffix": "\" }",
-          "bodyScalePercent": 5
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.charReplace",
-        "name": "charReplace",
-        "pattern": "a",
-        "op": "replaceAllLiteral",
-        "replacement": "xyz",
-        "match": "a",
-        "nonMatch": "b",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.greedyOnePass",
-        "name": "greedyOnePass",
-        "pattern": "^(.+)",
-        "op": "matches",
-        "match": "abcdefghijklmnopqrstuvwxyz",
-        "nonMatch": "\nabcdefghijklmnopqrstuvwxyz",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.layoutBlock",
-        "name": "layoutBlock",
-        "pattern": {
-          "java": "(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>",
-          "alternates": {
-            "rust-regex": {
-              "pattern": "(?s)<block>\\n((?-u:\\s))*# (category|group)_defined:.*?\\n</block>",
-              "reason": "Rust regex gives \\s Unicode semantics"
-            },
-            "dotnet": {
-              "pattern": "(?s)<block>\\n([ \\t\\n\\x0B\\f\\r])*# (category|group)_defined:.*?\\n</block>",
-              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "<block>\n  # category_defined: alpha, beta\n  entry: apple\n  entry: banana\n</block>\n",
-        "nonMatch": "<block>\n  # comment but not defined tag\n  entry: orange\n</block>\n",
-        "matchInput": {
-          "kind": "sparseMatch",
-          "nonMatchRepeats": 5,
-          "delimiterAlphabet": " "
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.turnTitleWhitespaceCjk",
-        "name": "turnTitleWhitespaceCjk",
-        "pattern": {
-          "java": "[ \\f\\r\\t\\v\\x{00a0}\\x{1680}\\x{2000}-\\x{200a}\\x{2028}\\x{2029}\\x{202f}\\x{205f}\\x{3000}\\x{feff}\\x{3164}]+",
-          "alternates": {
-            "dotnet": {
-              "pattern": "[ \\f\\r\\t\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff\\u3164]+",
-              "reason": ".NET uses UTF-16 escapes rather than Java code-point hex escapes"
-            }
-          }
-        },
-        "op": "replaceAllEmpty",
-        "replacement": "",
-        "match": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
-        "nonMatch": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch",
-        "name": "cjkSearch",
-        "pattern": "[一-龥]{3,}",
-        "op": "find",
-        "match": "这是一个中文测试句子",
-        "nonMatch": "This is a sentence containing only English characters.",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      },
-      {
-        "id": "RealWorldRegexBenchmark.runBenchmark.emojiSearch",
-        "name": "emojiSearch",
-        "pattern": {
-          "java": "[😀-😇]",
-          "alternates": {
-            "dotnet": {
-              "pattern": "\\uD83D[\\uDE00-\\uDE07]",
-              "reason": ".NET character classes operate on UTF-16 code units"
-            }
-          }
-        },
-        "op": "find",
-        "match": "Today is a beautiful day 😇 with warm sunshine.",
-        "nonMatch": "Today is a beautiful day with warm sunshine.",
-        "matchInput": {
-          "kind": "repeat"
-        },
-        "nonMatchInput": {
-          "kind": "repeat"
-        }
-      }
-    ]
-  },
-  "application": [
-    {
-      "id": "ApplicationBenchmark.uuidValidation",
-      "name": "uuidValidation",
-      "op": "matchesCorpus",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
-      "texts": [
-        "550e8400-e29b-41d4-a716-446655440000",
-        "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
-        "not-a-uuid",
-        "550e8400e29b41d4a716446655440000",
-        "ffffffff-ffff-5fff-bfff-ffffffffffff",
-        "12345678-1234-7234-9234-123456789abc"
-      ],
-      "expected": 3
-    },
-    {
-      "id": "ApplicationBenchmark.logLineParse",
-      "name": "logLineParse",
-      "op": "matchesGroupLengthSum",
-      "pattern": {
-        "java": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\s+(INFO|WARN|ERROR)\\s+([A-Za-z0-9_.-]+)\\s+-\\s+(.+)$",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)(?-u:\\s)+(INFO|WARN|ERROR)(?-u:\\s)+([A-Za-z0-9_.-]+)(?-u:\\s)+-(?-u:\\s)+(.+)$",
-            "reason": "Rust regex gives \\d and \\s Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)[ \\t\\n\\x0B\\f\\r]+(INFO|WARN|ERROR)[ \\t\\n\\x0B\\f\\r]+([A-Za-z0-9_.-]+)[ \\t\\n\\x0B\\f\\r]+-[ \\t\\n\\x0B\\f\\r]+(.+)$",
-            "reason": ".NET gives \\d and \\s Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "texts": [
-        "2026-03-31T14:22:08Z INFO api.gateway - request completed status=200 latency=38ms",
-        "2026-03-31T14:22:09Z WARN db.pool - connection wait exceeded threshold=100ms",
-        "2026-03-31T14:22:10Z ERROR worker-7 - job failed id=abc123 retry=2",
-        "debug line without structured prefix",
-        "2026-03-31 14:22:11 INFO api.gateway - malformed timestamp"
-      ],
-      "groups": [
-        2,
-        3
-      ],
-      "expected": 39
-    },
-    {
-      "id": "ApplicationBenchmark.apiRouteMatch",
-      "name": "apiRouteMatch",
-      "op": "matchesGroupLengthSum",
-      "pattern": "^/api/v[0-9]+/(users|orders|inventory)/([A-Za-z0-9_-]+)(?:\\?.*)?$",
-      "texts": [
-        "/api/v1/users/12345",
-        "/api/v2/orders/ord_9f3a?include=items",
-        "/api/v3/inventory/sku-7788",
-        "/assets/app.js",
-        "/api/v1/users/",
-        "/api/latest/users/12345"
-      ],
-      "groups": [
-        1,
-        2
-      ],
-      "expected": 41
-    },
-    {
-      "id": "ApplicationBenchmark.stackTraceExtract",
-      "name": "stackTraceExtract",
-      "op": "findAllGroupLengthSum",
-      "pattern": {
-        "java": "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "(?m)^(?-u:\\s)+at(?-u:\\s)+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):([0-9]+)\\)$",
-            "reason": "Rust regex gives \\d and \\s Unicode semantics"
-          },
-          "dotnet": {
-            "pattern": "(?m)^[ \\t\\n\\x0B\\f\\r]+at[ \\t\\n\\x0B\\f\\r]+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):([0-9]+)\\)$",
-            "reason": ".NET gives \\d and \\s Unicode semantics while Java defaults to ASCII"
-          }
-        }
-      },
-      "text": "java.lang.IllegalStateException: failed to process request\n\tat org.example.api.Handler.handle(Handler.java:87)\n\tat org.example.api.Router.dispatch(Router.java:142)\n\tat org.example.Main.main(Main.java:25)\nCaused by: java.io.IOException: timeout\n\tat org.example.net.Client.read(Client.java:203)",
-      "groups": [
-        1,
-        4
-      ],
-      "expected": 93
-    },
-    {
-      "id": "ApplicationBenchmark.caseInsensitiveKeywords",
-      "name": "caseInsensitiveKeywords",
-      "op": "findAllCount",
-      "pattern": {
-        "java": "(?i)\\b(error|warning|timeout|failed)\\b",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "(?i)(?-u:\\b)(error|warning|timeout|failed)(?-u:\\b)",
-            "reason": "Rust regex gives word boundaries Unicode semantics"
-          },
-          "dotnet": {
-            "unsupported": true,
-            "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-          }
-        }
-      },
-      "text": "INFO startup complete\nWarning cache miss ratio high\nrequest failed after TIMEOUT waiting for backend\nERROR circuit breaker opened\nhealth check passed",
-      "expected": 4
-    },
-    {
-      "id": "ApplicationBenchmark.urlExtraction",
-      "name": "urlExtraction",
-      "op": "findAllLengthSum",
-      "pattern": "(https?://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]*)?)",
-      "text": "Docs: https://example.com/docs/v1/index.html?lang=en and callback http://localhost:8080/api/callback?id=42; mirror at https://cdn.example.org/assets/app.js",
-      "expected": 124
-    },
-    {
-      "id": "ApplicationBenchmark.csvFieldScan",
-      "name": "csvFieldScan",
-      "op": "findAllLengthSum",
-      "pattern": "(?m)(?:^|,)(?:\"([^\"]*)\"|([^,\\r\\n]+))",
-      "text": "id,name,email,status,created_at\n42,\"Ada Lovelace\",ada@example.com,active,2026-03-31T14:22:08Z\n43,\"Grace Hopper\",grace@example.com,pending,2026-04-01T09:15:00Z",
-      "expected": 156
-    },
-    {
-      "id": "ApplicationBenchmark.secretRedaction",
-      "name": "secretRedaction",
-      "op": "replaceAll",
-      "pattern": {
-        "java": "(?i)\\b(password|token|secret)=([^\\s&]+)",
-        "alternates": {
-          "rust-regex": {
-            "pattern": "(?i)(?-u:\\b)(password|token|secret)=([^\\x20\\t\\n\\x0B\\f\\r&]+)",
-            "reason": "Rust regex gives \\s and word boundaries Unicode semantics"
-          },
-          "dotnet": {
-            "unsupported": true,
-            "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
-          }
-        }
-      },
-      "text": "user=service password=hunter2 token=abc123XYZ path=/api secret=prod-key-9 debug=true",
-      "replacement": {
-        "java": "$1=REDACTED",
-        "alternates": {
-          "re2-cpp": {
-            "replacement": "\\1=REDACTED",
-            "reason": "C++ RE2 uses backslash-number capture references"
-          }
-        }
-      },
-      "expected": "user=service password=REDACTED token=REDACTED path=/api secret=REDACTED debug=true"
-    }
-  ],
-  "pathological": {
-    "nValues": [
-      10,
-      15,
-      20,
-      25,
-      30,
-      50,
-      100
-    ],
-    "nValuesComparison": [
-      10,
-      15,
-      20
-    ],
-    "note": "Pattern is 'a?' repeated n times followed by 'a' repeated n times. Text is 'a' repeated n times."
-  },
-  "fanout": {
-    "unicodeFanout": {
-      "id": "FanoutBenchmark.fanoutUnicode",
-      "pattern": {
-        "java": "(?:[\\x{80}-\\x{10FFFF}]?){100}[\\x{80}-\\x{10FFFF}]",
-        "alternates": {
-          "dotnet": {
-            "pattern": "(?:(?:[\\u0080-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])?){100}(?:[\\u0080-\\uD7FF\\uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])",
-            "reason": ".NET character classes operate on UTF-16 code units"
-          }
-        }
-      },
-      "codePoints": [
-        19968,
-        19969,
-        19970,
-        233,
-        241,
-        252,
-        1040,
-        1041,
-        1042,
-        12354,
-        12356,
-        12358
-      ],
-      "seed": 42
-    },
-    "nestedQuantifier": {
-      "id": "FanoutBenchmark.nestedQuantifier",
-      "pattern": "(?:a?){20}a{20}",
-      "alphabet": "abcdefghijklmnopqrstuvwxyz",
-      "seed": 42
-    },
-    "textSizes": [
-      1024,
-      10240,
-      102400
-    ]
-  },
-  "patternSet": {
-    "basePatterns": [
-      "ERROR",
-      "WARNING",
-      "INFO",
-      "DEBUG",
-      "FATAL",
-      "connection\\s+timeout",
-      "\\d+\\.\\d+\\.\\d+\\.\\d+",
-      "host\\s+\\S+",
-      "port\\s*:\\s*\\d+",
-      "after\\s+\\d+s",
-      "[A-Z]{2,}:",
-      "\\w+\\.internal",
-      "db-\\w+",
-      "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d+",
-      "timeout|refused|reset|closed",
-      "\\[\\w+\\]",
-      "status\\s*=\\s*\\d+",
-      "retry\\s+\\d+/\\d+",
-      "latency\\s*>\\s*\\d+ms",
-      "queue\\s+full",
-      "memory\\s+\\d+[kmg]b?",
-      "cpu\\s+\\d+%",
-      "disk\\s+(full|low)",
-      "\\w+Exception",
-      "at\\s+\\w+\\.\\w+\\(",
-      "null\\s*pointer",
-      "stack\\s*overflow",
-      "out\\s+of\\s+memory",
-      "permission\\s+denied",
-      "not\\s+found",
-      "already\\s+exists",
-      "invalid\\s+\\w+",
-      "expired",
-      "unauthorized",
-      "rate\\s+limit",
-      "circuit\\s+breaker",
-      "health\\s+check\\s+failed",
-      "graceful\\s+shutdown",
-      "leader\\s+election",
-      "split\\s+brain",
-      "rebalancing",
-      "partition\\s+\\d+",
-      "offset\\s+\\d+",
-      "consumer\\s+group",
-      "dead\\s+letter",
-      "backpressure",
-      "throttled",
-      "degraded",
-      "failover",
-      "rollback",
-      "checkpoint\\s+\\d+",
-      "snapshot\\s+\\w+",
-      "compaction",
-      "gc\\s+pause\\s+\\d+ms",
-      "safepoint",
-      "jit\\s+compilation",
-      "class\\s+loading",
-      "thread\\s+pool\\s+\\w+",
-      "blocked\\s+thread",
-      "deadlock",
-      "lock\\s+contention",
-      "cache\\s+(hit|miss)",
-      "eviction",
-      "bloom\\s+filter"
-    ],
-    "patternCounts": [
-      4,
-      16,
-      64
-    ],
-    "matchText": "ERROR: connection timeout after 30s to host db-primary.internal:5432",
-    "noMatchText": "The quick brown fox jumps over the lazy dog near the riverbank"
-  },
   "workloads": [
     {
       "id": "RegexBenchmark.literalMatch",
@@ -3140,7 +1881,19 @@
       "id": "RegexBenchmark.findInText",
       "operation": "findAllCount",
       "patterns": [
-        "\\b\\w+ing\\b"
+        {
+          "java": "\\b\\w+ing\\b",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?-u:\\b)[A-Za-z0-9_]+ing(?-u:\\b)",
+              "reason": "Rust regex gives word classes and boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "crossEngine.RegexBenchmark.findInText.input"
@@ -3203,7 +1956,19 @@
       "id": "ApplicationBenchmark.logLineParse",
       "operation": "matchesGroupLengthSum",
       "patterns": [
-        "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\s+(INFO|WARN|ERROR)\\s+([A-Za-z0-9_.-]+)\\s+-\\s+(.+)$"
+        {
+          "java": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\s+(INFO|WARN|ERROR)\\s+([A-Za-z0-9_.-]+)\\s+-\\s+(.+)$",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)(?-u:\\s)+(INFO|WARN|ERROR)(?-u:\\s)+([A-Za-z0-9_.-]+)(?-u:\\s)+-(?-u:\\s)+(.+)$",
+              "reason": "Rust regex gives \\d and \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)[ \\t\\n\\x0B\\f\\r]+(INFO|WARN|ERROR)[ \\t\\n\\x0B\\f\\r]+([A-Za-z0-9_.-]+)[ \\t\\n\\x0B\\f\\r]+-[ \\t\\n\\x0B\\f\\r]+(.+)$",
+              "reason": ".NET gives \\d and \\s Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "crossEngine.ApplicationBenchmark.logLineParse.input.0",
@@ -3268,7 +2033,19 @@
       "id": "ApplicationBenchmark.stackTraceExtract",
       "operation": "findAllGroupLengthSum",
       "patterns": [
-        "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$"
+        {
+          "java": "(?m)^\\s+at\\s+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):(\\d+)\\)$",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?m)^(?-u:\\s)+at(?-u:\\s)+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):([0-9]+)\\)$",
+              "reason": "Rust regex gives \\d and \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "(?m)^[ \\t\\n\\x0B\\f\\r]+at[ \\t\\n\\x0B\\f\\r]+([A-Za-z0-9_.$]+)\\.([A-Za-z0-9_$<>]+)\\(([^:()]+):([0-9]+)\\)$",
+              "reason": ".NET gives \\d and \\s Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "crossEngine.ApplicationBenchmark.stackTraceExtract.input"
@@ -3296,7 +2073,19 @@
       "id": "ApplicationBenchmark.caseInsensitiveKeywords",
       "operation": "findAllCount",
       "patterns": [
-        "(?i)\\b(error|warning|timeout|failed)\\b"
+        {
+          "java": "(?i)\\b(error|warning|timeout|failed)\\b",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?i)(?-u:\\b)(error|warning|timeout|failed)(?-u:\\b)",
+              "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "crossEngine.ApplicationBenchmark.caseInsensitiveKeywords.input"
@@ -3362,7 +2151,19 @@
       "id": "ApplicationBenchmark.secretRedaction",
       "operation": "replaceAll",
       "patterns": [
-        "(?i)\\b(password|token|secret)=([^\\s&]+)"
+        {
+          "java": "(?i)\\b(password|token|secret)=([^\\s&]+)",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?i)(?-u:\\b)(password|token|secret)=([^\\x20\\t\\n\\x0B\\f\\r&]+)",
+              "reason": "Rust regex gives \\s and word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "crossEngine.ApplicationBenchmark.secretRedaction.input"
@@ -3376,7 +2177,15 @@
         ]
       },
       "arguments": {
-        "replacement": "$1=REDACTED"
+        "replacement": {
+          "java": "$1=REDACTED",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1=REDACTED",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        }
       },
       "requirements": [
         "numberedReplacement"
@@ -3390,7 +2199,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.mapFieldPath.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "([\\S]+)\\b\\[(.+)\\]"
+        {
+          "java": "([\\S]+)\\b\\[(.+)\\]",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "([^\\x20\\t\\n\\x0B\\f\\r]+)(?-u:\\b)\\[(.+)\\]",
+              "reason": "Rust regex gives \\S and word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII word-boundary semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.mapFieldPath.{matchLabel}.{size}"
@@ -3452,7 +2273,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.versionList.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]"
+        {
+          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
+          "alternates": {
+            "rust-regex": {
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "reason": "Rust regex gives \\d Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.versionList.{matchLabel}.{size}"
@@ -3576,7 +2409,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.wildcardSearch.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "(?is).*\\b(you|your)\\b.*"
+        {
+          "java": "(?is).*\\b(you|your)\\b.*",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?is).*(?-u:\\b)(you|your)(?-u:\\b).*",
+              "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.wildcardSearch.{matchLabel}.{size}"
@@ -3638,7 +2483,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.blockedTags1.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```"
+        {
+          "java": "```code_block\\n(\\s)*# (topic|tags)_identified:.*?\\n```",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "```code_block\\n((?-u:\\s))*# (topic|tags)_identified:.*?\\n```",
+              "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "```code_block\\n([ \\t\\n\\x0B\\f\\r])*# (topic|tags)_identified:.*?\\n```",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.blockedTags1.{matchLabel}.{size}"
@@ -3671,7 +2528,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.blockedTags2.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>"
+        {
+          "java": "<container>\\n(\\s)*# (topic|tags)_identified:.*?\\n</container>",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "<container>\\n((?-u:\\s))*# (topic|tags)_identified:.*?\\n</container>",
+              "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "<container>\\n([ \\t\\n\\x0B\\f\\r])*# (topic|tags)_identified:.*?\\n</container>",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.blockedTags2.{matchLabel}.{size}"
@@ -3704,7 +2573,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.overlappingUrl.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?"
+        {
+          "java": "(?i)\\b(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?i)(?-u:\\b)(?:https?://|www\\.)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}(?:/[a-zA-Z0-9-._~:/?#\\[\\]@!$&'()*+,;=]*)?",
+              "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.overlappingUrl.{matchLabel}.{size}"
@@ -3737,7 +2618,15 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeyword.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "(?i)keyword_to_find"
+        {
+          "java": "(?i)keyword_to_find",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.caseInsensitiveKeyword.{matchLabel}.{size}"
@@ -3770,7 +2659,15 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.boundedNameMatch.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)"
+        {
+          "java": "\\b[Ff]irst [Nn]ame (\\bvalue\\b|\\*\\*value\\*\\*)",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?-u:\\b)[Ff]irst [Nn]ame ((?-u:\\b)value(?-u:\\b)|\\*\\*value\\*\\*)",
+              "reason": "Rust regex gives word boundaries Unicode semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.boundedNameMatch.{matchLabel}.{size}"
@@ -3803,7 +2700,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.templateTagMatch.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)"
+        {
+          "java": "(?s)(<template\\s+name\\s*>.*?<\\s*/\\s*template[ \\t]*)([^>]|$)",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?s)(<template(?-u:\\s)+name(?-u:\\s)*>.*?<(?-u:\\s)*/(?-u:\\s)*template[ \\t]*)([^>]|$)",
+              "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "(?s)(<template[ \\t\\n\\x0B\\f\\r]+name[ \\t\\n\\x0B\\f\\r]*>.*?<[ \\t\\n\\x0B\\f\\r]*/[ \\t\\n\\x0B\\f\\r]*template[ \\t]*)([^>]|$)",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.templateTagMatch.{matchLabel}.{size}"
@@ -3869,7 +2778,15 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.unprefixedWordBoundary.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "\\b[a-zA-Z]{3,5}\\b"
+        {
+          "java": "\\b[a-zA-Z]{3,5}\\b",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?-u:\\b)[a-zA-Z]{3,5}(?-u:\\b)",
+              "reason": "Rust regex gives word boundaries Unicode semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.unprefixedWordBoundary.{matchLabel}.{size}"
@@ -3898,7 +2815,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.fruitSearchQuery.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "(?is).*\\b(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)\\b.*"
+        {
+          "java": "(?is).*\\b(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)\\b.*",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?is).*(?-u:\\b)(apples?.*for banana|cherry.*dates?|elderberry lists?|fig lists?|grape lists?)(?-u:\\b).*",
+              "reason": "Rust regex gives word boundaries Unicode semantics"
+            },
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.fruitSearchQuery.{matchLabel}.{size}"
@@ -3923,7 +2852,15 @@
         ]
       },
       "arguments": {
-        "replacement": "$1"
+        "replacement": {
+          "java": "$1",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        }
       },
       "requirements": [
         "numberedReplacement"
@@ -3980,7 +2917,15 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.jsonBlock.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "(\\{[\\s\\S]*\\})"
+        {
+          "java": "(\\{[\\s\\S]*\\})",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(\\{(?s:.)*\\})",
+              "reason": "Rust regex gives \\s and \\S Unicode semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.jsonBlock.{matchLabel}.{size}"
@@ -4077,7 +3022,19 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.layoutBlock.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>"
+        {
+          "java": "(?s)<block>\\n(\\s)*# (category|group)_defined:.*?\\n</block>",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "(?s)<block>\\n((?-u:\\s))*# (category|group)_defined:.*?\\n</block>",
+              "reason": "Rust regex gives \\s Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "(?s)<block>\\n([ \\t\\n\\x0B\\f\\r])*# (category|group)_defined:.*?\\n</block>",
+              "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "realWorldRegex.layoutBlock.{matchLabel}.{size}"
@@ -4789,7 +3746,19 @@
       "id": "CompileBenchmark.compileMedium",
       "operation": "compile",
       "patterns": [
-        "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})"
+        {
+          "java": "(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})",
+              "reason": "Rust regex gives \\d Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})",
+              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputRepresentations": [
         "javaString",
@@ -4906,7 +3875,19 @@
       "id": "CaptureScalingBenchmark.capture10",
       "operation": "captureGroups",
       "patterns": [
-        "(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+)"
+        {
+          "java": "(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+);(\\w+)=(\\w+)",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+)",
+              "reason": "Rust regex gives \\w Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+);([A-Za-z0-9_]+)=([A-Za-z0-9_]+)",
+              "reason": ".NET gives \\w Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "captureScaling.capture10.input"
@@ -4938,7 +3919,19 @@
       "id": "RegexBenchmark.captureGroups",
       "operation": "captureGroups",
       "patterns": [
-        "(\\d{4})-(\\d{2})-(\\d{2})"
+        {
+          "java": "(\\d{4})-(\\d{2})-(\\d{2})",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})",
+              "reason": "Rust regex gives \\d Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "([0-9]{4})-([0-9]{2})-([0-9]{2})",
+              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "crossEngine.RegexBenchmark.captureGroups.input"
@@ -5050,6 +4043,10 @@
             "rust-regex": {
               "replacement": "${2}${1}ay",
               "reason": "Rust replacement references need braces before adjacent letters"
+            },
+            "re2-cpp": {
+              "replacement": "\\2\\1ay",
+              "reason": "C++ RE2 uses backslash-number capture references"
             }
           }
         }
@@ -5062,7 +4059,19 @@
       "id": "ReplaceBenchmark.digitReplaceAll",
       "operation": "replaceAll",
       "patterns": [
-        "\\d+"
+        {
+          "java": "\\d+",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "[0-9]+",
+              "reason": "Rust regex gives \\d Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "[0-9]+",
+              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "replace.digitReplaceAll.input"
@@ -5141,7 +4150,19 @@
       "id": "Issue481ScalingBenchmark.splitWords.128",
       "operation": "splitLengthSum",
       "patterns": [
-        "\\W+"
+        {
+          "java": "\\W+",
+          "alternates": {
+            "rust-regex": {
+              "pattern": "[^A-Za-z0-9_]+",
+              "reason": "Rust regex gives \\W Unicode semantics"
+            },
+            "dotnet": {
+              "pattern": "[^A-Za-z0-9_]+",
+              "reason": ".NET gives \\W Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "issue481Scaling.splitW.128"
@@ -5801,7 +4822,15 @@
       "id": "Issue488ReplaceAllBenchmark.lazyAlt.1000",
       "operation": "replaceAll",
       "patterns": [
-        "(?i)(?s)\\s*\\n*(?:<block>|\\[block\\])\\s*\\n?renderElement\\(.*?\\)\\s*\\n?(?:</block>|\\[/block\\])"
+        {
+          "java": "(?i)(?s)\\s*\\n*(?:<block>|\\[block\\])\\s*\\n?renderElement\\(.*?\\)\\s*\\n?(?:</block>|\\[/block\\])",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "issue488ReplaceAll.lazyAlt.1000"
@@ -5836,7 +4865,15 @@
         ]
       },
       "arguments": {
-        "replacement": "$1<tag type=\"custom\""
+        "replacement": {
+          "java": "$1<tag type=\"custom\"",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1<tag type=\"custom\"",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        }
       },
       "requirements": [
         "numberedReplacement"
@@ -5980,7 +5017,15 @@
       "id": "MatcherApiBenchmark.lookingAt",
       "operation": "lookingAt",
       "patterns": [
-        "[A-Za-z]+:\\s+\\d+"
+        {
+          "java": "[A-Za-z]+:\\s+\\d+",
+          "alternates": {
+            "dotnet": {
+              "pattern": "[A-Za-z]+:[ \\t\\n\\x0B\\f\\r]+[0-9]+",
+              "reason": ".NET gives \\s and \\d Unicode semantics while Java defaults to ASCII"
+            }
+          }
+        }
       ],
       "inputs": [
         "matcherApi.lookingAt.input"
@@ -8181,7 +7226,15 @@
         "utf8.replacement.numbered"
       ],
       "arguments": {
-        "replacement": "$1=[$2]"
+        "replacement": {
+          "java": "$1=[$2]",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1=[\\2]",
+              "reason": "C++ RE2 uses backslash-number capture references"
+            }
+          }
+        }
       },
       "resultConsumption": "integer",
       "measurement": {
@@ -8202,7 +7255,15 @@
         "utf8.replacement.named"
       ],
       "arguments": {
-        "replacement": "${key}=[${value}]"
+        "replacement": {
+          "java": "${key}=[${value}]",
+          "alternates": {
+            "re2-cpp": {
+              "replacement": "\\1=[\\2]",
+              "reason": "C++ RE2 replacements reference named captures by number"
+            }
+          }
+        }
       },
       "resultConsumption": "integer",
       "measurement": {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4068,7 +4068,12 @@
             },
             "dotnet": {
               "pattern": "[0-9]+",
-              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+              "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII",
+              "flagSets": [
+                "0",
+                "CASE_INSENSITIVE",
+                "CASE_INSENSITIVE_UNICODE_CASE"
+              ]
             }
           }
         }
@@ -5521,7 +5526,12 @@
               "alternates": {
                 "dotnet": {
                   "pattern": "[A-Za-z0-9_]+",
-                  "reason": ".NET gives \\w Unicode semantics while Java defaults to ASCII"
+                  "reason": ".NET gives \\w Unicode semantics while Java defaults to ASCII",
+                  "flagSets": [
+                    "0",
+                    "CASE_INSENSITIVE",
+                    "CASE_INSENSITIVE_UNICODE_CASE"
+                  ]
                 }
               }
             }
@@ -5533,7 +5543,12 @@
               "alternates": {
                 "dotnet": {
                   "pattern": "[0-9]+",
-                  "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
+                  "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII",
+                  "flagSets": [
+                    "0",
+                    "CASE_INSENSITIVE",
+                    "CASE_INSENSITIVE_UNICODE_CASE"
+                  ]
                 }
               }
             }
@@ -5545,7 +5560,12 @@
               "alternates": {
                 "dotnet": {
                   "pattern": "[ \\t\\n\\x0B\\f\\r]+",
-                  "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII"
+                  "reason": ".NET gives \\s Unicode semantics while Java defaults to ASCII",
+                  "flagSets": [
+                    "0",
+                    "CASE_INSENSITIVE",
+                    "CASE_INSENSITIVE_UNICODE_CASE"
+                  ]
                 }
               }
             }

--- a/safere-benchmarks/cpp/native_regex_benchmark.cc
+++ b/safere-benchmarks/cpp/native_regex_benchmark.cc
@@ -46,22 +46,13 @@ using json = nlohmann::json;
 
 #ifdef SAFERE_PCRE2_JIT
 constexpr const char* kEngineId = "pcre2_jit";
-constexpr const char* kPatternProfileId = "pcre2";
-constexpr const char* kReplacementProfileId = "pcre2";
-constexpr bool kSupportsLinearTimeWorkloads = false;
-constexpr bool kSupportsMeasuredReplacementWorkloads = false;
 #else
 constexpr const char* kEngineId = "re2_cpp";
-constexpr const char* kPatternProfileId = "re2";
-constexpr const char* kReplacementProfileId = "re2-cpp";
-constexpr bool kSupportsLinearTimeWorkloads = true;
-constexpr bool kSupportsMeasuredReplacementWorkloads = true;
 #endif
 
 json benchmark_input_manifest;
+json benchmark_execution_plan;
 std::filesystem::path benchmark_input_directory;
-std::unordered_map<std::string, std::string> benchmark_pattern_profile;
-std::unordered_map<std::string, std::string> benchmark_replacement_profile;
 
 std::string sha256_hex(std::string_view input) {
   static constexpr std::array<uint32_t, 64> kRoundConstants = {
@@ -232,11 +223,14 @@ BenchResult measure(const std::string& name,
   double sum = 0;
   for (double s : samples) sum += s;
   double mean = sum / samples.size();
-  double var = 0;
-  for (double s : samples) var += (s - mean) * (s - mean);
-  double stddev = std::sqrt(var / (samples.size() - 1));
-  // t-value for 99.9% CI with 9 df ≈ 4.781
-  double error = 4.781 * stddev / std::sqrt(samples.size());
+  double error = 0;
+  if (samples.size() > 1) {
+    double var = 0;
+    for (double s : samples) var += (s - mean) * (s - mean);
+    double stddev = std::sqrt(var / (samples.size() - 1));
+    // t-value for 99.9% CI with 9 df ≈ 4.781
+    error = 4.781 * stddev / std::sqrt(samples.size());
+  }
 
   return {name, mean, error, unit};
 }
@@ -291,54 +285,12 @@ json load_benchmark_manifest(const std::string& manifest_path_string) {
     exit(1);
   }
   benchmark_input_manifest = manifest.at("inputs");
-  json benchmark_data = manifest.at("benchmarkData");
-  if (benchmark_data.contains("patternProfiles")) {
-    const auto& profiles = benchmark_data.at("patternProfiles");
-    if (profiles.contains(kPatternProfileId)) {
-      for (const auto& entry : profiles.at(kPatternProfileId)) {
-        benchmark_pattern_profile.emplace(
-            entry.at("java").get<std::string>(),
-            entry.at("alternate").get<std::string>());
-      }
-    }
+  benchmark_execution_plan = manifest.at("executionPlan");
+  if (benchmark_execution_plan.at("version").get<int>() != 1) {
+    fprintf(stderr, "ERROR: unsupported benchmark execution-plan version\n");
+    exit(1);
   }
-  if (benchmark_data.contains("replacementProfiles")) {
-    const auto& profiles = benchmark_data.at("replacementProfiles");
-    if (profiles.contains(kReplacementProfileId)) {
-      for (const auto& entry : profiles.at(kReplacementProfileId)) {
-        benchmark_replacement_profile.emplace(
-            entry.at("java").get<std::string>(),
-            entry.at("alternate").get<std::string>());
-      }
-    }
-  }
-  return benchmark_data;
-}
-
-std::string select_pattern(const std::string& java_pattern) {
-  auto alternate = benchmark_pattern_profile.find(java_pattern);
-  return alternate == benchmark_pattern_profile.end()
-             ? java_pattern
-             : alternate->second;
-}
-
-std::string select_replacement(const std::string& java_replacement) {
-  auto alternate = benchmark_replacement_profile.find(java_replacement);
-  return alternate == benchmark_replacement_profile.end()
-             ? java_replacement
-             : alternate->second;
-}
-
-void validate_pattern_profile() {
-  for (const auto& [java_pattern, alternate] : benchmark_pattern_profile) {
-    RE2 pattern(alternate);
-    if (!pattern.ok()) {
-      fprintf(
-          stderr, "ERROR: %s pattern alternate for %s does not compile\n",
-          kPatternProfileId, java_pattern.c_str());
-      exit(1);
-    }
-  }
+  return benchmark_execution_plan;
 }
 
 std::string load_benchmark_input(const std::string& key) {
@@ -382,766 +334,253 @@ std::string load_benchmark_input(const std::string& key) {
 // Benchmark implementations
 // ---------------------------------------------------------------------------
 
-void run_regex_benchmarks(const json& data,
-                          const std::vector<std::string>& filters) {
-  const auto& sec = data["regex"];
 
-  RE2 hello(select_pattern(sec["literalMatch"]["pattern"].get<std::string>()));
-  RE2 alpha(select_pattern(sec["charClassMatch"]["pattern"].get<std::string>()));
-  RE2 alt(select_pattern(sec["alternationFind"]["pattern"].get<std::string>()));
-  RE2 date(select_pattern(sec["captureGroups"]["pattern"].get<std::string>()));
-  RE2 find_ing(select_pattern(sec["findInText"]["pattern"].get<std::string>()));
-  RE2 email(select_pattern(sec["emailFind"]["pattern"].get<std::string>()));
-
-  std::string hello_text = sec["literalMatch"]["text"];
-  std::string alpha_text = sec["charClassMatch"]["text"];
-  std::string alt_text = sec["alternationFind"]["text"];
-  std::string date_text = sec["captureGroups"]["text"];
-  std::string prose = sec["findInText"]["text"];
-  std::string email_text = sec["emailFind"]["text"];
-  int capture_groups = sec["captureGroups"]["groups"];
-
-  auto run = [&](const std::string& name, const std::function<void()>& fn) {
-    if (matches_filter(name, filters)) {
-      print_json(measure(name, fn));
-    }
-  };
-
-  run("RegexBenchmark.literalMatch", [&]() {
-    do_not_optimize(RE2::FullMatch(hello_text, hello));
-  });
-  run("RegexBenchmark.charClassMatch", [&]() {
-    do_not_optimize(RE2::FullMatch(alpha_text, alpha));
-  });
-  run("RegexBenchmark.alternationFind", [&]() {
-    re2::StringPiece input(alt_text);
-    int count = 0;
-    std::string match;
-    while (RE2::FindAndConsume(&input, alt, &match)) { ++count; }
-    do_not_optimize(count);
-  });
-  run("RegexBenchmark.captureGroups", [&]() {
-    if (capture_groups == 3) {
-      std::string g1, g2, g3;
-      RE2::FullMatch(date_text, date, &g1, &g2, &g3);
-      do_not_optimize(g1);
-    } else {
-      do_not_optimize(RE2::FullMatch(date_text, date));
-    }
-  });
-  run("RegexBenchmark.findInText", [&]() {
-    re2::StringPiece input(prose);
-    int count = 0;
-    std::string match;
-    while (RE2::FindAndConsume(&input, find_ing, &match)) { ++count; }
-    do_not_optimize(count);
-  });
-  run("RegexBenchmark.emailFind", [&]() {
-    do_not_optimize(RE2::PartialMatch(email_text, email));
-  });
+size_t advance_utf8(const std::string& text, size_t position) {
+  if (position >= text.size()) return position + 1;
+  position++;
+  while (position < text.size() &&
+         (static_cast<unsigned char>(text[position]) & 0xc0) == 0x80) {
+    position++;
+  }
+  return position;
 }
 
-void run_application_benchmarks(const json& data,
-                                const std::vector<std::string>& filters) {
-  auto run = [&](const std::string& name, const std::function<void()>& fn) {
-    if (matches_filter(name, filters)) {
-      print_json(measure(name, fn));
-    }
-  };
+std::vector<re2::StringPiece> next_match(
+    const RE2& regex, const std::string& text, size_t start,
+    int capture_count, RE2::Anchor anchor = RE2::UNANCHORED) {
+  std::vector<re2::StringPiece> matches(capture_count);
+  if (!regex.Match(
+          text, start, text.size(), anchor, matches.data(), capture_count)) {
+    matches.clear();
+  }
+  return matches;
+}
 
-  struct AppCase {
-    std::string name;
-    std::string op;
-    std::string pattern;
+size_t piece_start(
+    const std::string& text, const re2::StringPiece& piece) {
+  return static_cast<size_t>(piece.data() - text.data());
+}
+
+json execute_workload(
+    const json& entry, const std::vector<std::unique_ptr<RE2>>& regexes,
+    const std::vector<std::string>& texts) {
+  const std::string operation = entry.at("operation");
+  const json& arguments = entry.at("arguments");
+  const std::string text = texts.empty() ? std::string() : texts.front();
+  const RE2& regex = *regexes.front();
+  std::vector<int> groups =
+      arguments.contains("groups")
+          ? arguments.at("groups").get<std::vector<int>>()
+          : std::vector<int>();
+  int group = arguments.value("group", 0);
+  int capture_count = 1;
+  for (int selected : groups) capture_count = std::max(capture_count, selected + 1);
+  capture_count = std::max(capture_count, group + 1);
+
+  if (operation == "compile") {
+    auto compiled =
+        std::make_unique<RE2>(entry.at("patterns").at(0).get<std::string>());
+    return compiled->ok();
+  }
+  if (operation == "matches") {
+    return regex.Match(
+        text, 0, text.size(), RE2::ANCHOR_BOTH, nullptr, 0);
+  }
+  if (operation == "find") {
+    return regex.Match(
+        text, 0, text.size(), RE2::UNANCHORED, nullptr, 0);
+  }
+  if (operation == "matchesCorpus") {
+    int count = 0;
+    for (const auto& candidate : texts) {
+      count += regex.Match(
+          candidate, 0, candidate.size(), RE2::ANCHOR_BOTH, nullptr, 0);
+    }
+    return count;
+  }
+  if (operation == "matchesGroupLengthSum") {
+    int total = 0;
+    for (const auto& candidate : texts) {
+      auto matches = next_match(
+          regex, candidate, 0, capture_count, RE2::ANCHOR_BOTH);
+      for (int selected : groups) {
+        if (!matches.empty() && matches[selected].data() != nullptr) {
+          total += matches[selected].size();
+        }
+      }
+    }
+    return total;
+  }
+  if (operation == "captureGroups") {
+    std::string result;
+    auto matches =
+        next_match(regex, text, 0, capture_count, RE2::ANCHOR_BOTH);
+    for (int selected : groups) {
+      if (!matches.empty() && matches[selected].data() != nullptr) {
+        result.append(matches[selected].data(), matches[selected].size());
+      }
+    }
+    return result;
+  }
+  if (operation == "findGroupPresent" || operation == "findGroup") {
+    auto matches = next_match(regex, text, 0, capture_count);
+    bool present =
+        !matches.empty() && matches[group].data() != nullptr;
+    if (operation == "findGroupPresent") return present;
+    return present
+               ? std::string(matches[group].data(), matches[group].size())
+               : std::string();
+  }
+  if (operation == "replaceFirst" || operation == "replaceAll") {
+    std::string result = text;
+    std::string replacement = arguments.value("replacement", "");
+    if (operation == "replaceFirst") {
+      RE2::Replace(&result, regex, replacement);
+    } else {
+      RE2::GlobalReplace(&result, regex, replacement);
+    }
+    return result;
+  }
+  if (operation == "replaceAllLengthSum") {
+    int total = 0;
+    std::string replacement = arguments.value("replacement", "");
+    for (const auto& item : regexes) {
+      std::string result = text;
+      RE2::GlobalReplace(&result, *item, replacement);
+      total += result.size();
+    }
+    return total;
+  }
+
+  int count = 0;
+  int total = 0;
+  size_t start = 0;
+  size_t previous = 0;
+  std::vector<std::string> split_parts;
+  int limit = arguments.value("limit", 0);
+  while (start <= text.size()) {
+    auto matches = next_match(regex, text, start, capture_count);
+    if (matches.empty()) break;
+    size_t match_start = piece_start(text, matches[0]);
+    size_t match_end = match_start + matches[0].size();
+    if (operation == "findAllCount") count++;
+    if (operation == "findAllLengthSum") total += matches[0].size();
+    if (operation == "findAllGroupLengthSum") {
+      for (int selected : groups) {
+        if (matches[selected].data() != nullptr) {
+          total += matches[selected].size();
+        }
+      }
+    }
+    if (operation == "splitLengthSum") {
+      if (limit > 0 && static_cast<int>(split_parts.size()) == limit - 1) {
+        break;
+      }
+      split_parts.push_back(text.substr(previous, match_start - previous));
+      previous = match_end;
+    }
+    start = match_end > start ? match_end : advance_utf8(text, start);
+  }
+  if (operation == "findAllCount") return count;
+  if (operation == "findAllLengthSum" ||
+      operation == "findAllGroupLengthSum") {
+    return total;
+  }
+  if (operation == "splitLengthSum") {
+    split_parts.push_back(text.substr(previous));
+    if (limit == 0) {
+      while (!split_parts.empty() && split_parts.back().empty()) {
+        split_parts.pop_back();
+      }
+    }
+    size_t length_sum = split_parts.size();
+    for (const auto& part : split_parts) length_sum += part.size();
+    return length_sum;
+  }
+  fprintf(
+      stderr, "ERROR: unsupported runnable operation: %s\n",
+      operation.c_str());
+  exit(1);
+}
+
+void run_execution_plan(
+    const std::vector<std::string>& filters, bool smoke, bool list,
+    bool list_exclusions) {
+  for (const auto& entry : benchmark_execution_plan.at("entries")) {
+    if (entry.at("engineId") != kEngineId) continue;
+    std::string id = entry.at("workloadId");
+    if (!matches_filter(id, filters)) continue;
+    std::string status = entry.at("status");
+    if (status == "excluded") {
+      if (list_exclusions) {
+        json output = {
+            {"engine", kEngineId},
+            {"benchmark", id},
+            {"reason", entry.at("exclusion").at("reason")}};
+        printf("%s\n", output.dump().c_str());
+      }
+      continue;
+    }
+    if (status != "runnable") {
+      fprintf(stderr, "ERROR: unknown execution-plan status: %s\n",
+              status.c_str());
+      exit(1);
+    }
+    if (list) {
+      printf("%s\n", id.c_str());
+      continue;
+    }
+    if (list_exclusions) continue;
+
+    std::vector<std::unique_ptr<RE2>> regexes;
+    for (const auto& pattern : entry.at("patterns")) {
+      regexes.push_back(
+          std::make_unique<RE2>(pattern.get<std::string>()));
+      if (!regexes.back()->ok()) {
+        fprintf(stderr, "ERROR: planned pattern failed to compile: %s\n",
+                id.c_str());
+        exit(1);
+      }
+    }
     std::vector<std::string> texts;
-    std::string text;
-    std::vector<int> groups;
-    std::string replacement;
-    json expected;
-    RE2 re;
-
-    explicit AppCase(const json& item)
-        : name(item.at("name").get<std::string>()),
-          op(item.at("op").get<std::string>()),
-          pattern(select_pattern(item.at("pattern").get<std::string>())),
-          texts(item.contains("texts")
-                    ? item.at("texts").get<std::vector<std::string>>()
-                    : std::vector<std::string>()),
-          text(item.value("text", "")),
-          groups(item.contains("groups") ? item.at("groups").get<std::vector<int>>()
-                                         : std::vector<int>()),
-          replacement(item.contains("replacement")
-                          ? select_replacement(item.at("replacement").get<std::string>())
-                          : ""),
-          expected(item.at("expected")),
-          re(pattern) {}
-  };
-
-  auto max_group = [](const std::vector<int>& groups) {
-    int max = 0;
-    for (int group : groups) {
-      if (group > max) max = group;
+    for (const auto& input : entry.at("inputs")) {
+      texts.push_back(load_benchmark_input(input.get<std::string>()));
     }
-    return max;
-  };
-
-  auto group_length_sum = [](const std::vector<re2::StringPiece>& matches,
-                             const std::vector<int>& groups) {
-    int sum = 0;
-    for (int group : groups) {
-      if (group < static_cast<int>(matches.size()) && matches[group].data() != nullptr) {
-        sum += matches[group].size();
-      }
-    }
-    return sum;
-  };
-
-  auto matches_groups =
-      [&](const AppCase& app_case, const std::string& text,
-          std::vector<re2::StringPiece>* matches) {
-        int match_count = std::max(1, max_group(app_case.groups) + 1);
-        matches->assign(match_count, re2::StringPiece());
-        return app_case.re.Match(
-            text, 0, text.size(), RE2::ANCHOR_BOTH, matches->data(), match_count);
-      };
-
-  auto run_int = [&](const AppCase& app_case) {
-    if (app_case.op == "matchesCorpus") {
-      int count = 0;
-      for (const auto& text : app_case.texts) {
-        if (RE2::FullMatch(text, app_case.re)) ++count;
-      }
-      return count;
-    }
-    if (app_case.op == "matchesGroupLengthSum") {
-      int count = 0;
-      std::vector<re2::StringPiece> matches;
-      for (const auto& text : app_case.texts) {
-        if (matches_groups(app_case, text, &matches)) {
-          count += group_length_sum(matches, app_case.groups);
-        }
-      }
-      return count;
-    }
-    if (app_case.op == "findAllCount") {
-      int count = 0;
-      int start = 0;
-      std::vector<re2::StringPiece> matches(1);
-      while (start <= static_cast<int>(app_case.text.size()) &&
-             app_case.re.Match(app_case.text, start, app_case.text.size(),
-                               RE2::UNANCHORED, matches.data(), matches.size())) {
-        ++count;
-        int end = matches[0].data() - app_case.text.data() + matches[0].size();
-        start = matches[0].empty() ? end + 1 : end;
-      }
-      return count;
-    }
-    if (app_case.op == "findAllLengthSum" ||
-        app_case.op == "findAllGroupLengthSum") {
-      int count = 0;
-      int start = 0;
-      int match_count = std::max(1, max_group(app_case.groups) + 1);
-      std::vector<re2::StringPiece> matches(match_count);
-      while (start <= static_cast<int>(app_case.text.size()) &&
-             app_case.re.Match(app_case.text, start, app_case.text.size(),
-                               RE2::UNANCHORED, matches.data(), matches.size())) {
-        if (app_case.op == "findAllLengthSum") {
-          count += matches[0].size();
-        } else {
-          count += group_length_sum(matches, app_case.groups);
-        }
-        int end = matches[0].data() - app_case.text.data() + matches[0].size();
-        start = matches[0].empty() ? end + 1 : end;
-      }
-      return count;
-    }
-    fprintf(stderr, "ERROR: string op used as int op: %s\n", app_case.op.c_str());
-    exit(1);
-  };
-
-  auto run_string = [](const AppCase& app_case) {
-    std::string s = app_case.text;
-    RE2::GlobalReplace(&s, app_case.re, app_case.replacement);
-    return s;
-  };
-
-  std::vector<std::unique_ptr<AppCase>> cases;
-  for (const auto& item : data["application"]) {
-    cases.push_back(std::make_unique<AppCase>(item));
-  }
-
-  for (const auto& app_case_ptr : cases) {
-    const AppCase& app_case = *app_case_ptr;
-    if (!app_case.re.ok()) {
-      fprintf(stderr, "ERROR: invalid application pattern: %s\n",
-              app_case.name.c_str());
-      exit(1);
-    }
-    if (app_case.op == "replaceAll" &&
-        !kSupportsMeasuredReplacementWorkloads) {
-      continue;
-    }
-    if (app_case.op.rfind("findAll", 0) == 0 &&
-        RE2::PartialMatch("", app_case.re)) {
-      fprintf(stderr, "ERROR: empty-width find-all application pattern: %s\n",
-              app_case.name.c_str());
-      exit(1);
-    }
-    if (app_case.op == "replaceAll") {
-      std::string actual = run_string(app_case);
-      if (actual != app_case.expected.get<std::string>()) {
-        fprintf(stderr, "ERROR: %s expected result mismatch\n", app_case.name.c_str());
-        exit(1);
-      }
-    } else {
-      int actual = run_int(app_case);
-      if (actual != app_case.expected.get<int>()) {
-        fprintf(stderr, "ERROR: %s expected %d but was %d\n",
-                app_case.name.c_str(), app_case.expected.get<int>(), actual);
+    json expected = entry.value("expected", json());
+    if (!expected.is_null()) {
+      json actual = execute_workload(entry, regexes, texts);
+      if (actual != expected.at("value")) {
+        fprintf(
+            stderr, "ERROR: result mismatch for %s: expected %s, got %s\n",
+            id.c_str(), expected.at("value").dump().c_str(),
+            actual.dump().c_str());
         exit(1);
       }
     }
-  }
-
-  for (const auto& app_case_ptr : cases) {
-    const AppCase& app_case = *app_case_ptr;
-    if (app_case.op == "replaceAll" &&
-        !kSupportsMeasuredReplacementWorkloads) {
-      continue;
-    }
-    run("ApplicationBenchmark." + app_case.name, [&]() {
-      if (app_case.op == "replaceAll") {
-        do_not_optimize(run_string(app_case));
-      } else {
-        do_not_optimize(run_int(app_case));
-      }
-    });
-  }
-}
-
-void run_real_world_regex_benchmarks(
-    const json& data, const std::vector<std::string>& filters) {
-  const auto& sec = data["realWorldRegex"];
-  std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
-
-  struct RealWorldCase {
-    std::string name;
-    std::string op;
-    std::string pattern;
-    std::string replacement;
-    RE2 re;
-
-    explicit RealWorldCase(const json& item)
-        : name(item.at("name").get<std::string>()),
-          op(item.at("op").get<std::string>()),
-          pattern(select_pattern(item.at("pattern").get<std::string>())),
-          replacement(item.contains("replacement")
-                          ? select_replacement(
-                                item.at("replacement").get<std::string>())
-                          : ""),
-          re(pattern) {}
-  };
-
-  std::vector<std::unique_ptr<RealWorldCase>> cases;
-  for (const auto& item : sec["cases"]) {
-    cases.push_back(std::make_unique<RealWorldCase>(item));
-  }
-
-  for (const auto& case_ptr : cases) {
-    const RealWorldCase& c = *case_ptr;
-    if (!c.re.ok()) {
-      fprintf(stderr, "ERROR: invalid real-world regex pattern: %s\n",
-              c.name.c_str());
-      exit(1);
-    }
-    if (c.op != "find" && c.op != "matches" && c.op != "replaceAllEmpty" && c.op != "replaceAllGroup1" && c.op != "replaceAllLiteral") {
-      fprintf(stderr, "ERROR: invalid real-world regex op: %s\n",
-              c.op.c_str());
-      exit(1);
-    }
-  }
-
-  for (const auto& case_ptr : cases) {
-    const RealWorldCase& c = *case_ptr;
-    if (c.op.rfind("replaceAll", 0) == 0 &&
-        !kSupportsMeasuredReplacementWorkloads) {
-      continue;
-    }
-    for (bool match : {true, false}) {
-      std::string match_label = match ? "match" : "noMatch";
-      for (int size : sizes) {
-        std::string text = load_benchmark_input(
-            "realWorldRegex." + c.name + "." + match_label + "." +
-            std::to_string(size));
-        std::string name = "RealWorldRegexBenchmark.runBenchmark." + c.name +
-                           "." + match_label + "." + std::to_string(size);
-        if (!matches_filter(name, filters)) {
-          continue;
-        }
-        if (c.op == "find") {
-          print_json(measure(name, [&]() {
-            do_not_optimize(RE2::PartialMatch(text, c.re));
-          }));
-        } else if (c.op == "matches") {
-          print_json(measure(name, [&]() {
-            do_not_optimize(RE2::FullMatch(text, c.re));
-          }));
-        } else if (c.op == "replaceAllEmpty") {
-          print_json(measure(name, [&]() {
-            std::string replaced = text;
-            RE2::GlobalReplace(&replaced, c.re, c.replacement);
-            do_not_optimize(replaced);
-          }));
-        } else if (c.op == "replaceAllGroup1") {
-          print_json(measure(name, [&]() {
-            std::string replaced = text;
-            RE2::GlobalReplace(&replaced, c.re, c.replacement);
-            do_not_optimize(replaced);
-          }));
-        } else if (c.op == "replaceAllLiteral") {
-          print_json(measure(name, [&]() {
-            std::string replaced = text;
-            RE2::GlobalReplace(&replaced, c.re, c.replacement);
-            do_not_optimize(replaced);
-          }));
-        }
-      }
-    }
-  }
-}
-
-void run_compile_benchmarks(const json& data,
-                            const std::vector<std::string>& filters) {
-  const auto& sec = data["compile"];
-
-  std::string simple =
-      select_pattern(sec["simple"]["pattern"].get<std::string>());
-  std::string medium =
-      select_pattern(sec["medium"]["pattern"].get<std::string>());
-  std::string complex_pat =
-      select_pattern(sec["complex"]["pattern"].get<std::string>());
-  std::string alternation =
-      select_pattern(sec["alternation"]["pattern"].get<std::string>());
-
-  auto run = [&](const std::string& name, const std::string& pattern) {
-    if (matches_filter(name, filters)) {
-      print_json(measure(name, [&]() {
-        RE2 re(pattern);
-        do_not_optimize(re.ok());
-      }, 2, 2.0, 10, 2.0, "us/op", 1000.0));
-    }
-  };
-
-  run("CompileBenchmark.compileSimple", simple);
-  run("CompileBenchmark.compileMedium", medium);
-  run("CompileBenchmark.compileComplex", complex_pat);
-  run("CompileBenchmark.compileAlternation", alternation);
-}
-
-void run_search_scaling_benchmarks(const json& data,
-                                   const std::vector<std::string>& filters) {
-  const auto& sec = data["searchScaling"];
-  std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
-
-  RE2 easy(select_pattern(sec["patterns"]["easy"].get<std::string>()));
-  RE2 medium(select_pattern(sec["patterns"]["medium"].get<std::string>()));
-  RE2 hard(select_pattern(sec["patterns"]["hard"].get<std::string>()));
-  RE2 find_ing(select_pattern(sec["findIngPattern"].get<std::string>()));
-
-  for (int size : sizes) {
-    std::string size_string = std::to_string(size);
-    std::string random_text =
-        load_benchmark_input("searchScaling.random." + size_string);
-    std::string text_with_match =
-        load_benchmark_input("searchScaling.success." + size_string);
-    std::string prose =
-        load_benchmark_input("searchScaling.prose." + size_string);
-
-    std::string suffix = "." + std::to_string(size);
-
-    auto run = [&](const std::string& name, const std::function<void()>& fn) {
-      std::string full_name = name + suffix;
-      if (matches_filter(full_name, filters)) {
-        print_json(measure(full_name, fn, 2, 2.0, 10, 2.0, "us/op", 1000.0));
-      }
+    auto operation = [&]() {
+      do_not_optimize(execute_workload(entry, regexes, texts));
     };
-
-    run("SearchScalingBenchmark.searchEasyFail", [&]() {
-      do_not_optimize(RE2::PartialMatch(random_text, easy));
-    });
-    run("SearchScalingBenchmark.searchEasySuccess", [&]() {
-      do_not_optimize(RE2::PartialMatch(text_with_match, easy));
-    });
-    run("SearchScalingBenchmark.searchMediumFail", [&]() {
-      do_not_optimize(RE2::PartialMatch(random_text, medium));
-    });
-    run("SearchScalingBenchmark.searchHardFail", [&]() {
-      do_not_optimize(RE2::PartialMatch(random_text, hard));
-    });
-    run("SearchScalingBenchmark.findIngScaled", [&]() {
-      re2::StringPiece input(prose);
-      int count = 0;
-      std::string match;
-      while (RE2::FindAndConsume(&input, find_ing, &match)) { ++count; }
-      do_not_optimize(count);
-    });
-  }
-}
-
-void run_issue481_scaling_benchmarks(const json& data,
-                                     const std::vector<std::string>& filters) {
-  const auto& sec = data["issue481Scaling"];
-  std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
-
-  RE2 split_w(select_pattern(sec["splitW"]["pattern"].get<std::string>()));
-  RE2 block(select_pattern(sec["block"]["pattern"].get<std::string>()));
-  RE2 tag(select_pattern(sec["tag"]["pattern"].get<std::string>()));
-  RE2 scheme(select_pattern(sec["scheme"]["pattern"].get<std::string>()));
-
-  auto split_length_sum = [](const std::string& text, RE2& re) {
-    int sum = 0;
-    int count = 0;
-    int start = 0;
-    int last = 0;
-    std::vector<re2::StringPiece> matches(1);
-    while (start <= static_cast<int>(text.size()) &&
-           re.Match(text, start, text.size(), RE2::UNANCHORED,
-                    matches.data(), matches.size())) {
-      int match_start = matches[0].data() - text.data();
-      int match_end = match_start + matches[0].size();
-      ++count;
-      sum += match_start - last;
-      last = match_end;
-      start = matches[0].empty() ? match_end + 1 : match_end;
-    }
-    if (last == 0) {
-      return static_cast<int>(text.size()) + 1;
-    }
-    int trailing_length = text.size() - last;
-    if (trailing_length > 0) {
-      ++count;
-      sum += trailing_length;
-    }
-    return sum + count;
-  };
-
-  auto find = [](const std::string& text, RE2& re) {
-    return RE2::PartialMatch(text, re);
-  };
-
-  auto scheme_extract = [](const std::string& text, RE2& re) {
-    int sum = 0;
-    int start = 0;
-    std::vector<re2::StringPiece> matches(3);
-    while (start <= static_cast<int>(text.size()) &&
-           re.Match(text, start, text.size(), RE2::UNANCHORED,
-                    matches.data(), matches.size())) {
-      sum += matches[1].size();
-      sum += matches[2].size();
-      int end = matches[0].data() - text.data() + matches[0].size();
-      start = matches[0].empty() ? end + 1 : end;
-    }
-    return sum;
-  };
-
-  for (int size : sizes) {
-    std::string size_string = std::to_string(size);
-    std::string split_text =
-        load_benchmark_input("issue481Scaling.splitW." + size_string);
-    std::string block_text =
-        load_benchmark_input("issue481Scaling.block." + size_string);
-    std::string block_negative_text =
-        load_benchmark_input("issue481Scaling.blockNegative." + size_string);
-    std::string tag_text =
-        load_benchmark_input("issue481Scaling.tag." + size_string);
-    std::string tag_negative_text =
-        load_benchmark_input("issue481Scaling.tagNegative." + size_string);
-    std::string scheme_text =
-        load_benchmark_input("issue481Scaling.scheme." + size_string);
-    std::string scheme_negative_text =
-        load_benchmark_input("issue481Scaling.schemeNegative." + size_string);
-
-    std::string suffix = "." + std::to_string(size);
-    auto run = [&](const std::string& name, const std::function<void()>& fn) {
-      std::string full_name = name + suffix;
-      if (matches_filter(full_name, filters)) {
-        print_json(measure(full_name, fn, 2, 2.0, 10, 2.0, "us/op", 1000.0));
-      }
-    };
-
-    run("Issue481ScalingBenchmark.splitWords", [&]() {
-      do_not_optimize(split_length_sum(split_text, split_w));
-    });
-    run("Issue481ScalingBenchmark.blockFind", [&]() {
-      do_not_optimize(find(block_text, block));
-    });
-    run("Issue481ScalingBenchmark.blockFindNegative", [&]() {
-      do_not_optimize(find(block_negative_text, block));
-    });
-    run("Issue481ScalingBenchmark.tagFind", [&]() {
-      do_not_optimize(find(tag_text, tag));
-    });
-    run("Issue481ScalingBenchmark.tagFindNegative", [&]() {
-      do_not_optimize(find(tag_negative_text, tag));
-    });
-    run("Issue481ScalingBenchmark.schemeExtract", [&]() {
-      do_not_optimize(scheme_extract(scheme_text, scheme));
-    });
-    run("Issue481ScalingBenchmark.schemeFindNegative", [&]() {
-      do_not_optimize(find(scheme_negative_text, scheme));
-    });
-  }
-}
-
-void run_capture_scaling_benchmarks(const json& data,
-                                    const std::vector<std::string>& filters) {
-  const auto& sec = data["captureScaling"];
-
-  RE2 pat0(select_pattern(sec["capture0"]["pattern"].get<std::string>()));
-  RE2 pat1(select_pattern(sec["capture1"]["pattern"].get<std::string>()));
-  RE2 pat3(select_pattern(sec["capture3"]["pattern"].get<std::string>()));
-  RE2 pat10(select_pattern(sec["capture10"]["pattern"].get<std::string>()));
-
-  std::string text0 = sec["capture0"]["text"];
-  std::string text1 = sec["capture1"]["text"];
-  std::string text3 = sec["capture3"]["text"];
-  std::string text10 = sec["capture10"]["text"];
-
-  int groups0 = sec["capture0"]["groups"];
-  int groups1 = sec["capture1"]["groups"];
-  int groups3 = sec["capture3"]["groups"];
-  int groups10 = sec["capture10"]["groups"];
-
-  auto run = [&](const std::string& name, const std::function<void()>& fn) {
-    if (matches_filter(name, filters)) {
-      print_json(measure(name, fn));
-    }
-  };
-
-  run("CaptureScalingBenchmark.capture0", [&]() {
-    do_not_optimize(RE2::FullMatch(text0, pat0));
-  });
-  run("CaptureScalingBenchmark.capture1", [&]() {
-    std::string g1;
-    RE2::FullMatch(text1, pat1, &g1);
-    do_not_optimize(g1);
-  });
-  run("CaptureScalingBenchmark.capture3", [&]() {
-    std::string g1, g2, g3;
-    RE2::FullMatch(text3, pat3, &g1, &g2, &g3);
-    do_not_optimize(g1);
-  });
-  run("CaptureScalingBenchmark.capture10", [&]() {
-    std::string g1, g2, g3, g4, g5, g6, g7, g8, g9, g10;
-    RE2::FullMatch(text10, pat10, &g1, &g2, &g3, &g4, &g5,
-                   &g6, &g7, &g8, &g9, &g10);
-    do_not_optimize(g1);
-  });
-
-  // Suppress unused variable warnings for groups (used to validate JSON).
-  do_not_optimize(groups0);
-  do_not_optimize(groups1);
-  do_not_optimize(groups3);
-  do_not_optimize(groups10);
-}
-
-void run_http_benchmarks(const json& data,
-                         const std::vector<std::string>& filters) {
-  const auto& sec = data["http"];
-
-  RE2 http(select_pattern(sec["pattern"].get<std::string>()));
-  std::string full = sec["fullRequest"];
-  std::string small = sec["smallRequest"];
-
-  auto run = [&](const std::string& name, const std::function<void()>& fn) {
-    if (matches_filter(name, filters)) {
-      print_json(measure(name, fn));
-    }
-  };
-
-  run("HttpBenchmark.httpFull", [&]() {
-    std::string path;
-    RE2::PartialMatch(full, http, &path);
-    do_not_optimize(path);
-  });
-  run("HttpBenchmark.httpSmall", [&]() {
-    std::string path;
-    RE2::PartialMatch(small, http, &path);
-    do_not_optimize(path);
-  });
-  run("HttpBenchmark.httpExtract", [&]() {
-    std::string path;
-    RE2::PartialMatch(full, http, &path);
-    do_not_optimize(path);
-  });
-}
-
-void run_replace_benchmarks(const json& data,
-                            const std::vector<std::string>& filters) {
-  const auto& sec = data["replace"];
-
-  struct ReplaceCase {
-    std::string name;
-    std::string pattern;
-    std::string text;
-    std::string replacement;
-    std::string op;
-  };
-
-  std::vector<ReplaceCase> cases;
-  for (auto& [key, val] : sec.items()) {
-    cases.push_back({
-        key,
-        select_pattern(val["pattern"].get<std::string>()),
-        val["text"].get<std::string>(),
-        select_replacement(val["replacement"].get<std::string>()),
-        val["op"].get<std::string>()
-    });
-  }
-
-  for (const auto& c : cases) {
-    std::string bench_name = "ReplaceBenchmark." + c.name;
-    if (!matches_filter(bench_name, filters)) continue;
-
-    RE2 re(c.pattern);
-    if (c.op == "replaceFirst") {
-      print_json(measure(bench_name, [&]() {
-        std::string s = c.text;
-        RE2::Replace(&s, re, c.replacement);
-        do_not_optimize(s);
-      }));
+    std::string timing_unit = entry.at("measurement").at("timingUnit");
+    std::string unit;
+    double divisor;
+    if (timing_unit == "nanoseconds") {
+      unit = "ns/op";
+      divisor = 1;
+    } else if (timing_unit == "microseconds") {
+      unit = "us/op";
+      divisor = 1000;
+    } else if (timing_unit == "milliseconds") {
+      unit = "ms/op";
+      divisor = 1000000;
     } else {
-      print_json(measure(bench_name, [&]() {
-        std::string s = c.text;
-        RE2::GlobalReplace(&s, re, c.replacement);
-        do_not_optimize(s);
-      }));
+      fprintf(stderr, "ERROR: unsupported timing unit: %s\n",
+              timing_unit.c_str());
+      exit(1);
     }
-  }
-}
-
-void run_pathological_benchmarks(const json& data,
-                                 const std::vector<std::string>& filters) {
-  std::vector<int> ns =
-      data["pathological"]["nValues"].get<std::vector<int>>();
-
-  for (int n : ns) {
-    std::string n_string = std::to_string(n);
-    std::string regex =
-        load_benchmark_input("pathological.pattern." + n_string);
-    std::string text =
-        load_benchmark_input("pathological.text." + n_string);
-
-    std::string name =
-        "PathologicalBenchmark.pathological." + std::to_string(n);
-    if (matches_filter(name, filters)) {
-      RE2 re(select_pattern(regex));
-      print_json(measure(name, [&]() {
-        do_not_optimize(RE2::FullMatch(text, re));
-      }, 2, 2.0, 10, 2.0, "us/op", 1000.0));
-    }
-  }
-}
-
-void run_fanout_benchmarks(const json& data,
-                           const std::vector<std::string>& filters) {
-  const auto& sec = data["fanout"];
-  std::vector<int> sizes = sec["textSizes"].get<std::vector<int>>();
-
-  RE2 fanout(select_pattern(sec["unicodeFanout"]["pattern"].get<std::string>()));
-  RE2 nested(select_pattern(sec["nestedQuantifier"]["pattern"].get<std::string>()));
-
-  for (int size : sizes) {
-    std::string size_string = std::to_string(size);
-    std::string unicode_text =
-        load_benchmark_input("fanout.unicode." + size_string);
-    std::string ascii_text =
-        load_benchmark_input("fanout.ascii." + size_string);
-
-    std::string suffix = "." + std::to_string(size);
-
-    auto run = [&](const std::string& name, const std::function<void()>& fn) {
-      std::string full_name = name + suffix;
-      if (matches_filter(full_name, filters)) {
-        print_json(measure(full_name, fn, 2, 2.0, 10, 2.0, "us/op", 1000.0));
-      }
-    };
-
-    run("FanoutBenchmark.fanoutUnicode", [&]() {
-      do_not_optimize(RE2::PartialMatch(unicode_text, fanout));
-    });
-    run("FanoutBenchmark.nestedQuantifier", [&]() {
-      do_not_optimize(RE2::PartialMatch(ascii_text, nested));
-    });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Memory benchmarks
-// ---------------------------------------------------------------------------
-
-// Measure the heap allocation for compiling a single RE2 pattern when
-// mallinfo2() is available. Also reports RE2's ProgramSize() (number of
-// compiled bytecode instructions) on every platform.
-void run_memory_benchmarks(const json& data,
-                           const std::vector<std::string>& filters) {
-  const auto& compile_sec = data["compile"];
-  const auto& regex_sec = data["regex"];
-
-  struct PatternInfo {
-    std::string name;
-    std::string pattern;
-  };
-
-  std::vector<PatternInfo> patterns = {
-      {"MemoryBenchmark.compileSimple",
-       compile_sec["simple"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.compileMedium",
-       compile_sec["medium"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.compileComplex",
-       compile_sec["complex"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.compileAlternation",
-       compile_sec["alternation"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.literalMatch",
-       regex_sec["literalMatch"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.charClassMatch",
-       regex_sec["charClassMatch"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.alternationFind",
-       regex_sec["alternationFind"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.captureGroups",
-       regex_sec["captureGroups"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.findInText",
-       regex_sec["findInText"]["pattern"].get<std::string>()},
-      {"MemoryBenchmark.emailFind",
-       regex_sec["emailFind"]["pattern"].get<std::string>()},
-  };
-
-  for (const auto& pi : patterns) {
-    if (!matches_filter(pi.name, filters)) continue;
-    std::string pattern = select_pattern(pi.pattern);
-
-#ifdef SAFERE_HAVE_MALLINFO2
-    // Measure heap delta around RE2 compilation using mallinfo2().
-    struct mallinfo2 before = mallinfo2();
-#endif
-    auto re = std::make_unique<RE2>(pattern);
-#ifdef SAFERE_HAVE_MALLINFO2
-    struct mallinfo2 after = mallinfo2();
-
-    long heap_delta = static_cast<long>(after.uordblks) -
-                      static_cast<long>(before.uordblks);
-    print_memory_json(pi.name + ".heapBytes", heap_delta);
-#endif
-
-#ifndef SAFERE_PCRE2_JIT
-    // Report RE2's program size (number of bytecode instructions).
-    if (re->ok()) {
-      print_memory_json(pi.name + ".programSize",
-                        re->ProgramSize(), "instructions");
-      print_memory_json(pi.name + ".reverseProgramSize",
-                        re->ReverseProgramSize(), "instructions");
-    }
-#endif
+    BenchResult result =
+        smoke ? measure(id, operation, 0, 0, 1, 0.001, unit, divisor)
+              : measure(id, operation, 2, 2, 10, 2, unit, divisor);
+    print_json(result);
   }
 }
 
@@ -1194,35 +633,27 @@ int main(int argc, char* argv[]) {
 
   std::string manifest_path = "../../target/benchmark-corpus/manifest.json";
   std::vector<std::string> filters;
+  bool smoke = false;
+  bool list = false;
+  bool list_exclusions = false;
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
     if (arg == "--manifest" && i + 1 < argc) {
       manifest_path = argv[++i];
+    } else if (arg == "--smoke") {
+      smoke = true;
+    } else if (arg == "--list") {
+      list = true;
+    } else if (arg == "--list-exclusions") {
+      list_exclusions = true;
     } else {
       filters.push_back(arg);
     }
   }
 
-  json data = load_benchmark_manifest(manifest_path);
-  validate_pattern_profile();
-
-  run_regex_benchmarks(data, filters);
-  run_application_benchmarks(data, filters);
-  run_real_world_regex_benchmarks(data, filters);
-  run_compile_benchmarks(data, filters);
-  run_search_scaling_benchmarks(data, filters);
-  run_issue481_scaling_benchmarks(data, filters);
-  run_capture_scaling_benchmarks(data, filters);
-  run_http_benchmarks(data, filters);
-  if (kSupportsMeasuredReplacementWorkloads) {
-    run_replace_benchmarks(data, filters);
-  }
-  if (kSupportsLinearTimeWorkloads) {
-    run_pathological_benchmarks(data, filters);
-  }
-  run_fanout_benchmarks(data, filters);
-  run_memory_benchmarks(data, filters);
+  load_benchmark_manifest(manifest_path);
+  run_execution_plan(filters, smoke, list, list_exclusions);
 
   return 0;
 }

--- a/safere-benchmarks/cpp/native_regex_benchmark.cc
+++ b/safere-benchmarks/cpp/native_regex_benchmark.cc
@@ -366,7 +366,8 @@ json execute_workload(
     const std::vector<std::string>& texts) {
   const std::string operation = entry.at("operation");
   const json& arguments = entry.at("arguments");
-  const std::string text = texts.empty() ? std::string() : texts.front();
+  static const std::string empty_text;
+  const std::string& text = texts.empty() ? empty_text : texts.front();
   const RE2& regex = *regexes.front();
   std::vector<int> groups =
       arguments.contains("groups")

--- a/safere-benchmarks/dotnet/ResolvedPlanProgram.cs
+++ b/safere-benchmarks/dotnet/ResolvedPlanProgram.cs
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
 // See LICENSE file in the project root for details.
 //
-// .NET non-backtracking regex benchmark harness. It consumes the resolved
-// engine-neutral workload plan emitted by BenchmarkInputMaterializer.
+// .NET non-backtracking regex benchmark harness. It consumes the common
+// engine-specific execution plan emitted by BenchmarkInputMaterializer.
 
 using System.Diagnostics;
 using System.Globalization;
@@ -19,33 +19,8 @@ internal static class ResolvedPlanProgram
     private const string EngineName = "dotnet_nonbacktracking";
     private static readonly JsonSerializerOptions JsonOptions =
         new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-    private static readonly HashSet<string> SupportedOperations =
-    [
-        "captureGroups",
-        "compile",
-        "compileAndFind",
-        "compileAndFindRotatingUtf16",
-        "find",
-        "findAllCount",
-        "findAllGroupLengthSum",
-        "findAllLengthSum",
-        "findGroup",
-        "findGroupPresent",
-        "findRotatingUtf16",
-        "lookingAt",
-        "matches",
-        "matchesCorpus",
-        "matchesGroupLengthSum",
-        "replaceAll",
-        "replaceAllLengthSum",
-        "replaceFirst",
-        "splitLengthSum"
-    ];
-
     private static JsonObject inputs = null!;
-    private static JsonArray workloads = null!;
-    private static Dictionary<string, string> patternProfile = [];
-    private static Dictionary<string, string> replacementProfile = [];
+    private static JsonArray entries = null!;
     private static string inputDirectory = "";
     private static string manifestPath = "";
     private static volatile bool boolSink;
@@ -92,11 +67,15 @@ internal static class ResolvedPlanProgram
         List<Exclusion> exclusions = [];
         List<Prepared> prepared = [];
 
-        foreach (JsonNode? raw in workloads)
+        foreach (JsonNode? raw in entries)
         {
-            JsonObject workload = raw?.AsObject()
-                ?? throw new InvalidDataException("Null resolved workload");
-            string id = String(workload, "id");
+            JsonObject entry = raw?.AsObject()
+                ?? throw new InvalidDataException("Null execution-plan entry");
+            if (String(entry, "engineId") != EngineName)
+            {
+                continue;
+            }
+            string id = String(entry, "workloadId");
             if (options.ColdChild is not null
                 ? options.ColdChild != id
                 : !MatchesFilter(id, options.Filters))
@@ -104,35 +83,17 @@ internal static class ResolvedPlanProgram
                 continue;
             }
 
-            string? staticReason = StaticExclusionReason(workload);
-            if (staticReason is not null)
+            string status = String(entry, "status");
+            if (status == "excluded")
             {
-                exclusions.Add(new(EngineName, id, staticReason));
+                exclusions.Add(new(EngineName, id, String(entry, "exclusion.reason")));
                 continue;
             }
-
-            try
+            if (status != "runnable")
             {
-                prepared.Add(Prepare(workload, options.ColdChild == id));
+                throw new InvalidDataException($"Unknown execution status for {id}: {status}");
             }
-            catch (ArgumentException exception)
-            {
-                exclusions.Add(
-                    new(
-                        EngineName,
-                        id,
-                        "pattern is not accepted by .NET non-backtracking mode: "
-                            + FirstLine(exception.Message)));
-            }
-            catch (NotSupportedException exception)
-            {
-                exclusions.Add(
-                    new(
-                        EngineName,
-                        id,
-                        "pattern is not supported by .NET non-backtracking mode: "
-                            + FirstLine(exception.Message)));
-            }
+            prepared.Add(Prepare(entry, options.ColdChild == id));
         }
 
         if (options.ColdChild is not null)
@@ -226,156 +187,19 @@ internal static class ResolvedPlanProgram
 
         inputDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath))!;
         inputs = manifest["inputs"]!.AsObject();
-        workloads = manifest["resolvedWorkloads"]?.AsArray()
+        JsonObject executionPlan = manifest["executionPlan"]?.AsObject()
             ?? throw new InvalidDataException(
-                "Manifest has no resolvedWorkloads; rerun materialize-benchmark-inputs.sh");
-        patternProfile = LoadProfile(
-            manifest["benchmarkData"]!,
-            "patternProfiles",
-            "dotnet");
-        replacementProfile = LoadProfile(
-            manifest["benchmarkData"]!,
-            "replacementProfiles",
-            "dotnet");
-    }
-
-    private static Dictionary<string, string> LoadProfile(
-        JsonNode data,
-        string registry,
-        string profileId)
-    {
-        Dictionary<string, string> result = [];
-        JsonArray? entries = data[registry]?[profileId]?.AsArray();
-        if (entries is null)
+                "Manifest has no executionPlan; rerun materialize-benchmark-inputs.sh");
+        if (executionPlan["version"]!.GetValue<int>() != 1)
         {
-            return result;
+            throw new InvalidDataException("Unsupported benchmark execution-plan version");
         }
-        foreach (JsonNode? rawEntry in entries)
-        {
-            JsonNode entry = rawEntry
-                ?? throw new InvalidDataException(
-                    $"Null {registry} entry: {profileId}");
-            result.Add(String(entry, "java"), String(entry, "alternate"));
-        }
-        return result;
-    }
-
-    private static string? StaticExclusionReason(JsonObject workload)
-    {
-        string operation = String(workload, "operation");
-        if (!SupportedOperations.Contains(operation))
-        {
-            return operation switch
-            {
-                "analyzePattern" or "cachedAnalysis" or "compileAndAnalyze"
-                    or "diagnosticsFind" =>
-                    "SafeRE diagnostics have no .NET Regex equivalent",
-                "dfaCacheGrowth" => ".NET does not expose its regex-engine cache state",
-                "patternSetMatches" => ".NET Regex has no compiled multi-pattern set API",
-                "matcherConstruction" or "utf8CaptureBounds" or "utf8DecodeFind"
-                    or "utf8Replacement" =>
-                    "workload measures SafeRE's byte-oriented UTF-8 API",
-                "manualReplaceAll" =>
-                    ".NET Regex has no append-replacement and append-tail matcher API",
-                "matcherRegionFind" or "matcherResetFind" =>
-                    ".NET Regex has no retained mutable matcher lifecycle",
-                _ => $"operation is not implemented by the .NET runner: {operation}"
-            };
-        }
-
-        string mode = String(workload, "measurement.mode");
-        if (mode == "retainedMemory")
-        {
-            return "retained-heap measurement is not available from the .NET Regex API";
-        }
-        if (mode is not ("averageTime" or "compileOnly" or "singleShotColdStart"))
-        {
-            return $"measurement mode is not implemented by the .NET runner: {mode}";
-        }
-
-        HashSet<string> representations =
-            Strings(workload, "inputRepresentations").ToHashSet();
-        if (!representations.Contains("javaString"))
-        {
-            return "workload has no UTF-16 string representation";
-        }
-
-        string flagSet = OptionalString(workload["arguments"], "flagSet") ?? "0";
-        if (flagSet == "CASE_INSENSITIVE")
-        {
-            return ".NET cannot combine non-backtracking mode with Java's ASCII-only "
-                + "case-insensitive semantics";
-        }
-        string[] patterns = Strings(workload, "patterns");
-        if (patterns.Any(EnablesInlineCaseInsensitive))
-        {
-            return ".NET inline case-insensitive matching is Unicode-aware, unlike Java's "
-                + "default ASCII-only mode";
-        }
-        bool unicodeCharacterClass = flagSet.Contains(
-            "UNICODE_CHARACTER_CLASS",
-            StringComparison.Ordinal);
-        if (!unicodeCharacterClass && patterns.Any(UsesJavaAsciiShorthand))
-        {
-            return ".NET gives \\d, \\s, and \\w Unicode semantics while Java defaults "
-                + "to ASCII semantics";
-        }
-        return null;
-    }
-
-    private static bool UsesJavaAsciiShorthand(string pattern)
-    {
-        for (int i = 0; i + 1 < pattern.Length; i++)
-        {
-            if (pattern[i] != '\\')
-            {
-                continue;
-            }
-            if ("dDsSwW".Contains(pattern[i + 1]))
-            {
-                return true;
-            }
-            i++;
-        }
-        return false;
-    }
-
-    private static bool EnablesInlineCaseInsensitive(string pattern)
-    {
-        for (int start = 0; start + 2 < pattern.Length; start++)
-        {
-            if (pattern[start] != '(' || pattern[start + 1] != '?')
-            {
-                continue;
-            }
-            bool enabled = true;
-            for (int i = start + 2; i < pattern.Length; i++)
-            {
-                char current = pattern[i];
-                if (current is ':' or ')')
-                {
-                    break;
-                }
-                if (current == '-')
-                {
-                    enabled = false;
-                }
-                else if (current == 'i' && enabled)
-                {
-                    return true;
-                }
-                else if (!char.IsAsciiLetter(current))
-                {
-                    break;
-                }
-            }
-        }
-        return false;
+        entries = executionPlan["entries"]!.AsArray();
     }
 
     private static Prepared Prepare(JsonObject workload, bool skipPatternProbe)
     {
-        string id = String(workload, "id");
+        string id = String(workload, "workloadId");
         string operation = String(workload, "operation");
         string mode = String(workload, "measurement.mode");
         string unit = String(workload, "measurement.timingUnit") switch
@@ -386,11 +210,8 @@ internal static class ResolvedPlanProgram
             string other => throw new InvalidDataException(
                 $"Unsupported timing unit for {id}: {other}")
         };
-        string flagSet = OptionalString(workload["arguments"], "flagSet") ?? "0";
-        RegexOptions options = OptionsFor(flagSet);
-        string[] patternSources = Strings(workload, "patterns")
-            .Select(SelectPattern)
-            .ToArray();
+        RegexOptions options = OptionsFor(Strings(workload, "options"));
+        string[] patternSources = Strings(workload, "patterns");
         foreach (string pattern in patternSources)
         {
             if (!skipPatternProbe)
@@ -440,8 +261,7 @@ internal static class ResolvedPlanProgram
         JsonNode arguments = workload["arguments"]!;
         int[] groups = OptionalInts(arguments, "groups");
         int group = OptionalInt(arguments, "group") ?? 0;
-        string replacement = SelectReplacement(
-            OptionalString(arguments, "replacement") ?? "");
+        string replacement = OptionalString(arguments, "replacement") ?? "";
         int limit = OptionalInt(arguments, "limit") ?? 0;
         int seed = OptionalInt(arguments, "seed") ?? 0;
         int count = OptionalInt(arguments, "count") ?? 0;
@@ -656,21 +476,23 @@ internal static class ResolvedPlanProgram
             workload.Unit);
     }
 
-    private static RegexOptions OptionsFor(string flagSet) =>
-        flagSet switch
+    private static RegexOptions OptionsFor(IEnumerable<string> options)
+    {
+        HashSet<string> selected = options.ToHashSet();
+        selected.Remove("unicodeCase");
+        selected.Remove("unicodeCharacterClass");
+        RegexOptions result = BaseOptions;
+        if (selected.Remove("caseInsensitive"))
         {
-            "0" or "UNICODE_CHARACTER_CLASS" => BaseOptions,
-            "CASE_INSENSITIVE" or "CASE_INSENSITIVE_UNICODE_CASE"
-                or "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS" =>
-                BaseOptions | RegexOptions.IgnoreCase,
-            _ => throw new NotSupportedException($"Java flag set has no mapping: {flagSet}")
-        };
-
-    private static string SelectPattern(string javaPattern) =>
-        patternProfile.GetValueOrDefault(javaPattern, javaPattern);
-
-    private static string SelectReplacement(string javaReplacement) =>
-        replacementProfile.GetValueOrDefault(javaReplacement, javaReplacement);
+            result |= RegexOptions.IgnoreCase;
+        }
+        if (selected.Count != 0)
+        {
+            throw new InvalidDataException(
+                $"Unsupported materialized .NET options: {string.Join(",", selected)}");
+        }
+        return result;
+    }
 
     private static string LoadBenchmarkInput(string key)
     {
@@ -740,28 +562,12 @@ internal static class ResolvedPlanProgram
             throw new InvalidOperationException(
                 "Java Random compatibility self-test produced the wrong UTF-16 sequence");
         }
-        if (!UsesJavaAsciiShorthand(@"\d+")
-            || UsesJavaAsciiShorthand(@"\\d+")
-            || !EnablesInlineCaseInsensitive("(?is)abc")
-            || !EnablesInlineCaseInsensitive("(?mi:abc)")
-            || EnablesInlineCaseInsensitive("(?-i:abc)"))
-        {
-            throw new InvalidOperationException(
-                "Java regex compatibility classification self-test failed");
-        }
         Regex letterWithoutUppercase =
             new(@"[\p{L}-[\p{Lu}]]+", BaseOptions);
         if (!letterWithoutUppercase.IsMatch("a") || letterWithoutUppercase.IsMatch("A"))
         {
             throw new InvalidOperationException(
                 ".NET character-class subtraction self-test failed");
-        }
-        replacementProfile = new() { ["$1word"] = "${1}word" };
-        if (SelectReplacement("$1word") != "${1}word"
-            || SelectReplacement("$1") != "$1")
-        {
-            throw new InvalidOperationException(
-                ".NET replacement-profile selection self-test failed");
         }
         return 0;
     }
@@ -801,10 +607,6 @@ internal static class ResolvedPlanProgram
 
     private static bool MatchesFilter(string name, IReadOnlyCollection<string> filters) =>
         filters.Count == 0 || filters.Any(name.Contains);
-
-    private static string FirstLine(string value) =>
-        value.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()
-            ?? value;
 
     private static JsonNode Get(JsonNode node, string path)
     {

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -163,7 +163,11 @@ func capturedText(text string, indices []int, groups []int) string {
 }
 
 func splitLengthSum(re *regexp.Regexp, text string, limit int) int {
-	parts := re.Split(text, limit)
+	goLimit := limit
+	if limit == 0 {
+		goLimit = -1
+	}
+	parts := re.Split(text, goLimit)
 	if limit == 0 {
 		for len(parts) > 0 && parts[len(parts)-1] == "" {
 			parts = parts[:len(parts)-1]

--- a/safere-benchmarks/go/regexp_benchmark.go
+++ b/safere-benchmarks/go/regexp_benchmark.go
@@ -1,20 +1,8 @@
 // Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
 // See LICENSE file in the project root for details.
 //
-// Go regexp benchmark harness. Runs the same patterns and inputs as the Java
-// JMH benchmarks and outputs JSON lines for cross-language comparison.
-// Patterns and inputs are loaded from a shared JSON data file.
-//
-// Build:
-//
-//	cd safere-benchmarks/go && go build -o regexp_benchmark .
-//
-// Run:
-//
-//	./regexp_benchmark [--manifest path/to/manifest.json] [filter...]
-//
-// Each filter is a substring match against benchmark names. If no filters
-// are given, all benchmarks are run.
+// Go regexp benchmark harness. The materialized execution plan is the sole
+// source of workload selection, engine syntax, arguments, and exclusions.
 package main
 
 import (
@@ -30,9 +18,51 @@ import (
 	"time"
 )
 
-// ---------------------------------------------------------------------------
-// Harness
-// ---------------------------------------------------------------------------
+const engineID = "go_regexp"
+
+type materializedInput struct {
+	File      string `json:"file"`
+	UTF8Bytes int    `json:"utf8Bytes"`
+	SHA256    string `json:"sha256"`
+}
+
+type measurement struct {
+	Mode       string `json:"mode"`
+	TimingUnit string `json:"timingUnit"`
+}
+
+type exclusion struct {
+	Kind   string `json:"kind"`
+	Reason string `json:"reason"`
+}
+
+type expectedResult struct {
+	Type  string `json:"type"`
+	Value any    `json:"value"`
+}
+
+type planEntry struct {
+	EngineID    string          `json:"engineId"`
+	WorkloadID  string          `json:"workloadId"`
+	Operation   string          `json:"operation"`
+	Status      string          `json:"status"`
+	Patterns    []string        `json:"patterns"`
+	Inputs      []string        `json:"inputs"`
+	Arguments   map[string]any  `json:"arguments"`
+	Options     []string        `json:"options"`
+	Measurement measurement     `json:"measurement"`
+	Expected    *expectedResult `json:"expected"`
+	Exclusion   *exclusion      `json:"exclusion"`
+}
+
+type manifest struct {
+	Version       int                          `json:"version"`
+	Inputs        map[string]materializedInput `json:"inputs"`
+	ExecutionPlan struct {
+		Version int         `json:"version"`
+		Entries []planEntry `json:"entries"`
+	} `json:"executionPlan"`
+}
 
 type benchResult struct {
 	Engine    string  `json:"engine"`
@@ -42,912 +72,377 @@ type benchResult struct {
 	Unit      string  `json:"unit"`
 }
 
-// measure runs fn in a warmup phase then a measurement phase, returning
-// the mean time per operation and 99.9% CI half-width.
-func measure(name string, fn func(), warmupIters int, warmupTime time.Duration,
-	measureIters int, measureTime time.Duration, unit string, unitDivisor float64) benchResult {
+type reportedExclusion struct {
+	Engine    string `json:"engine"`
+	Benchmark string `json:"benchmark"`
+	Reason    string `json:"reason"`
+}
 
-	// Warmup.
-	for w := 0; w < warmupIters; w++ {
-		deadline := time.Now().Add(warmupTime)
-		for time.Now().Before(deadline) {
-			fn()
+var benchmarkInputDirectory string
+var benchmarkInputs map[string]materializedInput
+var sink any
+
+func loadManifest(path string) manifest {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("cannot open benchmark input manifest: %v", err))
+	}
+	var result manifest
+	if err := json.Unmarshal(data, &result); err != nil {
+		panic(fmt.Sprintf("invalid benchmark input manifest: %v", err))
+	}
+	if result.Version != 1 || result.ExecutionPlan.Version != 1 {
+		panic("unsupported benchmark manifest or execution-plan version")
+	}
+	benchmarkInputDirectory = filepath.Dir(path)
+	benchmarkInputs = result.Inputs
+	return result
+}
+
+func loadBenchmarkInput(key string) string {
+	entry, ok := benchmarkInputs[key]
+	if !ok {
+		panic("unknown materialized benchmark input: " + key)
+	}
+	data, err := os.ReadFile(filepath.Join(benchmarkInputDirectory, entry.File))
+	if err != nil {
+		panic(fmt.Sprintf("cannot open materialized benchmark input %s: %v", key, err))
+	}
+	if len(data) != entry.UTF8Bytes {
+		panic(fmt.Sprintf("materialized benchmark input %s has wrong size", key))
+	}
+	if fmt.Sprintf("%x", sha256.Sum256(data)) != entry.SHA256 {
+		panic(fmt.Sprintf("materialized benchmark input %s has wrong SHA-256", key))
+	}
+	return string(data)
+}
+
+func stringsArgument(arguments map[string]any, key string) []int {
+	raw, _ := arguments[key].([]any)
+	result := make([]int, len(raw))
+	for i, value := range raw {
+		result[i] = int(value.(float64))
+	}
+	return result
+}
+
+func intArgument(arguments map[string]any, key string) int {
+	value, _ := arguments[key].(float64)
+	return int(value)
+}
+
+func stringArgument(arguments map[string]any, key string) string {
+	value, _ := arguments[key].(string)
+	return value
+}
+
+func compileFull(pattern string) *regexp.Regexp {
+	return regexp.MustCompile(`\A(?:` + pattern + `)\z`)
+}
+
+func groupLengthSum(indices []int, groups []int) int {
+	total := 0
+	for _, group := range groups {
+		offset := group * 2
+		if offset+1 < len(indices) && indices[offset] >= 0 {
+			total += indices[offset+1] - indices[offset]
 		}
 	}
+	return total
+}
 
-	// Measurement.
-	samples := make([]float64, 0, measureIters)
-	for i := 0; i < measureIters; i++ {
-		var ops int64
+func capturedText(text string, indices []int, groups []int) string {
+	var result strings.Builder
+	for _, group := range groups {
+		offset := group * 2
+		if offset+1 < len(indices) && indices[offset] >= 0 {
+			result.WriteString(text[indices[offset]:indices[offset+1]])
+		}
+	}
+	return result.String()
+}
+
+func splitLengthSum(re *regexp.Regexp, text string, limit int) int {
+	parts := re.Split(text, limit)
+	if limit == 0 {
+		for len(parts) > 0 && parts[len(parts)-1] == "" {
+			parts = parts[:len(parts)-1]
+		}
+	}
+	total := len(parts)
+	for _, part := range parts {
+		total += len(part)
+	}
+	return total
+}
+
+func prepare(entry planEntry) func() any {
+	if len(entry.Options) != 0 {
+		panic(fmt.Sprintf("%s has unsupported materialized options: %v",
+			entry.WorkloadID, entry.Options))
+	}
+	regexes := make([]*regexp.Regexp, len(entry.Patterns))
+	for i, pattern := range entry.Patterns {
+		regexes[i] = regexp.MustCompile(pattern)
+	}
+	texts := make([]string, len(entry.Inputs))
+	for i, input := range entry.Inputs {
+		texts[i] = loadBenchmarkInput(input)
+	}
+	var re *regexp.Regexp
+	if len(regexes) > 0 {
+		re = regexes[0]
+	}
+	text := ""
+	if len(texts) > 0 {
+		text = texts[0]
+	}
+	groups := stringsArgument(entry.Arguments, "groups")
+	group := intArgument(entry.Arguments, "group")
+	replacement := stringArgument(entry.Arguments, "replacement")
+	limit := intArgument(entry.Arguments, "limit")
+	var full *regexp.Regexp
+	if len(entry.Patterns) > 0 {
+		full = compileFull(entry.Patterns[0])
+	}
+
+	switch entry.Operation {
+	case "compile":
+		return func() any { return regexp.MustCompile(entry.Patterns[0]) }
+	case "matches":
+		return func() any { return full.MatchString(text) }
+	case "find":
+		return func() any { return re.MatchString(text) }
+	case "findAllCount":
+		return func() any { return len(re.FindAllStringIndex(text, -1)) }
+	case "matchesCorpus":
+		return func() any {
+			count := 0
+			for _, candidate := range texts {
+				if full.MatchString(candidate) {
+					count++
+				}
+			}
+			return count
+		}
+	case "matchesGroupLengthSum":
+		return func() any {
+			total := 0
+			for _, candidate := range texts {
+				total += groupLengthSum(full.FindStringSubmatchIndex(candidate), groups)
+			}
+			return total
+		}
+	case "findAllLengthSum":
+		return func() any {
+			total := 0
+			for _, match := range re.FindAllStringIndex(text, -1) {
+				total += match[1] - match[0]
+			}
+			return total
+		}
+	case "findAllGroupLengthSum":
+		return func() any {
+			total := 0
+			for _, match := range re.FindAllStringSubmatchIndex(text, -1) {
+				total += groupLengthSum(match, groups)
+			}
+			return total
+		}
+	case "captureGroups":
+		return func() any {
+			return capturedText(text, full.FindStringSubmatchIndex(text), groups)
+		}
+	case "replaceFirst":
+		return func() any {
+			match := re.FindStringSubmatchIndex(text)
+			if match == nil {
+				return text
+			}
+			result := append([]byte{}, text[:match[0]]...)
+			result = re.ExpandString(result, replacement, text, match)
+			result = append(result, text[match[1]:]...)
+			return string(result)
+		}
+	case "replaceAll":
+		return func() any { return re.ReplaceAllString(text, replacement) }
+	case "replaceAllLengthSum":
+		return func() any {
+			total := 0
+			for _, item := range regexes {
+				total += len(item.ReplaceAllString(text, replacement))
+			}
+			return total
+		}
+	case "splitLengthSum":
+		return func() any { return splitLengthSum(re, text, limit) }
+	case "findGroupPresent":
+		return func() any {
+			match := re.FindStringSubmatchIndex(text)
+			offset := group * 2
+			return offset+1 < len(match) && match[offset] >= 0
+		}
+	case "findGroup":
+		return func() any {
+			match := re.FindStringSubmatchIndex(text)
+			offset := group * 2
+			if offset+1 >= len(match) || match[offset] < 0 {
+				return ""
+			}
+			return text[match[offset]:match[offset+1]]
+		}
+	default:
+		panic("unsupported runnable operation: " + entry.Operation)
+	}
+}
+
+func validate(entry planEntry, operation func() any) {
+	if entry.Expected == nil {
+		return
+	}
+	actual := operation()
+	expected := entry.Expected.Value
+	if number, ok := expected.(float64); ok {
+		expected = int(number)
+	}
+	if fmt.Sprint(actual) != fmt.Sprint(expected) {
+		panic(fmt.Sprintf("%s result mismatch: expected %v, got %v",
+			entry.WorkloadID, expected, actual))
+	}
+}
+
+func measure(entry planEntry, operation func() any, smoke bool) benchResult {
+	unit := map[string]string{
+		"nanoseconds":  "ns/op",
+		"microseconds": "us/op",
+		"milliseconds": "ms/op",
+	}[entry.Measurement.TimingUnit]
+	divisor := map[string]float64{"ns/op": 1, "us/op": 1000, "ms/op": 1_000_000}[unit]
+	warmups, iterations := 2, 10
+	duration := 2 * time.Second
+	if smoke {
+		warmups, iterations, duration = 0, 1, time.Nanosecond
+	}
+	for i := 0; i < warmups; i++ {
+		deadline := time.Now().Add(duration)
+		for time.Now().Before(deadline) {
+			sink = operation()
+		}
+	}
+	samples := make([]float64, iterations)
+	for i := range samples {
 		start := time.Now()
-		deadline := start.Add(measureTime)
-		for time.Now().Before(deadline) {
-			fn()
-			ops++
+		deadline := start.Add(duration)
+		operations := 0
+		for operations == 0 || time.Now().Before(deadline) {
+			sink = operation()
+			operations++
 		}
-		elapsed := time.Since(start).Nanoseconds()
-		samples = append(samples, float64(elapsed)/float64(ops)/unitDivisor)
+		samples[i] = float64(time.Since(start).Nanoseconds()) / float64(operations) / divisor
 	}
-
-	// Stats.
-	var sum float64
-	for _, s := range samples {
-		sum += s
+	mean := samples[0]
+	error := 0.0
+	if len(samples) > 1 {
+		mean = 0
+		for _, sample := range samples {
+			mean += sample
+		}
+		mean /= float64(len(samples))
+		var variance float64
+		for _, sample := range samples {
+			variance += (sample - mean) * (sample - mean)
+		}
+		error = 4.781 * math.Sqrt(variance/float64(len(samples)-1)) /
+			math.Sqrt(float64(len(samples)))
 	}
-	mean := sum / float64(len(samples))
-	var variance float64
-	for _, s := range samples {
-		d := s - mean
-		variance += d * d
-	}
-	stddev := math.Sqrt(variance / float64(len(samples)-1))
-	// t-value for 99.9% CI with 9 df ≈ 4.781
-	err := 4.781 * stddev / math.Sqrt(float64(len(samples)))
-
-	return benchResult{
-		Engine:    "go_regexp",
-		Benchmark: name,
-		Score:     math.Round(mean*1000) / 1000,
-		Error:     math.Round(err*1000) / 1000,
-		Unit:      unit,
-	}
+	return benchResult{engineID, entry.WorkloadID, round(mean), round(error), unit}
 }
 
-// measureNs is a convenience wrapper for ns/op measurements.
-func measureNs(name string, fn func()) benchResult {
-	return measure(name, fn, 2, 2*time.Second, 10, 2*time.Second, "ns/op", 1.0)
+func measureCompiledSize(pattern string) int64 {
+	_ = regexp.MustCompile(pattern)
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	compiled := regexp.MustCompile(pattern)
+	runtime.GC()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	sink = compiled
+	return int64(after.TotalAlloc - before.TotalAlloc)
 }
 
-// measureUs is a convenience wrapper for µs/op measurements.
-func measureUs(name string, fn func()) benchResult {
-	return measure(name, fn, 2, 2*time.Second, 10, 2*time.Second, "us/op", 1000.0)
-}
-
-func printJSON(r benchResult) {
-	b, _ := json.Marshal(r)
-	fmt.Println(string(b))
-}
+func round(value float64) float64 { return math.Round(value*1000) / 1000 }
 
 func matchesFilter(name string, filters []string) bool {
 	if len(filters) == 0 {
 		return true
 	}
-	for _, f := range filters {
-		if strings.Contains(name, f) {
+	for _, filter := range filters {
+		if strings.Contains(name, filter) {
 			return true
 		}
 	}
 	return false
 }
 
-// sink prevents the compiler from optimizing away results.
-var sink any
-
-// ---------------------------------------------------------------------------
-// JSON loading
-// ---------------------------------------------------------------------------
-
-type materializedInput struct {
-	File      string `json:"file"`
-	UTF8Bytes int    `json:"utf8Bytes"`
-	SHA256    string `json:"sha256"`
+func printJSON(value any) {
+	data, _ := json.Marshal(value)
+	fmt.Println(string(data))
 }
-
-var benchmarkInputDirectory string
-var benchmarkInputs map[string]materializedInput
-var benchmarkPatternProfile map[string]string
-var benchmarkReplacementProfile map[string]string
-
-func loadBenchmarkManifest(manifestPath string) map[string]any {
-	benchmarkInputDirectory = filepath.Dir(manifestPath)
-	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: cannot open benchmark input manifest: %v\n", err)
-		os.Exit(1)
-	}
-	var manifest struct {
-		Version       int                          `json:"version"`
-		BenchmarkData map[string]any               `json:"benchmarkData"`
-		Inputs        map[string]materializedInput `json:"inputs"`
-	}
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: invalid benchmark input manifest: %v\n", err)
-		os.Exit(1)
-	}
-	if manifest.Version != 1 {
-		fmt.Fprintf(os.Stderr, "ERROR: unsupported benchmark input manifest version: %d\n",
-			manifest.Version)
-		os.Exit(1)
-	}
-	benchmarkInputs = manifest.Inputs
-	benchmarkPatternProfile = loadProfile(manifest.BenchmarkData, "patternProfiles", "re2")
-	benchmarkReplacementProfile =
-		loadProfile(manifest.BenchmarkData, "replacementProfiles", "go-regexp")
-	return manifest.BenchmarkData
-}
-
-func loadProfile(data map[string]any, registry string, profileID string) map[string]string {
-	result := make(map[string]string)
-	profiles, ok := data[registry].(map[string]any)
-	if !ok {
-		return result
-	}
-	entries, ok := profiles[profileID].([]any)
-	if !ok {
-		return result
-	}
-	for _, raw := range entries {
-		entry := raw.(map[string]any)
-		result[entry["java"].(string)] = entry["alternate"].(string)
-	}
-	return result
-}
-
-func mustCompile(javaPattern string) *regexp.Regexp {
-	return regexp.MustCompile(selectedPattern(javaPattern))
-}
-
-func selectedPattern(javaPattern string) string {
-	return selectedProfileValue(benchmarkPatternProfile, javaPattern)
-}
-
-func selectedReplacement(javaReplacement string) string {
-	return selectedProfileValue(benchmarkReplacementProfile, javaReplacement)
-}
-
-func selectedProfileValue(profile map[string]string, javaValue string) string {
-	if alternate, ok := profile[javaValue]; ok {
-		return alternate
-	}
-	return javaValue
-}
-
-func loadBenchmarkInput(key string) string {
-	entry, ok := benchmarkInputs[key]
-	if !ok {
-		fmt.Fprintf(os.Stderr, "ERROR: unknown materialized benchmark input: %s\n", key)
-		os.Exit(1)
-	}
-	path := filepath.Join(benchmarkInputDirectory, entry.File)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: cannot open materialized benchmark input %s: %v\n", key, err)
-		os.Exit(1)
-	}
-	if len(data) != entry.UTF8Bytes {
-		fmt.Fprintf(os.Stderr,
-			"ERROR: materialized benchmark input %s has size %d, expected %d\n",
-			key, len(data), entry.UTF8Bytes)
-		os.Exit(1)
-	}
-	actualHash := fmt.Sprintf("%x", sha256.Sum256(data))
-	if actualHash != entry.SHA256 {
-		fmt.Fprintf(os.Stderr,
-			"ERROR: materialized benchmark input %s has SHA-256 %s, expected %s\n",
-			key, actualHash, entry.SHA256)
-		os.Exit(1)
-	}
-	return string(data)
-}
-
-// get navigates a dot-separated path in the JSON structure.
-func get(data any, path string) any {
-	parts := strings.Split(path, ".")
-	current := data
-	for _, part := range parts {
-		m, ok := current.(map[string]any)
-		if !ok {
-			return nil
-		}
-		current = m[part]
-	}
-	return current
-}
-
-func getString(data any, path string) string {
-	v := get(data, path)
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return ""
-}
-
-func getInt(data any, path string) int {
-	v := get(data, path)
-	if f, ok := v.(float64); ok {
-		return int(f)
-	}
-	return 0
-}
-
-func getIntSlice(data any, path string) []int {
-	v := get(data, path)
-	arr, ok := v.([]any)
-	if !ok {
-		return nil
-	}
-	result := make([]int, len(arr))
-	for i, item := range arr {
-		if f, ok := item.(float64); ok {
-			result[i] = int(f)
-		}
-	}
-	return result
-}
-
-func getStringSlice(data any, path string) []string {
-	v := get(data, path)
-	arr, ok := v.([]any)
-	if !ok {
-		return nil
-	}
-	result := make([]string, len(arr))
-	for i, item := range arr {
-		if s, ok := item.(string); ok {
-			result[i] = s
-		}
-	}
-	return result
-}
-
-// ---------------------------------------------------------------------------
-// Benchmark implementations
-// ---------------------------------------------------------------------------
-
-func runRegexBenchmarks(data map[string]any, filters []string) {
-	sec := data["regex"]
-
-	hello := mustCompile(getString(sec, "literalMatch.pattern"))
-	alpha := mustCompile(getString(sec, "charClassMatch.pattern"))
-	alt := mustCompile(getString(sec, "alternationFind.pattern"))
-	date := mustCompile(getString(sec, "captureGroups.pattern"))
-	findIng := mustCompile(getString(sec, "findInText.pattern"))
-	email := mustCompile(getString(sec, "emailFind.pattern"))
-
-	helloText := getString(sec, "literalMatch.text")
-	alphaText := getString(sec, "charClassMatch.text")
-	altText := getString(sec, "alternationFind.text")
-	dateText := getString(sec, "captureGroups.text")
-	prose := getString(sec, "findInText.text")
-	emailText := getString(sec, "emailFind.text")
-
-	run := func(name string, fn func()) {
-		if matchesFilter(name, filters) {
-			printJSON(measureNs(name, fn))
-		}
-	}
-
-	run("RegexBenchmark.literalMatch", func() {
-		sink = hello.MatchString(helloText)
-	})
-	run("RegexBenchmark.charClassMatch", func() {
-		sink = alpha.MatchString(alphaText)
-	})
-	run("RegexBenchmark.alternationFind", func() {
-		sink = alt.FindAllString(altText, -1)
-	})
-	run("RegexBenchmark.captureGroups", func() {
-		sink = date.FindStringSubmatch(dateText)
-	})
-	run("RegexBenchmark.findInText", func() {
-		sink = findIng.FindAllString(prose, -1)
-	})
-	run("RegexBenchmark.emailFind", func() {
-		sink = email.FindString(emailText)
-	})
-}
-
-func runApplicationBenchmarks(data map[string]any, filters []string) {
-	run := func(name string, fn func()) {
-		if matchesFilter(name, filters) {
-			printJSON(measureNs(name, fn))
-		}
-	}
-
-	type appCase struct {
-		name        string
-		op          string
-		pattern     string
-		texts       []string
-		text        string
-		groups      []int
-		replacement string
-		expected    any
-		re          *regexp.Regexp
-		fullRe      *regexp.Regexp
-	}
-
-	rawCases, ok := data["application"].([]any)
-	if !ok {
-		fmt.Fprintln(os.Stderr, "ERROR: application benchmark data must be a list")
-		os.Exit(1)
-	}
-	cases := make([]appCase, 0, len(rawCases))
-	for _, raw := range rawCases {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			fmt.Fprintln(os.Stderr, "ERROR: invalid application benchmark case")
-			os.Exit(1)
-		}
-		pattern := getString(item, "pattern")
-		c := appCase{
-			name:        getString(item, "name"),
-			op:          getString(item, "op"),
-			pattern:     pattern,
-			texts:       getStringSlice(item, "texts"),
-			text:        getString(item, "text"),
-			groups:      getIntSlice(item, "groups"),
-			replacement: selectedReplacement(getString(item, "replacement")),
-			expected:    item["expected"],
-			re:          mustCompile(pattern),
-		}
-		if strings.HasPrefix(c.op, "matches") {
-			c.fullRe = mustCompile("^(?:" + selectedPattern(pattern) + ")$")
-		}
-		cases = append(cases, c)
-	}
-
-	groupLengthSum := func(indexes []int, groups []int) int {
-		sum := 0
-		for _, group := range groups {
-			start := indexes[2*group]
-			end := indexes[2*group+1]
-			if start >= 0 {
-				sum += end - start
-			}
-		}
-		return sum
-	}
-	runInt := func(c appCase) int {
-		switch c.op {
-		case "matchesCorpus":
-			count := 0
-			for _, text := range c.texts {
-				if c.fullRe.MatchString(text) {
-					count++
-				}
-			}
-			return count
-		case "matchesGroupLengthSum":
-			count := 0
-			for _, text := range c.texts {
-				indexes := c.fullRe.FindStringSubmatchIndex(text)
-				if indexes != nil {
-					count += groupLengthSum(indexes, c.groups)
-				}
-			}
-			return count
-		case "findAllCount":
-			return len(c.re.FindAllStringIndex(c.text, -1))
-		case "findAllLengthSum":
-			count := 0
-			for _, match := range c.re.FindAllStringIndex(c.text, -1) {
-				count += match[1] - match[0]
-			}
-			return count
-		case "findAllGroupLengthSum":
-			count := 0
-			for _, indexes := range c.re.FindAllStringSubmatchIndex(c.text, -1) {
-				count += groupLengthSum(indexes, c.groups)
-			}
-			return count
-		default:
-			fmt.Fprintf(os.Stderr, "ERROR: string op used as int op: %s\n", c.op)
-			os.Exit(1)
-		}
-		return 0
-	}
-	runString := func(c appCase) string {
-		return c.re.ReplaceAllString(c.text, c.replacement)
-	}
-
-	for _, c := range cases {
-		if strings.HasPrefix(c.op, "findAll") && c.re.FindStringIndex("") != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: empty-width find-all application pattern: %s\n", c.name)
-			os.Exit(1)
-		}
-		if c.op == "replaceAll" {
-			actual := runString(c)
-			if actual != c.expected.(string) {
-				fmt.Fprintf(os.Stderr, "ERROR: %s expected result mismatch\n", c.name)
-				os.Exit(1)
-			}
-		} else {
-			actual := runInt(c)
-			if actual != int(c.expected.(float64)) {
-				fmt.Fprintf(os.Stderr, "ERROR: %s expected %d but was %d\n",
-					c.name, int(c.expected.(float64)), actual)
-				os.Exit(1)
-			}
-		}
-	}
-
-	for _, c := range cases {
-		c := c
-		run("ApplicationBenchmark."+c.name, func() {
-			if c.op == "replaceAll" {
-				sink = runString(c)
-			} else {
-				sink = runInt(c)
-			}
-		})
-	}
-}
-
-func runRealWorldRegexBenchmarks(data map[string]any, filters []string) {
-	sec, ok := data["realWorldRegex"].(map[string]any)
-	if !ok {
-		fmt.Fprintln(os.Stderr, "ERROR: realWorldRegex benchmark data must be an object")
-		os.Exit(1)
-	}
-	sizes := getIntSlice(sec, "textSizes")
-	type realWorldCase struct {
-		name        string
-		op          string
-		replacement string
-		re          *regexp.Regexp
-		fullRe      *regexp.Regexp
-	}
-
-	rawCases, ok := sec["cases"].([]any)
-	if !ok {
-		fmt.Fprintln(os.Stderr, "ERROR: realWorldRegex cases must be a list")
-		os.Exit(1)
-	}
-	cases := make([]realWorldCase, 0, len(rawCases))
-	for _, raw := range rawCases {
-		item, ok := raw.(map[string]any)
-		if !ok {
-			fmt.Fprintln(os.Stderr, "ERROR: invalid realWorldRegex benchmark case")
-			os.Exit(1)
-		}
-		op := getString(item, "op")
-		if op != "find" && op != "matches" && op != "replaceAllEmpty" && op != "replaceAllGroup1" && op != "replaceAllLiteral" {
-			fmt.Fprintf(os.Stderr, "ERROR: invalid realWorldRegex op: %s\n", op)
-			os.Exit(1)
-		}
-		pattern := getString(item, "pattern")
-		c := realWorldCase{
-			name:        getString(item, "name"),
-			op:          op,
-			replacement: selectedReplacement(getString(item, "replacement")),
-			re:          mustCompile(pattern),
-		}
-		if op == "matches" {
-			c.fullRe = mustCompile("^(?:" + selectedPattern(pattern) + ")$")
-		}
-		cases = append(cases, c)
-	}
-
-	for _, c := range cases {
-		c := c
-		for _, match := range []bool{true, false} {
-			matchLabel := "noMatch"
-			if match {
-				matchLabel = "match"
-			}
-			for _, size := range sizes {
-				text := loadBenchmarkInput(fmt.Sprintf(
-					"realWorldRegex.%s.%s.%d", c.name, matchLabel, size))
-				name := fmt.Sprintf(
-					"RealWorldRegexBenchmark.runBenchmark.%s.%s.%d",
-					c.name, matchLabel, size)
-				if !matchesFilter(name, filters) {
-					continue
-				}
-				if c.op == "find" {
-					printJSON(measureNs(name, func() {
-						sink = c.re.FindStringIndex(text) != nil
-					}))
-				} else if c.op == "matches" {
-					printJSON(measureNs(name, func() {
-						sink = c.fullRe.MatchString(text)
-					}))
-				} else if c.op == "replaceAllEmpty" {
-					printJSON(measureNs(name, func() {
-						sink = c.re.ReplaceAllString(text, c.replacement)
-					}))
-				} else if c.op == "replaceAllGroup1" {
-					printJSON(measureNs(name, func() {
-						sink = c.re.ReplaceAllString(text, c.replacement)
-					}))
-				} else if c.op == "replaceAllLiteral" {
-					printJSON(measureNs(name, func() {
-						sink = c.re.ReplaceAllString(text, c.replacement)
-					}))
-				}
-			}
-		}
-	}
-}
-
-func runCompileBenchmarks(data map[string]any, filters []string) {
-	sec := data["compile"]
-
-	simple := getString(sec, "simple.pattern")
-	medium := getString(sec, "medium.pattern")
-	complex := getString(sec, "complex.pattern")
-	alternation := getString(sec, "alternation.pattern")
-
-	run := func(name string, pattern string) {
-		if matchesFilter(name, filters) {
-			selected := selectedPattern(pattern)
-			printJSON(measureUs(name, func() {
-				sink = regexp.MustCompile(selected)
-			}))
-		}
-	}
-
-	run("CompileBenchmark.compileSimple", simple)
-	run("CompileBenchmark.compileMedium", medium)
-	run("CompileBenchmark.compileComplex", complex)
-	run("CompileBenchmark.compileAlternation", alternation)
-}
-
-func runSearchScalingBenchmarks(data map[string]any, filters []string) {
-	sec := data["searchScaling"].(map[string]any)
-
-	sizes := getIntSlice(sec, "textSizes")
-	easy := mustCompile(getString(sec, "patterns.easy"))
-	medium := mustCompile(getString(sec, "patterns.medium"))
-	hard := mustCompile(getString(sec, "patterns.hard"))
-	findIng := mustCompile(getString(sec, "findIngPattern"))
-
-	for _, size := range sizes {
-		randomText := loadBenchmarkInput(fmt.Sprintf("searchScaling.random.%d", size))
-		textWithMatch := loadBenchmarkInput(fmt.Sprintf("searchScaling.success.%d", size))
-		proseText := loadBenchmarkInput(fmt.Sprintf("searchScaling.prose.%d", size))
-
-		suffix := fmt.Sprintf(".%d", size)
-
-		run := func(name string, fn func()) {
-			fullName := name + suffix
-			if matchesFilter(fullName, filters) {
-				printJSON(measureUs(fullName, fn))
-			}
-		}
-
-		run("SearchScalingBenchmark.searchEasyFail", func() {
-			sink = easy.MatchString(randomText)
-		})
-		run("SearchScalingBenchmark.searchEasySuccess", func() {
-			sink = easy.MatchString(textWithMatch)
-		})
-		run("SearchScalingBenchmark.searchMediumFail", func() {
-			sink = medium.MatchString(randomText)
-		})
-		run("SearchScalingBenchmark.searchHardFail", func() {
-			sink = hard.MatchString(randomText)
-		})
-		run("SearchScalingBenchmark.findIngScaled", func() {
-			sink = findIng.FindAllString(proseText, -1)
-		})
-	}
-}
-
-func runIssue481ScalingBenchmarks(data map[string]any, filters []string) {
-	sec := data["issue481Scaling"].(map[string]any)
-
-	sizes := getIntSlice(sec, "textSizes")
-	splitW := mustCompile(getString(sec, "splitW.pattern"))
-	block := mustCompile(getString(sec, "block.pattern"))
-	tag := mustCompile(getString(sec, "tag.pattern"))
-	scheme := mustCompile(getString(sec, "scheme.pattern"))
-
-	splitLengthSum := func(parts []string) int {
-		for len(parts) > 0 && parts[len(parts)-1] == "" {
-			parts = parts[:len(parts)-1]
-		}
-		sum := len(parts)
-		for _, part := range parts {
-			sum += len(part)
-		}
-		return sum
-	}
-	schemeExtract := func(text string, re *regexp.Regexp) int {
-		sum := 0
-		for _, match := range re.FindAllStringSubmatchIndex(text, -1) {
-			sum += match[3] - match[2]
-			sum += match[5] - match[4]
-		}
-		return sum
-	}
-
-	for _, size := range sizes {
-		splitText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.splitW.%d", size))
-		blockText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.block.%d", size))
-		blockNegativeText := loadBenchmarkInput(
-			fmt.Sprintf("issue481Scaling.blockNegative.%d", size))
-		tagText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.tag.%d", size))
-		tagNegativeText := loadBenchmarkInput(
-			fmt.Sprintf("issue481Scaling.tagNegative.%d", size))
-		schemeText := loadBenchmarkInput(fmt.Sprintf("issue481Scaling.scheme.%d", size))
-		schemeNegativeText := loadBenchmarkInput(
-			fmt.Sprintf("issue481Scaling.schemeNegative.%d", size))
-
-		suffix := fmt.Sprintf(".%d", size)
-		run := func(name string, fn func()) {
-			fullName := name + suffix
-			if matchesFilter(fullName, filters) {
-				printJSON(measureUs(fullName, fn))
-			}
-		}
-
-		run("Issue481ScalingBenchmark.splitWords", func() {
-			sink = splitLengthSum(splitW.Split(splitText, -1))
-		})
-		run("Issue481ScalingBenchmark.blockFind", func() {
-			sink = block.MatchString(blockText)
-		})
-		run("Issue481ScalingBenchmark.blockFindNegative", func() {
-			sink = block.MatchString(blockNegativeText)
-		})
-		run("Issue481ScalingBenchmark.tagFind", func() {
-			sink = tag.MatchString(tagText)
-		})
-		run("Issue481ScalingBenchmark.tagFindNegative", func() {
-			sink = tag.MatchString(tagNegativeText)
-		})
-		run("Issue481ScalingBenchmark.schemeExtract", func() {
-			sink = schemeExtract(schemeText, scheme)
-		})
-		run("Issue481ScalingBenchmark.schemeFindNegative", func() {
-			sink = scheme.MatchString(schemeNegativeText)
-		})
-	}
-}
-
-func runCaptureScalingBenchmarks(data map[string]any, filters []string) {
-	sec := data["captureScaling"]
-
-	pat0 := mustCompile(getString(sec, "capture0.pattern"))
-	pat1 := mustCompile(getString(sec, "capture1.pattern"))
-	pat3 := mustCompile(getString(sec, "capture3.pattern"))
-	pat10 := mustCompile(getString(sec, "capture10.pattern"))
-
-	text0 := getString(sec, "capture0.text")
-	text1 := getString(sec, "capture1.text")
-	text3 := getString(sec, "capture3.text")
-	text10 := getString(sec, "capture10.text")
-
-	run := func(name string, fn func()) {
-		if matchesFilter(name, filters) {
-			printJSON(measureNs(name, fn))
-		}
-	}
-
-	run("CaptureScalingBenchmark.capture0", func() {
-		sink = pat0.MatchString(text0)
-	})
-	run("CaptureScalingBenchmark.capture1", func() {
-		sink = pat1.FindStringSubmatch(text1)
-	})
-	run("CaptureScalingBenchmark.capture3", func() {
-		sink = pat3.FindStringSubmatch(text3)
-	})
-	run("CaptureScalingBenchmark.capture10", func() {
-		sink = pat10.FindStringSubmatch(text10)
-	})
-}
-
-func runHTTPBenchmarks(data map[string]any, filters []string) {
-	sec := data["http"]
-
-	http := mustCompile(getString(sec, "pattern"))
-	full := getString(sec, "fullRequest")
-	small := getString(sec, "smallRequest")
-
-	run := func(name string, fn func()) {
-		if matchesFilter(name, filters) {
-			printJSON(measureNs(name, fn))
-		}
-	}
-
-	run("HttpBenchmark.httpFull", func() {
-		sink = http.FindStringSubmatch(full)
-	})
-	run("HttpBenchmark.httpSmall", func() {
-		sink = http.FindStringSubmatch(small)
-	})
-	run("HttpBenchmark.httpExtract", func() {
-		sink = http.FindStringSubmatch(full)
-	})
-}
-
-func runReplaceBenchmarks(data map[string]any, filters []string) {
-	sec := data["replace"].(map[string]any)
-
-	for key, val := range sec {
-		entry := val.(map[string]any)
-		pattern := entry["pattern"].(string)
-		text := entry["text"].(string)
-		replacement := selectedReplacement(entry["replacement"].(string))
-		op := entry["op"].(string)
-
-		re := mustCompile(pattern)
-		benchName := "ReplaceBenchmark." + key
-
-		if !matchesFilter(benchName, filters) {
-			continue
-		}
-
-		if op == "replaceFirst" {
-			printJSON(measureNs(benchName, func() {
-				// Go has no replaceFirst; use ReplaceAllStringFunc with a once flag.
-				replaced := false
-				sink = re.ReplaceAllStringFunc(text, func(match string) string {
-					if !replaced {
-						replaced = true
-						return re.ReplaceAllString(match, replacement)
-					}
-					return match
-				})
-			}))
-		} else {
-			printJSON(measureNs(benchName, func() {
-				sink = re.ReplaceAllString(text, replacement)
-			}))
-		}
-	}
-}
-
-func runPathologicalBenchmarks(data map[string]any, filters []string) {
-	ns := getIntSlice(data, "pathological.nValues")
-
-	for _, n := range ns {
-		pattern := loadBenchmarkInput(fmt.Sprintf("pathological.pattern.%d", n))
-		text := loadBenchmarkInput(fmt.Sprintf("pathological.text.%d", n))
-
-		name := fmt.Sprintf("PathologicalBenchmark.pathological.%d", n)
-		if matchesFilter(name, filters) {
-			re := mustCompile(pattern)
-			printJSON(measureUs(name, func() {
-				sink = re.MatchString(text)
-			}))
-		}
-	}
-}
-
-func runFanoutBenchmarks(data map[string]any, filters []string) {
-	sec := data["fanout"].(map[string]any)
-	sizes := getIntSlice(sec, "textSizes")
-
-	fanout := mustCompile(getString(sec, "unicodeFanout.pattern"))
-	nested := mustCompile(getString(sec, "nestedQuantifier.pattern"))
-
-	for _, size := range sizes {
-		unicodeText := loadBenchmarkInput(fmt.Sprintf("fanout.unicode.%d", size))
-		asciiText := loadBenchmarkInput(fmt.Sprintf("fanout.ascii.%d", size))
-
-		suffix := fmt.Sprintf(".%d", size)
-
-		run := func(name string, fn func()) {
-			fullName := name + suffix
-			if matchesFilter(fullName, filters) {
-				printJSON(measureUs(fullName, fn))
-			}
-		}
-
-		run("FanoutBenchmark.fanoutUnicode", func() {
-			sink = fanout.MatchString(unicodeText)
-		})
-		run("FanoutBenchmark.nestedQuantifier", func() {
-			sink = nested.MatchString(asciiText)
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Memory benchmarks
-// ---------------------------------------------------------------------------
-
-type memoryResult struct {
-	Engine    string `json:"engine"`
-	Benchmark string `json:"benchmark"`
-	Score     int64  `json:"score"`
-	Error     int    `json:"error"`
-	Unit      string `json:"unit"`
-}
-
-func printMemoryJSON(r memoryResult) {
-	b, _ := json.Marshal(r)
-	fmt.Println(string(b))
-}
-
-// measureCompiledSize measures heap bytes allocated by compiling a regexp
-// pattern, using runtime.MemStats before/after with forced GC.
-func measureCompiledSize(pattern string) int64 {
-	// Warm up.
-	_ = regexp.MustCompile(pattern)
-
-	runtime.GC()
-	runtime.GC()
-	var before runtime.MemStats
-	runtime.ReadMemStats(&before)
-
-	re := regexp.MustCompile(pattern)
-
-	runtime.GC()
-	runtime.GC()
-	var after runtime.MemStats
-	runtime.ReadMemStats(&after)
-
-	// Keep re alive past the measurement.
-	sink = re
-
-	delta := int64(after.TotalAlloc - before.TotalAlloc)
-	if delta < 0 {
-		delta = 0
-	}
-	return delta
-}
-
-func runMemoryBenchmarks(data map[string]any, filters []string) {
-	compileSec := data["compile"]
-	regexSec := data["regex"]
-
-	type patternInfo struct {
-		name    string
-		pattern string
-	}
-
-	patterns := []patternInfo{
-		{"MemoryBenchmark.compileSimple", getString(compileSec, "simple.pattern")},
-		{"MemoryBenchmark.compileMedium", getString(compileSec, "medium.pattern")},
-		{"MemoryBenchmark.compileComplex", getString(compileSec, "complex.pattern")},
-		{"MemoryBenchmark.compileAlternation", getString(compileSec, "alternation.pattern")},
-		{"MemoryBenchmark.literalMatch", getString(regexSec, "literalMatch.pattern")},
-		{"MemoryBenchmark.charClassMatch", getString(regexSec, "charClassMatch.pattern")},
-		{"MemoryBenchmark.alternationFind", getString(regexSec, "alternationFind.pattern")},
-		{"MemoryBenchmark.captureGroups", getString(regexSec, "captureGroups.pattern")},
-		{"MemoryBenchmark.findInText", getString(regexSec, "findInText.pattern")},
-		{"MemoryBenchmark.emailFind", getString(regexSec, "emailFind.pattern")},
-	}
-
-	for _, pi := range patterns {
-		if !matchesFilter(pi.name, filters) {
-			continue
-		}
-		heapBytes := measureCompiledSize(selectedPattern(pi.pattern))
-		printMemoryJSON(memoryResult{
-			Engine:    "go_regexp",
-			Benchmark: pi.name + ".heapBytes",
-			Score:     heapBytes,
-			Unit:      "bytes",
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
 
 func main() {
 	manifestPath := "../../target/benchmark-corpus/manifest.json"
+	smoke, list, listExclusions := false, false, false
 	var filters []string
-
 	args := os.Args[1:]
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--manifest" && i+1 < len(args) {
-			manifestPath = args[i+1]
+		switch args[i] {
+		case "--manifest":
 			i++
-		} else {
+			manifestPath = args[i]
+		case "--smoke":
+			smoke = true
+		case "--list":
+			list = true
+		case "--list-exclusions":
+			listExclusions = true
+		default:
 			filters = append(filters, args[i])
 		}
 	}
 
-	data := loadBenchmarkManifest(manifestPath)
-
-	runRegexBenchmarks(data, filters)
-	runApplicationBenchmarks(data, filters)
-	runRealWorldRegexBenchmarks(data, filters)
-	runCompileBenchmarks(data, filters)
-	runSearchScalingBenchmarks(data, filters)
-	runIssue481ScalingBenchmarks(data, filters)
-	runCaptureScalingBenchmarks(data, filters)
-	runHTTPBenchmarks(data, filters)
-	runReplaceBenchmarks(data, filters)
-	runPathologicalBenchmarks(data, filters)
-	runFanoutBenchmarks(data, filters)
-	runMemoryBenchmarks(data, filters)
+	plan := loadManifest(manifestPath)
+	for _, entry := range plan.ExecutionPlan.Entries {
+		if entry.EngineID != engineID || !matchesFilter(entry.WorkloadID, filters) {
+			continue
+		}
+		if entry.Status == "excluded" {
+			if listExclusions {
+				printJSON(reportedExclusion{engineID, entry.WorkloadID, entry.Exclusion.Reason})
+			}
+			continue
+		}
+		if entry.Status != "runnable" {
+			panic("unknown execution-plan status: " + entry.Status)
+		}
+		if list {
+			fmt.Println(entry.WorkloadID)
+			continue
+		}
+		if listExclusions {
+			continue
+		}
+		if entry.Measurement.Mode == "retainedMemory" {
+			printJSON(benchResult{
+				engineID, entry.WorkloadID, float64(measureCompiledSize(entry.Patterns[0])),
+				0, "bytes",
+			})
+			continue
+		}
+		operation := prepare(entry)
+		validate(entry, operation)
+		printJSON(measure(entry, operation, smoke))
+	}
 }

--- a/safere-benchmarks/go/regexp_benchmark_test.go
+++ b/safere-benchmarks/go/regexp_benchmark_test.go
@@ -4,82 +4,20 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
 	"regexp"
 	"testing"
 )
 
-func TestCheckedInRE2PatternProfileCompiles(t *testing.T) {
-	contents, err := os.ReadFile("../benchmark-data.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var data map[string]any
-	if err := json.Unmarshal(contents, &data); err != nil {
-		t.Fatal(err)
-	}
-	alternateCount := 0
-	var visit func(any)
-	visit = func(value any) {
-		switch current := value.(type) {
-		case map[string]any:
-			if javaPattern, ok := current["java"].(string); ok {
-				alternates := current["alternates"].(map[string]any)
-				if re2, ok := alternates["re2"].(map[string]any); ok {
-					alternate := re2["pattern"].(string)
-					alternateCount++
-					if _, err := regexp.Compile(alternate); err != nil {
-						t.Errorf(
-							"%q alternate for %q does not compile: %v",
-							alternate,
-							javaPattern,
-							err,
-						)
-					}
-				}
-				return
-			}
-			for _, child := range current {
-				visit(child)
-			}
-		case []any:
-			for _, child := range current {
-				visit(child)
-			}
-		}
-	}
-	visit(data)
-	if alternateCount == 0 {
-		t.Fatal("no inline re2 pattern alternates found")
+func TestMaterializedReplacementIsUsedExactly(t *testing.T) {
+	re := regexp.MustCompile("(qu|[b-df-hj-np-tv-z]*)([a-z]+)")
+	if actual := re.ReplaceAllString("the", "${2}${1}ay"); actual != "ethay" {
+		t.Fatalf("replacement result %q, want %q", actual, "ethay")
 	}
 }
 
-func TestReplacementProfileSelectsExactAlternateWithJavaFallback(t *testing.T) {
-	data := map[string]any{
-		"replacementProfiles": map[string]any{
-			"go-regexp": []any{
-				map[string]any{
-					"java":      "$2$1ay",
-					"alternate": "${2}${1}ay",
-				},
-			},
-		},
-	}
-
-	benchmarkReplacementProfile = loadProfile(data, "replacementProfiles", "go-regexp")
-	t.Cleanup(func() {
-		benchmarkReplacementProfile = nil
-	})
-
-	if actual := selectedReplacement("$2$1ay"); actual != "${2}${1}ay" {
-		t.Fatalf("selected replacement %q, want %q", actual, "${2}${1}ay")
-	}
-	if actual := selectedReplacement("$1=REDACTED"); actual != "$1=REDACTED" {
-		t.Fatalf("fallback replacement %q, want unchanged Java value", actual)
-	}
-	re := regexp.MustCompile("(qu|[b-df-hj-np-tv-z]*)([a-z]+)")
-	if actual := re.ReplaceAllString("the", selectedReplacement("$2$1ay")); actual != "ethay" {
-		t.Fatalf("replacement result %q, want %q", actual, "ethay")
+func TestFullMatchIsNotWeakenedByMultilineMode(t *testing.T) {
+	re := compileFull("(?m)abc")
+	if !re.MatchString("abc") || re.MatchString("abc\nother") {
+		t.Fatal("full match did not anchor the complete input")
 	}
 }

--- a/safere-benchmarks/go/regexp_benchmark_test.go
+++ b/safere-benchmarks/go/regexp_benchmark_test.go
@@ -21,3 +21,10 @@ func TestFullMatchIsNotWeakenedByMultilineMode(t *testing.T) {
 		t.Fatal("full match did not anchor the complete input")
 	}
 }
+
+func TestJavaZeroSplitLimitMeansUnlimitedAndDropsTrailingEmptyParts(t *testing.T) {
+	re := regexp.MustCompile(",")
+	if actual := splitLengthSum(re, "a,b,", 0); actual != 4 {
+		t.Fatalf("split length sum %d, want %d", actual, 4)
+	}
+}

--- a/safere-benchmarks/rust/src/main.rs
+++ b/safere-benchmarks/rust/src/main.rs
@@ -205,41 +205,45 @@ fn captured_text(regex: &Regex, text: &str, groups: &[usize]) -> String {
 
 struct Prepared {
     entry: Value,
+    operation: String,
     patterns: Vec<String>,
     regexes: Vec<Regex>,
     full_regex: Option<Regex>,
     inputs: Vec<String>,
+    groups: Vec<usize>,
+    group: usize,
+    replacement: String,
+    limit: usize,
 }
 
 fn prepare(entry: &Value, corpus: &Corpus) -> Prepared {
     let patterns = string_list(entry, "patterns");
+    let arguments = &entry["arguments"];
     Prepared {
+        operation: required_string(entry, "operation"),
         regexes: patterns.iter().map(|pattern| compile(pattern)).collect(),
         full_regex: patterns.first().map(|pattern| compile_full(pattern)),
         inputs: string_list(entry, "inputs")
             .iter()
             .map(|key| corpus.input(key))
             .collect(),
+        groups: int_list(arguments, "groups"),
+        group: optional_usize(arguments, "group"),
+        replacement: optional_string(arguments, "replacement"),
+        limit: optional_usize(arguments, "limit"),
         entry: entry.clone(),
         patterns,
     }
 }
 
 fn execute(prepared: &Prepared) -> Value {
-    let entry = &prepared.entry;
-    let operation = required_string(entry, "operation");
     let patterns = &prepared.patterns;
     let inputs = &prepared.inputs;
-    let arguments = &entry["arguments"];
-    let groups = int_list(arguments, "groups");
-    let group = optional_usize(arguments, "group");
-    let replacement = optional_string(arguments, "replacement");
-    let limit = optional_usize(arguments, "limit");
     let regexes = &prepared.regexes;
     let regex = regexes.first();
     let text = inputs.first().map(String::as_str).unwrap_or_default();
 
-    match operation.as_str() {
+    match prepared.operation.as_str() {
         "compile" => {
             black_box(compile(&patterns[0]));
             json!(true)
@@ -257,7 +261,7 @@ fn execute(prepared: &Prepared) -> Value {
                 inputs
                     .iter()
                     .filter_map(|input| full.captures(input))
-                    .map(|captures| group_length_sum(&captures, &groups))
+                    .map(|captures| group_length_sum(&captures, &prepared.groups))
                     .sum::<usize>()
             )
         }
@@ -275,7 +279,7 @@ fn execute(prepared: &Prepared) -> Value {
                 regex
                     .unwrap()
                     .captures_iter(text)
-                    .map(|captures| group_length_sum(&captures, &groups))
+                    .map(|captures| group_length_sum(&captures, &prepared.groups))
                     .sum::<usize>()
             )
         }
@@ -283,26 +287,38 @@ fn execute(prepared: &Prepared) -> Value {
             json!(captured_text(
                 prepared.full_regex.as_ref().unwrap(),
                 text,
-                &groups
+                &prepared.groups
             ))
         }
-        "replaceFirst" => json!(regex.unwrap().replacen(text, 1, replacement.as_str())),
-        "replaceAll" => json!(regex.unwrap().replace_all(text, replacement.as_str())),
+        "replaceFirst" => {
+            json!(
+                regex
+                    .unwrap()
+                    .replacen(text, 1, prepared.replacement.as_str())
+            )
+        }
+        "replaceAll" => {
+            json!(
+                regex
+                    .unwrap()
+                    .replace_all(text, prepared.replacement.as_str())
+            )
+        }
         "replaceAllLengthSum" => {
             json!(
                 regexes
                     .iter()
-                    .map(|item| item.replace_all(text, replacement.as_str()).len())
+                    .map(|item| { item.replace_all(text, prepared.replacement.as_str()).len() })
                     .sum::<usize>()
             )
         }
         "splitLengthSum" => {
-            let mut parts: Vec<&str> = if limit > 0 {
-                regex.unwrap().splitn(text, limit).collect()
+            let mut parts: Vec<&str> = if prepared.limit > 0 {
+                regex.unwrap().splitn(text, prepared.limit).collect()
             } else {
                 regex.unwrap().split(text).collect()
             };
-            if limit == 0 {
+            if prepared.limit == 0 {
                 while parts.last() == Some(&"") {
                     parts.pop();
                 }
@@ -314,7 +330,7 @@ fn execute(prepared: &Prepared) -> Value {
                 regex
                     .unwrap()
                     .captures(text)
-                    .and_then(|captures| captures.get(group))
+                    .and_then(|captures| captures.get(prepared.group))
                     .is_some()
             )
         }
@@ -323,7 +339,11 @@ fn execute(prepared: &Prepared) -> Value {
                 regex
                     .unwrap()
                     .captures(text)
-                    .and_then(|captures| captures.get(group).map(|found| found.as_str().to_owned()))
+                    .and_then(|captures| {
+                        captures
+                            .get(prepared.group)
+                            .map(|found| found.as_str().to_owned())
+                    })
                     .unwrap_or_default()
             )
         }
@@ -413,6 +433,11 @@ fn matches_filter(name: &str, filters: &[String]) -> bool {
     filters.is_empty() || filters.iter().any(|filter| name.contains(filter))
 }
 
+fn matches_build_mode(entry: &Value, memory_tracking: bool) -> bool {
+    let memory = entry["measurement"]["mode"].as_str() == Some("retainedMemory");
+    memory == memory_tracking
+}
+
 fn main() {
     let mut manifest_path = PathBuf::from("../../target/benchmark-corpus/manifest.json");
     let mut filters = Vec::new();
@@ -441,6 +466,9 @@ fn main() {
         if !matches_filter(&id, &filters) {
             continue;
         }
+        if !matches_build_mode(entry, cfg!(feature = "memory-tracking")) {
+            continue;
+        }
         if entry["status"].as_str() == Some("excluded") {
             if list_exclusions {
                 println!(
@@ -455,15 +483,11 @@ fn main() {
             continue;
         }
         assert_eq!(entry["status"].as_str(), Some("runnable"));
-        let memory = entry["measurement"]["mode"].as_str() == Some("retainedMemory");
-        if memory != cfg!(feature = "memory-tracking") {
-            continue;
-        }
         if list {
             println!("{id}");
         } else if !list_exclusions {
             #[cfg(feature = "memory-tracking")]
-            if memory {
+            if matches_build_mode(entry, true) {
                 println!(
                     "{}",
                     json!({
@@ -495,5 +519,16 @@ mod tests {
         let regex = compile_full("(?m)abc");
         assert!(regex.is_match("abc"));
         assert!(!regex.is_match("abc\nother"));
+    }
+
+    #[test]
+    fn entries_are_partitioned_between_timing_and_memory_builds() {
+        let timing = json!({"measurement": {"mode": "averageTime"}});
+        let memory = json!({"measurement": {"mode": "retainedMemory"}});
+
+        assert!(matches_build_mode(&timing, false));
+        assert!(!matches_build_mode(&timing, true));
+        assert!(!matches_build_mode(&memory, false));
+        assert!(matches_build_mode(&memory, true));
     }
 }

--- a/safere-benchmarks/rust/src/main.rs
+++ b/safere-benchmarks/rust/src/main.rs
@@ -1,33 +1,30 @@
 // Copyright (c) 2026 Eddie Aftandilian. Licensed under the MIT License.
 // See LICENSE file in the project root for details.
 //
-// Rust regex benchmark harness. Runs the same patterns and inputs as the Java,
-// C++, and Go benchmarks and outputs JSON lines for cross-language comparison.
+// Rust regex benchmark harness. The materialized execution plan is the sole
+// source of workload selection, engine syntax, arguments, and exclusions.
 
 use regex::Regex;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 #[cfg(feature = "memory-tracking")]
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::hint::black_box;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 #[cfg(feature = "memory-tracking")]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
+const ENGINE_ID: &str = "rust_regex";
+
 #[cfg(feature = "memory-tracking")]
 struct TrackingAllocator;
-
 #[cfg(feature = "memory-tracking")]
 static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
 #[cfg(feature = "memory-tracking")]
 static RETAINED_BYTES: AtomicUsize = AtomicUsize::new(0);
-static PATTERN_PROFILE: OnceLock<HashMap<String, String>> = OnceLock::new();
-static REPLACEMENT_PROFILE: OnceLock<HashMap<String, String>> = OnceLock::new();
 
 // SAFETY: Every operation delegates to the system allocator with the original
 // pointer and layout. The counters only observe successful allocations.
@@ -48,16 +45,16 @@ unsafe impl GlobalAlloc for TrackingAllocator {
         unsafe { System.dealloc(pointer, layout) };
     }
 
-    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
-        if !new_pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
-            if new_size >= layout.size() {
-                RETAINED_BYTES.fetch_add(new_size - layout.size(), Ordering::Relaxed);
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        let result = unsafe { System.realloc(pointer, layout, size) };
+        if !result.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            if size >= layout.size() {
+                RETAINED_BYTES.fetch_add(size - layout.size(), Ordering::Relaxed);
             } else {
-                RETAINED_BYTES.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+                RETAINED_BYTES.fetch_sub(layout.size() - size, Ordering::Relaxed);
             }
         }
-        new_pointer
+        result
     }
 }
 
@@ -66,274 +63,132 @@ unsafe impl GlobalAlloc for TrackingAllocator {
 static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator;
 
 struct Corpus {
-    data: Value,
+    manifest: Value,
     input_directory: PathBuf,
-    inputs: Value,
-    pattern_profile: HashMap<String, String>,
-    replacement_profile: HashMap<String, String>,
 }
 
 impl Corpus {
-    fn load(manifest_path: &Path) -> Self {
-        let manifest_text = fs::read_to_string(manifest_path).unwrap_or_else(|error| {
-            panic!(
-                "cannot open benchmark input manifest {}: {error}",
-                manifest_path.display()
-            )
-        });
-        let manifest: Value = serde_json::from_str(&manifest_text)
-            .unwrap_or_else(|error| panic!("invalid benchmark input manifest: {error}"));
-        assert_eq!(
-            manifest["version"].as_u64(),
-            Some(1),
-            "unsupported benchmark input manifest version"
-        );
-        let data = manifest["benchmarkData"].clone();
+    fn load(path: &Path) -> Self {
+        let text = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("cannot open manifest {}: {error}", path.display()));
+        let manifest: Value = serde_json::from_str(&text)
+            .unwrap_or_else(|error| panic!("invalid benchmark manifest: {error}"));
+        assert_eq!(manifest["version"].as_u64(), Some(1));
+        assert_eq!(manifest["executionPlan"]["version"].as_u64(), Some(1));
         Self {
-            pattern_profile: load_profile(&data, "patternProfiles", "rust-regex"),
-            replacement_profile: load_profile(&data, "replacementProfiles", "rust-regex"),
-            data,
-            input_directory: manifest_path
-                .parent()
-                .unwrap_or(Path::new("."))
-                .to_path_buf(),
-            inputs: manifest["inputs"].clone(),
+            manifest,
+            input_directory: path.parent().unwrap_or(Path::new(".")).to_path_buf(),
         }
     }
 
-    fn input(&self, key: &str) -> String {
-        let entry = self.inputs.get(key).unwrap_or_else(|| {
-            panic!("unknown materialized benchmark input: {key}");
-        });
-        let file = required_string(entry, "file");
-        let path = self.input_directory.join(file);
-        let bytes = fs::read(&path).unwrap_or_else(|error| {
-            panic!("cannot open materialized benchmark input {key}: {error}");
-        });
-        let expected_size = required_usize(entry, "utf8Bytes");
-        assert_eq!(
-            bytes.len(),
-            expected_size,
-            "materialized benchmark input {key} has wrong size"
-        );
-        let actual_hash = format!("{:x}", Sha256::digest(&bytes));
-        assert_eq!(
-            actual_hash,
-            required_string(entry, "sha256"),
-            "materialized benchmark input {key} has wrong SHA-256"
-        );
-        String::from_utf8(bytes).unwrap_or_else(|error| {
-            panic!("materialized benchmark input {key} is not UTF-8: {error}")
-        })
+    fn entries(&self) -> &[Value] {
+        self.manifest["executionPlan"]["entries"]
+            .as_array()
+            .expect("executionPlan.entries must be an array")
     }
-}
 
-fn load_profile(data: &Value, registry: &str, profile_id: &str) -> HashMap<String, String> {
-    data.get(registry)
-        .and_then(|profiles| profiles.get(profile_id))
-        .map(|entries| {
-            entries
-                .as_array()
-                .expect("benchmark pattern profile must be a list")
-                .iter()
-                .map(|entry| {
-                    (
-                        required_string(entry, "java"),
-                        required_string(entry, "alternate"),
-                    )
-                })
-                .collect()
-        })
-        .unwrap_or_default()
+    fn input(&self, key: &str) -> String {
+        let entry = &self.manifest["inputs"][key];
+        assert!(
+            !entry.is_null(),
+            "unknown materialized benchmark input: {key}"
+        );
+        let path = self.input_directory.join(required_string(entry, "file"));
+        let bytes = fs::read(path)
+            .unwrap_or_else(|error| panic!("cannot read materialized input {key}: {error}"));
+        assert_eq!(bytes.len(), required_usize(entry, "utf8Bytes"));
+        assert_eq!(
+            format!("{:x}", Sha256::digest(&bytes)),
+            required_string(entry, "sha256")
+        );
+        String::from_utf8(bytes).expect("materialized input must be UTF-8")
+    }
 }
 
 fn at_path<'a>(value: &'a Value, path: &str) -> &'a Value {
     path.split('.').fold(value, |current, part| {
         current
             .get(part)
-            .unwrap_or_else(|| panic!("missing benchmark data path: {path}"))
+            .unwrap_or_else(|| panic!("missing execution-plan path: {path}"))
     })
 }
 
 fn required_string(value: &Value, path: &str) -> String {
     at_path(value, path)
         .as_str()
-        .unwrap_or_else(|| panic!("benchmark data path is not a string: {path}"))
+        .unwrap_or_else(|| panic!("execution-plan path is not a string: {path}"))
+        .to_owned()
+}
+
+fn optional_string(value: &Value, path: &str) -> String {
+    value
+        .get(path)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
         .to_owned()
 }
 
 fn required_usize(value: &Value, path: &str) -> usize {
     at_path(value, path)
         .as_u64()
-        .unwrap_or_else(|| panic!("benchmark data path is not an integer: {path}"))
+        .unwrap_or_else(|| panic!("execution-plan path is not an integer: {path}"))
         .try_into()
-        .expect("benchmark integer does not fit usize")
+        .expect("execution-plan integer does not fit usize")
 }
 
-fn int_list(value: &Value, path: &str) -> Vec<usize> {
-    at_path(value, path)
-        .as_array()
-        .unwrap_or_else(|| panic!("benchmark data path is not a list: {path}"))
-        .iter()
-        .map(|item| {
-            item.as_u64()
-                .expect("benchmark list item is not an integer")
-                .try_into()
-                .expect("benchmark integer does not fit usize")
-        })
-        .collect()
+fn optional_usize(value: &Value, key: &str) -> usize {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+        .try_into()
+        .expect("execution-plan integer does not fit usize")
 }
 
 fn string_list(value: &Value, path: &str) -> Vec<String> {
     at_path(value, path)
         .as_array()
-        .unwrap_or_else(|| panic!("benchmark data path is not a list: {path}"))
+        .unwrap_or_else(|| panic!("execution-plan path is not an array: {path}"))
         .iter()
         .map(|item| {
             item.as_str()
-                .expect("benchmark list item is not a string")
+                .expect("array item must be a string")
                 .to_owned()
         })
         .collect()
 }
 
-fn selected_pattern(java_pattern: &str) -> String {
-    PATTERN_PROFILE
-        .get()
-        .and_then(|profile| profile.get(java_pattern))
-        .map_or_else(|| java_pattern.to_owned(), Clone::clone)
-}
-
-fn selected_replacement(java_replacement: &str) -> String {
-    REPLACEMENT_PROFILE
-        .get()
-        .and_then(|profile| profile.get(java_replacement))
-        .map_or_else(|| java_replacement.to_owned(), Clone::clone)
-}
-
-fn compile_rust_pattern(pattern: &str) -> Regex {
-    Regex::new(pattern).unwrap_or_else(|error| panic!("cannot compile /{pattern}/: {error}"))
+fn int_list(value: &Value, key: &str) -> Vec<usize> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| {
+                    item.as_u64()
+                        .expect("array item must be an integer")
+                        .try_into()
+                        .expect("integer does not fit usize")
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn compile(pattern: &str) -> Regex {
-    compile_rust_pattern(&selected_pattern(pattern))
+    Regex::new(pattern).unwrap_or_else(|error| panic!("cannot compile /{pattern}/: {error}"))
 }
 
 fn compile_full(pattern: &str) -> Regex {
-    compile_rust_pattern(&format!(r"\A(?:{})\z", selected_pattern(pattern)))
-}
-
-fn matches_filter(name: &str, filters: &[String]) -> bool {
-    filters.is_empty() || filters.iter().any(|filter| name.contains(filter))
-}
-
-fn measure<F>(name: &str, mut operation: F, unit: &str, divisor: f64) -> Value
-where
-    F: FnMut(),
-{
-    for _ in 0..2 {
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < deadline {
-            operation();
-        }
-    }
-
-    let mut samples = Vec::with_capacity(10);
-    for _ in 0..10 {
-        let start = Instant::now();
-        let deadline = start + Duration::from_secs(2);
-        let mut operations = 0_u64;
-        while Instant::now() < deadline {
-            operation();
-            operations += 1;
-        }
-        samples.push(start.elapsed().as_nanos() as f64 / operations as f64 / divisor);
-    }
-
-    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
-    let variance = samples
-        .iter()
-        .map(|sample| (sample - mean).powi(2))
-        .sum::<f64>()
-        / (samples.len() - 1) as f64;
-    let error = 4.781 * variance.sqrt() / (samples.len() as f64).sqrt();
-    json!({
-        "engine": "rust_regex",
-        "benchmark": name,
-        "score": round_millis(mean),
-        "error": round_millis(error),
-        "unit": unit,
-    })
-}
-
-fn round_millis(value: f64) -> f64 {
-    (value * 1000.0).round() / 1000.0
-}
-
-fn run_ns<F: FnMut()>(name: &str, filters: &[String], operation: F) {
-    if matches_filter(name, filters) {
-        println!("{}", measure(name, operation, "ns/op", 1.0));
-    }
-}
-
-fn run_us<F: FnMut()>(name: &str, filters: &[String], operation: F) {
-    if matches_filter(name, filters) {
-        println!("{}", measure(name, operation, "us/op", 1000.0));
-    }
-}
-
-fn run_regex_benchmarks(data: &Value, filters: &[String]) {
-    let section = &data["regex"];
-    let hello = compile_full(&required_string(section, "literalMatch.pattern"));
-    let alpha = compile_full(&required_string(section, "charClassMatch.pattern"));
-    let alternate = compile(&required_string(section, "alternationFind.pattern"));
-    let date = compile_full(&required_string(section, "captureGroups.pattern"));
-    let find_ing = compile(&required_string(section, "findInText.pattern"));
-    let email = compile(&required_string(section, "emailFind.pattern"));
-    let hello_text = required_string(section, "literalMatch.text");
-    let alpha_text = required_string(section, "charClassMatch.text");
-    let alternate_text = required_string(section, "alternationFind.text");
-    let date_text = required_string(section, "captureGroups.text");
-    let prose = required_string(section, "findInText.text");
-    let email_text = required_string(section, "emailFind.text");
-
-    run_ns("RegexBenchmark.literalMatch", filters, || {
-        black_box(hello.is_match(black_box(&hello_text)));
-    });
-    run_ns("RegexBenchmark.charClassMatch", filters, || {
-        black_box(alpha.is_match(black_box(&alpha_text)));
-    });
-    run_ns("RegexBenchmark.alternationFind", filters, || {
-        black_box(alternate.find_iter(black_box(&alternate_text)).count());
-    });
-    run_ns("RegexBenchmark.captureGroups", filters, || {
-        black_box(captured_text(&date, black_box(&date_text), &[1, 2, 3]));
-    });
-    run_ns("RegexBenchmark.findInText", filters, || {
-        black_box(find_ing.find_iter(black_box(&prose)).count());
-    });
-    run_ns("RegexBenchmark.emailFind", filters, || {
-        black_box(email.is_match(black_box(&email_text)));
-    });
-}
-
-struct ApplicationCase {
-    name: String,
-    operation: String,
-    texts: Vec<String>,
-    text: String,
-    groups: Vec<usize>,
-    replacement: String,
-    expected: Value,
-    regex: Regex,
-    full_regex: Option<Regex>,
+    compile(&format!(r"\A(?:{pattern})\z"))
 }
 
 fn group_length_sum(captures: &regex::Captures<'_>, groups: &[usize]) -> usize {
     groups
         .iter()
         .filter_map(|group| captures.get(*group))
-        .map(|capture| capture.end() - capture.start())
+        .map(|capture| capture.len())
         .sum()
 }
 
@@ -341,524 +196,294 @@ fn captured_text(regex: &Regex, text: &str, groups: &[usize]) -> String {
     let Some(captures) = regex.captures(text) else {
         return String::new();
     };
-    let mut result = String::new();
-    for group in groups {
-        if let Some(capture) = captures.get(*group) {
-            result.push_str(capture.as_str());
-        }
-    }
-    result
-}
-
-fn application_int(case: &ApplicationCase) -> usize {
-    match case.operation.as_str() {
-        "matchesCorpus" => case
-            .texts
-            .iter()
-            .filter(|text| case.full_regex.as_ref().unwrap().is_match(text))
-            .count(),
-        "matchesGroupLengthSum" => case
-            .texts
-            .iter()
-            .filter_map(|text| case.full_regex.as_ref().unwrap().captures(text))
-            .map(|captures| group_length_sum(&captures, &case.groups))
-            .sum(),
-        "findAllCount" => case.regex.find_iter(&case.text).count(),
-        "findAllLengthSum" => case
-            .regex
-            .find_iter(&case.text)
-            .map(|found| found.end() - found.start())
-            .sum(),
-        "findAllGroupLengthSum" => case
-            .regex
-            .captures_iter(&case.text)
-            .map(|captures| group_length_sum(&captures, &case.groups))
-            .sum(),
-        operation => panic!("string op used as integer op: {operation}"),
-    }
-}
-
-fn application_string(case: &ApplicationCase) -> String {
-    case.regex
-        .replace_all(&case.text, case.replacement.as_str())
-        .into_owned()
-}
-
-fn run_application_benchmarks(data: &Value, filters: &[String]) {
-    let raw_cases = data["application"]
-        .as_array()
-        .expect("application benchmark data must be a list");
-    let cases: Vec<ApplicationCase> = raw_cases
+    groups
         .iter()
-        .map(|item| {
-            let pattern = required_string(item, "pattern");
-            let operation = required_string(item, "op");
-            let replacement = item
-                .get("replacement")
-                .map(|_| selected_replacement(&required_string(item, "replacement")))
-                .unwrap_or_default();
-            ApplicationCase {
-                name: required_string(item, "name"),
-                texts: item
-                    .get("texts")
-                    .map(|_| string_list(item, "texts"))
-                    .unwrap_or_default(),
-                text: item
-                    .get("text")
-                    .map(|_| required_string(item, "text"))
-                    .unwrap_or_default(),
-                groups: item
-                    .get("groups")
-                    .map(|_| int_list(item, "groups"))
-                    .unwrap_or_default(),
-                replacement,
-                expected: item["expected"].clone(),
-                regex: compile(&pattern),
-                full_regex: operation
-                    .starts_with("matches")
-                    .then(|| compile_full(&pattern)),
-                operation,
-            }
-        })
-        .collect();
+        .filter_map(|group| captures.get(*group))
+        .map(|capture| capture.as_str())
+        .collect()
+}
 
-    for case in &cases {
-        if case.operation.starts_with("findAll") {
-            assert!(
-                case.regex.find("").is_none(),
-                "empty-width find-all application pattern: {}",
-                case.name
-            );
-        }
-        if case.operation == "replaceAll" {
-            assert_eq!(
-                application_string(case),
-                case.expected.as_str().unwrap(),
-                "{} expected result mismatch",
-                case.name
-            );
-        } else {
-            assert_eq!(
-                application_int(case) as u64,
-                case.expected.as_u64().unwrap(),
-                "{} expected result mismatch",
-                case.name
-            );
-        }
+struct Prepared {
+    entry: Value,
+    patterns: Vec<String>,
+    regexes: Vec<Regex>,
+    full_regex: Option<Regex>,
+    inputs: Vec<String>,
+}
+
+fn prepare(entry: &Value, corpus: &Corpus) -> Prepared {
+    let patterns = string_list(entry, "patterns");
+    Prepared {
+        regexes: patterns.iter().map(|pattern| compile(pattern)).collect(),
+        full_regex: patterns.first().map(|pattern| compile_full(pattern)),
+        inputs: string_list(entry, "inputs")
+            .iter()
+            .map(|key| corpus.input(key))
+            .collect(),
+        entry: entry.clone(),
+        patterns,
     }
+}
 
-    for case in &cases {
-        let name = format!("ApplicationBenchmark.{}", case.name);
-        run_ns(&name, filters, || {
-            if case.operation == "replaceAll" {
-                black_box(application_string(black_box(case)));
+fn execute(prepared: &Prepared) -> Value {
+    let entry = &prepared.entry;
+    let operation = required_string(entry, "operation");
+    let patterns = &prepared.patterns;
+    let inputs = &prepared.inputs;
+    let arguments = &entry["arguments"];
+    let groups = int_list(arguments, "groups");
+    let group = optional_usize(arguments, "group");
+    let replacement = optional_string(arguments, "replacement");
+    let limit = optional_usize(arguments, "limit");
+    let regexes = &prepared.regexes;
+    let regex = regexes.first();
+    let text = inputs.first().map(String::as_str).unwrap_or_default();
+
+    match operation.as_str() {
+        "compile" => {
+            black_box(compile(&patterns[0]));
+            json!(true)
+        }
+        "matches" => json!(prepared.full_regex.as_ref().unwrap().is_match(text)),
+        "find" => json!(regex.unwrap().is_match(text)),
+        "findAllCount" => json!(regex.unwrap().find_iter(text).count()),
+        "matchesCorpus" => {
+            let full = prepared.full_regex.as_ref().unwrap();
+            json!(inputs.iter().filter(|input| full.is_match(input)).count())
+        }
+        "matchesGroupLengthSum" => {
+            let full = prepared.full_regex.as_ref().unwrap();
+            json!(
+                inputs
+                    .iter()
+                    .filter_map(|input| full.captures(input))
+                    .map(|captures| group_length_sum(&captures, &groups))
+                    .sum::<usize>()
+            )
+        }
+        "findAllLengthSum" => {
+            json!(
+                regex
+                    .unwrap()
+                    .find_iter(text)
+                    .map(|found| found.len())
+                    .sum::<usize>()
+            )
+        }
+        "findAllGroupLengthSum" => {
+            json!(
+                regex
+                    .unwrap()
+                    .captures_iter(text)
+                    .map(|captures| group_length_sum(&captures, &groups))
+                    .sum::<usize>()
+            )
+        }
+        "captureGroups" => {
+            json!(captured_text(
+                prepared.full_regex.as_ref().unwrap(),
+                text,
+                &groups
+            ))
+        }
+        "replaceFirst" => json!(regex.unwrap().replacen(text, 1, replacement.as_str())),
+        "replaceAll" => json!(regex.unwrap().replace_all(text, replacement.as_str())),
+        "replaceAllLengthSum" => {
+            json!(
+                regexes
+                    .iter()
+                    .map(|item| item.replace_all(text, replacement.as_str()).len())
+                    .sum::<usize>()
+            )
+        }
+        "splitLengthSum" => {
+            let mut parts: Vec<&str> = if limit > 0 {
+                regex.unwrap().splitn(text, limit).collect()
             } else {
-                black_box(application_int(black_box(case)));
-            }
-        });
-    }
-}
-
-fn run_real_world_benchmarks(corpus: &Corpus, filters: &[String]) {
-    let section = &corpus.data["realWorldRegex"];
-    let sizes = int_list(section, "textSizes");
-    for item in section["cases"]
-        .as_array()
-        .expect("realWorldRegex cases must be a list")
-    {
-        let case_name = required_string(item, "name");
-        let operation = required_string(item, "op");
-        let pattern = required_string(item, "pattern");
-        let replacement = operation
-            .starts_with("replaceAll")
-            .then(|| selected_replacement(&required_string(item, "replacement")));
-        let regex = compile(&pattern);
-        let full_regex = (operation == "matches").then(|| compile_full(&pattern));
-        for matches in [true, false] {
-            let match_label = if matches { "match" } else { "noMatch" };
-            for size in &sizes {
-                let text =
-                    corpus.input(&format!("realWorldRegex.{case_name}.{match_label}.{size}"));
-                let name = format!(
-                    "RealWorldRegexBenchmark.runBenchmark.{case_name}.{match_label}.{size}"
-                );
-                match operation.as_str() {
-                    "find" => run_ns(&name, filters, || {
-                        black_box(regex.is_match(black_box(&text)));
-                    }),
-                    "matches" => run_ns(&name, filters, || {
-                        black_box(full_regex.as_ref().unwrap().is_match(black_box(&text)));
-                    }),
-                    "replaceAllEmpty" => run_ns(&name, filters, || {
-                        black_box(
-                            regex.replace_all(black_box(&text), replacement.as_deref().unwrap()),
-                        );
-                    }),
-                    "replaceAllGroup1" => run_ns(&name, filters, || {
-                        black_box(
-                            regex.replace_all(black_box(&text), replacement.as_deref().unwrap()),
-                        );
-                    }),
-                    "replaceAllLiteral" => run_ns(&name, filters, || {
-                        black_box(
-                            regex.replace_all(black_box(&text), replacement.as_deref().unwrap()),
-                        );
-                    }),
-                    _ => panic!("invalid realWorldRegex op: {operation}"),
-                }
-            }
-        }
-    }
-}
-
-fn run_compile_benchmarks(data: &Value, filters: &[String]) {
-    let section = &data["compile"];
-    for (name, path) in [
-        ("CompileBenchmark.compileSimple", "simple.pattern"),
-        ("CompileBenchmark.compileMedium", "medium.pattern"),
-        ("CompileBenchmark.compileComplex", "complex.pattern"),
-        ("CompileBenchmark.compileAlternation", "alternation.pattern"),
-    ] {
-        let pattern = selected_pattern(&required_string(section, path));
-        run_us(name, filters, || {
-            black_box(compile_rust_pattern(black_box(&pattern)));
-        });
-    }
-}
-
-fn run_search_scaling_benchmarks(corpus: &Corpus, filters: &[String]) {
-    let section = &corpus.data["searchScaling"];
-    let easy = compile(&required_string(section, "patterns.easy"));
-    let medium = compile(&required_string(section, "patterns.medium"));
-    let hard = compile(&required_string(section, "patterns.hard"));
-    let find_ing = compile(&required_string(section, "findIngPattern"));
-    for size in int_list(section, "textSizes") {
-        let random = corpus.input(&format!("searchScaling.random.{size}"));
-        let success = corpus.input(&format!("searchScaling.success.{size}"));
-        let prose = corpus.input(&format!("searchScaling.prose.{size}"));
-        run_us(
-            &format!("SearchScalingBenchmark.searchEasyFail.{size}"),
-            filters,
-            || {
-                black_box(easy.is_match(black_box(&random)));
-            },
-        );
-        run_us(
-            &format!("SearchScalingBenchmark.searchEasySuccess.{size}"),
-            filters,
-            || {
-                black_box(easy.is_match(black_box(&success)));
-            },
-        );
-        run_us(
-            &format!("SearchScalingBenchmark.searchMediumFail.{size}"),
-            filters,
-            || {
-                black_box(medium.is_match(black_box(&random)));
-            },
-        );
-        run_us(
-            &format!("SearchScalingBenchmark.searchHardFail.{size}"),
-            filters,
-            || {
-                black_box(hard.is_match(black_box(&random)));
-            },
-        );
-        run_us(
-            &format!("SearchScalingBenchmark.findIngScaled.{size}"),
-            filters,
-            || {
-                black_box(find_ing.find_iter(black_box(&prose)).count());
-            },
-        );
-    }
-}
-
-fn run_issue_481_benchmarks(corpus: &Corpus, filters: &[String]) {
-    let section = &corpus.data["issue481Scaling"];
-    let split_words = compile(&required_string(section, "splitW.pattern"));
-    let block = compile(&required_string(section, "block.pattern"));
-    let tag = compile(&required_string(section, "tag.pattern"));
-    let scheme = compile(&required_string(section, "scheme.pattern"));
-    for size in int_list(section, "textSizes") {
-        let split_text = corpus.input(&format!("issue481Scaling.splitW.{size}"));
-        let block_text = corpus.input(&format!("issue481Scaling.block.{size}"));
-        let block_negative = corpus.input(&format!("issue481Scaling.blockNegative.{size}"));
-        let tag_text = corpus.input(&format!("issue481Scaling.tag.{size}"));
-        let tag_negative = corpus.input(&format!("issue481Scaling.tagNegative.{size}"));
-        let scheme_text = corpus.input(&format!("issue481Scaling.scheme.{size}"));
-        let scheme_negative = corpus.input(&format!("issue481Scaling.schemeNegative.{size}"));
-        run_us(
-            &format!("Issue481ScalingBenchmark.splitWords.{size}"),
-            filters,
-            || {
-                let mut parts: Vec<&str> = split_words.split(&split_text).collect();
+                regex.unwrap().split(text).collect()
+            };
+            if limit == 0 {
                 while parts.last() == Some(&"") {
                     parts.pop();
                 }
-                black_box(parts.len() + parts.iter().map(|part| part.len()).sum::<usize>());
-            },
-        );
-        for (name, regex, text) in [
-            ("blockFind", &block, &block_text),
-            ("blockFindNegative", &block, &block_negative),
-            ("tagFind", &tag, &tag_text),
-            ("tagFindNegative", &tag, &tag_negative),
-            ("schemeFindNegative", &scheme, &scheme_negative),
-        ] {
-            run_us(
-                &format!("Issue481ScalingBenchmark.{name}.{size}"),
-                filters,
-                || {
-                    black_box(regex.is_match(black_box(text)));
-                },
-            );
-        }
-        run_us(
-            &format!("Issue481ScalingBenchmark.schemeExtract.{size}"),
-            filters,
-            || {
-                let sum: usize = scheme
-                    .captures_iter(&scheme_text)
-                    .map(|captures| {
-                        [1, 2]
-                            .iter()
-                            .filter_map(|group| captures.get(*group))
-                            .map(|capture| capture.end() - capture.start())
-                            .sum::<usize>()
-                    })
-                    .sum();
-                black_box(sum);
-            },
-        );
-    }
-}
-
-fn run_capture_benchmarks(data: &Value, filters: &[String]) {
-    let section = &data["captureScaling"];
-    for (name, key, captures) in [
-        ("CaptureScalingBenchmark.capture0", "capture0", false),
-        ("CaptureScalingBenchmark.capture1", "capture1", true),
-        ("CaptureScalingBenchmark.capture3", "capture3", true),
-        ("CaptureScalingBenchmark.capture10", "capture10", true),
-    ] {
-        let pattern = required_string(section, &format!("{key}.pattern"));
-        let regex = compile_full(&pattern);
-        let text = required_string(section, &format!("{key}.text"));
-        let groups: Vec<usize> = (1..regex.captures_len()).collect();
-        run_ns(name, filters, || {
-            if captures {
-                black_box(captured_text(&regex, black_box(&text), &groups));
-            } else {
-                black_box(regex.is_match(black_box(&text)));
             }
-        });
+            json!(parts.len() + parts.iter().map(|part| part.len()).sum::<usize>())
+        }
+        "findGroupPresent" => {
+            json!(
+                regex
+                    .unwrap()
+                    .captures(text)
+                    .and_then(|captures| captures.get(group))
+                    .is_some()
+            )
+        }
+        "findGroup" => {
+            json!(
+                regex
+                    .unwrap()
+                    .captures(text)
+                    .and_then(|captures| captures.get(group).map(|found| found.as_str().to_owned()))
+                    .unwrap_or_default()
+            )
+        }
+        other => panic!("unsupported runnable operation: {other}"),
     }
 }
 
-fn run_http_benchmarks(data: &Value, filters: &[String]) {
-    let section = &data["http"];
-    let regex = compile(&required_string(section, "pattern"));
-    let full = required_string(section, "fullRequest");
-    let small = required_string(section, "smallRequest");
-    run_ns("HttpBenchmark.httpFull", filters, || {
-        black_box(
-            regex
-                .captures(black_box(&full))
-                .and_then(|captures| captures.get(1))
-                .is_some(),
+fn validate(entry: &Value, actual: &Value) {
+    if let Some(expected) = entry.get("expected") {
+        assert_eq!(
+            actual,
+            &expected["value"],
+            "{} result mismatch",
+            required_string(entry, "workloadId")
         );
-    });
-    run_ns("HttpBenchmark.httpSmall", filters, || {
-        black_box(
-            regex
-                .captures(black_box(&small))
-                .and_then(|captures| captures.get(1))
-                .is_some(),
-        );
-    });
-    run_ns("HttpBenchmark.httpExtract", filters, || {
-        black_box(
-            regex
-                .captures(black_box(&full))
-                .and_then(|captures| captures.get(1))
-                .map(|capture| capture.as_str().to_owned()),
-        );
-    });
+    }
 }
 
-fn run_replace_benchmarks(data: &Value, filters: &[String]) {
-    let section = data["replace"]
-        .as_object()
-        .expect("replace benchmark data must be an object");
-    for (key, entry) in section {
-        let name = format!("ReplaceBenchmark.{key}");
-        if !matches_filter(&name, filters) {
-            continue;
-        }
-        let regex = compile(&required_string(entry, "pattern"));
-        let text = required_string(entry, "text");
-        let replacement = selected_replacement(&required_string(entry, "replacement"));
-        match required_string(entry, "op").as_str() {
-            "replaceFirst" => run_ns(&name, filters, || {
-                black_box(regex.replace(black_box(&text), replacement.as_str()));
-            }),
-            "replaceAll" => run_ns(&name, filters, || {
-                black_box(regex.replace_all(black_box(&text), replacement.as_str()));
-            }),
-            operation => panic!("invalid replacement operation: {operation}"),
+fn measure(prepared: &Prepared, smoke: bool) -> Value {
+    let entry = &prepared.entry;
+    let (warmups, iterations, duration) = if smoke {
+        (0, 1, Duration::ZERO)
+    } else {
+        (2, 10, Duration::from_secs(2))
+    };
+    for _ in 0..warmups {
+        let deadline = Instant::now() + duration;
+        while Instant::now() < deadline {
+            black_box(execute(prepared));
         }
     }
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        let deadline = start + duration;
+        let mut operations = 0_u64;
+        while operations == 0 || Instant::now() < deadline {
+            black_box(execute(prepared));
+            operations += 1;
+        }
+        samples.push(start.elapsed().as_nanos() as f64 / operations as f64);
+    }
+    let unit_name = required_string(entry, "measurement.timingUnit");
+    let (unit, divisor) = match unit_name.as_str() {
+        "nanoseconds" => ("ns/op", 1.0),
+        "microseconds" => ("us/op", 1_000.0),
+        "milliseconds" => ("ms/op", 1_000_000.0),
+        other => panic!("unsupported timing unit: {other}"),
+    };
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64 / divisor;
+    let error = if samples.len() == 1 {
+        0.0
+    } else {
+        let variance = samples
+            .iter()
+            .map(|sample| (sample / divisor - mean).powi(2))
+            .sum::<f64>()
+            / (samples.len() - 1) as f64;
+        4.781 * variance.sqrt() / (samples.len() as f64).sqrt()
+    };
+    json!({
+        "engine": ENGINE_ID,
+        "benchmark": required_string(entry, "workloadId"),
+        "score": round(mean),
+        "error": round(error),
+        "unit": unit,
+    })
 }
 
-fn run_pathological_benchmarks(corpus: &Corpus, filters: &[String]) {
-    for n in int_list(&corpus.data, "pathological.nValues") {
-        let regex = compile_full(&corpus.input(&format!("pathological.pattern.{n}")));
-        let text = corpus.input(&format!("pathological.text.{n}"));
-        let name = format!("PathologicalBenchmark.pathological.{n}");
-        run_us(&name, filters, || {
-            black_box(regex.is_match(black_box(&text)));
-        });
-    }
-}
-
-fn run_fanout_benchmarks(corpus: &Corpus, filters: &[String]) {
-    let section = &corpus.data["fanout"];
-    let fanout = compile(&required_string(section, "unicodeFanout.pattern"));
-    let nested = compile(&required_string(section, "nestedQuantifier.pattern"));
-    for size in int_list(section, "textSizes") {
-        let unicode = corpus.input(&format!("fanout.unicode.{size}"));
-        let ascii = corpus.input(&format!("fanout.ascii.{size}"));
-        run_us(
-            &format!("FanoutBenchmark.fanoutUnicode.{size}"),
-            filters,
-            || {
-                black_box(fanout.is_match(black_box(&unicode)));
-            },
-        );
-        run_us(
-            &format!("FanoutBenchmark.nestedQuantifier.{size}"),
-            filters,
-            || {
-                black_box(nested.is_match(black_box(&ascii)));
-            },
-        );
-    }
+fn round(value: f64) -> f64 {
+    (value * 1000.0).round() / 1000.0
 }
 
 #[cfg(feature = "memory-tracking")]
 fn compiled_retained_bytes(pattern: &str) -> usize {
-    let pattern = selected_pattern(pattern);
-    black_box(compile_rust_pattern(&pattern));
-    RETAINED_BYTES.store(0, Ordering::Relaxed);
+    let _ = compile(pattern);
+    RETAINED_BYTES.store(0, Ordering::SeqCst);
     TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
-    let regex = compile_rust_pattern(&pattern);
+    let regex = compile(pattern);
     TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
-    let bytes = RETAINED_BYTES.load(Ordering::Relaxed);
-    black_box(regex);
+    let bytes = RETAINED_BYTES.load(Ordering::SeqCst);
+    black_box(&regex);
     bytes
 }
 
-#[cfg(feature = "memory-tracking")]
-fn run_memory_benchmarks(data: &Value, filters: &[String]) {
-    let compile_section = &data["compile"];
-    let regex_section = &data["regex"];
-    for (name, pattern) in [
-        (
-            "MemoryBenchmark.compileSimple",
-            required_string(compile_section, "simple.pattern"),
-        ),
-        (
-            "MemoryBenchmark.compileMedium",
-            required_string(compile_section, "medium.pattern"),
-        ),
-        (
-            "MemoryBenchmark.compileComplex",
-            required_string(compile_section, "complex.pattern"),
-        ),
-        (
-            "MemoryBenchmark.compileAlternation",
-            required_string(compile_section, "alternation.pattern"),
-        ),
-        (
-            "MemoryBenchmark.literalMatch",
-            required_string(regex_section, "literalMatch.pattern"),
-        ),
-        (
-            "MemoryBenchmark.charClassMatch",
-            required_string(regex_section, "charClassMatch.pattern"),
-        ),
-        (
-            "MemoryBenchmark.alternationFind",
-            required_string(regex_section, "alternationFind.pattern"),
-        ),
-        (
-            "MemoryBenchmark.captureGroups",
-            required_string(regex_section, "captureGroups.pattern"),
-        ),
-        (
-            "MemoryBenchmark.findInText",
-            required_string(regex_section, "findInText.pattern"),
-        ),
-        (
-            "MemoryBenchmark.emailFind",
-            required_string(regex_section, "emailFind.pattern"),
-        ),
-    ] {
-        let benchmark = format!("{name}.heapBytes");
-        if matches_filter(name, filters) || matches_filter(&benchmark, filters) {
-            println!(
-                "{}",
-                json!({
-                    "engine": "rust_regex",
-                    "benchmark": benchmark,
-                    "score": compiled_retained_bytes(&pattern),
-                    "error": 0,
-                    "unit": "bytes",
-                })
-            );
-        }
-    }
+fn matches_filter(name: &str, filters: &[String]) -> bool {
+    filters.is_empty() || filters.iter().any(|filter| name.contains(filter))
 }
 
 fn main() {
     let mut manifest_path = PathBuf::from("../../target/benchmark-corpus/manifest.json");
     let mut filters = Vec::new();
+    let mut smoke = false;
+    let mut list = false;
+    let mut list_exclusions = false;
     let mut arguments = env::args().skip(1);
     while let Some(argument) = arguments.next() {
-        if argument == "--manifest" {
-            manifest_path = PathBuf::from(
-                arguments
-                    .next()
-                    .expect("--manifest requires a following path"),
-            );
-        } else {
-            filters.push(argument);
+        match argument.as_str() {
+            "--manifest" => {
+                manifest_path = PathBuf::from(arguments.next().expect("--manifest needs a path"));
+            }
+            "--smoke" => smoke = true,
+            "--list" => list = true,
+            "--list-exclusions" => list_exclusions = true,
+            _ => filters.push(argument),
         }
     }
 
     let corpus = Corpus::load(&manifest_path);
-    PATTERN_PROFILE
-        .set(corpus.pattern_profile.clone())
-        .expect("Rust pattern profile must only be initialized once");
-    REPLACEMENT_PROFILE
-        .set(corpus.replacement_profile.clone())
-        .expect("Rust replacement profile must only be initialized once");
-    if !cfg!(feature = "memory-tracking") {
-        run_regex_benchmarks(&corpus.data, &filters);
-        run_application_benchmarks(&corpus.data, &filters);
-        run_real_world_benchmarks(&corpus, &filters);
-        run_compile_benchmarks(&corpus.data, &filters);
-        run_search_scaling_benchmarks(&corpus, &filters);
-        run_issue_481_benchmarks(&corpus, &filters);
-        run_capture_benchmarks(&corpus.data, &filters);
-        run_http_benchmarks(&corpus.data, &filters);
-        run_replace_benchmarks(&corpus.data, &filters);
-        run_pathological_benchmarks(&corpus, &filters);
-        run_fanout_benchmarks(&corpus, &filters);
+    for entry in corpus.entries() {
+        if entry["engineId"].as_str() != Some(ENGINE_ID) {
+            continue;
+        }
+        let id = required_string(entry, "workloadId");
+        if !matches_filter(&id, &filters) {
+            continue;
+        }
+        if entry["status"].as_str() == Some("excluded") {
+            if list_exclusions {
+                println!(
+                    "{}",
+                    json!({
+                        "engine": ENGINE_ID,
+                        "benchmark": id,
+                        "reason": required_string(entry, "exclusion.reason"),
+                    })
+                );
+            }
+            continue;
+        }
+        assert_eq!(entry["status"].as_str(), Some("runnable"));
+        let memory = entry["measurement"]["mode"].as_str() == Some("retainedMemory");
+        if memory != cfg!(feature = "memory-tracking") {
+            continue;
+        }
+        if list {
+            println!("{id}");
+        } else if !list_exclusions {
+            #[cfg(feature = "memory-tracking")]
+            if memory {
+                println!(
+                    "{}",
+                    json!({
+                        "engine": ENGINE_ID,
+                        "benchmark": id,
+                        "score": compiled_retained_bytes(
+                            &string_list(entry, "patterns")[0]
+                        ),
+                        "error": 0,
+                        "unit": "bytes",
+                    })
+                );
+                continue;
+            }
+            let prepared = prepare(entry, &corpus);
+            let actual = execute(&prepared);
+            validate(entry, &actual);
+            println!("{}", measure(&prepared, smoke));
+        }
     }
-    #[cfg(feature = "memory-tracking")]
-    run_memory_benchmarks(&corpus.data, &filters);
 }
 
 #[cfg(test)]
@@ -866,34 +491,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn explicit_profile_alternate_is_selected_with_java_fallback() {
-        let data = json!({
-            "patternProfiles": {
-                "rust-regex": [{
-                    "java": "same",
-                    "alternate": "pattern"
-                }]
-            },
-            "replacementProfiles": {
-                "rust-regex": [{
-                    "java": "same",
-                    "alternate": "replacement"
-                }]
-            }
-        });
-        let patterns = load_profile(&data, "patternProfiles", "rust-regex");
-        let replacements = load_profile(&data, "replacementProfiles", "rust-regex");
-
-        assert_eq!(patterns.get("same").unwrap(), "pattern");
-        assert_eq!(replacements.get("same").unwrap(), "replacement");
-        assert!(!patterns.contains_key("unchanged"));
-        assert!(!replacements.contains_key("unchanged"));
-    }
-
-    #[test]
     fn full_match_is_not_weakened_by_multiline_mode() {
         let regex = compile_full("(?m)abc");
-
         assert!(regex.is_match("abc"));
         assert!(!regex.is_match("abc\nother"));
     }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
@@ -87,7 +87,7 @@ final class BenchmarkCollectionPlan {
 
   List<Runner> allocationRunners() {
     List<String> prefixes =
-        BenchmarkData.get().getStringList("collection.allocationWorkloadPrefixes");
+        BenchmarkData.get().getStringList("configuration.collection.allocationWorkloadPrefixes");
     Set<String> allocationOnly = allocationOnlyTrialIds();
     return filterRunners(
         allRunners(),

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
@@ -252,12 +252,12 @@ final class BenchmarkCollectionPlan {
       DeclarativeBenchmarkPlan.Measurement measurement) {}
 
   record ReportExclusion(String workloadId, String executionVariant, String kind, String reason) {
-    static ReportExclusion from(DeclarativeBenchmarkPlan.Exclusion exclusion) {
+    static ReportExclusion from(MaterializedExecutionPlan.Entry exclusion) {
       return new ReportExclusion(
           exclusion.workloadId(),
           exclusion.engineId(),
-          exclusion.kind().name(),
-          exclusion.reason());
+          exclusion.exclusion().kind(),
+          exclusion.exclusion().reason());
     }
   }
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkData.java
@@ -31,8 +31,8 @@ public final class BenchmarkData {
 
   private final Path corpusDirectory;
   private final JsonObject root;
+  private final JsonObject executionPlan;
   private final JsonObject materializedInputs;
-  private final PatternProfiles patternProfiles;
   private final Map<String, byte[]> inputBytes = new ConcurrentHashMap<>();
   private final Map<String, String> inputStrings = new ConcurrentHashMap<>();
 
@@ -53,8 +53,12 @@ public final class BenchmarkData {
             "Unsupported benchmark input manifest version: " + manifest.get("version"));
       }
       root = manifest.getAsJsonObject("benchmarkData");
+      executionPlan = manifest.getAsJsonObject("executionPlan");
+      if (executionPlan == null
+          || executionPlan.get("version").getAsInt() != ResolvedBenchmarkPlan.VERSION) {
+        throw new IllegalArgumentException("Unsupported or missing benchmark execution plan");
+      }
       materializedInputs = manifest.getAsJsonObject("inputs");
-      patternProfiles = PatternProfiles.parse(root.get("patternProfiles"));
     } catch (Exception e) {
       throw new RuntimeException("Failed to load materialized benchmark data: " + manifestPath, e);
     }
@@ -65,12 +69,8 @@ public final class BenchmarkData {
     return INSTANCE;
   }
 
-  JsonObject declarativePlan() {
-    JsonObject plan = new JsonObject();
-    plan.add("schemaVersion", root.get("schemaVersion").deepCopy());
-    plan.add("inputs", root.getAsJsonArray("inputs").deepCopy());
-    plan.add("workloads", root.getAsJsonArray("workloads").deepCopy());
-    return plan;
+  JsonObject executionPlan() {
+    return executionPlan.deepCopy();
   }
 
   /**
@@ -128,17 +128,6 @@ public final class BenchmarkData {
    */
   public byte[] getInputBytes(String key) {
     return loadInputBytes(key).clone();
-  }
-
-  /**
-   * Selects an explicit profile alternative or returns the Java-canonical pattern unchanged.
-   *
-   * @param profileId pattern profile selected by an engine adapter
-   * @param javaPattern Java-canonical benchmark pattern
-   * @return exact pattern source for the selected profile
-   */
-  public String getPattern(String profileId, String javaPattern) {
-    return patternProfiles.select(profileId, javaPattern);
   }
 
   private byte[] loadInputBytes(String key) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkDataSchema.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkDataSchema.java
@@ -1,0 +1,111 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.Set;
+
+/** Validates the complete checked-in {@code benchmark-data.json} document envelope. */
+final class BenchmarkDataSchema {
+  private static final Set<String> ROOT_FIELDS =
+      Set.of("schemaVersion", "configuration", "inputs", "workloads");
+  private static final Set<String> CONFIGURATION_FIELDS =
+      Set.of("collection", "crosscheckOverhead");
+  private static final Set<String> COLLECTION_FIELDS = Set.of("allocationWorkloadPrefixes");
+  private static final Set<String> CROSSCHECK_OVERHEAD_FIELDS = Set.of("pattern", "replacement");
+
+  private BenchmarkDataSchema() {}
+
+  static void validate(JsonObject source) {
+    requireOnly(source, "benchmark-data.json", ROOT_FIELDS);
+    required(source, "schemaVersion").getAsInt();
+    requiredArray(source, "inputs");
+    if (source.has("workloads")) {
+      requiredArray(source, "workloads");
+    }
+    if (source.has("configuration")) {
+      validateConfiguration(requiredObject(source, "configuration"));
+    }
+  }
+
+  static void requireWorkloads(JsonObject source) {
+    JsonArray workloads = requiredArray(source, "workloads");
+    if (workloads.isEmpty()) {
+      throw new IllegalArgumentException("benchmark-data.json workloads must not be empty");
+    }
+  }
+
+  private static void validateConfiguration(JsonObject configuration) {
+    requireOnly(configuration, "benchmark-data.json configuration", CONFIGURATION_FIELDS);
+    if (configuration.has("collection")) {
+      JsonObject collection = requiredObject(configuration, "collection");
+      requireOnly(collection, "benchmark-data.json configuration.collection", COLLECTION_FIELDS);
+      JsonArray prefixes = requiredArray(collection, "allocationWorkloadPrefixes");
+      for (JsonElement prefix : prefixes) {
+        if (!prefix.isJsonPrimitive()
+            || !prefix.getAsJsonPrimitive().isString()
+            || prefix.getAsString().isBlank()) {
+          throw new IllegalArgumentException(
+              "benchmark-data.json allocation workload prefixes must be nonblank strings");
+        }
+      }
+    }
+    if (configuration.has("crosscheckOverhead")) {
+      JsonObject crosscheck = requiredObject(configuration, "crosscheckOverhead");
+      requireOnly(
+          crosscheck,
+          "benchmark-data.json configuration.crosscheckOverhead",
+          CROSSCHECK_OVERHEAD_FIELDS);
+      requiredString(crosscheck, "pattern");
+      requiredString(crosscheck, "replacement");
+    }
+  }
+
+  private static void requireOnly(JsonObject object, String context, Set<String> allowed) {
+    for (String field : object.keySet()) {
+      if (!allowed.contains(field)) {
+        throw new IllegalArgumentException(context + " has unknown field: " + field);
+      }
+    }
+  }
+
+  private static JsonElement required(JsonObject object, String field) {
+    JsonElement value = object.get(field);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("benchmark-data.json requires " + field);
+    }
+    return value;
+  }
+
+  private static JsonObject requiredObject(JsonObject object, String field) {
+    JsonElement value = required(object, field);
+    if (!value.isJsonObject()) {
+      throw new IllegalArgumentException("benchmark-data.json field must be an object: " + field);
+    }
+    return value.getAsJsonObject();
+  }
+
+  private static JsonArray requiredArray(JsonObject object, String field) {
+    JsonElement value = required(object, field);
+    if (!value.isJsonArray()) {
+      throw new IllegalArgumentException("benchmark-data.json field must be an array: " + field);
+    }
+    return value.getAsJsonArray();
+  }
+
+  private static String requiredString(JsonObject object, String field) {
+    JsonElement value = required(object, field);
+    if (!value.isJsonPrimitive()
+        || !value.getAsJsonPrimitive().isString()
+        || value.getAsString().isBlank()) {
+      throw new IllegalArgumentException(
+          "benchmark-data.json field must be a nonblank string: " + field);
+    }
+    return value.getAsString();
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -42,6 +42,7 @@ public final class BenchmarkInputMaterializer {
   private final Map<String, byte[]> inputs = new LinkedHashMap<>();
 
   private BenchmarkInputMaterializer(JsonObject data, String benchmarkDataSha256) {
+    BenchmarkDataSchema.validate(data);
     this.data = PatternProfiles.normalizeInline(data);
     this.benchmarkDataSha256 = benchmarkDataSha256;
     if (!this.data.has("schemaVersion")
@@ -86,6 +87,7 @@ public final class BenchmarkInputMaterializer {
 
     BenchmarkInputMaterializer materializer =
         new BenchmarkInputMaterializer(data, sha256(benchmarkDataBytes));
+    BenchmarkDataSchema.requireWorkloads(data);
     materializer.generate();
     materializer.write(outputDirectory);
   }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkInputMaterializer.java
@@ -438,7 +438,7 @@ public final class BenchmarkInputMaterializer {
         "description", "Resolved benchmark configuration and generated UTF-8 inputs.");
     manifest.addProperty("benchmarkDataSha256", benchmarkDataSha256);
     manifest.add("benchmarkData", data.deepCopy());
-    manifest.add("resolvedWorkloads", ResolvedBenchmarkPlan.create(data));
+    manifest.add("executionPlan", ResolvedBenchmarkPlan.create(data));
     JsonObject entries = new JsonObject();
     for (Map.Entry<String, byte[]> input : inputs.entrySet()) {
       byte[] bytes = input.getValue();

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
@@ -42,74 +42,45 @@ final class CrossEngineBenchmarkPlan {
           DeclarativeBenchmarkPlan.Operation.MATCHER_REGION_FIND,
           DeclarativeBenchmarkPlan.Operation.FIND_GROUP_PRESENT,
           DeclarativeBenchmarkPlan.Operation.FIND_GROUP);
-  private static final EnumSet<DeclarativeBenchmarkPlan.Operation> IMPLEMENTED_OPERATIONS =
-      EnumSet.copyOf(CROSS_ENGINE_OPERATIONS);
-
-  static {
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.ANALYZE_PATTERN);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.CACHED_ANALYSIS);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.COMPILE_AND_ANALYZE);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.DFA_CACHE_GROWTH);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.DIAGNOSTICS_FIND);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.FIND_IN_WINDOW);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.MATCHER_CONSTRUCTION);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.PATTERN_SET_MATCHES);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.UTF8_CAPTURE_BOUNDS);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.UTF8_DECODE_FIND);
-    IMPLEMENTED_OPERATIONS.add(DeclarativeBenchmarkPlan.Operation.UTF8_REPLACEMENT);
-  }
-
   private final Map<String, CrossEngineWorkload> workloads;
   private final Map<String, Trial> trials;
-  private final List<DeclarativeBenchmarkPlan.Exclusion> exclusions;
+  private final List<MaterializedExecutionPlan.Entry> exclusions;
 
   private CrossEngineBenchmarkPlan(
       Map<String, CrossEngineWorkload> workloads,
       Map<String, Trial> trials,
-      List<DeclarativeBenchmarkPlan.Exclusion> exclusions) {
+      List<MaterializedExecutionPlan.Entry> exclusions) {
     this.workloads = Collections.unmodifiableMap(new LinkedHashMap<>(workloads));
     this.trials = Collections.unmodifiableMap(new LinkedHashMap<>(trials));
     this.exclusions = List.copyOf(exclusions);
   }
 
   static CrossEngineBenchmarkPlan load() {
-    BenchmarkData data = BenchmarkData.get();
-    DeclarativeBenchmarkPlan plan = DeclarativeBenchmarkPlan.parse(data.declarativePlan());
-    List<DeclarativeBenchmarkPlan.EngineDeclaration> engines =
-        Arrays.stream(RegexEngineVariant.values()).map(RegexEngineVariant::declaration).toList();
-    return fromExpanded(plan.expand(engines, IMPLEMENTED_OPERATIONS));
+    return fromMaterialized(MaterializedExecutionPlan.load().entriesForRunner("java"));
   }
 
-  private static CrossEngineBenchmarkPlan fromExpanded(
-      DeclarativeBenchmarkPlan.ExpandedPlan expanded) {
+  private static CrossEngineBenchmarkPlan fromMaterialized(
+      List<MaterializedExecutionPlan.Entry> entries) {
     Map<String, CrossEngineWorkload> workloads = new LinkedHashMap<>();
-    for (DeclarativeBenchmarkPlan.ExpandedWorkload workload : expanded.workloads()) {
-      if (!CROSS_ENGINE_OPERATIONS.contains(workload.operation())
-          || !workload.measurement().timingUnit().isTime()) {
-        continue;
-      }
-      CrossEngineWorkload converted = convert(workload);
-      if (workloads.put(converted.id(), converted) != null) {
-        throw new IllegalArgumentException("Duplicate cross-engine workload ID: " + converted.id());
-      }
-    }
-
     Map<String, Trial> trials = new LinkedHashMap<>();
-    for (DeclarativeBenchmarkPlan.Trial trial : expanded.trials()) {
-      CrossEngineWorkload workload = workloads.get(trial.workload().id());
-      if (workload == null) {
+    List<MaterializedExecutionPlan.Entry> exclusions = new ArrayList<>();
+    for (MaterializedExecutionPlan.Entry entry : entries) {
+      if (!CROSS_ENGINE_OPERATIONS.contains(entry.operation())
+          || !entry.measurement().timingUnit().isTime()) {
         continue;
       }
-      RegexEngineVariant variant = RegexEngineVariant.fromId(trial.engine().id());
+      if (!entry.runnable()) {
+        exclusions.add(entry);
+        continue;
+      }
+      CrossEngineWorkload workload = convert(entry.workload());
+      workloads.putIfAbsent(entry.workloadId(), workload);
+      RegexEngineVariant variant = RegexEngineVariant.fromId(entry.engineId());
       Trial converted = new Trial(workload, variant);
       if (trials.put(converted.id(), converted) != null) {
         throw new IllegalArgumentException("Duplicate cross-engine trial ID: " + converted.id());
       }
     }
-    List<DeclarativeBenchmarkPlan.Exclusion> exclusions =
-        expanded.exclusions().stream()
-            .filter(exclusion -> workloads.containsKey(exclusion.workloadId()))
-            .toList();
     return new CrossEngineBenchmarkPlan(workloads, trials, exclusions);
   }
 
@@ -140,7 +111,7 @@ final class CrossEngineBenchmarkPlan {
     return List.copyOf(workloads.values());
   }
 
-  List<DeclarativeBenchmarkPlan.Exclusion> exclusions() {
+  List<MaterializedExecutionPlan.Entry> exclusions() {
     return exclusions;
   }
 
@@ -161,7 +132,7 @@ final class CrossEngineBenchmarkPlan {
       throw new IllegalArgumentException("Unknown cross-engine workload ID: " + workloadId);
     }
     RegexEngineVariant.fromId(variantId);
-    DeclarativeBenchmarkPlan.Exclusion exclusion =
+    MaterializedExecutionPlan.Entry exclusion =
         exclusions.stream()
             .filter(
                 candidate ->
@@ -178,9 +149,9 @@ final class CrossEngineBenchmarkPlan {
             + " uses "
             + workload.operation()
             + "; "
-            + exclusion.kind()
+            + exclusion.exclusion().kind()
             + ": "
-            + exclusion.reason());
+            + exclusion.exclusion().reason());
   }
 
   static void main(String[] args) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
@@ -60,10 +60,7 @@ final class CrossEngineTrialRunner implements AutoCloseable {
 
     List<RegexEngineVariant.RegexInput> inputs =
         trial.variant().prepareInputs(data, workload.inputKeys());
-    List<String> patternSources =
-        workload.patterns().stream()
-            .map(pattern -> data.getPattern(trial.variant().patternProfile(), pattern))
-            .toList();
+    List<String> patternSources = workload.patterns();
     List<RegexEngineVariant.CompiledRegex> patterns = new ArrayList<>();
     try {
       if (workload.operation() != BenchmarkOperation.COMPILE) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrosscheckOverheadBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrosscheckOverheadBenchmark.java
@@ -44,9 +44,9 @@ public class CrosscheckOverheadBenchmark {
     }
     text = sb.toString();
     BenchmarkData data = BenchmarkData.get();
-    replacement = data.getString("crosscheckOverhead.replacement");
+    replacement = data.getString("configuration.crosscheckOverhead.replacement");
 
-    String regex = data.getString("crosscheckOverhead.pattern");
+    String regex = data.getString("configuration.crosscheckOverhead.pattern");
     saferePattern = org.safere.Pattern.compile(regex);
     jdkPattern = java.util.regex.Pattern.compile(regex);
     crosscheckPattern = org.safere.crosscheck.Pattern.compile(regex);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MaterializedExecutionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MaterializedExecutionPlan.java
@@ -1,0 +1,282 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Typed Java consumer of the common materialized execution-plan artifact. */
+final class MaterializedExecutionPlan {
+  private final Map<String, Engine> engines;
+  private final Map<String, Entry> entries;
+
+  private MaterializedExecutionPlan(Map<String, Engine> engines, Map<String, Entry> entries) {
+    this.engines = Collections.unmodifiableMap(new LinkedHashMap<>(engines));
+    this.entries = Collections.unmodifiableMap(new LinkedHashMap<>(entries));
+  }
+
+  static MaterializedExecutionPlan load() {
+    return parse(BenchmarkData.get().executionPlan());
+  }
+
+  static MaterializedExecutionPlan parse(JsonObject json) {
+    int version = required(json, "version").getAsInt();
+    if (version != ResolvedBenchmarkPlan.VERSION) {
+      throw new IllegalArgumentException("Unsupported execution-plan version: " + version);
+    }
+    Map<String, Engine> engines = new LinkedHashMap<>();
+    for (JsonElement element : required(json, "engines").getAsJsonArray()) {
+      JsonObject object = element.getAsJsonObject();
+      Engine engine =
+          new Engine(
+              string(object, "id"), string(object, "reportEngine"), string(object, "runner"));
+      if (engines.put(engine.id(), engine) != null) {
+        throw new IllegalArgumentException("Duplicate materialized engine ID: " + engine.id());
+      }
+    }
+
+    Map<String, Entry> entries = new LinkedHashMap<>();
+    Map<String, Integer> workloadCounts = new LinkedHashMap<>();
+    for (JsonElement element : required(json, "entries").getAsJsonArray()) {
+      Entry entry = parseEntry(element.getAsJsonObject(), engines);
+      if (entries.put(entry.id(), entry) != null) {
+        throw new IllegalArgumentException("Duplicate materialized execution ID: " + entry.id());
+      }
+      workloadCounts.merge(entry.workloadId(), 1, Integer::sum);
+    }
+    int expectedWorkloads = required(json, "workloadCount").getAsInt();
+    int expectedEngines = required(json, "engineCount").getAsInt();
+    if (engines.size() != expectedEngines
+        || workloadCounts.size() != expectedWorkloads
+        || entries.size() != expectedWorkloads * expectedEngines
+        || workloadCounts.values().stream().anyMatch(count -> count != expectedEngines)) {
+      throw new IllegalArgumentException(
+          "Execution plan does not contain the complete workload/engine join");
+    }
+    return new MaterializedExecutionPlan(engines, entries);
+  }
+
+  List<Entry> entries() {
+    return List.copyOf(entries.values());
+  }
+
+  List<Entry> entriesForRunner(String runner) {
+    Set<String> engineIds = new LinkedHashSet<>();
+    engines.values().stream()
+        .filter(engine -> engine.runner().equals(runner))
+        .map(Engine::id)
+        .forEach(engineIds::add);
+    return entries.values().stream().filter(entry -> engineIds.contains(entry.engineId())).toList();
+  }
+
+  Entry resolve(String id) {
+    Entry entry = entries.get(id);
+    if (entry == null) {
+      throw new IllegalArgumentException("Unknown materialized execution ID: " + id);
+    }
+    return entry;
+  }
+
+  private static Entry parseEntry(JsonObject object, Map<String, Engine> engines) {
+    String id = string(object, "id");
+    String workloadId = string(object, "workloadId");
+    String engineId = string(object, "engineId");
+    Engine engine = engines.get(engineId);
+    if (engine == null) {
+      throw new IllegalArgumentException(
+          id + " references unknown materialized engine " + engineId);
+    }
+    if (!id.equals(workloadId + "@" + engineId)) {
+      throw new IllegalArgumentException("Malformed materialized execution ID: " + id);
+    }
+    if (!string(object, "reportEngine").equals(engine.reportEngine())) {
+      throw new IllegalArgumentException(id + " report engine differs from engine declaration");
+    }
+    String status = string(object, "status");
+    DeclarativeBenchmarkPlan.Operation operation =
+        DeclarativeBenchmarkPlan.Operation.fromJson(string(object, "operation"));
+    DeclarativeBenchmarkPlan.Measurement measurement =
+        parseMeasurement(required(object, "measurement").getAsJsonObject());
+    return switch (status) {
+      case "runnable" ->
+          new Entry(
+              id,
+              workloadId,
+              engineId,
+              engine.reportEngine(),
+              operation,
+              measurement,
+              parseWorkload(object),
+              null);
+      case "excluded" -> {
+        JsonObject exclusion = required(object, "exclusion").getAsJsonObject();
+        yield new Entry(
+            id,
+            workloadId,
+            engineId,
+            engine.reportEngine(),
+            operation,
+            measurement,
+            null,
+            new Exclusion(string(exclusion, "kind"), string(exclusion, "reason")));
+      }
+      default -> throw new IllegalArgumentException(id + " has unknown status " + status);
+    };
+  }
+
+  private static DeclarativeBenchmarkPlan.ExpandedWorkload parseWorkload(JsonObject object) {
+    String id = string(object, "workloadId");
+    DeclarativeBenchmarkPlan.Operation operation =
+        DeclarativeBenchmarkPlan.Operation.fromJson(string(object, "operation"));
+    Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments =
+        parseArguments(required(object, "arguments").getAsJsonObject());
+    DeclarativeBenchmarkPlan.ExpectedResult expected = null;
+    if (object.has("expected")) {
+      JsonObject expectedJson = object.getAsJsonObject("expected");
+      expected =
+          new DeclarativeBenchmarkPlan.ExpectedResult(
+              DeclarativeBenchmarkPlan.ResultType.fromJson(string(expectedJson, "type")),
+              required(expectedJson, "value").deepCopy(),
+              null);
+    }
+    DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle =
+        parseLifecycle(required(object, "lifecycle").getAsJsonObject());
+    DeclarativeBenchmarkPlan.Measurement measurement =
+        parseMeasurement(required(object, "measurement").getAsJsonObject());
+    DeclarativeBenchmarkPlan.InputRepresentation representation =
+        DeclarativeBenchmarkPlan.InputRepresentation.fromJson(
+            string(object, "inputRepresentation"));
+    EnumSet<DeclarativeBenchmarkPlan.Flag> options =
+        EnumSet.noneOf(DeclarativeBenchmarkPlan.Flag.class);
+    for (String option : strings(object, "options")) {
+      options.add(DeclarativeBenchmarkPlan.Flag.fromJson(option));
+    }
+    return new DeclarativeBenchmarkPlan.ExpandedWorkload(
+        id,
+        operation,
+        strings(object, "patterns"),
+        strings(object, "inputs"),
+        Map.of(),
+        arguments,
+        options,
+        EnumSet.noneOf(DeclarativeBenchmarkPlan.Feature.class),
+        EnumSet.of(representation),
+        null,
+        DeclarativeBenchmarkPlan.ResultConsumption.fromJson(string(object, "resultConsumption")),
+        expected,
+        lifecycle,
+        measurement,
+        null);
+  }
+
+  private static Map<String, DeclarativeBenchmarkPlan.RecipeValue> parseArguments(
+      JsonObject object) {
+    Map<String, DeclarativeBenchmarkPlan.RecipeValue> result = new LinkedHashMap<>();
+    for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+      JsonElement value = entry.getValue();
+      DeclarativeBenchmarkPlan.RecipeValue parsed;
+      if (value.isJsonArray()) {
+        JsonArray array = value.getAsJsonArray();
+        if (array.isEmpty() || array.get(0).getAsJsonPrimitive().isString()) {
+          List<String> strings = new ArrayList<>();
+          array.forEach(item -> strings.add(item.getAsString()));
+          parsed = new DeclarativeBenchmarkPlan.RecipeStringList(strings);
+        } else {
+          List<Integer> integers = new ArrayList<>();
+          array.forEach(item -> integers.add(item.getAsInt()));
+          parsed = new DeclarativeBenchmarkPlan.RecipeIntegerList(integers);
+        }
+      } else if (value.getAsJsonPrimitive().isString()) {
+        parsed = new DeclarativeBenchmarkPlan.RecipeString(value.getAsString());
+      } else {
+        parsed = new DeclarativeBenchmarkPlan.RecipeInteger(value.getAsInt());
+      }
+      result.put(entry.getKey(), parsed);
+    }
+    return Collections.unmodifiableMap(result);
+  }
+
+  private static DeclarativeBenchmarkPlan.MatcherLifecycle parseLifecycle(JsonObject object) {
+    DeclarativeBenchmarkPlan.MatcherReuse matcher =
+        DeclarativeBenchmarkPlan.MatcherReuse.fromJson(string(object, "matcher"));
+    List<DeclarativeBenchmarkPlan.LifecycleStep> steps = new ArrayList<>();
+    for (JsonElement element : required(object, "steps").getAsJsonArray()) {
+      JsonObject step = element.getAsJsonObject();
+      steps.add(
+          new DeclarativeBenchmarkPlan.LifecycleStep(
+              DeclarativeBenchmarkPlan.LifecycleStepKind.fromJson(string(step, "kind")),
+              optionalInt(step, "start"),
+              optionalInt(step, "end"),
+              optionalBoolean(step, "enabled")));
+    }
+    return new DeclarativeBenchmarkPlan.MatcherLifecycle(matcher, steps);
+  }
+
+  private static DeclarativeBenchmarkPlan.Measurement parseMeasurement(JsonObject object) {
+    EnumSet<DeclarativeBenchmarkPlan.ExecutionConstraint> constraints =
+        EnumSet.noneOf(DeclarativeBenchmarkPlan.ExecutionConstraint.class);
+    for (String constraint : strings(object, "constraints")) {
+      constraints.add(DeclarativeBenchmarkPlan.ExecutionConstraint.fromJson(constraint));
+    }
+    return new DeclarativeBenchmarkPlan.Measurement(
+        DeclarativeBenchmarkPlan.MeasurementMode.fromJson(string(object, "mode")),
+        DeclarativeBenchmarkPlan.TimingUnit.fromJson(string(object, "timingUnit")),
+        constraints);
+  }
+
+  private static JsonElement required(JsonObject object, String name) {
+    JsonElement value = object.get(name);
+    if (value == null || value.isJsonNull()) {
+      throw new IllegalArgumentException("Materialized execution plan requires " + name);
+    }
+    return value;
+  }
+
+  private static String string(JsonObject object, String name) {
+    return required(object, name).getAsString();
+  }
+
+  private static List<String> strings(JsonObject object, String name) {
+    List<String> result = new ArrayList<>();
+    required(object, name).getAsJsonArray().forEach(item -> result.add(item.getAsString()));
+    return List.copyOf(result);
+  }
+
+  private static Integer optionalInt(JsonObject object, String name) {
+    return object.has(name) ? object.get(name).getAsInt() : null;
+  }
+
+  private static Boolean optionalBoolean(JsonObject object, String name) {
+    return object.has(name) ? object.get(name).getAsBoolean() : null;
+  }
+
+  record Engine(String id, String reportEngine, String runner) {}
+
+  record Exclusion(String kind, String reason) {}
+
+  record Entry(
+      String id,
+      String workloadId,
+      String engineId,
+      String reportEngine,
+      DeclarativeBenchmarkPlan.Operation operation,
+      DeclarativeBenchmarkPlan.Measurement measurement,
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload,
+      Exclusion exclusion) {
+    boolean runnable() {
+      return workload != null;
+    }
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
@@ -21,9 +21,9 @@ import java.util.regex.Pattern;
 final class PatternProfiles {
   private static final Pattern PROFILE_ID = Pattern.compile("[a-z][a-z0-9-]*");
 
-  private final Map<String, Map<String, String>> profiles;
+  private final Map<String, Map<String, Selection>> profiles;
 
-  private PatternProfiles(Map<String, Map<String, String>> profiles) {
+  private PatternProfiles(Map<String, Map<String, Selection>> profiles) {
     this.profiles = Collections.unmodifiableMap(new LinkedHashMap<>(profiles));
   }
 
@@ -124,21 +124,34 @@ final class PatternProfiles {
       }
       JsonObject alternateObject = entry.getValue().getAsJsonObject();
       for (String field : alternateObject.keySet()) {
-        if (!field.equals("pattern") && !field.equals("replacement") && !field.equals("reason")) {
+        if (!field.equals("pattern")
+            && !field.equals("replacement")
+            && !field.equals("unsupported")
+            && !field.equals("reason")) {
           throw new IllegalArgumentException(
               "Inline benchmark pattern alternate " + profileId + " has unknown field: " + field);
         }
       }
       boolean hasPattern = alternateObject.has("pattern");
       boolean hasReplacement = alternateObject.has("replacement");
-      if (hasPattern == hasReplacement) {
+      boolean unsupported = alternateObject.has("unsupported");
+      int selectionCount = (hasPattern ? 1 : 0) + (hasReplacement ? 1 : 0) + (unsupported ? 1 : 0);
+      if (selectionCount != 1) {
         throw new IllegalArgumentException(
             "Inline benchmark pattern alternate "
                 + profileId
-                + " requires exactly one of: pattern, replacement");
+                + " requires exactly one of: pattern, replacement, unsupported");
       }
-      String valueField = hasPattern ? "pattern" : "replacement";
-      ValueKind alternateKind = hasPattern ? ValueKind.PATTERN : ValueKind.REPLACEMENT;
+      if (unsupported
+          && (!alternateObject.get("unsupported").isJsonPrimitive()
+              || !alternateObject.getAsJsonPrimitive("unsupported").isBoolean()
+              || !alternateObject.get("unsupported").getAsBoolean())) {
+        throw new IllegalArgumentException(
+            "Inline benchmark pattern alternate " + profileId + " field unsupported must be true");
+      }
+      String valueField = hasPattern ? "pattern" : hasReplacement ? "replacement" : null;
+      ValueKind alternateKind =
+          hasPattern ? ValueKind.PATTERN : hasReplacement ? ValueKind.REPLACEMENT : expectedKind;
       if (alternateKind != expectedKind) {
         throw new IllegalArgumentException(
             "Inline benchmark "
@@ -147,24 +160,35 @@ final class PatternProfiles {
                 + alternateKind.field()
                 + " alternate");
       }
-      if (definitionKind != null && !definitionKind.equals(valueField)) {
+      if (valueField != null && definitionKind != null && !definitionKind.equals(valueField)) {
         throw new IllegalArgumentException(
             "Inline benchmark definition mixes pattern and replacement alternates");
       }
-      definitionKind = valueField;
+      if (valueField != null) {
+        definitionKind = valueField;
+      }
       Alternate alternate =
           new Alternate(
-              requiredInlineString(
-                  alternateObject, valueField, "Inline benchmark pattern alternate " + profileId),
+              unsupported
+                  ? null
+                  : requiredInlineString(
+                      alternateObject,
+                      valueField,
+                      "Inline benchmark pattern alternate " + profileId),
               requiredInlineString(
                   alternateObject, "reason", "Inline benchmark pattern alternate " + profileId));
       Alternate previous =
-          (hasPattern ? patternProfiles : replacementProfiles)
+          (expectedKind == ValueKind.PATTERN ? patternProfiles : replacementProfiles)
               .computeIfAbsent(profileId, unused -> new LinkedHashMap<>())
               .putIfAbsent(javaPattern, alternate);
       if (previous != null && !previous.equals(alternate)) {
         throw new IllegalArgumentException(
-            "Conflicting " + profileId + " alternates for Java " + valueField + ": " + javaPattern);
+            "Conflicting "
+                + profileId
+                + " alternates for Java "
+                + expectedKind.field()
+                + ": "
+                + javaPattern);
       }
     }
     return new JsonPrimitive(javaPattern);
@@ -189,7 +213,11 @@ final class PatternProfiles {
       for (Map.Entry<String, Alternate> alternate : profile.getValue().entrySet()) {
         JsonObject entry = new JsonObject();
         entry.addProperty("java", alternate.getKey());
-        entry.addProperty("alternate", alternate.getValue().value());
+        if (alternate.getValue().value() == null) {
+          entry.addProperty("unsupported", true);
+        } else {
+          entry.addProperty("alternate", alternate.getValue().value());
+        }
         entry.addProperty("reason", alternate.getValue().reason());
         entries.add(entry);
       }
@@ -205,7 +233,7 @@ final class PatternProfiles {
     if (!element.isJsonObject()) {
       throw new IllegalArgumentException("patternProfiles must be an object");
     }
-    Map<String, Map<String, String>> profiles = new LinkedHashMap<>();
+    Map<String, Map<String, Selection>> profiles = new LinkedHashMap<>();
     for (Map.Entry<String, JsonElement> profileEntry : element.getAsJsonObject().entrySet()) {
       String profileId = profileEntry.getKey();
       if (!PROFILE_ID.matcher(profileId).matches()) {
@@ -214,15 +242,15 @@ final class PatternProfiles {
       if (!profileEntry.getValue().isJsonArray()) {
         throw new IllegalArgumentException("Pattern profile " + profileId + " must be an array");
       }
-      Map<String, String> alternatives =
+      Map<String, Selection> alternatives =
           parseProfile(profileId, profileEntry.getValue().getAsJsonArray());
       profiles.put(profileId, Collections.unmodifiableMap(alternatives));
     }
     return new PatternProfiles(profiles);
   }
 
-  private static Map<String, String> parseProfile(String profileId, JsonArray entries) {
-    Map<String, String> alternatives = new LinkedHashMap<>();
+  private static Map<String, Selection> parseProfile(String profileId, JsonArray entries) {
+    Map<String, Selection> alternatives = new LinkedHashMap<>();
     for (JsonElement element : entries) {
       if (!element.isJsonObject()) {
         throw new IllegalArgumentException(
@@ -230,15 +258,32 @@ final class PatternProfiles {
       }
       JsonObject entry = element.getAsJsonObject();
       for (String field : entry.keySet()) {
-        if (!field.equals("java") && !field.equals("alternate") && !field.equals("reason")) {
+        if (!field.equals("java")
+            && !field.equals("alternate")
+            && !field.equals("unsupported")
+            && !field.equals("reason")) {
           throw new IllegalArgumentException(
               "Pattern profile " + profileId + " entry has unknown field: " + field);
         }
       }
       String javaPattern = requiredString(entry, profileId, "java");
-      String alternate = requiredString(entry, profileId, "alternate");
-      requiredString(entry, profileId, "reason");
-      if (alternatives.put(javaPattern, alternate) != null) {
+      boolean unsupported =
+          entry.has("unsupported")
+              && entry.get("unsupported").isJsonPrimitive()
+              && entry.getAsJsonPrimitive("unsupported").isBoolean()
+              && entry.get("unsupported").getAsBoolean();
+      if (entry.has("alternate") == unsupported) {
+        throw new IllegalArgumentException(
+            "Pattern profile "
+                + profileId
+                + " entry requires exactly one of alternate or unsupported=true");
+      }
+      String reason = requiredString(entry, profileId, "reason");
+      Selection selection =
+          unsupported
+              ? new Selection(null, reason)
+              : new Selection(requiredString(entry, profileId, "alternate"), null);
+      if (alternatives.put(javaPattern, selection) != null) {
         throw new IllegalArgumentException(
             "Pattern profile " + profileId + " repeats Java pattern: " + javaPattern);
       }
@@ -261,8 +306,24 @@ final class PatternProfiles {
   }
 
   String select(String profileId, String javaPattern) {
-    Map<String, String> alternatives = profiles.get(profileId);
-    return alternatives == null ? javaPattern : alternatives.getOrDefault(javaPattern, javaPattern);
+    Selection selection = resolve(profileId, javaPattern);
+    if (selection.unsupportedReason() != null) {
+      throw new IllegalArgumentException(
+          "Profile "
+              + profileId
+              + " does not support Java syntax "
+              + javaPattern
+              + ": "
+              + selection.unsupportedReason());
+    }
+    return selection.value();
+  }
+
+  Selection resolve(String profileId, String javaPattern) {
+    Map<String, Selection> alternatives = profiles.get(profileId);
+    return alternatives == null
+        ? new Selection(javaPattern, null)
+        : alternatives.getOrDefault(javaPattern, new Selection(javaPattern, null));
   }
 
   private enum ValueKind {
@@ -281,6 +342,8 @@ final class PatternProfiles {
   }
 
   private record NormalizationFrame(JsonElement element, ValueKind kind) {}
+
+  record Selection(String value, String unsupportedReason) {}
 
   private record Alternate(String value, String reason) {}
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
@@ -15,6 +15,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /** Explicit engine-profile alternatives for Java-canonical benchmark regex syntax. */
@@ -36,7 +37,11 @@ final class PatternProfiles {
     Map<String, Map<String, Alternate>> patternProfiles = new LinkedHashMap<>();
     Map<String, Map<String, Alternate>> replacementProfiles = new LinkedHashMap<>();
     Deque<NormalizationFrame> pending = new ArrayDeque<>();
-    pending.push(new NormalizationFrame(normalized, null));
+    JsonElement syntaxRoot =
+        normalized.has("schemaVersion") ? normalized.getAsJsonArray("workloads") : normalized;
+    if (syntaxRoot != null) {
+      pending.push(new NormalizationFrame(syntaxRoot, null));
+    }
     while (!pending.isEmpty()) {
       NormalizationFrame frame = pending.pop();
       JsonElement element = frame.element();
@@ -324,6 +329,17 @@ final class PatternProfiles {
     return alternatives == null
         ? new Selection(javaPattern, null)
         : alternatives.getOrDefault(javaPattern, new Selection(javaPattern, null));
+  }
+
+  void validateReferences(Set<String> authoritativeValues, String kind) {
+    for (Map.Entry<String, Map<String, Selection>> profile : profiles.entrySet()) {
+      for (String javaValue : profile.getValue().keySet()) {
+        if (!authoritativeValues.contains(javaValue)) {
+          throw new IllegalArgumentException(
+              "Unreferenced " + kind + " profile value for " + profile.getKey() + ": " + javaValue);
+        }
+      }
+    }
   }
 
   private enum ValueKind {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
@@ -13,6 +13,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +22,13 @@ import java.util.regex.Pattern;
 /** Explicit engine-profile alternatives for Java-canonical benchmark regex syntax. */
 final class PatternProfiles {
   private static final Pattern PROFILE_ID = Pattern.compile("[a-z][a-z0-9-]*");
+  private static final Set<String> FLAG_SETS =
+      Set.of(
+          "0",
+          "CASE_INSENSITIVE",
+          "CASE_INSENSITIVE_UNICODE_CASE",
+          "UNICODE_CHARACTER_CLASS",
+          "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS");
 
   private final Map<String, Map<String, Selection>> profiles;
 
@@ -132,7 +140,8 @@ final class PatternProfiles {
         if (!field.equals("pattern")
             && !field.equals("replacement")
             && !field.equals("unsupported")
-            && !field.equals("reason")) {
+            && !field.equals("reason")
+            && !field.equals("flagSets")) {
           throw new IllegalArgumentException(
               "Inline benchmark pattern alternate " + profileId + " has unknown field: " + field);
         }
@@ -181,7 +190,8 @@ final class PatternProfiles {
                       valueField,
                       "Inline benchmark pattern alternate " + profileId),
               requiredInlineString(
-                  alternateObject, "reason", "Inline benchmark pattern alternate " + profileId));
+                  alternateObject, "reason", "Inline benchmark pattern alternate " + profileId),
+              optionalFlagSets(alternateObject, "Inline benchmark pattern alternate " + profileId));
       Alternate previous =
           (expectedKind == ValueKind.PATTERN ? patternProfiles : replacementProfiles)
               .computeIfAbsent(profileId, unused -> new LinkedHashMap<>())
@@ -224,6 +234,11 @@ final class PatternProfiles {
           entry.addProperty("alternate", alternate.getValue().value());
         }
         entry.addProperty("reason", alternate.getValue().reason());
+        if (!alternate.getValue().flagSets().isEmpty()) {
+          JsonArray flagSets = new JsonArray();
+          alternate.getValue().flagSets().forEach(flagSets::add);
+          entry.add("flagSets", flagSets);
+        }
         entries.add(entry);
       }
       result.add(profile.getKey(), entries);
@@ -266,7 +281,8 @@ final class PatternProfiles {
         if (!field.equals("java")
             && !field.equals("alternate")
             && !field.equals("unsupported")
-            && !field.equals("reason")) {
+            && !field.equals("reason")
+            && !field.equals("flagSets")) {
           throw new IllegalArgumentException(
               "Pattern profile " + profileId + " entry has unknown field: " + field);
         }
@@ -286,8 +302,11 @@ final class PatternProfiles {
       String reason = requiredString(entry, profileId, "reason");
       Selection selection =
           unsupported
-              ? new Selection(null, reason)
-              : new Selection(requiredString(entry, profileId, "alternate"), null);
+              ? new Selection(null, reason, optionalFlagSets(entry, "Pattern profile " + profileId))
+              : new Selection(
+                  requiredString(entry, profileId, "alternate"),
+                  null,
+                  optionalFlagSets(entry, "Pattern profile " + profileId));
       if (alternatives.put(javaPattern, selection) != null) {
         throw new IllegalArgumentException(
             "Pattern profile " + profileId + " repeats Java pattern: " + javaPattern);
@@ -310,8 +329,36 @@ final class PatternProfiles {
     return string;
   }
 
+  private static Set<String> optionalFlagSets(JsonObject entry, String description) {
+    JsonElement value = entry.get("flagSets");
+    if (value == null) {
+      return Set.of();
+    }
+    if (!value.isJsonArray() || value.getAsJsonArray().isEmpty()) {
+      throw new IllegalArgumentException(description + " field flagSets must be a nonempty array");
+    }
+    Set<String> result = new LinkedHashSet<>();
+    for (JsonElement element : value.getAsJsonArray()) {
+      if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) {
+        throw new IllegalArgumentException(description + " flagSets must contain strings");
+      }
+      String flagSet = element.getAsString();
+      if (!FLAG_SETS.contains(flagSet)) {
+        throw new IllegalArgumentException(description + " has unknown flag set: " + flagSet);
+      }
+      if (!result.add(flagSet)) {
+        throw new IllegalArgumentException(description + " repeats flag set: " + flagSet);
+      }
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
   String select(String profileId, String javaPattern) {
-    Selection selection = resolve(profileId, javaPattern);
+    return select(profileId, javaPattern, "0");
+  }
+
+  String select(String profileId, String javaPattern, String flagSet) {
+    Selection selection = resolve(profileId, javaPattern, flagSet);
     if (selection.unsupportedReason() != null) {
       throw new IllegalArgumentException(
           "Profile "
@@ -325,10 +372,16 @@ final class PatternProfiles {
   }
 
   Selection resolve(String profileId, String javaPattern) {
+    return resolve(profileId, javaPattern, "0");
+  }
+
+  Selection resolve(String profileId, String javaPattern, String flagSet) {
     Map<String, Selection> alternatives = profiles.get(profileId);
-    return alternatives == null
-        ? new Selection(javaPattern, null)
-        : alternatives.getOrDefault(javaPattern, new Selection(javaPattern, null));
+    Selection selection = alternatives == null ? null : alternatives.get(javaPattern);
+    return selection == null
+            || (!selection.flagSets().isEmpty() && !selection.flagSets().contains(flagSet))
+        ? new Selection(javaPattern, null, Set.of())
+        : selection;
   }
 
   void validateReferences(Set<String> authoritativeValues, String kind) {
@@ -359,7 +412,7 @@ final class PatternProfiles {
 
   private record NormalizationFrame(JsonElement element, ValueKind kind) {}
 
-  record Selection(String value, String unsupportedReason) {}
+  record Selection(String value, String unsupportedReason, Set<String> flagSets) {}
 
-  private record Alternate(String value, String reason) {}
+  private record Alternate(String value, String reason, Set<String> flagSets) {}
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
@@ -314,6 +314,7 @@ final class ResolvedBenchmarkPlan {
     entry.addProperty("reportEngine", engine.reportEngine());
     entry.addProperty("operation", workload.operation().jsonName());
     entry.add("measurement", measurement(workload.measurement()));
+    String flagSet = flagSet(workload);
 
     Exclusion exclusion = exclusion(workload, engine, patternProfiles, replacementProfiles);
     if (exclusion != null) {
@@ -330,11 +331,11 @@ final class ResolvedBenchmarkPlan {
         "patterns",
         strings(
             workload.patterns().stream()
-                .map(pattern -> patternProfiles.select(engine.patternProfile(), pattern))
+                .map(pattern -> patternProfiles.select(engine.patternProfile(), pattern, flagSet))
                 .toList()));
     entry.add("inputs", strings(workload.inputIds()));
-    entry.add("arguments", arguments(workload.arguments(), engine, replacementProfiles));
-    entry.add("options", strings(options(flagSet(workload))));
+    entry.add("arguments", arguments(workload.arguments(), engine, replacementProfiles, flagSet));
+    entry.add("options", strings(options(flagSet)));
     entry.addProperty("inputRepresentation", engine.declaration().inputRepresentation().jsonName());
     entry.addProperty("resultConsumption", workload.resultConsumption().jsonName());
     if (workload.expected() != null) {
@@ -389,7 +390,8 @@ final class ResolvedBenchmarkPlan {
       return new Exclusion("unsupportedFeature", "engine lacks " + featureNames(missing));
     }
     for (String pattern : workload.patterns()) {
-      String reason = patternProfiles.resolve(engine.patternProfile(), pattern).unsupportedReason();
+      String reason =
+          patternProfiles.resolve(engine.patternProfile(), pattern, flagSet).unsupportedReason();
       if (reason != null) {
         return new Exclusion("unsupportedSyntax", reason);
       }
@@ -398,7 +400,9 @@ final class ResolvedBenchmarkPlan {
     if (replacement != null) {
       String value = ((DeclarativeBenchmarkPlan.RecipeString) replacement).value();
       String reason =
-          replacementProfiles.resolve(engine.replacementProfile(), value).unsupportedReason();
+          replacementProfiles
+              .resolve(engine.replacementProfile(), value, flagSet)
+              .unsupportedReason();
       if (reason != null) {
         return new Exclusion("unsupportedSyntax", reason);
       }
@@ -409,7 +413,8 @@ final class ResolvedBenchmarkPlan {
   private static JsonObject arguments(
       Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments,
       Engine engine,
-      PatternProfiles replacementProfiles) {
+      PatternProfiles replacementProfiles,
+      String flagSet) {
     JsonObject result = new JsonObject();
     arguments.forEach(
         (name, value) -> {
@@ -417,7 +422,8 @@ final class ResolvedBenchmarkPlan {
           if (name.equals("replacement")) {
             json =
                 new JsonPrimitive(
-                    replacementProfiles.select(engine.replacementProfile(), json.getAsString()));
+                    replacementProfiles.select(
+                        engine.replacementProfile(), json.getAsString(), flagSet));
           }
           result.add(name, json);
         });

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
@@ -88,6 +88,19 @@ final class ResolvedBenchmarkPlan {
             }));
 
     List<DeclarativeBenchmarkPlan.ExpandedWorkload> workloads = plan.expandedWorkloads();
+    patternProfiles.validateReferences(
+        workloads.stream()
+            .flatMap(workload -> workload.patterns().stream())
+            .collect(java.util.stream.Collectors.toSet()),
+        "pattern");
+    replacementProfiles.validateReferences(
+        workloads.stream()
+            .map(workload -> workload.arguments().get("replacement"))
+            .filter(DeclarativeBenchmarkPlan.RecipeString.class::isInstance)
+            .map(DeclarativeBenchmarkPlan.RecipeString.class::cast)
+            .map(DeclarativeBenchmarkPlan.RecipeString::value)
+            .collect(java.util.stream.Collectors.toSet()),
+        "replacement");
     JsonArray entries = new JsonArray();
     for (DeclarativeBenchmarkPlan.ExpandedWorkload workload : workloads) {
       for (Engine engine : engines) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
@@ -9,67 +9,405 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
- * Serializes expanded engine-neutral workloads for cross-runtime benchmark harnesses.
+ * Materializes the complete engine/workload compatibility join for every benchmark runner.
  *
- * <p>The Java harness can consume the typed declarative plan directly, but external runtimes
- * cannot. This projection resolves axes and recipe references once during materialization so a
- * native runner can execute or explicitly exclude every concrete workload without interpreting the
- * checked-in plan schema. Pattern and replacement profile selection remains the responsibility of
- * each engine adapter.
+ * <p>The resulting execution plan is the only workload contract consumed by Java and cross-runtime
+ * runners. Every concrete workload/engine pair is represented exactly once as either runnable, with
+ * engine-selected syntax and resolved arguments, or excluded with a durable reason.
  */
 final class ResolvedBenchmarkPlan {
+  static final int VERSION = 1;
+
+  private static final EnumSet<DeclarativeBenchmarkPlan.Operation> PORTABLE_OPERATIONS =
+      EnumSet.of(
+          DeclarativeBenchmarkPlan.Operation.MATCHES,
+          DeclarativeBenchmarkPlan.Operation.FIND,
+          DeclarativeBenchmarkPlan.Operation.LOOKING_AT,
+          DeclarativeBenchmarkPlan.Operation.FIND_ALL_COUNT,
+          DeclarativeBenchmarkPlan.Operation.MATCHES_CORPUS,
+          DeclarativeBenchmarkPlan.Operation.MATCHES_GROUP_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.FIND_ALL_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.FIND_ALL_GROUP_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.CAPTURE_GROUPS,
+          DeclarativeBenchmarkPlan.Operation.REPLACE_FIRST,
+          DeclarativeBenchmarkPlan.Operation.REPLACE_ALL,
+          DeclarativeBenchmarkPlan.Operation.REPLACE_ALL_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.SPLIT_LENGTH_SUM,
+          DeclarativeBenchmarkPlan.Operation.COMPILE,
+          DeclarativeBenchmarkPlan.Operation.COMPILE_AND_FIND,
+          DeclarativeBenchmarkPlan.Operation.FIND_GROUP_PRESENT,
+          DeclarativeBenchmarkPlan.Operation.FIND_GROUP);
+
+  private static final EnumSet<DeclarativeBenchmarkPlan.MeasurementMode> PORTABLE_MODES =
+      EnumSet.of(
+          DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME,
+          DeclarativeBenchmarkPlan.MeasurementMode.COMPILE_ONLY,
+          DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY);
+
   private ResolvedBenchmarkPlan() {}
 
-  static JsonArray create(JsonObject normalizedBenchmarkData) {
+  static JsonObject create(JsonObject normalizedBenchmarkData) {
+    return create(normalizedBenchmarkData, engines());
+  }
+
+  static JsonObject create(JsonObject normalizedBenchmarkData, List<Engine> engines) {
     JsonObject planData = new JsonObject();
     planData.add("schemaVersion", normalizedBenchmarkData.get("schemaVersion").deepCopy());
     planData.add("inputs", normalizedBenchmarkData.getAsJsonArray("inputs").deepCopy());
     planData.add("workloads", normalizedBenchmarkData.getAsJsonArray("workloads").deepCopy());
 
-    JsonArray result = new JsonArray();
-    DeclarativeBenchmarkPlan.parse(planData)
-        .expandedWorkloads()
-        .forEach(workload -> result.add(toJson(workload)));
+    DeclarativeBenchmarkPlan plan = DeclarativeBenchmarkPlan.parse(planData);
+    PatternProfiles patternProfiles =
+        PatternProfiles.parse(normalizedBenchmarkData.get("patternProfiles"));
+    PatternProfiles replacementProfiles =
+        PatternProfiles.parse(normalizedBenchmarkData.get("replacementProfiles"));
+
+    validateEngines(engines);
+    JsonObject result = new JsonObject();
+    result.addProperty("version", VERSION);
+    result.add(
+        "engines",
+        array(
+            engines,
+            engine -> {
+              JsonObject json = new JsonObject();
+              json.addProperty("id", engine.id());
+              json.addProperty("reportEngine", engine.reportEngine());
+              json.addProperty("runner", engine.runner());
+              return json;
+            }));
+
+    List<DeclarativeBenchmarkPlan.ExpandedWorkload> workloads = plan.expandedWorkloads();
+    JsonArray entries = new JsonArray();
+    for (DeclarativeBenchmarkPlan.ExpandedWorkload workload : workloads) {
+      for (Engine engine : engines) {
+        entries.add(toEntry(workload, engine, patternProfiles, replacementProfiles));
+      }
+    }
+    result.addProperty("workloadCount", workloads.size());
+    result.addProperty("engineCount", engines.size());
+    result.add("entries", entries);
     return result;
   }
 
-  private static JsonObject toJson(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    JsonObject result = new JsonObject();
-    result.addProperty("id", workload.id());
-    result.addProperty("operation", workload.operation().jsonName());
-    result.add("patterns", strings(workload.patterns()));
-    result.add("inputs", strings(workload.inputIds()));
-    result.add("arguments", arguments(workload.arguments()));
-    result.add("flags", names(workload.flags(), DeclarativeBenchmarkPlan.Flag::jsonName));
+  static List<Engine> engines() {
+    List<Engine> result = new ArrayList<>();
+    for (RegexEngineVariant variant : RegexEngineVariant.values()) {
+      result.add(
+          new Engine(
+              variant.id(),
+              variant.reportEngine(),
+              "java",
+              variant.patternProfile(),
+              "java",
+              variant.declaration(),
+              EnumSet.allOf(DeclarativeBenchmarkPlan.Operation.class),
+              EnumSet.allOf(DeclarativeBenchmarkPlan.MeasurementMode.class),
+              variant == RegexEngineVariant.SAFERE_STRING
+                      || variant == RegexEngineVariant.SAFERE_UTF8
+                      || variant == RegexEngineVariant.JDK_STRING
+                  ? allFlagSets()
+                  : Set.of("0")));
+    }
+
     result.add(
-        "requirements", names(workload.requirements(), DeclarativeBenchmarkPlan.Feature::jsonName));
+        portableEngine(
+            "re2_cpp",
+            "re2_cpp",
+            "cpp",
+            "re2",
+            "re2-cpp",
+            true,
+            true,
+            false,
+            PORTABLE_OPERATIONS,
+            PORTABLE_MODES));
     result.add(
-        "inputRepresentations",
-        names(
-            workload.inputRepresentations(),
-            DeclarativeBenchmarkPlan.InputRepresentation::jsonName));
-    result.addProperty("resultConsumption", workload.resultConsumption().jsonName());
+        portableEngine(
+            "pcre2_jit",
+            "pcre2_jit",
+            "cpp",
+            "pcre2",
+            "pcre2",
+            false,
+            false,
+            false,
+            withoutReplacement(PORTABLE_OPERATIONS),
+            PORTABLE_MODES));
+    result.add(
+        portableEngine(
+            "go_regexp",
+            "go_regexp",
+            "go",
+            "re2",
+            "go-regexp",
+            true,
+            true,
+            true,
+            PORTABLE_OPERATIONS,
+            PORTABLE_MODES));
+    result.add(
+        portableEngine(
+            "rust_regex",
+            "rust_regex",
+            "rust",
+            "rust-regex",
+            "rust-regex",
+            true,
+            true,
+            true,
+            PORTABLE_OPERATIONS,
+            PORTABLE_MODES));
+
+    EnumSet<DeclarativeBenchmarkPlan.Feature> dotnetFeatures = portableFeatures(false, true, false);
+    dotnetFeatures.add(DeclarativeBenchmarkPlan.Feature.FLAGGED_COMPILE);
+    dotnetFeatures.add(DeclarativeBenchmarkPlan.Feature.JAVA_CHARACTER_CLASS);
+    EnumSet<DeclarativeBenchmarkPlan.Operation> dotnetOperations =
+        EnumSet.copyOf(PORTABLE_OPERATIONS);
+    dotnetOperations.add(DeclarativeBenchmarkPlan.Operation.FIND_ROTATING_UTF16);
+    dotnetOperations.add(DeclarativeBenchmarkPlan.Operation.COMPILE_AND_FIND_ROTATING_UTF16);
+    result.add(
+        new Engine(
+            "dotnet_nonbacktracking",
+            "dotnet_nonbacktracking",
+            "dotnet",
+            "dotnet",
+            "dotnet",
+            new DeclarativeBenchmarkPlan.EngineDeclaration(
+                "dotnet_nonbacktracking",
+                DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                dotnetFeatures,
+                EnumSet.noneOf(DeclarativeBenchmarkPlan.Flag.class),
+                true),
+            dotnetOperations,
+            EnumSet.of(
+                DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME,
+                DeclarativeBenchmarkPlan.MeasurementMode.COMPILE_ONLY,
+                DeclarativeBenchmarkPlan.MeasurementMode.SINGLE_SHOT_COLD_START),
+            Set.of(
+                "0",
+                "CASE_INSENSITIVE_UNICODE_CASE",
+                "UNICODE_CHARACTER_CLASS",
+                "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS")));
+    return List.copyOf(result);
+  }
+
+  private static Engine portableEngine(
+      String id,
+      String reportEngine,
+      String runner,
+      String patternProfile,
+      String replacementProfile,
+      boolean linearTime,
+      boolean replacement,
+      boolean retainedHeap,
+      EnumSet<DeclarativeBenchmarkPlan.Operation> operations,
+      EnumSet<DeclarativeBenchmarkPlan.MeasurementMode> modes) {
+    return new Engine(
+        id,
+        reportEngine,
+        runner,
+        patternProfile,
+        replacementProfile,
+        new DeclarativeBenchmarkPlan.EngineDeclaration(
+            id,
+            DeclarativeBenchmarkPlan.InputRepresentation.PREEXISTING_UTF8,
+            portableFeatures(linearTime, replacement, retainedHeap),
+            EnumSet.noneOf(DeclarativeBenchmarkPlan.Flag.class),
+            true),
+        operations,
+        modes,
+        Set.of("0"));
+  }
+
+  private static EnumSet<DeclarativeBenchmarkPlan.Feature> portableFeatures(
+      boolean linearTime, boolean replacement, boolean retainedHeap) {
+    EnumSet<DeclarativeBenchmarkPlan.Feature> features =
+        EnumSet.of(
+            DeclarativeBenchmarkPlan.Feature.FIND,
+            DeclarativeBenchmarkPlan.Feature.MATCHES,
+            DeclarativeBenchmarkPlan.Feature.LOOKING_AT,
+            DeclarativeBenchmarkPlan.Feature.CAPTURE_PARTICIPATION,
+            DeclarativeBenchmarkPlan.Feature.CAPTURE_TEXT,
+            DeclarativeBenchmarkPlan.Feature.NAMED_GROUPS,
+            DeclarativeBenchmarkPlan.Feature.SPLIT);
+    if (linearTime) {
+      features.add(DeclarativeBenchmarkPlan.Feature.LINEAR_TIME);
+    }
+    if (replacement) {
+      features.add(DeclarativeBenchmarkPlan.Feature.REPLACE);
+      features.add(DeclarativeBenchmarkPlan.Feature.NUMBERED_REPLACEMENT);
+      features.add(DeclarativeBenchmarkPlan.Feature.NAMED_REPLACEMENT);
+    }
+    if (retainedHeap) {
+      features.add(DeclarativeBenchmarkPlan.Feature.RETAINED_HEAP);
+    }
+    return features;
+  }
+
+  private static EnumSet<DeclarativeBenchmarkPlan.Operation> withoutReplacement(
+      EnumSet<DeclarativeBenchmarkPlan.Operation> operations) {
+    EnumSet<DeclarativeBenchmarkPlan.Operation> result = EnumSet.copyOf(operations);
+    result.remove(DeclarativeBenchmarkPlan.Operation.REPLACE_FIRST);
+    result.remove(DeclarativeBenchmarkPlan.Operation.REPLACE_ALL);
+    result.remove(DeclarativeBenchmarkPlan.Operation.REPLACE_ALL_LENGTH_SUM);
+    return result;
+  }
+
+  private static Set<String> allFlagSets() {
+    return Set.of(
+        "0",
+        "CASE_INSENSITIVE",
+        "CASE_INSENSITIVE_UNICODE_CASE",
+        "UNICODE_CHARACTER_CLASS",
+        "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS");
+  }
+
+  private static void validateEngines(List<Engine> engines) {
+    if (engines.isEmpty()) {
+      throw new IllegalArgumentException("Execution plan requires at least one engine");
+    }
+    Set<String> ids = new LinkedHashSet<>();
+    for (Engine engine : engines) {
+      if (!ids.add(engine.id())) {
+        throw new IllegalArgumentException("Duplicate execution-plan engine ID: " + engine.id());
+      }
+      if (!engine.id().equals(engine.declaration().id())) {
+        throw new IllegalArgumentException(
+            "Execution-plan engine declaration ID differs from engine ID: " + engine.id());
+      }
+    }
+  }
+
+  private static JsonObject toEntry(
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload,
+      Engine engine,
+      PatternProfiles patternProfiles,
+      PatternProfiles replacementProfiles) {
+    JsonObject entry = new JsonObject();
+    entry.addProperty("id", workload.id() + "@" + engine.id());
+    entry.addProperty("workloadId", workload.id());
+    entry.addProperty("engineId", engine.id());
+    entry.addProperty("reportEngine", engine.reportEngine());
+    entry.addProperty("operation", workload.operation().jsonName());
+    entry.add("measurement", measurement(workload.measurement()));
+
+    Exclusion exclusion = exclusion(workload, engine, patternProfiles, replacementProfiles);
+    if (exclusion != null) {
+      entry.addProperty("status", "excluded");
+      JsonObject reason = new JsonObject();
+      reason.addProperty("kind", exclusion.kind());
+      reason.addProperty("reason", exclusion.reason());
+      entry.add("exclusion", reason);
+      return entry;
+    }
+
+    entry.addProperty("status", "runnable");
+    entry.add(
+        "patterns",
+        strings(
+            workload.patterns().stream()
+                .map(pattern -> patternProfiles.select(engine.patternProfile(), pattern))
+                .toList()));
+    entry.add("inputs", strings(workload.inputIds()));
+    entry.add("arguments", arguments(workload.arguments(), engine, replacementProfiles));
+    entry.add("options", strings(options(flagSet(workload))));
+    entry.addProperty("inputRepresentation", engine.declaration().inputRepresentation().jsonName());
+    entry.addProperty("resultConsumption", workload.resultConsumption().jsonName());
     if (workload.expected() != null) {
       JsonObject expected = new JsonObject();
       expected.addProperty("type", workload.expected().type().jsonName());
       expected.add("value", workload.expected().value());
-      result.add("expected", expected);
+      entry.add("expected", expected);
     }
-    result.add("lifecycle", lifecycle(workload.lifecycle()));
-    result.add("measurement", measurement(workload.measurement()));
-    if (workload.disabledReason() != null) {
-      result.addProperty("disabledReason", workload.disabledReason());
-    }
-    return result;
+    entry.add("lifecycle", lifecycle(workload.lifecycle()));
+    return entry;
   }
 
-  private static JsonObject arguments(Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments) {
+  private static Exclusion exclusion(
+      DeclarativeBenchmarkPlan.ExpandedWorkload workload,
+      Engine engine,
+      PatternProfiles patternProfiles,
+      PatternProfiles replacementProfiles) {
+    if (workload.disabledReason() != null) {
+      return new Exclusion("workloadDisabled", workload.disabledReason());
+    }
+    if (!engine.declaration().adapterAvailable()) {
+      return new Exclusion("missingEngineAdapter", "engine adapter is not available");
+    }
+    if (!engine.operations().contains(workload.operation())) {
+      return new Exclusion(
+          "unsupportedOperation",
+          "engine does not implement operation " + workload.operation().jsonName());
+    }
+    if (!engine.measurementModes().contains(workload.measurement().mode())) {
+      return new Exclusion(
+          "unsupportedMeasurementMode",
+          "engine does not implement measurement mode " + workload.measurement().mode().jsonName());
+    }
+    if ((!workload.inputIds().isEmpty() || engine.runner().equals("java"))
+        && !workload.inputRepresentations().contains(engine.declaration().inputRepresentation())) {
+      return new Exclusion(
+          "unsupportedInputRepresentation",
+          "workload does not accept " + engine.declaration().inputRepresentation().jsonName());
+    }
+    EnumSet<DeclarativeBenchmarkPlan.Flag> unsupportedFlags = workload.flags();
+    unsupportedFlags.removeAll(engine.declaration().supportedFlags());
+    if (!unsupportedFlags.isEmpty()) {
+      return new Exclusion("unsupportedFlag", "engine lacks flags " + flagNames(unsupportedFlags));
+    }
+    String flagSet = flagSet(workload);
+    if (!engine.flagSets().contains(flagSet)) {
+      return new Exclusion("unsupportedOptions", "engine does not support flag set " + flagSet);
+    }
+    EnumSet<DeclarativeBenchmarkPlan.Feature> missing = workload.requirements();
+    missing.removeAll(engine.declaration().features());
+    if (!missing.isEmpty()) {
+      return new Exclusion("unsupportedFeature", "engine lacks " + featureNames(missing));
+    }
+    for (String pattern : workload.patterns()) {
+      String reason = patternProfiles.resolve(engine.patternProfile(), pattern).unsupportedReason();
+      if (reason != null) {
+        return new Exclusion("unsupportedSyntax", reason);
+      }
+    }
+    DeclarativeBenchmarkPlan.RecipeValue replacement = workload.arguments().get("replacement");
+    if (replacement != null) {
+      String value = ((DeclarativeBenchmarkPlan.RecipeString) replacement).value();
+      String reason =
+          replacementProfiles.resolve(engine.replacementProfile(), value).unsupportedReason();
+      if (reason != null) {
+        return new Exclusion("unsupportedSyntax", reason);
+      }
+    }
+    return null;
+  }
+
+  private static JsonObject arguments(
+      Map<String, DeclarativeBenchmarkPlan.RecipeValue> arguments,
+      Engine engine,
+      PatternProfiles replacementProfiles) {
     JsonObject result = new JsonObject();
-    arguments.forEach((name, value) -> result.add(name, recipeValue(value)));
+    arguments.forEach(
+        (name, value) -> {
+          JsonElement json = recipeValue(value);
+          if (name.equals("replacement")) {
+            json =
+                new JsonPrimitive(
+                    replacementProfiles.select(engine.replacementProfile(), json.getAsString()));
+          }
+          result.add(name, json);
+        });
     return result;
   }
 
@@ -86,6 +424,23 @@ final class ResolvedBenchmarkPlan {
       case DeclarativeBenchmarkPlan.RecipeAxisReference reference ->
           throw new IllegalStateException(
               "Expanded workload retains unresolved argument axis: " + reference.axis());
+    };
+  }
+
+  private static String flagSet(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    DeclarativeBenchmarkPlan.RecipeValue value = workload.arguments().get("flagSet");
+    return value == null ? "0" : ((DeclarativeBenchmarkPlan.RecipeString) value).value();
+  }
+
+  private static List<String> options(String flagSet) {
+    return switch (flagSet) {
+      case "0" -> List.of();
+      case "CASE_INSENSITIVE" -> List.of("caseInsensitive");
+      case "CASE_INSENSITIVE_UNICODE_CASE" -> List.of("caseInsensitive", "unicodeCase");
+      case "UNICODE_CHARACTER_CLASS" -> List.of("unicodeCharacterClass");
+      case "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS" ->
+          List.of("caseInsensitive", "unicodeCase", "unicodeCharacterClass");
+      default -> throw new IllegalArgumentException("Unknown benchmark flag set: " + flagSet);
     };
   }
 
@@ -121,15 +476,64 @@ final class ResolvedBenchmarkPlan {
     return result;
   }
 
+  private static String flagNames(Set<DeclarativeBenchmarkPlan.Flag> values) {
+    return values.stream()
+        .map(DeclarativeBenchmarkPlan.Flag::jsonName)
+        .sorted()
+        .toList()
+        .toString();
+  }
+
+  private static String featureNames(Set<DeclarativeBenchmarkPlan.Feature> values) {
+    return values.stream()
+        .map(DeclarativeBenchmarkPlan.Feature::jsonName)
+        .sorted()
+        .toList()
+        .toString();
+  }
+
   private static JsonArray strings(Iterable<String> values) {
     JsonArray result = new JsonArray();
     values.forEach(result::add);
     return result;
   }
 
-  private static <T> JsonArray names(Iterable<T> values, Function<T, String> name) {
+  private static <T> JsonArray array(Iterable<T> values, Function<T, JsonElement> converter) {
     JsonArray result = new JsonArray();
-    values.forEach(value -> result.add(name.apply(value)));
+    values.forEach(value -> result.add(converter.apply(value)));
     return result;
   }
+
+  private static <T> JsonArray names(Iterable<T> values, Function<T, String> name) {
+    return array(values, value -> new JsonPrimitive(name.apply(value)));
+  }
+
+  record Engine(
+      String id,
+      String reportEngine,
+      String runner,
+      String patternProfile,
+      String replacementProfile,
+      DeclarativeBenchmarkPlan.EngineDeclaration declaration,
+      EnumSet<DeclarativeBenchmarkPlan.Operation> operations,
+      EnumSet<DeclarativeBenchmarkPlan.MeasurementMode> measurementModes,
+      Set<String> flagSets) {
+    Engine {
+      operations = operations.clone();
+      measurementModes = measurementModes.clone();
+      flagSets = Collections.unmodifiableSet(new LinkedHashSet<>(flagSets));
+    }
+
+    @Override
+    public EnumSet<DeclarativeBenchmarkPlan.Operation> operations() {
+      return operations.clone();
+    }
+
+    @Override
+    public EnumSet<DeclarativeBenchmarkPlan.MeasurementMode> measurementModes() {
+      return measurementModes.clone();
+    }
+  }
+
+  private record Exclusion(String kind, String reason) {}
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
@@ -5,9 +5,7 @@
 
 package org.safere.benchmark;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,42 +15,38 @@ import java.util.stream.Collectors;
 /** Resolves data-declared workloads that use specialized measurement machinery. */
 final class SpecializedBenchmarkPlan {
   private final Map<String, Trial> trials;
-  private final List<DeclarativeBenchmarkPlan.Exclusion> exclusions;
+  private final List<MaterializedExecutionPlan.Entry> exclusions;
 
   private SpecializedBenchmarkPlan(
-      Map<String, Trial> trials, List<DeclarativeBenchmarkPlan.Exclusion> exclusions) {
+      Map<String, Trial> trials, List<MaterializedExecutionPlan.Entry> exclusions) {
     this.trials = Collections.unmodifiableMap(new LinkedHashMap<>(trials));
     this.exclusions = List.copyOf(exclusions);
   }
 
   static SpecializedBenchmarkPlan load() {
-    DeclarativeBenchmarkPlan plan =
-        DeclarativeBenchmarkPlan.parse(BenchmarkData.get().declarativePlan());
-    List<DeclarativeBenchmarkPlan.EngineDeclaration> engines =
-        Arrays.stream(RegexEngineVariant.values()).map(RegexEngineVariant::declaration).toList();
-    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
-        plan.expand(engines, EnumSet.allOf(DeclarativeBenchmarkPlan.Operation.class));
     Map<String, Trial> trials = new LinkedHashMap<>();
-    for (DeclarativeBenchmarkPlan.Trial trial : expanded.trials()) {
-      if (!isSpecialized(trial.workload())) {
+    List<MaterializedExecutionPlan.Entry> exclusions = new java.util.ArrayList<>();
+    for (MaterializedExecutionPlan.Entry entry :
+        MaterializedExecutionPlan.load().entriesForRunner("java")) {
+      if (!isSpecialized(entry.operation(), entry.measurement())) {
         continue;
       }
-      Trial converted = new Trial(trial.workload(), RegexEngineVariant.fromId(trial.engine().id()));
+      if (!entry.runnable()) {
+        exclusions.add(entry);
+        continue;
+      }
+      Trial converted = new Trial(entry.workload(), RegexEngineVariant.fromId(entry.engineId()));
       if (trials.put(converted.id(), converted) != null) {
         throw new IllegalArgumentException("Duplicate specialized trial ID: " + converted.id());
       }
     }
-    var workloadIds =
-        trials.values().stream().map(trial -> trial.workload().id()).collect(Collectors.toSet());
-    List<DeclarativeBenchmarkPlan.Exclusion> exclusions =
-        expanded.exclusions().stream()
-            .filter(exclusion -> workloadIds.contains(exclusion.workloadId()))
-            .toList();
     return new SpecializedBenchmarkPlan(trials, exclusions);
   }
 
-  private static boolean isSpecialized(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    return switch (workload.operation()) {
+  private static boolean isSpecialized(
+      DeclarativeBenchmarkPlan.Operation operation,
+      DeclarativeBenchmarkPlan.Measurement measurement) {
+    return switch (operation) {
           case PATTERN_SET_MATCHES,
               UTF8_CAPTURE_BOUNDS,
               UTF8_DECODE_FIND,
@@ -66,9 +60,8 @@ final class SpecializedBenchmarkPlan {
               true;
           default -> false;
         }
-        || workload.measurement().mode() == DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY
-        || workload.measurement().mode()
-            == DeclarativeBenchmarkPlan.MeasurementMode.SUBPROCESS_MEMORY;
+        || measurement.mode() == DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY
+        || measurement.mode() == DeclarativeBenchmarkPlan.MeasurementMode.SUBPROCESS_MEMORY;
   }
 
   Trial resolve(String id) {
@@ -106,7 +99,7 @@ final class SpecializedBenchmarkPlan {
         .toList();
   }
 
-  List<DeclarativeBenchmarkPlan.Exclusion> exclusions() {
+  List<MaterializedExecutionPlan.Entry> exclusions() {
     return exclusions;
   }
 

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkDataSchemaTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkDataSchemaTest.java
@@ -1,0 +1,72 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BenchmarkDataSchemaTest {
+  @Test
+  void checkedInDocumentUsesOnlyTheAuthoritativeSchema() throws Exception {
+    Path benchmarkData =
+        Files.exists(Path.of("benchmark-data.json"))
+            ? Path.of("benchmark-data.json")
+            : Path.of("safere-benchmarks", "benchmark-data.json");
+    JsonObject root = JsonParser.parseString(Files.readString(benchmarkData)).getAsJsonObject();
+
+    BenchmarkDataSchema.validate(root);
+    BenchmarkDataSchema.requireWorkloads(root);
+
+    assertThat(root.keySet())
+        .containsExactlyInAnyOrder("schemaVersion", "configuration", "inputs", "workloads");
+    assertThat(root.getAsJsonObject("configuration").keySet())
+        .containsExactlyInAnyOrder("collection", "crosscheckOverhead");
+  }
+
+  @Test
+  void rejectsUnknownTopLevelFields() {
+    JsonObject root =
+        JsonParser.parseString(
+                """
+                {
+                  "schemaVersion": 1,
+                  "inputs": [],
+                  "workloads": [],
+                  "regex": {}
+                }
+                """)
+            .getAsJsonObject();
+
+    assertThatThrownBy(() -> BenchmarkDataSchema.validate(root))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("benchmark-data.json has unknown field: regex");
+  }
+
+  @Test
+  void rejectsUnknownConfigurationFields() {
+    JsonObject root =
+        JsonParser.parseString(
+                """
+                {
+                  "schemaVersion": 1,
+                  "configuration": {"legacyWorkloads": {}},
+                  "inputs": [],
+                  "workloads": []
+                }
+                """)
+            .getAsJsonObject();
+
+    assertThatThrownBy(() -> BenchmarkDataSchema.validate(root))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("benchmark-data.json configuration has unknown field: legacyWorkloads");
+  }
+}

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -156,8 +158,42 @@ class BenchmarkInputMaterializerTest {
         .hasSize(6);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("rust-regex"))
         .hasSize(1);
-    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("dotnet")).hasSize(8);
-    assertThat(manifest.getAsJsonArray("resolvedWorkloads")).hasSize(485);
+    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("dotnet"))
+        .hasSize(38);
+    JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
+    assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(485);
+    assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(4_850);
+    for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
+      String engineId = engineElement.getAsJsonObject().get("id").getAsString();
+      assertThat(
+              executionPlan.getAsJsonArray("entries").asList().stream()
+                  .map(JsonElement::getAsJsonObject)
+                  .filter(planEntry -> planEntry.get("engineId").getAsString().equals(engineId))
+                  .filter(
+                      planEntry ->
+                          Set.of("runnable", "excluded")
+                              .contains(planEntry.get("status").getAsString())))
+          .as(engineId)
+          .hasSize(485);
+    }
+    assertThat(
+            executionPlan.getAsJsonArray("entries").asList().stream()
+                .map(JsonElement::getAsJsonObject)
+                .filter(
+                    planEntry ->
+                        planEntry
+                            .get("workloadId")
+                            .getAsString()
+                            .equals("CompileBenchmark.compileSimple"))
+                .filter(
+                    planEntry ->
+                        Set.of("re2_cpp", "pcre2_jit", "go_regexp", "rust_regex")
+                            .contains(planEntry.get("engineId").getAsString())))
+        .hasSize(4)
+        .allSatisfy(
+            planEntry -> assertThat(planEntry.get("status").getAsString()).isEqualTo("runnable"));
     assertThat(
             resolvedData.getAsJsonArray("workloads").asList().stream()
                 .filter(

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -165,6 +165,22 @@ class BenchmarkInputMaterializerTest {
     assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(485);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
     assertThat(executionPlan.getAsJsonArray("entries")).hasSize(4_850);
+    assertThat(
+            executionEntry(
+                    executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
+                .getAsJsonArray("patterns")
+                .get(0)
+                .getAsString())
+        .isEqualTo("[A-Za-z0-9_]+");
+    assertThat(
+            executionEntry(
+                    executionPlan,
+                    "UnicodeCompileBenchmark.compile.word."
+                        + "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS@dotnet_nonbacktracking")
+                .getAsJsonArray("patterns")
+                .get(0)
+                .getAsString())
+        .isEqualTo("\\w+");
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -229,5 +245,13 @@ class BenchmarkInputMaterializerTest {
 
   private static String text(Map<String, byte[]> inputs, String id) {
     return new String(inputs.get(id), StandardCharsets.UTF_8);
+  }
+
+  private static JsonObject executionEntry(JsonObject plan, String id) {
+    return plan.getAsJsonArray("entries").asList().stream()
+        .map(JsonElement::getAsJsonObject)
+        .filter(entry -> entry.get("id").getAsString().equals(id))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonParser;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class PatternProfilesTest {
@@ -182,6 +183,26 @@ class PatternProfilesTest {
     PatternProfiles replacements = PatternProfiles.parse(normalized.get("replacementProfiles"));
     assertThat(patterns.select("rust-regex", "same")).isEqualTo("pattern");
     assertThat(replacements.select("rust-regex", "same")).isEqualTo("replacement");
+  }
+
+  @Test
+  void rejectsProfilesThatNoAuthoritativeWorkloadReferences() {
+    PatternProfiles profiles =
+        PatternProfiles.parse(
+            JsonParser.parseString(
+                """
+                {
+                  "re2": [{
+                    "java": "legacy-only",
+                    "alternate": "alternate",
+                    "reason": "Only a deleted legacy section used this value"
+                  }]
+                }
+                """));
+
+    assertThatThrownBy(() -> profiles.validateReferences(Set.of("used"), "pattern"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unreferenced pattern profile value for re2: legacy-only");
   }
 
   @Test

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -222,7 +222,7 @@ class PatternProfilesTest {
     assertThat(replacements.select("pcre2", "$1")).isEqualTo("$1");
     assertThat(replacements.select("rust-regex", "$2$1ay")).isEqualTo("${2}${1}ay");
     assertThat(patterns.select("dotnet", "^\\s*<(\\QApple\\E|\\QBanana\\E|\\QCherry\\E)>\\s*$"))
-        .isEqualTo("^\\s*<(Apple|Banana|Cherry)>\\s*$");
+        .isEqualTo("^[ \\t\\n\\x0B\\f\\r]*<(Apple|Banana|Cherry)>[ \\t\\n\\x0B\\f\\r]*$");
     assertThat(patterns.select("dotnet", "[😀-😇]")).isEqualTo("\\uD83D[\\uDE00-\\uDE07]");
     assertThat(patterns.select("dotnet", "\\p{javaLetter}")).isEqualTo("\\p{L}");
     assertThat(patterns.select("dotnet", "\\p{block=BasicLatin}+")).isEqualTo("[\\u0000-\\u007F]+");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/PatternProfilesTest.java
@@ -250,6 +250,10 @@ class PatternProfilesTest {
     assertThat(patterns.select("dotnet", "\\p{block=CJK_Unified_Ideographs}+"))
         .isEqualTo("[\\u4E00-\\u9FFF]+");
     assertThat(patterns.select("dotnet", "[\\p{L}&&[^\\p{Lu}]]+")).isEqualTo("[\\p{L}-[\\p{Lu}]]+");
+    assertThat(patterns.select("dotnet", "\\w+", "0")).isEqualTo("[A-Za-z0-9_]+");
+    assertThat(patterns.select("dotnet", "\\w+", "UNICODE_CHARACTER_CLASS")).isEqualTo("\\w+");
+    assertThat(patterns.select("dotnet", "\\w+", "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS"))
+        .isEqualTo("\\w+");
     for (String profileType : List.of("patternProfiles", "replacementProfiles")) {
       for (JsonElement profile : normalized.getAsJsonObject(profileType).asMap().values()) {
         for (JsonElement entry : profile.getAsJsonArray()) {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/ResolvedBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/ResolvedBenchmarkPlanTest.java
@@ -1,0 +1,182 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ResolvedBenchmarkPlanTest {
+
+  @Test
+  void materializationAccountsForCompleteSyntheticWorkloadAndEngineJoin() {
+    JsonObject plan =
+        ResolvedBenchmarkPlan.create(
+            normalizedData(),
+            List.of(
+                engine(
+                    "find-only",
+                    "java",
+                    EnumSet.of(DeclarativeBenchmarkPlan.Feature.FIND),
+                    EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND)),
+                engine(
+                    "find-and-replace",
+                    "alternate",
+                    EnumSet.of(
+                        DeclarativeBenchmarkPlan.Feature.FIND,
+                        DeclarativeBenchmarkPlan.Feature.REPLACE,
+                        DeclarativeBenchmarkPlan.Feature.NUMBERED_REPLACEMENT),
+                    EnumSet.of(
+                        DeclarativeBenchmarkPlan.Operation.FIND,
+                        DeclarativeBenchmarkPlan.Operation.REPLACE_ALL))));
+
+    assertThat(plan.get("version").getAsInt()).isEqualTo(ResolvedBenchmarkPlan.VERSION);
+    assertThat(plan.get("workloadCount").getAsInt()).isEqualTo(2);
+    assertThat(plan.get("engineCount").getAsInt()).isEqualTo(2);
+    JsonArray entries = plan.getAsJsonArray("entries");
+    assertThat(entries).hasSize(4);
+    assertThat(
+            entries.asList().stream()
+                .map(JsonObject.class::cast)
+                .map(ResolvedBenchmarkPlanTest::id))
+        .containsExactly(
+            "Synthetic.find@find-only",
+            "Synthetic.find@find-and-replace",
+            "Synthetic.replace@find-only",
+            "Synthetic.replace@find-and-replace");
+    assertThat(
+            entries.asList().stream()
+                .map(JsonObject.class::cast)
+                .filter(entry -> entry.get("status").getAsString().equals("runnable")))
+        .hasSize(3);
+    assertThat(
+            entries.asList().stream()
+                .map(JsonObject.class::cast)
+                .filter(entry -> entry.get("status").getAsString().equals("excluded")))
+        .singleElement()
+        .satisfies(
+            entry -> {
+              assertThat(id(entry)).isEqualTo("Synthetic.replace@find-only");
+              assertThat(entry.getAsJsonObject("exclusion").get("kind").getAsString())
+                  .isEqualTo("unsupportedOperation");
+            });
+  }
+
+  @Test
+  void runnableEntriesContainExactSelectedSyntaxAndUnchangedFallback() {
+    JsonObject plan =
+        ResolvedBenchmarkPlan.create(
+            normalizedData(),
+            List.of(
+                engine(
+                    "alternate-engine",
+                    "alternate",
+                    EnumSet.of(
+                        DeclarativeBenchmarkPlan.Feature.FIND,
+                        DeclarativeBenchmarkPlan.Feature.REPLACE,
+                        DeclarativeBenchmarkPlan.Feature.NUMBERED_REPLACEMENT),
+                    EnumSet.of(
+                        DeclarativeBenchmarkPlan.Operation.FIND,
+                        DeclarativeBenchmarkPlan.Operation.REPLACE_ALL))));
+
+    JsonObject find = entry(plan, "Synthetic.find@alternate-engine");
+    JsonObject replace = entry(plan, "Synthetic.replace@alternate-engine");
+    assertThat(find.getAsJsonArray("patterns").get(0).getAsString()).isEqualTo("alternate-pattern");
+    assertThat(replace.getAsJsonArray("patterns").get(0).getAsString())
+        .isEqualTo("unchanged-pattern");
+    assertThat(replace.getAsJsonObject("arguments").get("replacement").getAsString())
+        .isEqualTo("alternate-replacement");
+  }
+
+  private static ResolvedBenchmarkPlan.Engine engine(
+      String id,
+      String profile,
+      EnumSet<DeclarativeBenchmarkPlan.Feature> features,
+      EnumSet<DeclarativeBenchmarkPlan.Operation> operations) {
+    return new ResolvedBenchmarkPlan.Engine(
+        id,
+        id,
+        "test",
+        profile,
+        profile,
+        new DeclarativeBenchmarkPlan.EngineDeclaration(
+            id,
+            DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+            features,
+            EnumSet.noneOf(DeclarativeBenchmarkPlan.Flag.class),
+            true),
+        operations,
+        EnumSet.of(DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME),
+        Set.of("0"));
+  }
+
+  private static JsonObject normalizedData() {
+    return JsonParser.parseString(
+            """
+            {
+              "schemaVersion": 1,
+              "inputs": [{
+                "id": "input",
+                "recipe": {"kind": "literal", "text": "text"},
+                "shared": true
+              }],
+              "workloads": [
+                {
+                  "id": "Synthetic.find",
+                  "operation": "find",
+                  "patterns": ["canonical-pattern"],
+                  "inputs": ["input"],
+                  "resultConsumption": "boolean",
+                  "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                },
+                {
+                  "id": "Synthetic.replace",
+                  "operation": "replaceAll",
+                  "patterns": ["unchanged-pattern"],
+                  "inputs": ["input"],
+                  "arguments": {"replacement": "canonical-replacement"},
+                  "requirements": ["numberedReplacement"],
+                  "resultConsumption": "string",
+                  "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                }
+              ],
+              "patternProfiles": {
+                "alternate": [{
+                  "java": "canonical-pattern",
+                  "alternate": "alternate-pattern",
+                  "reason": "synthetic alternate"
+                }]
+              },
+              "replacementProfiles": {
+                "alternate": [{
+                  "java": "canonical-replacement",
+                  "alternate": "alternate-replacement",
+                  "reason": "synthetic alternate"
+                }]
+              }
+            }
+            """)
+        .getAsJsonObject();
+  }
+
+  private static JsonObject entry(JsonObject plan, String id) {
+    return plan.getAsJsonArray("entries").asList().stream()
+        .map(JsonObject.class::cast)
+        .filter(entry -> id(entry).equals(id))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static String id(JsonObject entry) {
+    return entry.get("id").getAsString();
+  }
+}


### PR DESCRIPTION
## Summary

- materialize one versioned execution plan containing the complete workload/engine join
- resolve axes, input recipes, engine syntax, arguments, options, and compatibility before runner execution
- migrate Java, C++ RE2, PCRE2 JIT, Go `regexp`, Rust `regex`, and .NET non-backtracking to the shared plan
- replace runtime compatibility inference with declared capabilities and explicit syntax metadata
- remove the legacy workload-family mirrors from `benchmark-data.json`, moving their unique syntax annotations beside authoritative workload declarations
- strictly validate the complete JSON envelope and reject unknown legacy sections or syntax profiles unused by authoritative workloads
- keep runner setup outside timed operations and preserve Java split and flag-sensitive syntax semantics across native engines
- document the common contract and add complete-accounting, syntax-selection, schema, and smoke coverage

## Base

This work is built on the benchmark-plan changes merged in #634.

## Workload preservation

The cleanup retains all 144 input declarations and 226 workload declarations. A clean checkout before the cleanup and the updated branch both materialize:

- 304 exact UTF-8 inputs
- 485 expanded workloads
- 10 engines
- 4,850 workload/engine execution-plan entries

All 4,850 execution-plan entry identities and all materialized input metadata remain identical. Before the review fixes, the complete sorted execution plan was byte-for-byte identical across the legacy-section cleanup. Review then intentionally corrected four .NET Unicode-shorthand pattern selections; those are the only execution-plan entry differences from the pre-cleanup baseline.

## Verification

Run:

- `mvn test -q`
- `mvn -pl safere-benchmarks test -q`
- `mvn spotless:check -q`
- exact pre/post comparison of execution-plan entry identities and input metadata
- three-pass Codex review/fix loop, ending with no actionable correctness findings
- complete `--smoke` execution-plan runs for Go, Rust, .NET, C++ RE2, and PCRE2 JIT
- focused Go split-scaling, Rust prepared-operation/exclusion, C++ large-input, and .NET flagged-compile smoke runs
- `go test ./...`
- `cargo test --locked`
- `cargo test --locked --features memory-tracking`
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `dotnet build safere-benchmarks/dotnet/SafeRE.Benchmarks.csproj --configuration Release --nologo`
- `ctest --test-dir safere-benchmarks/cpp/build --output-on-failure`

Not run:

- standard or long benchmark measurements; this changes benchmark planning, workload representation, and harness architecture rather than making performance claims

Fixes #640
