### PR TITLE
Explicitly ignore an unused return value

### DIFF
--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkDataSchema.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkDataSchema.java
@@ -23,7 +23,7 @@ final class BenchmarkDataSchema {
 
   static void validate(JsonObject source) {
     requireOnly(source, "benchmark-data.json", ROOT_FIELDS);
-    required(source, "schemaVersion").getAsInt();
+    var _ = required(source, "schemaVersion").getAsInt();
     requiredArray(source, "inputs");
     if (source.has("workloads")) {
       requiredArray(source, "workloads");


### PR DESCRIPTION
This suppresses a https://errorprone.info/bugpattern/CheckReturnValue error