### PR TITLE
Accelerate fixed-offset literal searches

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -273,6 +273,56 @@
       "shared": true
     },
     {
+      "id": "phoneSearch.digitsNoSlash.text",
+      "recipe": {
+        "kind": "randomChars",
+        "alphabet": "abcdefghijklmnopqrstuvwxyz0123456789 ",
+        "length": 32768,
+        "seed": 20260729
+      },
+      "shared": true
+    },
+    {
+      "id": "phoneSearch.slashNoise.text",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "service 42 completed path /api/v1/items with 7 records ",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "phoneSearch.denseDigitsAndSlashes.text",
+      "recipe": {
+        "kind": "randomChars",
+        "alphabet": "/0123456789",
+        "length": 32768,
+        "seed": 20260729
+      },
+      "shared": true
+    },
+    {
+      "id": "phoneSearch.sparseMatches.{nonMatchRepeats}",
+      "axes": {
+        "nonMatchRepeats": [
+          511,
+          63,
+          7,
+          1
+        ]
+      },
+      "recipe": {
+        "kind": "sparseMatchToLength",
+        "match": "123/456/7890",
+        "nonMatch": "ordinary prose event 42 completed normally",
+        "nonMatchRepeats": "{nonMatchRepeats}",
+        "delimiterAlphabet": " .,;:-",
+        "seed": 20260729,
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
       "id": "utf8Matching.requiredClassNonmatch.text",
       "recipe": {
         "kind": "repeatToLength",
@@ -7111,6 +7161,137 @@
       "inputRepresentationReason": "Controls for SafeRE literal start acceleration over the same preexisting UTF-8 bytes.",
       "requirements": [],
       "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FixedOffsetAccelerationBenchmark.findDigitsWithoutSlash",
+      "operation": "find",
+      "patterns": [
+        "\\d{3}/\\d{3}/\\d{4}"
+      ],
+      "inputs": [
+        "phoneSearch.digitsNoSlash.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures fixed-offset phone-pattern rejection in realistic text containing unrelated digits but no slash.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FixedOffsetAccelerationBenchmark.findSlashNoise",
+      "operation": "find",
+      "patterns": [
+        "\\d{3}/\\d{3}/\\d{4}"
+      ],
+      "inputs": [
+        "phoneSearch.slashNoise.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures fixed-offset candidate filtering when unrelated digits and slashes are present.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FixedOffsetAccelerationBenchmark.findSparse.{nonMatchRepeats}",
+      "operation": "find",
+      "patterns": [
+        "\\d{3}/\\d{3}/\\d{4}"
+      ],
+      "inputs": [
+        "phoneSearch.sparseMatches.{nonMatchRepeats}"
+      ],
+      "axes": {
+        "nonMatchRepeats": [
+          511,
+          63,
+          7,
+          1
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures fixed-offset acceleration for planted phone numbers at several realistic match densities.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FixedOffsetAccelerationBenchmark.countSparse.{nonMatchRepeats}",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\d{3}/\\d{3}/\\d{4}"
+      ],
+      "inputs": [
+        "phoneSearch.sparseMatches.{nonMatchRepeats}"
+      ],
+      "axes": {
+        "nonMatchRepeats": [
+          511,
+          63,
+          7,
+          1
+        ]
+      },
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures repeated UTF-8 find cost for planted phone numbers at several match densities.",
+      "requirements": [],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "FixedOffsetAccelerationBenchmark.countDenseDigitsAndSlashes",
+      "operation": "findAllCount",
+      "patterns": [
+        "\\d{3}/\\d{3}/\\d{4}"
+      ],
+      "inputs": [
+        "phoneSearch.denseDigitsAndSlashes.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Provides the dense synthetic control where neither digit nor slash filtering is selective.",
+      "requirements": [],
+      "resultConsumption": "integer",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -7179,9 +7179,10 @@
         "phoneSearch.digitsNoSlash.text"
       ],
       "inputRepresentations": [
+        "javaString",
         "preexistingUtf8"
       ],
-      "inputRepresentationReason": "Measures fixed-offset phone-pattern rejection in realistic text containing unrelated digits but no slash.",
+      "inputRepresentationReason": "Compares fixed-offset phone-pattern rejection over Java strings and preexisting UTF-8 in realistic text containing unrelated digits but no slash.",
       "requirements": [],
       "resultConsumption": "boolean",
       "measurement": {
@@ -7202,9 +7203,10 @@
         "phoneSearch.slashNoise.text"
       ],
       "inputRepresentations": [
+        "javaString",
         "preexistingUtf8"
       ],
-      "inputRepresentationReason": "Measures fixed-offset candidate filtering when unrelated digits and slashes are present.",
+      "inputRepresentationReason": "Compares fixed-offset candidate filtering over Java strings and preexisting UTF-8 when unrelated digits and slashes are present.",
       "requirements": [],
       "resultConsumption": "boolean",
       "measurement": {
@@ -7233,9 +7235,10 @@
         ]
       },
       "inputRepresentations": [
+        "javaString",
         "preexistingUtf8"
       ],
-      "inputRepresentationReason": "Measures fixed-offset acceleration for planted phone numbers at several realistic match densities.",
+      "inputRepresentationReason": "Compares Java-string and preexisting-UTF-8 searches for planted phone numbers at several realistic match densities.",
       "requirements": [],
       "resultConsumption": "boolean",
       "measurement": {
@@ -7264,9 +7267,10 @@
         ]
       },
       "inputRepresentations": [
+        "javaString",
         "preexistingUtf8"
       ],
-      "inputRepresentationReason": "Measures repeated UTF-8 find cost for planted phone numbers at several match densities.",
+      "inputRepresentationReason": "Compares repeated Java-string and UTF-8 find cost for planted phone numbers at several match densities.",
       "requirements": [],
       "resultConsumption": "integer",
       "measurement": {
@@ -7287,9 +7291,10 @@
         "phoneSearch.denseDigitsAndSlashes.text"
       ],
       "inputRepresentations": [
+        "javaString",
         "preexistingUtf8"
       ],
-      "inputRepresentationReason": "Provides the dense synthetic control where neither digit nor slash filtering is selective.",
+      "inputRepresentationReason": "Provides Java-string and UTF-8 dense synthetic controls where neither digit nor slash filtering is selective.",
       "requirements": [],
       "resultConsumption": "integer",
       "measurement": {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(306);
+    assertThat(first).hasSize(313);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(489);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(500);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(4_890);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_000);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -192,7 +192,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(489);
+          .hasSize(500);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(412);
+    assertThat(ids).hasSize(423);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1462);
-    assertThat(plan.exclusions()).hasSize(598);
-    assertThat(accounted).hasSize(412 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(1473);
+    assertThat(plan.exclusions()).hasSize(642);
+    assertThat(accounted).hasSize(423 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -93,7 +93,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(832);
+        .hasSize(843);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -399,8 +399,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1501);
-    assertThat(plan.reportPlan().trials()).hasSize(1501);
+        .hasSize(1512);
+    assertThat(plan.reportPlan().trials()).hasSize(1512);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -77,8 +77,8 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1473);
-    assertThat(plan.exclusions()).hasSize(642);
+    assertThat(allTrials).hasSize(1506);
+    assertThat(plan.exclusions()).hasSize(609);
     assertThat(accounted).hasSize(423 * RegexEngineVariant.values().length);
   }
 
@@ -93,7 +93,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(843);
+        .hasSize(876);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -399,8 +399,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1512);
-    assertThat(plan.reportPlan().trials()).hasSize(1512);
+        .hasSize(1545);
+    assertThat(plan.reportPlan().trials()).hasSize(1545);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1596,6 +1596,7 @@ public final class Matcher implements MatchResult {
 
     boolean hasAcceleratedSearchPath =
         (parentPattern.prefix() != null)
+            || (options.startAcceleration() && parentPattern.fixedOffsetLiteral() != null)
             || (prog.anchorEnd()
                 && scanner.length() >= MIN_REVERSE_FIRST_LEN
                 && canUseReverseDfa());
@@ -1698,6 +1699,20 @@ public final class Matcher implements MatchResult {
       literalPrefixCandidateStart = true;
     }
 
+    Pattern.FixedOffsetLiteral fixedOffsetLiteral = parentPattern.fixedOffsetLiteral();
+    if (options.startAcceleration()
+        && fixedOffsetLiteral != null
+        && (text != null || scanner instanceof Utf8InputScanner)) {
+      diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
+      int idx = nextFixedOffsetCandidate(scanner, fixedOffsetLiteral, searchFrom);
+      if (idx < 0) {
+        diagnosticBoundary(MatchStrategy.LITERAL);
+        return applyFailedMatchResult();
+      }
+      effectiveStart = idx;
+      literalPrefixCandidateStart = true;
+    }
+
     // Character-class prefix acceleration: when the pattern starts with a character class (and
     // no literal prefix exists), scan for the first character that could begin a match. This
     // avoids running the full engine on text regions where no match can start.
@@ -1705,6 +1720,7 @@ public final class Matcher implements MatchResult {
     if (options.startAcceleration()
         && !prog.hasWordBoundary()
         && ccPrefixAscii != null
+        && !literalPrefixCandidateStart
         && (text != null || scanner instanceof Utf8InputScanner)) {
       diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
       int idx =
@@ -2110,6 +2126,45 @@ public final class Matcher implements MatchResult {
       WorkCounter.record(Math.max(0, text.length() - searchFrom));
     }
     return text.indexOf(requiredLiteral, searchFrom);
+  }
+
+  private int nextFixedOffsetCandidate(
+      InputScanner scanner, Pattern.FixedOffsetLiteral fixedOffsetLiteral, int fromIndex) {
+    if (fixedOffsetLiteral.offset() > scanner.length() - fromIndex) {
+      return -1;
+    }
+    int literalFrom = fromIndex + fixedOffsetLiteral.offset();
+    boolean[] firstAscii = parentPattern.charClassPrefixAscii();
+    while (literalFrom <= scanner.length()) {
+      int literalStart;
+      if (scanner instanceof Utf8InputScanner utf8Scanner) {
+        literalStart =
+            utf8Scanner.indexOf(
+                fixedOffsetLiteral.utf8(),
+                fixedOffsetLiteral.failure(),
+                fixedOffsetLiteral.shifts(),
+                literalFrom);
+      } else {
+        literalStart = text.indexOf(fixedOffsetLiteral.literal(), literalFrom);
+        if (WorkCounterConfig.ENABLED) {
+          int scanned =
+              literalStart >= 0
+                  ? literalStart - literalFrom + fixedOffsetLiteral.literal().length()
+                  : text.length() - literalFrom;
+          WorkCounter.record(Math.max(0, scanned));
+        }
+      }
+      if (literalStart < 0) {
+        return -1;
+      }
+      int candidateStart = literalStart - fixedOffsetLiteral.offset();
+      int first = scanner.asciiAt(candidateStart);
+      if (firstAscii == null || (first >= 0 && first < firstAscii.length && firstAscii[first])) {
+        return candidateStart;
+      }
+      literalFrom = literalStart + 1;
+    }
+    return -1;
   }
 
   private boolean findKeywordAlternation(

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -150,6 +150,7 @@ public final class Pattern implements Serializable {
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
   private final transient boolean[] charClassPrefixAscii;
+  private final transient FixedOffsetLiteral fixedOffsetLiteral;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
   private final transient EnginePathOptions enginePathOptions;
@@ -292,6 +293,7 @@ public final class Pattern implements Serializable {
       boolean startsWithGraphemeClusterBoundary,
       boolean hasInternalGraphemeClusterBoundary,
       boolean[] charClassPrefixAscii,
+      FixedOffsetLiteral fixedOffsetLiteral,
       StartAcceleration startAcceleration,
       KeywordAlternation keywordAlternation,
       int[] charClassMatchRanges,
@@ -355,6 +357,7 @@ public final class Pattern implements Serializable {
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
     this.charClassPrefixAscii = charClassPrefixAscii;
+    this.fixedOffsetLiteral = fixedOffsetLiteral;
     this.startAcceleration = startAcceleration;
     this.keywordAlternation = keywordAlternation;
     this.enginePathOptions = enginePathOptions;
@@ -488,8 +491,12 @@ public final class Pattern implements Serializable {
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
     // Extract character-class prefix for acceleration when no literal prefix exists.
     boolean[] ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
+    FixedOffsetLiteral fixedOffsetLiteral =
+        prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
     StartAcceleration startAcceleration =
-        (prefix == null && ccPrefixAscii == null) ? extractStartAcceleration(metadataAst) : null;
+        (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null)
+            ? extractStartAcceleration(metadataAst)
+            : null;
     KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
@@ -514,6 +521,7 @@ public final class Pattern implements Serializable {
         startsWithGcb,
         hasInternalGcb,
         ccPrefixAscii,
+        fixedOffsetLiteral,
         startAcceleration,
         keywordAlternation,
         ccMatch != null ? ccMatch.ranges : null,
@@ -663,6 +671,11 @@ public final class Pattern implements Serializable {
       if (searchStart < 0) {
         return false;
       }
+    } else if (enginePathOptions.startAcceleration() && fixedOffsetLiteral != null) {
+      searchStart = nextFixedOffsetCandidate(scanner, 0);
+      if (searchStart < 0) {
+        return false;
+      }
     } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
       searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
       if (searchStart < 0) {
@@ -725,6 +738,13 @@ public final class Pattern implements Serializable {
         diagnostics.boundary(MatchStrategy.LITERAL);
         return false;
       }
+    } else if (enginePathOptions.startAcceleration() && fixedOffsetLiteral != null) {
+      diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
+      searchStart = nextFixedOffsetCandidate(scanner, 0);
+      if (searchStart < 0) {
+        diagnostics.boundary(MatchStrategy.LITERAL);
+        return false;
+      }
     } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
       diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
       searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
@@ -759,6 +779,29 @@ public final class Pattern implements Serializable {
             != null;
     diagnostics.boundary(MatchStrategy.NFA);
     return matched;
+  }
+
+  private int nextFixedOffsetCandidate(Utf8InputScanner scanner, int searchFrom) {
+    int literalFrom = searchFrom + fixedOffsetLiteral.offset();
+    while (literalFrom <= scanner.length()) {
+      int literalStart =
+          scanner.indexOf(
+              fixedOffsetLiteral.utf8(),
+              fixedOffsetLiteral.failure(),
+              fixedOffsetLiteral.shifts(),
+              literalFrom);
+      if (literalStart < 0) {
+        return -1;
+      }
+      int candidateStart = literalStart - fixedOffsetLiteral.offset();
+      int first = scanner.asciiAt(candidateStart);
+      if (charClassPrefixAscii == null
+          || (first >= 0 && first < charClassPrefixAscii.length && charClassPrefixAscii[first])) {
+        return candidateStart;
+      }
+      literalFrom = literalStart + 1;
+    }
+    return -1;
   }
 
   private static int[] literalFailure(byte[] literal) {
@@ -1218,6 +1261,11 @@ public final class Pattern implements Serializable {
    */
   boolean[] charClassPrefixAscii() {
     return charClassPrefixAscii;
+  }
+
+  /** Returns a mandatory ASCII literal at a fixed offset from the match start, or {@code null}. */
+  FixedOffsetLiteral fixedOffsetLiteral() {
+    return fixedOffsetLiteral;
   }
 
   /** Returns conservative start-position acceleration data, or {@code null} if unavailable. */
@@ -2029,6 +2077,42 @@ public final class Pattern implements Serializable {
     }
   }
 
+  static final class FixedOffsetLiteral {
+    private final String literal;
+    private final int offset;
+    private final byte[] utf8;
+    private final int[] failure;
+    private final int[] shifts;
+
+    FixedOffsetLiteral(String literal, int offset) {
+      this.literal = literal;
+      this.offset = offset;
+      this.utf8 = literal.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      this.failure = literalFailure(utf8);
+      this.shifts = literalShifts(utf8);
+    }
+
+    String literal() {
+      return literal;
+    }
+
+    int offset() {
+      return offset;
+    }
+
+    byte[] utf8() {
+      return utf8;
+    }
+
+    int[] failure() {
+      return failure;
+    }
+
+    int[] shifts() {
+      return shifts;
+    }
+  }
+
   /** Fast-path data for {@code (?i)\b(keyword|...)\b} and its greedy whole-input form. */
   static final class KeywordAlternation {
     final String[] keywords;
@@ -2049,6 +2133,119 @@ public final class Pattern implements Serializable {
       this.unicodeWordBoundary = unicodeWordBoundary;
       this.greedyWholeInput = greedyWholeInput;
     }
+  }
+
+  /**
+   * Finds the longest case-sensitive ASCII literal after a fixed-width ASCII match prefix.
+   *
+   * <p>This deliberately recognizes only the simple concatenation shape produced by simplification.
+   * Stopping at the first variable-width or non-ASCII atom keeps byte and UTF-16 offsets identical
+   * and makes every derived start position exact.
+   */
+  private static FixedOffsetLiteral extractFixedOffsetLiteral(Regexp re) {
+    Regexp node = unwrapFixedOffsetNode(re);
+    if (node.op != RegexpOp.CONCAT || node.subs == null) {
+      return null;
+    }
+    FixedOffsetLiteral best = null;
+    int offset = 0;
+    for (Regexp sub : node.subs) {
+      String literal = fixedOffsetAsciiLiteral(sub);
+      if (offset > 0
+          && literal != null
+          && (best == null || literal.length() > best.literal().length())) {
+        best = new FixedOffsetLiteral(literal, offset);
+      }
+      int width = exactAsciiWidth(sub);
+      if (width < 0 || offset > Integer.MAX_VALUE - width) {
+        break;
+      }
+      offset += width;
+    }
+    return best;
+  }
+
+  private static Regexp unwrapFixedOffsetNode(Regexp re) {
+    Regexp node = re;
+    while (node.op == RegexpOp.CAPTURE || node.op == RegexpOp.NON_CAPTURE) {
+      node = node.sub();
+    }
+    return node;
+  }
+
+  private static String fixedOffsetAsciiLiteral(Regexp re) {
+    Regexp node = unwrapFixedOffsetNode(re);
+    if ((node.flags & ParseFlags.FOLD_CASE) != 0) {
+      return null;
+    }
+    if (node.op == RegexpOp.LITERAL && node.rune >= 0 && node.rune < 128) {
+      return Character.toString(node.rune);
+    }
+    if (node.op != RegexpOp.LITERAL_STRING || node.runes == null || node.runes.length == 0) {
+      return null;
+    }
+    for (int rune : node.runes) {
+      if (rune < 0 || rune >= 128) {
+        return null;
+      }
+    }
+    return new String(node.runes, 0, node.runes.length);
+  }
+
+  private static int exactAsciiWidth(Regexp re) {
+    record WidthNode(Regexp regexp, int multiplier) {}
+    Deque<WidthNode> pending = new ArrayDeque<>();
+    pending.push(new WidthNode(re, 1));
+    int width = 0;
+    while (!pending.isEmpty()) {
+      WidthNode current = pending.pop();
+      Regexp node = current.regexp();
+      int multiplier = current.multiplier();
+      if (node.op == RegexpOp.CAPTURE || node.op == RegexpOp.NON_CAPTURE) {
+        pending.push(new WidthNode(node.sub(), multiplier));
+        continue;
+      }
+      if (node.op == RegexpOp.CONCAT && node.subs != null) {
+        for (int index = node.subs.size() - 1; index >= 0; index--) {
+          pending.push(new WidthNode(node.subs.get(index), multiplier));
+        }
+        continue;
+      }
+      if (node.op == RegexpOp.REPEAT && node.min == node.max && node.min >= 0) {
+        if (node.min != 0 && multiplier > Integer.MAX_VALUE / node.min) {
+          return -1;
+        }
+        pending.push(new WidthNode(node.sub(), multiplier * node.min));
+        continue;
+      }
+      int atomWidth;
+      if (node.op == RegexpOp.EMPTY_MATCH) {
+        atomWidth = 0;
+      } else if (node.op == RegexpOp.LITERAL) {
+        atomWidth = node.rune >= 0 && node.rune < 128 ? 1 : -1;
+      } else if (node.op == RegexpOp.LITERAL_STRING && node.runes != null) {
+        atomWidth = node.runes.length;
+        for (int rune : node.runes) {
+          if (rune < 0 || rune >= 128) {
+            return -1;
+          }
+        }
+      } else if (node.op == RegexpOp.CHAR_CLASS
+          && node.charClass != null
+          && !node.charClass.isEmpty()
+          && node.charClass.hi(node.charClass.numRanges() - 1) < 128) {
+        atomWidth = 1;
+      } else {
+        return -1;
+      }
+      if (atomWidth < 0
+          || (atomWidth != 0 && multiplier > Integer.MAX_VALUE / atomWidth)
+          || width > Integer.MAX_VALUE - atomWidth * multiplier) {
+        return -1;
+      }
+      width += atomWidth * multiplier;
+    }
+    return width;
   }
 
   /**
@@ -2627,13 +2824,15 @@ public final class Pattern implements Serializable {
       CharClass required = requiredCharClass(node, inspectAlternation);
       return required != null ? buildCharClassScanInfo(required) : null;
     }
+    CharClass mostSelective = null;
     for (Regexp sub : node.subs) {
       CharClass required = requiredCharClass(sub, inspectAlternation);
-      if (required != null) {
-        return buildCharClassScanInfo(required);
+      if (required != null
+          && (mostSelective == null || required.numRunes() < mostSelective.numRunes())) {
+        mostSelective = required;
       }
     }
-    return null;
+    return mostSelective != null ? buildCharClassScanInfo(mostSelective) : null;
   }
 
   private static CharClass requiredCharClass(Regexp re, boolean inspectAlternation) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -626,6 +626,14 @@ class MatcherTest {
       assertAllFindsMatchJdk("(?m)^\\s+at\\s+(\\w+)$", "header\u2028\tat alpha\u2029\tat beta");
     }
 
+    @Test
+    @DisplayName("find() skips fixed-offset literals that cannot start a match")
+    void findSkipsInvalidFixedOffsetLiteralCandidates() {
+      assertAllFindsMatchJdk(
+          "\\d{3}/\\d{3}/\\d{4}",
+          "path /api/42 then 12/345/6789 and finally 123/456/7890 plus 987/654/3210");
+    }
+
     @ParameterizedTest
     @ValueSource(
         strings = {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -191,6 +191,40 @@ class PatternInternalTest {
 
   @ParameterizedTest
   @CsvSource({
+    "'\\d{3}/\\d{3}/\\d{4}', /, 0",
+    "'[A-Z]{2}:[0-9]{4}',    :, A",
+    "'\\w+#[a-f0-9]{8}',     #, a"
+  })
+  void requiredCharacterClassPrefersTheMostSelectiveMandatoryAtom(
+      String regex, char expectedMember, char expectedNonMember) {
+    Pattern p = Pattern.compile(regex);
+
+    assertThat(requiredClassContains(p, expectedMember)).isTrue();
+    assertThat(requiredClassContains(p, expectedNonMember)).isFalse();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'\\d{3}/\\d{3}/\\d{4}', /, 3",
+    "'[A-Z][0-9]::[a-z]+',   ::, 2",
+    "'[ab][cd]-xyz',          -xyz, 2"
+  })
+  void fixedOffsetAsciiLiteralsAreRecorded(String regex, String literal, int offset) {
+    Pattern.FixedOffsetLiteral fixedOffsetLiteral = Pattern.compile(regex).fixedOffsetLiteral();
+
+    assertThat(fixedOffsetLiteral).isNotNull();
+    assertThat(fixedOffsetLiteral.literal()).isEqualTo(literal);
+    assertThat(fixedOffsetLiteral.offset()).isEqualTo(offset);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"\\d+/x", "[αβ]/x", "[ab](?i:x)", "literal-prefix"})
+  void variableWidthUnicodeAndOrdinaryPrefixesDoNotRecordFixedOffsetLiterals(String regex) {
+    assertThat(Pattern.compile(regex).fixedOffsetLiteral()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
     "'.*(x|y).*',             xy, az",
     "'.*(?:m|n).*',           mn, xz",
     "'.*([0-2]|[7-9]).*',     08, 56",

--- a/safere/src/test/java/org/safere/Utf8LinearTimeTest.java
+++ b/safere/src/test/java/org/safere/Utf8LinearTimeTest.java
@@ -34,6 +34,8 @@ class Utf8LinearTimeTest {
         size -> findAll("([a-z]+)([0-9]+)", "a1".repeat(size).getBytes(UTF_8)));
     assertLargeFourXInputStaysNearLinear(
         size -> findAll("\\bword\\b", "word ".repeat(size).getBytes(UTF_8)));
+    assertLargeFourXInputStaysNearLinear(
+        size -> findAll("\\d{3}/\\d{3}/\\d{4}", "path /api ".repeat(size).getBytes(UTF_8)));
     assertLargeFourXInputStaysNearLinear(size -> findAll("\\X", "á".repeat(size).getBytes(UTF_8)));
     assertLargeFourXInputStaysNearLinear(size -> findAll(".", malformedInput(size)));
   }

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -274,6 +274,16 @@ class Utf8MatcherStateMachineTest {
   }
 
   @Test
+  void patternBooleanSearchUsesFixedOffsetLiteralCandidates() {
+    Pattern phone = Pattern.compile("\\d{3}/\\d{3}/\\d{4}");
+
+    assertThat(phone.find(Utf8Input.validated("path /api/42".getBytes(UTF_8)))).isFalse();
+    assertThat(phone.find(Utf8Input.validated("path /api then 123/456/7890".getBytes(UTF_8))))
+        .isTrue();
+    assertThat(phone.find(Utf8Input.validated("digits 1234567890".getBytes(UTF_8)))).isFalse();
+  }
+
+  @Test
   void requiredNonAsciiClassRejectsAsciiInputAcrossUtf8EntryPoints() {
     Pattern pattern = Pattern.compile("[一-龥]{3,}");
     Utf8Input absent = Utf8Input.trusted("ordinary ASCII text".getBytes(UTF_8));


### PR DESCRIPTION
## Summary

- choose the smallest mandatory character class for negative prefiltering
- detect case-sensitive ASCII literals at an exact offset from the match start
- scan those literals and reject candidates whose derived start cannot match the leading ASCII class
- add Java-string and preexisting-UTF-8 no-slash, unrelated-slash, sparse-match, and
  dense-control workloads

This builds on issue proposals 1 and 2 in #642 and implements issue proposal 3 from #636.

The measured acceleration is specific to the preexisting-UTF-8 path. Before this PR, the
Java-string matcher already searched required literals with the JDK's optimized
`String.indexOf()`. The fixed-offset String path uses that same primitive, so it does not introduce
a new source of acceleration; it preserves the existing fast behavior when the new selectivity
choice changes which prefilter wins. The preexisting-UTF-8 path lacked an equivalent
start-candidate route, which is why it receives the large speedups below. Long before/after
measurements show no statistically resolved String speedup.

Part of #636

## Benchmark results

### Preexisting UTF-8

Standard Java benchmark configuration: 2 forks, 2 x 500 ms warmup iterations, and 5 x 500 ms
measurement iterations. Times are ns/op; lower is better.

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| find, digits but no slash | 50,733 | 1,027 | 49.4x faster |
| find, unrelated slash noise | 50,076 | 4,888 | 10.2x faster |
| find, sparse 511 | 33,677 | 651 | 51.7x faster |
| find, sparse 63 | 4,106 | 104 | 39.3x faster |
| find, sparse 7 | 401 | 25 | 15.7x faster |
| find, sparse 1 | 61 | 18 | 3.3x faster |
| find-all, sparse 511 | 39,859 | 999 | 39.9x faster |
| find-all, sparse 63 | 51,823 | 1,548 | 33.5x faster |
| find-all, sparse 7 | 48,343 | 6,036 | 8.0x faster |
| find-all, sparse 1 | 54,633 | 30,194 | 1.8x faster |
| find-all, dense digits/slashes | 57,927 | 54,697 | 5.9% faster |

### Java String

Long confirmation configuration: 2 forks, 3 x 1 s warmup iterations, and 5 x 1 s measurement
iterations.

| Workload | Before | After |
| --- | ---: | ---: |
| find, digits but no slash | 1,029 | 1,077 |
| find, unrelated slash noise | 8,897 | 8,978 |
| find, sparse 511 | 718 | 695 |
| find, sparse 63 | 141 | 144 |
| find, sparse 7 | 54 | 56 |
| find, sparse 1 | 50 | 48 |
| find-all, sparse 511 | 1,194 | 1,175 |
| find-all, sparse 63 | 1,675 | 1,695 |
| find-all, sparse 7 | 5,947 | 6,798 |
| find-all, sparse 1 | 30,024 | 33,754 |
| find-all, dense digits/slashes | 54,585 | 54,727 |

All String before/after 99.9% confidence intervals overlap. The two larger point-estimate
differences are the noisy sparse-7 and sparse-1 find-all cases; their branch-side error intervals
were ±1,129 ns/op and ±5,014 ns/op, respectively. The remaining nine workloads have a 1.003
geometric-mean after/before ratio (0.3% slower), so the String result is effectively unchanged.

## Verification

Ran:

- `mvn test -q`
- `mvn -pl safere -Pwork-counters -Dtest=Utf8LinearTimeTest test -q`
- `mvn -pl safere spotless:check -q`
- `mvn -pl safere-benchmarks spotless:check -q`
- focused standard JMH before/after runs for all UTF-8 workloads in the table
- focused standard and long JMH before/after runs for all Java-string workloads in the table

Not run:

- the full benchmark collection
- the external OpenJDK-derived benchmark suite
