### PR TITLE
Accelerate UTF-8 ASCII character-class scans

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -264,6 +264,15 @@
       "shared": true
     },
     {
+      "id": "utf8Matching.asciiClassNonmatch.text",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "a",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
       "id": "utf8Matching.requiredClassNonmatch.text",
       "recipe": {
         "kind": "repeatToLength",
@@ -7031,6 +7040,75 @@
         "preexistingUtf8"
       ],
       "inputRepresentationReason": "Measures SafeRE required-class rejection over preexisting UTF-8 bytes.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.requiredSingleAsciiNonmatchBytes",
+      "operation": "find",
+      "patterns": [
+        ".*x.*"
+      ],
+      "inputs": [
+        "utf8Matching.asciiClassNonmatch.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures SafeRE single-ASCII required-class rejection over preexisting UTF-8 bytes.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.asciiRangePrefixNonmatchBytes",
+      "operation": "find",
+      "patterns": [
+        "\\d{3}/\\d{3}/\\d{4}"
+      ],
+      "inputs": [
+        "utf8Matching.asciiClassNonmatch.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures SafeRE contiguous-ASCII class start acceleration over preexisting UTF-8 bytes.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8MatchingBenchmark.literalPrefixNonmatchBytes",
+      "operation": "find",
+      "patterns": [
+        "x.*"
+      ],
+      "inputs": [
+        "utf8Matching.asciiClassNonmatch.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Controls for SafeRE literal start acceleration over the same preexisting UTF-8 bytes.",
       "requirements": [],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(305);
+    assertThat(first).hasSize(306);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(486);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(489);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(4_860);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(4_890);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -192,7 +192,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(486);
+          .hasSize(489);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(409);
+    assertThat(ids).hasSize(412);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1459);
-    assertThat(plan.exclusions()).hasSize(586);
-    assertThat(accounted).hasSize(409 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(1462);
+    assertThat(plan.exclusions()).hasSize(598);
+    assertThat(accounted).hasSize(412 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -93,7 +93,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(829);
+        .hasSize(832);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -399,8 +399,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1498);
-    assertThat(plan.reportPlan().trials()).hasSize(1498);
+        .hasSize(1501);
+    assertThat(plan.reportPlan().trials()).hasSize(1501);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -89,8 +89,14 @@ final class Utf8InputScanner implements InputScanner {
   @Override
   public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
     int position = Math.max(0, start);
-    if (!WorkCounterConfig.ENABLED && bitmap0 == 0 && bitmap1 == 0) {
-      return indexOfNonAsciiCodePointClass(ranges, position);
+    if (!WorkCounterConfig.ENABLED) {
+      int asciiResult = indexOfAsciiRanges(ranges, position);
+      if (asciiResult >= -1) {
+        return asciiResult;
+      }
+      if (bitmap0 == 0 && bitmap1 == 0) {
+        return indexOfNonAsciiCodePointClass(ranges, position);
+      }
     }
     while (position < length) {
       int codePointPosition = position;
@@ -110,6 +116,34 @@ final class Utf8InputScanner implements InputScanner {
       }
     }
     return -1;
+  }
+
+  /**
+   * Searches classes that can be represented by the specialized ASCII scanners.
+   *
+   * @return the match position, {@code -1} when the class is absent, or {@code -2} when the class
+   *     requires the general code-point scan
+   */
+  private int indexOfAsciiRanges(int[] ranges, int start) {
+    if (ranges.length == 2 && ranges[0] >= 0 && ranges[1] < 0x80) {
+      int low = ranges[0];
+      int high = ranges[1];
+      if (low == high) {
+        return indexOfByte((byte) low, start);
+      }
+      if (high == low + 1) {
+        return indexOfBytePair((byte) low, (byte) high, start);
+      }
+      return indexOfByteRange(low, high, start);
+    }
+    if (ranges.length == 4
+        && ranges[0] == ranges[1]
+        && ranges[2] == ranges[3]
+        && ranges[0] >= 0
+        && ranges[3] < 0x80) {
+      return indexOfBytePair((byte) ranges[0], (byte) ranges[2], start);
+    }
+    return -2;
   }
 
   private int indexOfNonAsciiCodePointClass(int[] ranges, int start) {
@@ -212,15 +246,17 @@ final class Utf8InputScanner implements InputScanner {
   int indexOfAsciiClass(boolean[] asciiClass, int start) {
     int first = -1;
     int second = -1;
+    int last = -1;
+    boolean contiguous = true;
     for (int value = 0; value < asciiClass.length; value++) {
       if (asciiClass[value]) {
         if (first < 0) {
           first = value;
         } else if (second < 0) {
           second = value;
-        } else {
-          return indexOfAsciiClassScalar(asciiClass, start);
         }
+        contiguous &= last < 0 || value == last + 1;
+        last = value;
       }
     }
     if (first < 0) {
@@ -232,7 +268,12 @@ final class Utf8InputScanner implements InputScanner {
     if (second < 0) {
       return indexOfByte((byte) first, start);
     }
-    return indexOfBytePair((byte) first, (byte) second, start);
+    if (last == second) {
+      return indexOfBytePair((byte) first, (byte) second, start);
+    }
+    return contiguous
+        ? indexOfByteRange(first, last, start)
+        : indexOfAsciiClassScalar(asciiClass, start);
   }
 
   /**
@@ -400,6 +441,44 @@ final class Utf8InputScanner implements InputScanner {
     while (position < length) {
       byte value = bytes[offset + position];
       if (value == first || value == second) {
+        return position;
+      }
+      position++;
+    }
+    return -1;
+  }
+
+  /**
+   * Searches for a byte in the inclusive ASCII range {@code [low, high]}.
+   *
+   * <p>The word filter compares the common binary prefix of the range endpoints across eight bytes
+   * at once. Every byte in the range has that prefix, so the filter cannot miss a match. It may
+   * admit bytes outside the range when the endpoints do not cover their entire binary-prefix
+   * bucket; the scalar candidate check provides the exact answer.
+   */
+  private int indexOfByteRange(int low, int high, int start) {
+    int differingBit = Integer.highestOneBit(low ^ high);
+    int commonMask = ~((differingBit << 1) - 1) & 0xFF;
+    long repeatedMask = (commonMask & 0xFFL) * BYTE_ONES;
+    long repeatedPrefix = (low & commonMask) * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long difference = (word & repeatedMask) ^ repeatedPrefix;
+      if (((difference - BYTE_ONES) & ~difference & BYTE_HIGH_BITS) != 0) {
+        for (int index = 0; index < Long.BYTES; index++) {
+          int value = unsignedByteAt(position + index);
+          if (value >= low && value <= high) {
+            return position + index;
+          }
+        }
+      }
+      position += Long.BYTES;
+    }
+    while (position < length) {
+      int value = unsignedByteAt(position);
+      if (value >= low && value <= high) {
         return position;
       }
       position++;

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -122,6 +122,87 @@ class Utf8InputScannerTest {
   }
 
   @Test
+  void asciiCodePointClassSearchCoversOptimizedShapesAlignmentsAndPositions() {
+    for (int[] ranges :
+        List.of(new int[] {'x', 'x'}, new int[] {'x', 'x', 'z', 'z'}, new int[] {'0', '9'})) {
+      int matchingByte =
+          ranges.length == 2 && ranges[0] != ranges[1] ? '5' : ranges[ranges.length - 1];
+      long bitmap0 = asciiBitmap(ranges, 0, 63);
+      long bitmap1 = asciiBitmap(ranges, 64, 127);
+      for (int offset = 0; offset < Long.BYTES * 2; offset++) {
+        for (int expected = 0; expected < 40; expected++) {
+          byte[] storage = new byte[offset + 40 + Long.BYTES];
+          Arrays.fill(storage, (byte) 'a');
+          storage[offset + expected] = (byte) matchingByte;
+          Utf8InputScanner scanner = new Utf8InputScanner(storage, offset, 40);
+
+          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, 0))
+              .as("ranges %s, offset %s, position %s", Arrays.toString(ranges), offset, expected)
+              .isEqualTo(expected);
+        }
+      }
+    }
+  }
+
+  @Test
+  void asciiCodePointClassSearchHonorsStartsAndSkipsNonAsciiScalars() {
+    byte[] bytes = "5é😀a7".getBytes(UTF_8);
+    int[] digits = {'0', '9'};
+    long bitmap0 = asciiBitmap(digits, 0, 63);
+
+    Utf8InputScanner scanner = new Utf8InputScanner(bytes);
+
+    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, -4)).isEqualTo(0);
+    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, 1)).isEqualTo(bytes.length - 1);
+    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, bytes.length)).isEqualTo(-1);
+  }
+
+  @Test
+  void asciiCodePointClassSearchAgreesForEveryRangeAndWindowAlignment() {
+    for (int offset = 0; offset < Long.BYTES * 2; offset++) {
+      byte[] storage = new byte[offset + 128 + Long.BYTES];
+      Arrays.fill(storage, (byte) 0x7F);
+      for (int value = 0; value < 128; value++) {
+        storage[offset + value] = (byte) value;
+      }
+      Utf8InputScanner scanner = new Utf8InputScanner(storage, offset, 128);
+
+      for (int low = 0; low < 128; low++) {
+        for (int high = low; high < 128; high++) {
+          int[] ranges = {low, high};
+          long bitmap0 = asciiBitmap(ranges, 0, 63);
+          long bitmap1 = asciiBitmap(ranges, 64, 127);
+          for (int start : new int[] {-1, 0, low, high, high + 1, 127, 128}) {
+            int clampedStart = Math.max(0, start);
+            int expected = clampedStart <= high ? Math.max(clampedStart, low) : -1;
+
+            assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, start))
+                .as("offset %s, range [%s, %s], start %s", offset, low, high, start)
+                .isEqualTo(expected);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void asciiPrefixClassSearchCoversSingletonPairAndRange() {
+    for (int[] members : List.of(new int[] {'x'}, new int[] {'x', 'z'}, asciiRange('0', '9'))) {
+      boolean[] asciiClass = new boolean[128];
+      for (int member : members) {
+        asciiClass[member] = true;
+      }
+      byte matchingByte = (byte) members[members.length - 1];
+      byte[] bytes = "a".repeat(40).getBytes(UTF_8);
+      bytes[31] = matchingByte;
+      Utf8InputScanner scanner = new Utf8InputScanner(bytes);
+
+      assertThat(scanner.indexOfAsciiClass(asciiClass, 0)).isEqualTo(31);
+      assertThat(scanner.indexOfAsciiClass(asciiClass, 32)).isEqualTo(-1);
+    }
+  }
+
+  @Test
   void captureFreePrefixSearchCanSkipAFailingCandidateAndFindALaterMatch() {
     Pattern pattern = Pattern.compile("ab+c");
 
@@ -406,6 +487,26 @@ class Utf8InputScannerTest {
       return position;
     }
     return -1;
+  }
+
+  private static long asciiBitmap(int[] ranges, int first, int last) {
+    long bitmap = 0;
+    for (int index = 0; index < ranges.length; index += 2) {
+      int low = Math.max(first, ranges[index]);
+      int high = Math.min(last, ranges[index + 1]);
+      for (int value = low; value <= high; value++) {
+        bitmap |= 1L << (value - first);
+      }
+    }
+    return bitmap;
+  }
+
+  private static int[] asciiRange(int low, int high) {
+    int[] result = new int[high - low + 1];
+    for (int value = low; value <= high; value++) {
+      result[value - low] = value;
+    }
+    return result;
   }
 
   private static String randomFromAlphabet(Random random, int length, int alphabet) {


### PR DESCRIPTION
## Summary

- route one- and two-code-point ASCII classes through the existing SWAR byte scanners
- add an eight-byte common-prefix filter for contiguous ASCII ranges, with exact scalar candidate verification
- preserve scalar scanning when work counting is enabled
- add exhaustive range/alignment coverage and declarative JMH workloads for the optimized paths

This implements proposals 1 and 2 from #636. The fixed-offset/selectivity and repeated-`find()` DFA proposals remain out of scope.

Refs #636

## Profiling

JFR on the contiguous-digit-range workload attributed 100% of sampled Java execution time before the change to `Utf8InputScanner.indexOfAsciiClassScalar`.

## Benchmarks

Standard Java benchmark configuration on OpenJDK 26.0.1:

| Workload | Before | After | Change |
|---|---:|---:|---:|
| single ASCII required-class rejection (`.*x.*`) | 9,171.986 ns/op | 951.358 ns/op | 9.64x faster |
| contiguous ASCII range rejection (`\d{3}/\d{3}/\d{4}`) | 10,165.548 ns/op | 1,154.255 ns/op | 8.81x faster |
| literal rejection control (`x.*`) | 958.001 ns/op | 950.862 ns/op | no material change |

Command:

```bash
./run-java-benchmarks.sh --fastbuild \
  '^org\.safere\.benchmark\.CrossEngineBenchmark\.run$' -- \
  -p 'crossEngineTrial=Utf8MatchingBenchmark.requiredSingleAsciiNonmatchBytes@safere-utf8,Utf8MatchingBenchmark.asciiRangePrefixNonmatchBytes@safere-utf8,Utf8MatchingBenchmark.literalPrefixNonmatchBytes@safere-utf8'
```

## Verification

Run:

- `mvn -pl safere test -q`
- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere,safere-benchmarks spotless:check -q`
- `git diff --check`
- standard two-fork JMH before/after comparison shown above
- JFR profile of the contiguous ASCII range workload

Not run:

- public API crosscheck profile, because this is an internal behavior-preserving scanner optimization
- full benchmark collection or external OpenJDK-derived benchmarks, because the change is limited to preexisting UTF-8 character-class scanning
