### PR TITLE
Update PMD for JDK 26 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <error-prone.version>2.50.0</error-prone.version>
     <error-prone.checks>-Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF -Xep:ExposedPrivateType:OFF -Xep:ImmutableEnumChecker:OFF -Xep:JdkObsolete:OFF -Xep:ThreadPriorityCheck:OFF</error-prone.checks>
     <google-java-format.version>1.35.0</google-java-format.version>
+    <pmd.version>7.26.0</pmd.version>
     <spotless.version>2.44.4</spotless.version>
   </properties>
 

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -171,6 +171,28 @@ final class WorkCounterConfig {
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.28.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-core</artifactId>
+            <version>${pmd.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-java</artifactId>
+            <version>${pmd.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-javascript</artifactId>
+            <version>${pmd.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-jsp</artifactId>
+            <version>${pmd.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <rulesets>
             <ruleset>pmd-ruleset.xml</ruleset>


### PR DESCRIPTION
## Summary

- override the PMD runtime bundled with Maven PMD Plugin 3.28.0
- update all bundled PMD modules to 7.26.0 as a coherent set
- restore PMD type resolution when Maven runs under JDK 26

Fixes #604

## Verification

Ran under JDK 26.0.1:

- `mvn install -DskipTests -q`
- `mvn -pl safere test -q`
- `git diff --check`

The full public API crosscheck suite was not run.
