### PR TITLE
Enable Error Prone checks across all modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,9 +265,14 @@ bug you find immediately**. Do not just report it and move on. The workflow is:
   acceptable only for test helpers or implementation details with a clearly
   static, small bound.
 - **No `\C`**: RE2's "match any byte" is not applicable to Java strings.
-- **No `@SuppressWarnings`**: Do not add `@SuppressWarnings` annotations
-  without explicit approval from the project owner. Fix the underlying
-  issue instead.
+- **No `@SuppressWarnings` by default**: Do not add `@SuppressWarnings`
+  annotations without explicit approval from the project owner. Fix the
+  underlying issue instead.
+  `@SuppressWarnings("ArrayRecordComponent")` is pre-approved for non-public
+  records that intentionally hold arrays as internal data carriers, provided
+  array value semantics are not relied upon and an adjacent comment explains
+  the ownership or performance rationale. Public API records and records that
+  require value semantics still require explicit approval.
 - **Avoid `Object` arrays**: Use typed collections (`List<T>`, etc.) instead
   of `Object[]` to maintain type safety. Primitive arrays (e.g., `int[]`)
   are fine for performance reasons.

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <gson.version>2.11.0</gson.version>
     <jmh.version>1.37</jmh.version>
     <error-prone.version>2.50.0</error-prone.version>
-    <error-prone.checks>-Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF -Xep:ExposedPrivateType:OFF -Xep:ImmutableEnumChecker:OFF -Xep:ThreadPriorityCheck:OFF</error-prone.checks>
+    <error-prone.checks>-Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF -Xep:ExposedPrivateType:OFF -Xep:ImmutableEnumChecker:OFF -Xep:JdkObsolete:OFF -Xep:ThreadPriorityCheck:OFF</error-prone.checks>
     <google-java-format.version>1.35.0</google-java-format.version>
     <spotless.version>2.44.4</spotless.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,31 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint</arg>
+            <arg>-Werror</arg>
+            <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
+                 compile all files in a single batch (required by Error Prone). -->
+            <arg>-XDcompilePolicy=simple</arg>
+            <!-- Continue compilation past type-checking errors so Error Prone can analyze
+                 code that has downstream errors in later phases. -->
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <gson.version>2.11.0</gson.version>
     <jmh.version>1.37</jmh.version>
     <error-prone.version>2.50.0</error-prone.version>
+    <error-prone.checks>-Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF -Xep:ExposedPrivateType:OFF -Xep:ImmutableEnumChecker:OFF -Xep:ThreadPriorityCheck:OFF</error-prone.checks>
     <google-java-format.version>1.35.0</google-java-format.version>
     <spotless.version>2.44.4</spotless.version>
   </properties>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.compiler.release>22</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -77,31 +78,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
         <configuration>
-          <release>22</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
+          <compilerArgs combine.children="append">
             <arg>-Xlint:-processing</arg>
-            <arg>-Werror</arg>
-            <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
-                 compile all files in a single batch (required by Error Prone). -->
-            <arg>-XDcompilePolicy=simple</arg>
-            <!-- Continue compilation past type-checking errors so Error Prone can analyze
-                 code that has downstream errors in later phases. -->
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
-          <annotationProcessorPaths>
+          <annotationProcessorPaths combine.children="append">
             <path>
               <groupId>org.openjdk.jmh</groupId>
               <artifactId>jmh-generator-annprocess</artifactId>
               <version>${jmh.version}</version>
-            </path>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -81,13 +81,15 @@
         <configuration>
           <release>22</release>
           <compilerArgs>
+            <arg>-Xlint</arg>
+            <arg>-Werror</arg>
             <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
                  compile all files in a single batch (required by Error Prone). -->
             <arg>-XDcompilePolicy=simple</arg>
             <!-- Continue compilation past type-checking errors so Error Prone can analyze
                  code that has downstream errors in later phases. -->
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -82,6 +82,7 @@
           <release>22</release>
           <compilerArgs>
             <arg>-Xlint</arg>
+            <arg>-Xlint:-processing</arg>
             <arg>-Werror</arg>
             <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
                  compile all files in a single batch (required by Error Prone). -->

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
@@ -189,7 +189,7 @@ final class BenchmarkCollectionPlan {
     return new ReportPlan(trials, exclusions.stream().distinct().toList());
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     if (args.length == 0) {
       throw new IllegalArgumentException(
           "Usage: BenchmarkCollectionPlan "

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
@@ -154,7 +154,7 @@ final class CrossEngineBenchmarkPlan {
             + exclusion.exclusion().reason());
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     if (args.length < 1) {
       throw new IllegalArgumentException(
           "Usage: CrossEngineBenchmarkPlan "

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineWorkload.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineWorkload.java
@@ -9,51 +9,33 @@ import java.util.List;
 import java.util.Objects;
 
 /** One regex workload executed consistently across multiple engines. */
-final class CrossEngineWorkload {
-  private final String id;
-  private final BenchmarkOperation operation;
-  private final List<String> patterns;
-  private final List<String> inputKeys;
-  private final int[] groups;
-  private final String replacement;
-  private final Object expected;
-  private final int limit;
-  private final DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle;
-  private final String flagSet;
-  private final int seed;
-  private final int count;
-  private final DeclarativeBenchmarkPlan.Measurement measurement;
-  private final TimingGroup timingGroup;
+// groups is internal benchmark metadata; callers do not use record value semantics.
+@SuppressWarnings("ArrayRecordComponent")
+record CrossEngineWorkload(
+    String id,
+    BenchmarkOperation operation,
+    List<String> patterns,
+    List<String> inputKeys,
+    int[] groups,
+    String replacement,
+    Object expected,
+    int limit,
+    DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
+    String flagSet,
+    int seed,
+    int count,
+    DeclarativeBenchmarkPlan.Measurement measurement,
+    TimingGroup timingGroup) {
 
-  CrossEngineWorkload(
-      String id,
-      BenchmarkOperation operation,
-      List<String> patterns,
-      List<String> inputKeys,
-      int[] groups,
-      String replacement,
-      Object expected,
-      int limit,
-      DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
-      String flagSet,
-      int seed,
-      int count,
-      DeclarativeBenchmarkPlan.Measurement measurement,
-      TimingGroup timingGroup) {
-    this.id = Objects.requireNonNull(id);
-    this.operation = Objects.requireNonNull(operation);
-    this.patterns = List.copyOf(patterns);
-    this.inputKeys = List.copyOf(inputKeys);
-    this.groups = groups.clone();
-    this.replacement = replacement;
-    this.expected = expected;
-    this.limit = limit;
-    this.lifecycle = Objects.requireNonNull(lifecycle);
-    this.flagSet = flagSet;
-    this.seed = seed;
-    this.count = count;
-    this.measurement = Objects.requireNonNull(measurement);
-    this.timingGroup = Objects.requireNonNull(timingGroup);
+  CrossEngineWorkload {
+    Objects.requireNonNull(id);
+    Objects.requireNonNull(operation);
+    patterns = List.copyOf(patterns);
+    inputKeys = List.copyOf(inputKeys);
+    groups = groups.clone();
+    Objects.requireNonNull(lifecycle);
+    Objects.requireNonNull(measurement);
+    Objects.requireNonNull(timingGroup);
     if (id.isBlank()) {
       throw new IllegalArgumentException("Cross-engine workload ID must not be blank");
     }
@@ -69,62 +51,6 @@ final class CrossEngineWorkload {
         && operation != BenchmarkOperation.COMPILE_AND_FIND_ROTATING_UTF16) {
       throw new IllegalArgumentException(id + " requires at least one input");
     }
-  }
-
-  String id() {
-    return id;
-  }
-
-  BenchmarkOperation operation() {
-    return operation;
-  }
-
-  List<String> patterns() {
-    return patterns;
-  }
-
-  List<String> inputKeys() {
-    return inputKeys;
-  }
-
-  int[] groups() {
-    return groups;
-  }
-
-  String replacement() {
-    return replacement;
-  }
-
-  Object expected() {
-    return expected;
-  }
-
-  int limit() {
-    return limit;
-  }
-
-  DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle() {
-    return lifecycle;
-  }
-
-  String flagSet() {
-    return flagSet;
-  }
-
-  int seed() {
-    return seed;
-  }
-
-  int count() {
-    return count;
-  }
-
-  DeclarativeBenchmarkPlan.Measurement measurement() {
-    return measurement;
-  }
-
-  TimingGroup timingGroup() {
-    return timingGroup;
   }
 
   /** Benchmark schedule group, kept separate so historical output units remain stable. */

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineWorkload.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineWorkload.java
@@ -9,31 +9,51 @@ import java.util.List;
 import java.util.Objects;
 
 /** One regex workload executed consistently across multiple engines. */
-record CrossEngineWorkload(
-    String id,
-    BenchmarkOperation operation,
-    List<String> patterns,
-    List<String> inputKeys,
-    int[] groups,
-    String replacement,
-    Object expected,
-    int limit,
-    DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
-    String flagSet,
-    int seed,
-    int count,
-    DeclarativeBenchmarkPlan.Measurement measurement,
-    TimingGroup timingGroup) {
+final class CrossEngineWorkload {
+  private final String id;
+  private final BenchmarkOperation operation;
+  private final List<String> patterns;
+  private final List<String> inputKeys;
+  private final int[] groups;
+  private final String replacement;
+  private final Object expected;
+  private final int limit;
+  private final DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle;
+  private final String flagSet;
+  private final int seed;
+  private final int count;
+  private final DeclarativeBenchmarkPlan.Measurement measurement;
+  private final TimingGroup timingGroup;
 
-  CrossEngineWorkload {
-    Objects.requireNonNull(id);
-    Objects.requireNonNull(operation);
-    patterns = List.copyOf(patterns);
-    inputKeys = List.copyOf(inputKeys);
-    groups = groups.clone();
-    Objects.requireNonNull(lifecycle);
-    Objects.requireNonNull(measurement);
-    Objects.requireNonNull(timingGroup);
+  CrossEngineWorkload(
+      String id,
+      BenchmarkOperation operation,
+      List<String> patterns,
+      List<String> inputKeys,
+      int[] groups,
+      String replacement,
+      Object expected,
+      int limit,
+      DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
+      String flagSet,
+      int seed,
+      int count,
+      DeclarativeBenchmarkPlan.Measurement measurement,
+      TimingGroup timingGroup) {
+    this.id = Objects.requireNonNull(id);
+    this.operation = Objects.requireNonNull(operation);
+    this.patterns = List.copyOf(patterns);
+    this.inputKeys = List.copyOf(inputKeys);
+    this.groups = groups.clone();
+    this.replacement = replacement;
+    this.expected = expected;
+    this.limit = limit;
+    this.lifecycle = Objects.requireNonNull(lifecycle);
+    this.flagSet = flagSet;
+    this.seed = seed;
+    this.count = count;
+    this.measurement = Objects.requireNonNull(measurement);
+    this.timingGroup = Objects.requireNonNull(timingGroup);
     if (id.isBlank()) {
       throw new IllegalArgumentException("Cross-engine workload ID must not be blank");
     }
@@ -49,6 +69,62 @@ record CrossEngineWorkload(
         && operation != BenchmarkOperation.COMPILE_AND_FIND_ROTATING_UTF16) {
       throw new IllegalArgumentException(id + " requires at least one input");
     }
+  }
+
+  String id() {
+    return id;
+  }
+
+  BenchmarkOperation operation() {
+    return operation;
+  }
+
+  List<String> patterns() {
+    return patterns;
+  }
+
+  List<String> inputKeys() {
+    return inputKeys;
+  }
+
+  int[] groups() {
+    return groups;
+  }
+
+  String replacement() {
+    return replacement;
+  }
+
+  Object expected() {
+    return expected;
+  }
+
+  int limit() {
+    return limit;
+  }
+
+  DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle() {
+    return lifecycle;
+  }
+
+  String flagSet() {
+    return flagSet;
+  }
+
+  int seed() {
+    return seed;
+  }
+
+  int count() {
+    return count;
+  }
+
+  DeclarativeBenchmarkPlan.Measurement measurement() {
+    return measurement;
+  }
+
+  TimingGroup timingGroup() {
+    return timingGroup;
   }
 
   /** Benchmark schedule group, kept separate so historical output units remain stable. */

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/EngineCapability.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/EngineCapability.java
@@ -17,5 +17,21 @@ enum EngineCapability {
   APPEND_REPLACEMENT,
   SPLIT,
   MATCHER_RESET,
-  REGIONS
+  REGIONS;
+
+  int bit() {
+    return switch (this) {
+      case COMPILE -> 1;
+      case FIND -> 1 << 1;
+      case MATCHES -> 1 << 2;
+      case LOOKING_AT -> 1 << 3;
+      case GROUP_PARTICIPATION -> 1 << 4;
+      case GROUP_TEXT -> 1 << 5;
+      case REPLACE -> 1 << 6;
+      case APPEND_REPLACEMENT -> 1 << 7;
+      case SPLIT -> 1 << 8;
+      case MATCHER_RESET -> 1 << 9;
+      case REGIONS -> 1 << 10;
+    };
+  }
 }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
@@ -83,7 +83,7 @@ public final class MemoryBenchmark {
     for (int trial = 0; trial < TRIALS; trial++) {
       // Warm up the factory (JIT compile, class loading).
       for (int i = 0; i < 20; i++) {
-        var unused = factory.get();
+        var _ = factory.get();
       }
 
       forceGc();

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/PatternProfiles.java
@@ -194,7 +194,7 @@ final class PatternProfiles {
               optionalFlagSets(alternateObject, "Inline benchmark pattern alternate " + profileId));
       Alternate previous =
           (expectedKind == ValueKind.PATTERN ? patternProfiles : replacementProfiles)
-              .computeIfAbsent(profileId, unused -> new LinkedHashMap<>())
+              .computeIfAbsent(profileId, _ -> new LinkedHashMap<>())
               .putIfAbsent(javaPattern, alternate);
       if (previous != null && !previous.equals(alternate)) {
         throw new IllegalArgumentException(

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
@@ -395,7 +395,7 @@ enum RegexEngineVariant {
   private final String reportEngine;
   private final String patternProfile;
   private final InputRepresentation inputRepresentation;
-  private final EnumSet<EngineCapability> capabilities;
+  private final long capabilities;
 
   RegexEngineVariant(
       String id,
@@ -407,7 +407,11 @@ enum RegexEngineVariant {
     this.reportEngine = reportEngine;
     this.patternProfile = patternProfile;
     this.inputRepresentation = inputRepresentation;
-    this.capabilities = capabilities;
+    long capabilityBits = 0;
+    for (EngineCapability capability : capabilities) {
+      capabilityBits |= capability.bit();
+    }
+    this.capabilities = capabilityBits;
   }
 
   String id() {
@@ -427,13 +431,19 @@ enum RegexEngineVariant {
   }
 
   EnumSet<EngineCapability> capabilities() {
-    return capabilities.clone();
+    EnumSet<EngineCapability> result = EnumSet.noneOf(EngineCapability.class);
+    for (EngineCapability capability : EngineCapability.values()) {
+      if ((capabilities & capability.bit()) != 0) {
+        result.add(capability);
+      }
+    }
+    return result;
   }
 
   DeclarativeBenchmarkPlan.EngineDeclaration declaration() {
     EnumSet<DeclarativeBenchmarkPlan.Feature> features =
         EnumSet.noneOf(DeclarativeBenchmarkPlan.Feature.class);
-    for (EngineCapability capability : capabilities) {
+    for (EngineCapability capability : capabilities()) {
       switch (capability) {
         case COMPILE -> {}
         case FIND -> features.add(DeclarativeBenchmarkPlan.Feature.FIND);

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
@@ -103,7 +103,7 @@ final class SpecializedBenchmarkPlan {
     return exclusions;
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     if (args.length != 1) {
       throw new IllegalArgumentException(
           "Usage: SpecializedBenchmarkPlan <average-time|pattern-set|retained-memory>");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
@@ -1020,7 +1020,6 @@ class DeclarativeBenchmarkPlanTest {
         .formatted(workloads);
   }
 
-  @SafeVarargs
   private static DeclarativeBenchmarkPlan.EngineDeclaration engine(
       String id,
       DeclarativeBenchmarkPlan.InputRepresentation representation,

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -53,28 +53,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
-        <configuration>
-          <release>21</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
-            <arg>-Werror</arg>
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
-          </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
       </plugin>

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -60,7 +60,17 @@
           <compilerArgs>
             <arg>-Xlint</arg>
             <arg>-Werror</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -603,6 +603,12 @@ public final class Matcher implements MatchResult {
     return utf8Shadow != null;
   }
 
+  /** Returns a string representation of this matcher's state. */
+  @Override
+  public String toString() {
+    return safereMatcher.toString();
+  }
+
   private void checkBoolean(String method, String args, boolean sr, boolean jr) {
     if (sr != jr) {
       trace.recordDivergence(method, args, sr, jr);

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -135,6 +135,7 @@ public final class Matcher implements MatchResult {
   }
 
   /** Returns the input subsequence captured by the given named group. */
+  @Override
   public String group(String name) {
     String sr = safereMatcher.group(name);
     String jr = jdkMatcher.group(name);
@@ -171,6 +172,7 @@ public final class Matcher implements MatchResult {
   }
 
   /** Returns the start index of the given named group. */
+  @Override
   public int start(String name) {
     int sr = safereMatcher.start(name);
     int jr = jdkMatcher.start(name);
@@ -207,6 +209,7 @@ public final class Matcher implements MatchResult {
   }
 
   /** Returns the end index (exclusive) of the given named group. */
+  @Override
   public int end(String name) {
     int sr = safereMatcher.end(name);
     int jr = jdkMatcher.end(name);
@@ -457,6 +460,7 @@ public final class Matcher implements MatchResult {
   }
 
   /** Returns the named groups from the pattern. */
+  @Override
   public Map<String, Integer> namedGroups() {
     return crosscheckPattern.namedGroups();
   }

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Shadow.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Utf8Shadow.java
@@ -12,7 +12,7 @@ final class Utf8Shadow {
   private final org.safere.Pattern pattern;
   private final byte[] bytes;
   private final Utf8Coordinates coordinates;
-  private org.safere.Utf8Matcher matcher;
+  private final org.safere.Utf8Matcher matcher;
 
   private Utf8Shadow(org.safere.Pattern pattern, byte[] bytes, Utf8Coordinates coordinates) {
     this.pattern = pattern;

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -140,8 +140,8 @@ class CrosscheckTest {
     @DisplayName("UTF-8 shadow excludes inputs that cannot round-trip through UTF-8")
     void utf8ShadowExcludesUnpairedSurrogatesAndMutableInputs() {
       assertThat(Pattern.compile(".").matcher("a\ud800b").utf8ShadowActive()).isFalse();
-      assertThat(Pattern.compile(".").matcher(new StringBuilder("abc")).utf8ShadowActive())
-          .isFalse();
+      CharSequence mutableInput = new StringBuffer("abc");
+      assertThat(Pattern.compile(".").matcher(mutableInput).utf8ShadowActive()).isFalse();
     }
 
     @Test

--- a/safere-exhaustive/pom.xml
+++ b/safere-exhaustive/pom.xml
@@ -64,7 +64,17 @@
           <compilerArgs>
             <arg>-Xlint</arg>
             <arg>-Werror</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/safere-exhaustive/pom.xml
+++ b/safere-exhaustive/pom.xml
@@ -56,28 +56,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
-        <configuration>
-          <release>21</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
-            <arg>-Werror</arg>
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
-          </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.5.0</version>

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -724,13 +724,6 @@ public final class CharacterClassDivergenceSweep {
         .replace("\"", "\\\"");
   }
 
-  private static String differenceInputs(Outcome jdk, Outcome safere) {
-    if (jdk.accepted() != safere.accepted()) {
-      return "compile";
-    }
-    return "jdk=" + jdk.matches() + ";safere=" + safere.matches();
-  }
-
   private static String bucketFor(CaseSpec spec, Outcome jdk, Outcome safere) {
     String kind = jdk.accepted() != safere.accepted() ? "compile" : "membership";
     String direction = direction(jdk, safere);
@@ -1266,9 +1259,5 @@ public final class CharacterClassDivergenceSweep {
       return false;
     }
     return !left.accepted() || left.matches().equals(right.matches());
-  }
-
-  private static String printable(String value) {
-    return value.replace("\n", "\\n").replace("\t", "\\t");
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceExpander.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceExpander.java
@@ -135,23 +135,11 @@ public final class CompactDivergenceExpander {
                 output.writeLong(record.caseIndex());
               }
             });
-      } finally {
-        IOException failure = null;
-        for (DataOutputStream output : indexOutputs.values()) {
-          try {
-            output.close();
-          } catch (IOException e) {
-            if (failure == null) {
-              failure = e;
-            } else {
-              failure.addSuppressed(e);
-            }
-          }
-        }
-        if (failure != null) {
-          throw failure;
-        }
+      } catch (IOException | RuntimeException | Error e) {
+        closeOutputs(indexOutputs.values(), e);
+        throw e;
       }
+      closeOutputs(indexOutputs.values(), null);
       for (String classification : indexPaths.keySet()) {
         try (BufferedWriter writer =
             Files.newBufferedWriter(
@@ -381,6 +369,29 @@ public final class CompactDivergenceExpander {
 
   interface StatusPredicate {
     boolean test(DivergenceStatus status);
+  }
+
+  private static void closeOutputs(Iterable<DataOutputStream> outputs, Throwable primary)
+      throws IOException {
+    IOException failure = null;
+    for (DataOutputStream output : outputs) {
+      try {
+        output.close();
+      } catch (IOException e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
+        }
+      }
+    }
+    if (failure != null) {
+      if (primary != null) {
+        primary.addSuppressed(failure);
+      } else {
+        throw failure;
+      }
+    }
   }
 
   private record SweepDefinition(

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceLogs.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceLogs.java
@@ -380,27 +380,7 @@ final class CompactDivergenceLogs implements AutoCloseable {
     }
   }
 
-  private static final class WorkerSnapshot {
-    private final long nextCaseIndex;
-    private final long durableBytes;
-    private final long[] classCounts;
-
-    WorkerSnapshot(long nextCaseIndex, long durableBytes, long[] classCounts) {
-      this.nextCaseIndex = nextCaseIndex;
-      this.durableBytes = durableBytes;
-      this.classCounts = classCounts;
-    }
-
-    long nextCaseIndex() {
-      return nextCaseIndex;
-    }
-
-    long durableBytes() {
-      return durableBytes;
-    }
-
-    long[] classCounts() {
-      return classCounts;
-    }
-  }
+  // classCounts is a private snapshot buffer; record value semantics are not used.
+  @SuppressWarnings("ArrayRecordComponent")
+  private record WorkerSnapshot(long nextCaseIndex, long durableBytes, long[] classCounts) {}
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceLogs.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceLogs.java
@@ -238,7 +238,7 @@ final class CompactDivergenceLogs implements AutoCloseable {
           try {
             long caseIndex = input.readLong();
             int classificationId = input.readUnsignedByte();
-            consumer.accept(new Record(caseIndex, classificationId));
+            consumer.accept(new DivergenceRecord(caseIndex, classificationId));
           } catch (EOFException e) {
             break;
           }
@@ -275,20 +275,30 @@ final class CompactDivergenceLogs implements AutoCloseable {
           queue.add(input);
         }
       }
-    } finally {
-      IOException failure = null;
-      for (WorkerInput input : inputs) {
-        try {
-          input.close();
-        } catch (IOException e) {
-          if (failure == null) {
-            failure = e;
-          } else {
-            failure.addSuppressed(e);
-          }
+    } catch (IOException | RuntimeException | Error e) {
+      closeInputs(inputs, e);
+      throw e;
+    }
+    closeInputs(inputs, null);
+  }
+
+  private static void closeInputs(List<WorkerInput> inputs, Throwable primary) throws IOException {
+    IOException failure = null;
+    for (WorkerInput input : inputs) {
+      try {
+        input.close();
+      } catch (IOException e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
         }
       }
-      if (failure != null) {
+    }
+    if (failure != null) {
+      if (primary != null) {
+        primary.addSuppressed(failure);
+      } else {
         throw failure;
       }
     }
@@ -303,15 +313,15 @@ final class CompactDivergenceLogs implements AutoCloseable {
       List<String> classifications,
       List<DivergenceStatus> classificationStatuses) {}
 
-  record Record(long caseIndex, int classificationId) {}
+  record DivergenceRecord(long caseIndex, int classificationId) {}
 
   interface RecordConsumer {
-    void accept(Record record) throws IOException;
+    void accept(DivergenceRecord record) throws IOException;
   }
 
   private static final class WorkerInput implements AutoCloseable {
     private final DataInputStream input;
-    Record record;
+    DivergenceRecord record;
 
     WorkerInput(Path path) throws IOException {
       input = new DataInputStream(new BufferedInputStream(Files.newInputStream(path)));
@@ -319,7 +329,7 @@ final class CompactDivergenceLogs implements AutoCloseable {
 
     boolean advance() throws IOException {
       try {
-        record = new Record(input.readLong(), input.readUnsignedByte());
+        record = new DivergenceRecord(input.readLong(), input.readUnsignedByte());
         return true;
       } catch (EOFException e) {
         record = null;
@@ -370,5 +380,27 @@ final class CompactDivergenceLogs implements AutoCloseable {
     }
   }
 
-  private record WorkerSnapshot(long nextCaseIndex, long durableBytes, long[] classCounts) {}
+  private static final class WorkerSnapshot {
+    private final long nextCaseIndex;
+    private final long durableBytes;
+    private final long[] classCounts;
+
+    WorkerSnapshot(long nextCaseIndex, long durableBytes, long[] classCounts) {
+      this.nextCaseIndex = nextCaseIndex;
+      this.durableBytes = durableBytes;
+      this.classCounts = classCounts;
+    }
+
+    long nextCaseIndex() {
+      return nextCaseIndex;
+    }
+
+    long durableBytes() {
+      return durableBytes;
+    }
+
+    long[] classCounts() {
+      return classCounts;
+    }
+  }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
@@ -167,14 +167,6 @@ public final class ControlEscapeDivergenceSweep {
     }
   }
 
-  private static Outcome jdkOutcome(String regex) {
-    return jdkOutcome(regex, 0, defaultReplayInputs());
-  }
-
-  private static Outcome safeReOutcome(String regex) {
-    return safeReOutcome(regex, 0, defaultReplayInputs());
-  }
-
   private static String matches(java.util.regex.Pattern pattern, List<String> inputs) {
     StringBuilder result = new StringBuilder();
     for (String input : inputs) {
@@ -222,10 +214,6 @@ public final class ControlEscapeDivergenceSweep {
       inputs.add(target + "a");
     }
     return List.copyOf(inputs);
-  }
-
-  private static List<String> defaultReplayInputs() {
-    return List.of("", "a", "A", "!", "\u0001", "\u001b", "\u0140", "\uf57f", "\uD83D\uDE40");
   }
 
   private static void addIfValid(Set<String> inputs, int codePoint) {

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/DfaSandwichLeftmostStartDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/DfaSandwichLeftmostStartDivergenceSweep.java
@@ -240,7 +240,7 @@ public final class DfaSandwichLeftmostStartDivergenceSweep {
     DivergenceClass classification = classify(jdk, safere);
     String json = divergenceJson(spec, regex, jdk, safere, classification, caseIndex);
     if (workerIndex >= 0 && caseIndex >= 0) {
-      runState.recordCompactDivergence(workerIndex, caseIndex, classification.ordinal());
+      runState.recordCompactDivergence(workerIndex, caseIndex, classificationId(classification));
     } else {
       runState.recordDivergence();
     }
@@ -388,6 +388,14 @@ public final class DfaSandwichLeftmostStartDivergenceSweep {
     public String rationale() {
       return rationale;
     }
+  }
+
+  private static int classificationId(DivergenceClass classification) {
+    return switch (classification) {
+      case ACCEPTANCE_MISMATCH -> 0;
+      case TRACE_MISMATCH -> 1;
+      case UNKNOWN -> 2;
+    };
   }
 
   private record PrefixCase(String label, String regex) {}

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -614,7 +614,7 @@ public final class GraphemeClusterDivergenceSweep {
     return !left.accepted() || left.trace().equals(right.trace());
   }
 
-  private static DivergenceClass classifyDivergence(CaseSpec spec, Outcome jdk, Outcome safere) {
+  private static DivergenceClass classifyDivergence(CaseSpec spec) {
     String regexLabel = spec.regexTemplate().label();
     if (isNonAnchoringDollarRegionEnd(spec)) {
       return DivergenceClass.NON_ANCHORING_DOLLAR_REGION_END;
@@ -881,7 +881,7 @@ public final class GraphemeClusterDivergenceSweep {
           input(
               "targetEmojiZwjModifierChain" + chainLength,
               "\uD83D\uDC69\uD83C\uDFFD"
-                  + ("\u200D\uD83D\uDC69\uD83C\uDFFD").repeat(chainLength - 1)));
+                  + "\u200D\uD83D\uDC69\uD83C\uDFFD".repeat(chainLength - 1)));
     }
 
     for (int leadingCount = 1; leadingCount <= 6; leadingCount++) {
@@ -901,8 +901,8 @@ public final class GraphemeClusterDivergenceSweep {
     for (int count = 1; count <= 8; count++) {
       addInput(inputs, input("targetHighLowPairs" + count, "\uD83D\uDE00".repeat(count)));
       addInput(inputs, input("targetLowHighPairs" + count, "\uDE00\uD83D".repeat(count)));
-      addInput(inputs, input("targetHighLowZwj" + count, ("\uD83D\uDE00\u200D").repeat(count)));
-      addInput(inputs, input("targetLowZwj" + count, ("\uDE00\u200D").repeat(count)));
+      addInput(inputs, input("targetHighLowZwj" + count, "\uD83D\uDE00\u200D".repeat(count)));
+      addInput(inputs, input("targetLowZwj" + count, "\uDE00\u200D".repeat(count)));
     }
 
     return List.copyOf(inputs.values());
@@ -1203,6 +1203,19 @@ public final class GraphemeClusterDivergenceSweep {
     }
   }
 
+  private static int classificationId(DivergenceClass classification) {
+    return switch (classification) {
+      case BOUNDARY_CLUSTER_BOUNDARY_COMPOSITION -> 0;
+      case BOUNDARY_ONLY_ALTERNATIVE_FIND_CURSOR -> 1;
+      case BOUNDARY_CLUSTER_ALTERNATIVE_FIND_CURSOR -> 2;
+      case REGION_LOCAL_CONTINUATION_CLUSTER -> 3;
+      case TRANSPARENT_BOUNDARY_JDK_DETAIL -> 4;
+      case NON_ANCHORING_DOLLAR_REGION_END -> 5;
+      case GRAPHEME_CANDIDATE_START_DEDUP -> 6;
+      case UNKNOWN -> 7;
+    };
+  }
+
   private record Divergence(
       long caseIndex,
       CaseSpec spec,
@@ -1318,11 +1331,11 @@ public final class GraphemeClusterDivergenceSweep {
       return;
     }
     String bucketName = bucketFor(spec, jdk, safere);
-    DivergenceClass classification = classifyDivergence(spec, jdk, safere);
+    DivergenceClass classification = classifyDivergence(spec);
     Divergence divergence =
         new Divergence(caseIndex, spec, jdk, safere, bucketName, classification);
     if (workerIndex >= 0) {
-      runState.recordCompactDivergence(workerIndex, caseIndex, classification.ordinal());
+      runState.recordCompactDivergence(workerIndex, caseIndex, classificationId(classification));
       summary.record(classification, caseIndex, null);
       return;
     }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/RegionScalarDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/RegionScalarDivergenceSweep.java
@@ -137,13 +137,12 @@ public final class RegionScalarDivergenceSweep {
     }
     options.printStartup("region-scalar");
 
-    RegionScalarDivergenceSweep sweep = new RegionScalarDivergenceSweep();
     if (options.replayFile() != null) {
-      sweep.runReplay(options);
+      RegionScalarDivergenceSweep.runReplay(options);
       return;
     }
 
-    SweepRunState state = sweep.runSweep(options);
+    SweepRunState state = RegionScalarDivergenceSweep.runSweep(options);
     System.out.println("checked=" + state.checked.sum());
     System.out.println("generated=" + state.generated);
     System.out.println("totalCases=" + totalCases());
@@ -205,7 +204,7 @@ public final class RegionScalarDivergenceSweep {
     return null;
   }
 
-  private SweepRunState runSweep(SweepOptions options) throws IOException {
+  private static SweepRunState runSweep(SweepOptions options) throws IOException {
     try (SweepRunState runState = new SweepRunState(options, options.totalChecks(totalCases()))) {
       runState.enableCompactLogs(
           "region-scalar",
@@ -236,7 +235,7 @@ public final class RegionScalarDivergenceSweep {
     }
   }
 
-  private void runReplay(SweepOptions options) throws IOException {
+  private static void runReplay(SweepOptions options) throws IOException {
     try (BufferedReader reader =
             Files.newBufferedReader(options.replayFile(), StandardCharsets.UTF_8);
         SweepRunState runState = new SweepRunState(options, 0)) {
@@ -263,7 +262,7 @@ public final class RegionScalarDivergenceSweep {
     }
   }
 
-  private void evaluateCase(
+  private static void evaluateCase(
       SweepRunState runState, CaseSpec spec, int workerIndex, long caseIndex) {
     Outcome jdk = jdkOutcome(spec);
     Outcome safere = safeReOutcome(spec);
@@ -272,7 +271,7 @@ public final class RegionScalarDivergenceSweep {
     }
     DivergenceClass classification = classifyDivergence(spec);
     if (workerIndex >= 0) {
-      runState.recordCompactDivergence(workerIndex, caseIndex, classification.ordinal());
+      runState.recordCompactDivergence(workerIndex, caseIndex, classificationId(classification));
       return;
     }
     if (classification.status() == DivergenceStatus.KNOWN_INTENTIONAL) {
@@ -290,8 +289,8 @@ public final class RegionScalarDivergenceSweep {
   }
 
   private static boolean isQuantifiedSplitSurrogateScalarComposition(CaseSpec spec) {
-    return ("starGreedy".equals(spec.wrapperCase().label())
-            || "plusGreedy".equals(spec.wrapperCase().label()))
+    return (spec.wrapperCase().label().equals("starGreedy")
+            || spec.wrapperCase().label().equals("plusGreedy"))
         && regionEndsInsideSurrogatePair(spec.textRegion());
   }
 
@@ -304,7 +303,7 @@ public final class RegionScalarDivergenceSweep {
         && Character.isLowSurrogate(text.charAt(end));
   }
 
-  private Outcome jdkOutcome(CaseSpec spec) {
+  private static Outcome jdkOutcome(CaseSpec spec) {
     try {
       java.util.regex.Pattern pattern =
           java.util.regex.Pattern.compile(spec.regex(), spec.flagMode().flags());
@@ -318,7 +317,7 @@ public final class RegionScalarDivergenceSweep {
     }
   }
 
-  private Outcome safeReOutcome(CaseSpec spec) {
+  private static Outcome safeReOutcome(CaseSpec spec) {
     try {
       org.safere.Pattern pattern =
           org.safere.Pattern.compile(spec.regex(), spec.flagMode().flags());
@@ -750,8 +749,16 @@ public final class RegionScalarDivergenceSweep {
       return status;
     }
 
-    String rationale() {
-      return rationale;
+    @Override
+    public String toString() {
+      return name() + ": " + rationale;
     }
+  }
+
+  private static int classificationId(DivergenceClass classification) {
+    return switch (classification) {
+      case QUANTIFIED_SPLIT_SURROGATE_SCALAR_COMPOSITION -> 0;
+      case UNKNOWN -> 1;
+    };
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/RegionZeroWidthDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/RegionZeroWidthDivergenceSweep.java
@@ -265,7 +265,7 @@ public final class RegionZeroWidthDivergenceSweep {
     }
     DivergenceClass classification = classifyDivergence(spec);
     if (workerIndex >= 0) {
-      runState.recordCompactDivergence(workerIndex, caseIndex, classification.ordinal());
+      runState.recordCompactDivergence(workerIndex, caseIndex, classificationId(classification));
       return;
     }
     if (classification.status() == DivergenceStatus.KNOWN_INTENTIONAL) {
@@ -292,8 +292,8 @@ public final class RegionZeroWidthDivergenceSweep {
   }
 
   private static boolean isKnownAsciiWordBoundaryCombiningMarkDivergence(CaseSpec spec) {
-    return ("baseBeforeMark".equals(spec.textRegion().label())
-            || "markOnlyAfterBase".equals(spec.textRegion().label()))
+    return (spec.textRegion().label().equals("baseBeforeMark")
+            || spec.textRegion().label().equals("markOnlyAfterBase"))
         && spec.boundsMode().transparentBounds()
         && switch (spec.regexCase().label()) {
           case "wordBoundary",
@@ -322,7 +322,7 @@ public final class RegionZeroWidthDivergenceSweep {
   }
 
   private static boolean isOpaqueRegionCrlfPairContextDivergence(CaseSpec spec) {
-    return "finalCrLfLfOnly".equals(spec.textRegion().label())
+    return spec.textRegion().label().equals("finalCrLfLfOnly")
         && !spec.boundsMode().transparentBounds()
         && spec.boundsMode().anchoringBounds()
         && switch (spec.regexCase().label()) {
@@ -334,7 +334,7 @@ public final class RegionZeroWidthDivergenceSweep {
 
   private static boolean isBoundaryAnyClassSplitSurrogateScalarCompositionDivergence(
       CaseSpec spec) {
-    return "splitHighThroughAscii".equals(spec.textRegion().label())
+    return spec.textRegion().label().equals("splitHighThroughAscii")
         && spec.boundsMode().transparentBounds()
         && switch (spec.regexCase().label()) {
           case "nonWordBoundaryThenAnyClass",
@@ -346,7 +346,7 @@ public final class RegionZeroWidthDivergenceSweep {
   }
 
   private static boolean isNonWordBoundarySplitSurrogateInteriorPositionDivergence(CaseSpec spec) {
-    return "splitHighThroughAscii".equals(spec.textRegion().label())
+    return spec.textRegion().label().equals("splitHighThroughAscii")
         && spec.boundsMode().transparentBounds()
         && switch (spec.regexCase().label()) {
           case "nonWordBoundary",
@@ -704,8 +704,19 @@ public final class RegionZeroWidthDivergenceSweep {
       return status;
     }
 
-    String rationale() {
-      return rationale;
+    @Override
+    public String toString() {
+      return name() + ": " + rationale;
     }
+  }
+
+  private static int classificationId(DivergenceClass classification) {
+    return switch (classification) {
+      case ASCII_WORD_BOUNDARY_COMBINING_MARK -> 0;
+      case OPAQUE_REGION_CRLF_PAIR_CONTEXT -> 1;
+      case BOUNDARY_ANY_CLASS_SPLIT_SURROGATE_SCALAR_COMPOSITION -> 2;
+      case NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION -> 3;
+      case UNKNOWN -> 4;
+    };
   }
 }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ZeroWidthQuantifierDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ZeroWidthQuantifierDivergenceSweep.java
@@ -646,6 +646,25 @@ public final class ZeroWidthQuantifierDivergenceSweep {
     }
   }
 
+  private static int classificationId(DivergenceClass classification) {
+    return switch (classification) {
+      case STACK_OVERFLOW -> 0;
+      case RELUCTANT_QUANTIFIER_MODIFIER -> 1;
+      case COMMENTS_MODE_GRAPHEME_QUANTIFIER_TRIVIA -> 2;
+      case INVALID_QUANTIFIER_CHAIN_ACCEPTED -> 3;
+      case ZERO_WIDTH_POSSESSIVE_QUANTIFIER_REJECTED -> 4;
+      case ZERO_WIDTH_POSSESSIVE_CAPTURE_RETENTION -> 5;
+      case POSSESSIVE_QUANTIFIER_UNSUPPORTED -> 6;
+      case GRAPHEME_BOUNDARY_ALTERNATIVE_FIND_CURSOR -> 7;
+      case REPEATED_GRAPHEME_BOUNDARY_COMPOSITION -> 8;
+      case GRAPHEME_BOUNDARY_ALTERNATIVE_GRAPHEME_MODEL -> 9;
+      case GRAPHEME_BOUNDARY_CAPTURE_GRAPHEME_MODEL -> 10;
+      case ASCII_WORD_BOUNDARY_COMBINING_MARK -> 11;
+      case FAILED_PATH_CAPTURE_LEAKAGE -> 12;
+      case UNKNOWN -> 13;
+    };
+  }
+
   private record CaseSpec(
       Operand operand,
       Wrapper wrapper,
@@ -869,7 +888,7 @@ public final class ZeroWidthQuantifierDivergenceSweep {
       DivergenceClass classification,
       int workerIndex) {
     if (workerIndex >= 0) {
-      runState.recordCompactDivergence(workerIndex, caseIndex, classification.ordinal());
+      runState.recordCompactDivergence(workerIndex, caseIndex, classificationId(classification));
       summary.record(classification, caseIndex, null);
       return;
     }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/CompactDivergenceLogsTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/CompactDivergenceLogsTest.java
@@ -73,11 +73,11 @@ class CompactDivergenceLogsTest {
         new byte[] {1, 2, 3},
         StandardOpenOption.APPEND);
 
-    List<CompactDivergenceLogs.Record> records = new ArrayList<>();
+    List<CompactDivergenceLogs.DivergenceRecord> records = new ArrayList<>();
     CompactDivergenceLogs.readRecords(
         tempDir, CompactDivergenceLogs.readManifest(tempDir), records::add);
 
-    assertThat(records).containsExactly(new CompactDivergenceLogs.Record(12, 0));
+    assertThat(records).containsExactly(new CompactDivergenceLogs.DivergenceRecord(12, 0));
   }
 
   @Test
@@ -98,12 +98,12 @@ class CompactDivergenceLogsTest {
       logs.record(1, 3, 0);
     }
 
-    List<CompactDivergenceLogs.Record> records = new ArrayList<>();
+    List<CompactDivergenceLogs.DivergenceRecord> records = new ArrayList<>();
     CompactDivergenceLogs.readRecordsSorted(
         tempDir, CompactDivergenceLogs.readManifest(tempDir), records::add);
 
     assertThat(records)
-        .extracting(CompactDivergenceLogs.Record::caseIndex)
+        .extracting(CompactDivergenceLogs.DivergenceRecord::caseIndex)
         .containsExactly(0L, 1L, 2L, 3L);
   }
 

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepRunStateTest.java
@@ -100,7 +100,7 @@ class SweepRunStateTest {
     assertThat(Files.readString(tempDir.resolve("progress.json"))).contains("\"nextCaseIndex\":7");
   }
 
-  private ByteArrayOutputStream progressOutputAfterCheckedCases(
+  private static ByteArrayOutputStream progressOutputAfterCheckedCases(
       SweepOptions options, long checkedCases, long generated, long totalChecks) throws Exception {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     PrintStream originalOut = System.out;

--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -90,7 +90,7 @@
             <!-- Continue compilation past type-checking errors so Error Prone can analyze
                  code that has downstream errors in later phases. -->
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>

--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.compiler.release>22</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -77,28 +78,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
         <configuration>
-          <release>22</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
+          <compilerArgs combine.children="append">
             <arg>-Xlint:-restricted</arg>
-            <arg>-Werror</arg>
-            <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
-                 compile all files in a single batch (required by Error Prone). -->
-            <arg>-XDcompilePolicy=simple</arg>
-            <!-- Continue compilation past type-checking errors so Error Prone can analyze
-                 code that has downstream errors in later phases. -->
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-          </annotationProcessorPaths>
         </configuration>
       </plugin>
 

--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -56,28 +56,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
-        <configuration>
-          <release>21</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
-            <arg>-Werror</arg>
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
-          </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>

--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -63,7 +63,17 @@
           <compilerArgs>
             <arg>-Xlint</arg>
             <arg>-Werror</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
@@ -8,6 +8,7 @@ package org.safere.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
+import java.util.Objects;
 
 final class DialectSyntaxFuzzer {
 
@@ -86,7 +87,7 @@ final class DialectSyntaxFuzzer {
     if (!matcher.matches()) {
       throw new AssertionError("SafeRE Python-style named group did not match: " + regex);
     }
-    if (!"a".equals(matcher.group(1))) {
+    if (!Objects.equals(matcher.group(1), "a")) {
       throw new AssertionError("SafeRE Python-style named group captured wrong text: " + regex);
     }
   }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -106,8 +106,7 @@ final class FuzzSupport {
 
   static boolean jdkOracleCompletesForTesting(String regex, String input) {
     java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regex);
-    return runJdkOracle(
-            "matches", regex, 0, input, () -> pattern.matcher(interruptible(input)).matches())
+    return runJdkOracle("matches", () -> pattern.matcher(interruptible(input)).matches())
         .available();
   }
 
@@ -156,8 +155,7 @@ final class FuzzSupport {
     void split(CharSequence input) {
       String inputText = input.toString();
       JdkOracleResult<String[]> jdk =
-          runJdkOracle(
-              "split", regex, flags, inputText, () -> jdkPattern.split(interruptible(input)));
+          runJdkOracle("split", () -> jdkPattern.split(interruptible(input)));
       if (!jdk.available()) {
         return;
       }
@@ -167,12 +165,7 @@ final class FuzzSupport {
     void split(CharSequence input, int limit) {
       String inputText = input.toString();
       JdkOracleResult<String[]> jdk =
-          runJdkOracle(
-              "split(" + limit + ")",
-              regex,
-              flags,
-              inputText,
-              () -> jdkPattern.split(interruptible(input), limit));
+          runJdkOracle("split(" + limit + ")", () -> jdkPattern.split(interruptible(input), limit));
       if (!jdk.available()) {
         return;
       }
@@ -184,11 +177,7 @@ final class FuzzSupport {
       String inputText = input.toString();
       JdkOracleResult<String[]> jdk =
           runJdkOracle(
-              "splitWithDelimiters",
-              regex,
-              flags,
-              inputText,
-              () -> jdkPattern.splitWithDelimiters(interruptible(input), 0));
+              "splitWithDelimiters", () -> jdkPattern.splitWithDelimiters(interruptible(input), 0));
       if (!jdk.available()) {
         return;
       }
@@ -201,9 +190,6 @@ final class FuzzSupport {
       JdkOracleResult<String[]> jdk =
           runJdkOracle(
               "splitWithDelimiters(" + limit + ")",
-              regex,
-              flags,
-              inputText,
               () -> jdkPattern.splitWithDelimiters(interruptible(input), limit));
       if (!jdk.available()) {
         return;
@@ -569,10 +555,6 @@ final class FuzzSupport {
       throw divergence(operation, replacement, safeRe.describe(), jdk.describe());
     }
 
-    private AssertionError divergence(String operation, Object safeRe, Object jdk) {
-      return divergence(operation, lastReplacement, safeRe, jdk);
-    }
-
     private AssertionError divergence(
         String operation, String replacement, Object safeRe, Object jdk) {
       return new AssertionError(
@@ -605,8 +587,7 @@ final class FuzzSupport {
       if (!jdkOracleAvailable) {
         return fallback;
       }
-      JdkOracleResult<T> result =
-          FuzzSupport.runJdkOracle(operation, regex, flags, input, jdkOperation);
+      JdkOracleResult<T> result = FuzzSupport.runJdkOracle(operation, jdkOperation);
       if (!result.available()) {
         jdkOracleAvailable = false;
         return fallback;
@@ -642,7 +623,7 @@ final class FuzzSupport {
   private record JdkOracleResult<T>(boolean available, T value) {}
 
   private static <T> JdkOracleResult<T> runJdkOracle(
-      String operation, String regex, int flags, String input, JdkOracleOperation<T> jdkOperation) {
+      String operation, JdkOracleOperation<T> jdkOperation) {
     Future<T> task = JDK_ORACLE_EXECUTOR.submit(jdkOperation::run);
 
     try {
@@ -652,7 +633,8 @@ final class FuzzSupport {
       return unavailableJdkOracle();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new AssertionError("interrupted while waiting for JDK regex oracle", e);
+      throw new AssertionError(
+          "interrupted while waiting for JDK regex oracle during " + operation, e);
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof JdkOracleInterruptedException) {
@@ -770,7 +752,7 @@ final class FuzzSupport {
   }
 
   private static boolean isOverCompilerBudget(PatternSyntaxException safeReException) {
-    return "compiled program too large".equals(safeReException.getDescription());
+    return Objects.equals(safeReException.getDescription(), "compiled program too large");
   }
 
   private static boolean hasLookaround(String regex) {

--- a/safere-unicode/pom.xml
+++ b/safere-unicode/pom.xml
@@ -17,4 +17,31 @@
   <name>SafeRE Unicode Generator</name>
   <description>Generator tool for SafeRE's Unicode tables</description>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>21</release>
+          <compilerArgs>
+            <arg>-Xlint</arg>
+            <arg>-Werror</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/safere-unicode/pom.xml
+++ b/safere-unicode/pom.xml
@@ -17,31 +17,4 @@
   <name>SafeRE Unicode Generator</name>
   <description>Generator tool for SafeRE's Unicode tables</description>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
-        <configuration>
-          <release>21</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
-            <arg>-Werror</arg>
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
-          </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -107,28 +107,6 @@ final class WorkCounterConfig {
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
-        <configuration>
-          <release>21</release>
-          <compilerArgs>
-            <arg>-Xlint</arg>
-            <arg>-Werror</arg>
-            <!-- Error Prone runs as a javac plugin. -XDcompilePolicy=simple tells javac to
-                 compile all files in a single batch (required by Error Prone). -->
-            <arg>-XDcompilePolicy=simple</arg>
-            <!-- Continue compilation past type-checking errors so Error Prone can analyze
-                 code that has downstream errors in later phases. -->
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
-          </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${error-prone.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
         <executions>
           <execution>
             <id>default-testCompile</id>

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -119,7 +119,7 @@ final class WorkCounterConfig {
             <!-- Continue compilation past type-checking errors so Error Prone can analyze
                  code that has downstream errors in later phases. -->
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne -Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
@@ -146,7 +146,7 @@ final class WorkCounterConfig {
                 <!-- Continue compilation past type-checking errors so Error Prone can analyze
                      code that has downstream errors in later phases. -->
                 <arg>--should-stop=ifError=FLOW</arg>
-                <arg>-Xplugin:ErrorProne -XepCompilingTestOnlyCode -Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF</arg>
+                <arg>-Xplugin:ErrorProne -XepCompilingTestOnlyCode ${error-prone.checks}</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>


### PR DESCRIPTION
Fixes #645

## Summary

- Centralize the existing `safere` Error Prone policy and shared compiler configuration in the
  parent POM.
- Enable the same policy for every Java module, preserving module-specific Java versions, warning
  options, and annotation processors.
- Fix existing findings exposed in crosscheck, exhaustive-validation, fuzz, and benchmark code.
- Document and use the approved localized suppression policy for intentional internal array record
  components.
- Explicitly exclude checks that are unrelated to the current policy.

## Verification

- `mvn clean test -DskipTests -q`
- `mvn -pl safere-crosscheck -am -Pcrosscheck-public-api-tests test -DskipTests -q`
- `mvn -pl safere test -q`
- `mvn -pl safere-benchmarks test -q`
- Focused `CompactDivergenceLogsTest` run in `safere-exhaustive`
- Effective POM inspection for `safere`, `safere-crosscheck`, `safere-ffm-re2`, and
  `safere-benchmarks`
- `mvn spotless:check -q`
- `git diff --check`

Not run:

- Full test suites for `safere-crosscheck`, `safere-fuzz`, or `safere-exhaustive`
- Benchmarks
