### PR TITLE
Configure grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- enable weekly grouped Maven dependency updates
- enable monthly grouped GitHub Actions updates
- keep the two ecosystems in separate pull requests

Fixes #647

## Verification

- Parsed `.github/dependabot.yml` with Ruby's YAML parser
- Ran `git diff --check`
- Java tests were not run because this change only adds GitHub Dependabot configuration
