### PR TITLE
Preclassify UTF-8 ASCII prefix scans

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -273,6 +273,67 @@
       "shared": true
     },
     {
+      "id": "utf8AsciiPrefix.shortFirst.text",
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "x5",
+        "unit": "b",
+        "suffix": "",
+        "length": 256
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8AsciiPrefix.shortAbsent.text",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "b",
+        "length": 256
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8AsciiPrefix.longAbsent.text",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "b",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8AsciiPrefix.longLate.text",
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "b",
+        "suffix": "x5",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8AsciiPrefix.sparse.text",
+      "recipe": {
+        "kind": "sparseMatchToLength",
+        "match": "x5",
+        "nonMatch": "bbb",
+        "nonMatchRepeats": 31,
+        "delimiterAlphabet": "b",
+        "seed": 20260731,
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "utf8AsciiPrefix.dense.text",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "bxy5",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
       "id": "phoneSearch.digitsNoSlash.text",
       "recipe": {
         "kind": "randomChars",
@@ -7161,6 +7222,282 @@
       "inputRepresentationReason": "Controls for SafeRE literal start acceleration over the same preexisting UTF-8 bytes.",
       "requirements": [],
       "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findPair.shortFirst",
+      "operation": "find",
+      "patterns": [
+        "[xy]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.shortFirst.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures a short UTF-8 search whose first byte is in a two-member ASCII prefix class.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findRange.shortFirst",
+      "operation": "find",
+      "patterns": [
+        "[0-9]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.shortFirst.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures a short UTF-8 search whose first candidate is in a contiguous ASCII prefix range.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findPair.shortAbsent",
+      "operation": "find",
+      "patterns": [
+        "[xy]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.shortAbsent.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures fixed prefix-class metadata cost when a short UTF-8 input contains no pair member.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findRange.shortAbsent",
+      "operation": "find",
+      "patterns": [
+        "[0-9]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.shortAbsent.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures fixed prefix-class metadata cost when a short UTF-8 input contains no range member.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findPair.longAbsent",
+      "operation": "find",
+      "patterns": [
+        "[xy]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.longAbsent.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Controls for a long absent pair scan where input traversal dominates fixed prefix metadata cost.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findRange.longAbsent",
+      "operation": "find",
+      "patterns": [
+        "[0-9]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.longAbsent.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Controls for a long absent range scan where input traversal dominates fixed prefix metadata cost.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findPair.longLate",
+      "operation": "find",
+      "patterns": [
+        "[xy]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.longLate.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Controls for a pair candidate near the end of a long UTF-8 input.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.findRange.longLate",
+      "operation": "find",
+      "patterns": [
+        "[0-9]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.longLate.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Controls for a range candidate near the end of a long UTF-8 input.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.countPair.sparse",
+      "operation": "findAllCount",
+      "patterns": [
+        "[xy]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.sparse.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures repeated UTF-8 searches with pair-prefix candidates approximately every 128 bytes.",
+      "requirements": [],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.countRange.sparse",
+      "operation": "findAllCount",
+      "patterns": [
+        "[0-9]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.sparse.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures repeated UTF-8 searches with range-prefix candidates approximately every 128 bytes.",
+      "requirements": [],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.countPair.dense",
+      "operation": "findAllCount",
+      "patterns": [
+        "[xy]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.dense.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures repeated UTF-8 searches over dense two-member ASCII prefix candidates.",
+      "requirements": [],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "Utf8AsciiPrefixBenchmark.countRange.dense",
+      "operation": "findAllCount",
+      "patterns": [
+        "[0-9]q?"
+      ],
+      "inputs": [
+        "utf8AsciiPrefix.dense.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures repeated UTF-8 searches over dense contiguous-range prefix candidates.",
+      "requirements": [],
+      "resultConsumption": "integer",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(423);
+    assertThat(ids).hasSize(435);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1506);
-    assertThat(plan.exclusions()).hasSize(609);
-    assertThat(accounted).hasSize(423 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(1518);
+    assertThat(plan.exclusions()).hasSize(657);
+    assertThat(accounted).hasSize(435 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -93,7 +93,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(876);
+        .hasSize(888);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -399,8 +399,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1545);
-    assertThat(plan.reportPlan().trials()).hasSize(1545);
+        .hasSize(1557);
+    assertThat(plan.reportPlan().trials()).hasSize(1557);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1717,6 +1717,7 @@ public final class Matcher implements MatchResult {
     // no literal prefix exists), scan for the first character that could begin a match. This
     // avoids running the full engine on text regions where no match can start.
     boolean[] ccPrefixAscii = parentPattern.charClassPrefixAscii();
+    Pattern.CharClassScanInfo ccPrefixScanInfo = parentPattern.charClassPrefixScanInfo();
     if (options.startAcceleration()
         && !prog.hasWordBoundary()
         && ccPrefixAscii != null
@@ -1725,7 +1726,11 @@ public final class Matcher implements MatchResult {
       diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
       int idx =
           scanner instanceof Utf8InputScanner utf8Scanner
-              ? utf8Scanner.indexOfAsciiClass(ccPrefixAscii, searchFrom)
+              ? utf8Scanner.indexOfCodePointClass(
+                  ccPrefixScanInfo.ranges,
+                  ccPrefixScanInfo.bitmap0,
+                  ccPrefixScanInfo.bitmap1,
+                  searchFrom)
               : indexOfCharClass(text, ccPrefixAscii, searchFrom);
       if (idx < 0) {
         diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -150,6 +150,7 @@ public final class Pattern implements Serializable {
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
   private final transient boolean[] charClassPrefixAscii;
+  private final transient CharClassScanInfo charClassPrefixScanInfo;
   private final transient FixedOffsetLiteral fixedOffsetLiteral;
   private final transient StartAcceleration startAcceleration;
   private final transient KeywordAlternation keywordAlternation;
@@ -357,6 +358,7 @@ public final class Pattern implements Serializable {
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
     this.charClassPrefixAscii = charClassPrefixAscii;
+    this.charClassPrefixScanInfo = buildAsciiClassScanInfo(charClassPrefixAscii);
     this.fixedOffsetLiteral = fixedOffsetLiteral;
     this.startAcceleration = startAcceleration;
     this.keywordAlternation = keywordAlternation;
@@ -676,8 +678,13 @@ public final class Pattern implements Serializable {
       if (searchStart < 0) {
         return false;
       }
-    } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
-      searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
+    } else if (!prog.hasWordBoundary() && charClassPrefixScanInfo != null) {
+      searchStart =
+          scanner.indexOfCodePointClass(
+              charClassPrefixScanInfo.ranges,
+              charClassPrefixScanInfo.bitmap0,
+              charClassPrefixScanInfo.bitmap1,
+              0);
       if (searchStart < 0) {
         return false;
       }
@@ -745,9 +752,14 @@ public final class Pattern implements Serializable {
         diagnostics.boundary(MatchStrategy.LITERAL);
         return false;
       }
-    } else if (!prog.hasWordBoundary() && charClassPrefixAscii != null) {
+    } else if (!prog.hasWordBoundary() && charClassPrefixScanInfo != null) {
       diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION);
-      searchStart = scanner.indexOfAsciiClass(charClassPrefixAscii, 0);
+      searchStart =
+          scanner.indexOfCodePointClass(
+              charClassPrefixScanInfo.ranges,
+              charClassPrefixScanInfo.bitmap0,
+              charClassPrefixScanInfo.bitmap1,
+              0);
       if (searchStart < 0) {
         diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
         return false;
@@ -1261,6 +1273,11 @@ public final class Pattern implements Serializable {
    */
   boolean[] charClassPrefixAscii() {
     return charClassPrefixAscii;
+  }
+
+  /** Returns preclassified UTF-8 scan data for the character-class prefix, or {@code null}. */
+  CharClassScanInfo charClassPrefixScanInfo() {
+    return charClassPrefixScanInfo;
   }
 
   /** Returns a mandatory ASCII literal at a fixed offset from the match start, or {@code null}. */
@@ -2694,7 +2711,7 @@ public final class Pattern implements Serializable {
   private record CharClassMatchInfo(int[] ranges, long bitmap0, long bitmap1, boolean allowEmpty) {}
 
   /** Holds precomputed data for scanning one character class. */
-  private static final class CharClassScanInfo {
+  static final class CharClassScanInfo {
     final int[] ranges;
     final long bitmap0;
     final long bitmap1;
@@ -2704,6 +2721,43 @@ public final class Pattern implements Serializable {
       this.bitmap0 = bitmap0;
       this.bitmap1 = bitmap1;
     }
+  }
+
+  static CharClassScanInfo buildAsciiClassScanInfo(boolean[] asciiClass) {
+    if (asciiClass == null) {
+      return null;
+    }
+    int[] ranges = new int[asciiClass.length * 2];
+    int rangeCount = 0;
+    long bitmap0 = 0;
+    long bitmap1 = 0;
+    int value = 0;
+    while (value < asciiClass.length) {
+      if (!asciiClass[value]) {
+        value++;
+        continue;
+      }
+      int low = value;
+      while (value + 1 < asciiClass.length && asciiClass[value + 1]) {
+        value++;
+      }
+      int high = value;
+      ranges[rangeCount * 2] = low;
+      ranges[rangeCount * 2 + 1] = high;
+      rangeCount++;
+      for (int member = low; member <= high; member++) {
+        if (member < Long.SIZE) {
+          bitmap0 |= 1L << member;
+        } else {
+          bitmap1 |= 1L << (member - Long.SIZE);
+        }
+      }
+      value++;
+    }
+    if (rangeCount == 0) {
+      return null;
+    }
+    return new CharClassScanInfo(Arrays.copyOf(ranges, rangeCount * 2), bitmap0, bitmap1);
   }
 
   /**

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -64,6 +64,30 @@ class PatternInternalTest {
   }
 
   @Test
+  void asciiPrefixScanInfoHandlesMissingAndEmptyClasses() {
+    assertThat(Pattern.buildAsciiClassScanInfo(null)).isNull();
+    assertThat(Pattern.buildAsciiClassScanInfo(new boolean[128])).isNull();
+  }
+
+  @Test
+  void asciiPrefixScanInfoExactlyRepresentsCommonClassShapes() {
+    assertAsciiScanInfo(new int[] {'x'}, new int[] {'x', 'x'});
+    assertAsciiScanInfo(new int[] {'x', 'y'}, new int[] {'x', 'y'});
+    assertAsciiScanInfo(new int[] {'x', 'z'}, new int[] {'x', 'x', 'z', 'z'});
+    assertAsciiScanInfo(asciiRange('0', '9'), new int[] {'0', '9'});
+    assertAsciiScanInfo(new int[] {'a', 'c', 'e'}, new int[] {'a', 'a', 'c', 'c', 'e', 'e'});
+  }
+
+  @Test
+  void asciiPrefixScanInfoPreservesMembersAcrossBitmapBoundary() {
+    Pattern.CharClassScanInfo info =
+        assertAsciiScanInfo(new int[] {62, 63, 64, 65}, new int[] {62, 65});
+
+    assertThat(info.bitmap0).isEqualTo((1L << 62) | (1L << 63));
+    assertThat(info.bitmap1).isEqualTo((1L << 0) | (1L << 1));
+  }
+
+  @Test
   void transparentGroupsPreserveKeywordAlternationAccelerator() {
     Pattern p = Pattern.compile("(?i)\\b(?:error|warning)\\b");
 
@@ -295,6 +319,33 @@ class PatternInternalTest {
         pattern.requiredMatchClassBitmap0(),
         pattern.requiredMatchClassBitmap1(),
         codePoint);
+  }
+
+  private static Pattern.CharClassScanInfo assertAsciiScanInfo(
+      int[] members, int[] expectedRanges) {
+    boolean[] asciiClass = new boolean[128];
+    for (int member : members) {
+      asciiClass[member] = true;
+    }
+
+    Pattern.CharClassScanInfo info = Pattern.buildAsciiClassScanInfo(asciiClass);
+
+    assertThat(info).isNotNull();
+    assertThat(info.ranges).containsExactly(expectedRanges);
+    for (int codePoint = 0; codePoint < asciiClass.length; codePoint++) {
+      assertThat(InputScanner.classContains(info.ranges, info.bitmap0, info.bitmap1, codePoint))
+          .as("ASCII member %s", codePoint)
+          .isEqualTo(asciiClass[codePoint]);
+    }
+    return info;
+  }
+
+  private static int[] asciiRange(int low, int high) {
+    int[] members = new int[high - low + 1];
+    for (int index = 0; index < members.length; index++) {
+      members[index] = low + index;
+    }
+    return members;
   }
 
   @ParameterizedTest(name = "compile(\"{0}\").numGroups() == {1}")

--- a/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
@@ -146,6 +146,25 @@ class Utf8DiagnosticsTest {
   }
 
   @Test
+  void patternBooleanFindReportsAsciiPrefixClassRejection() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("[xy]q?");
+
+    assertThat(pattern.find(input("bbbb"))).isFalse();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.CHARACTER_CLASS);
+              assertThat(event.auxiliaryStrategies())
+                  .containsExactly(
+                      new StrategyParticipation(
+                          MatchStrategy.CHARACTER_CLASS, StrategyRole.START_ACCELERATION));
+            });
+  }
+
+  @Test
   void patternBooleanFindReportsNfaForGraphemeSemantics() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile("\\Xz");

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -284,6 +284,37 @@ class Utf8MatcherStateMachineTest {
   }
 
   @Test
+  void asciiPrefixClassesAgreeAcrossStringAndUtf8SearchState() {
+    String text = "ébbxqbybbzbb5qbb7bb@qbb";
+    Utf8Input input = Utf8Input.validated(text.getBytes(UTF_8));
+
+    for (String regex : List.of("[x]q?", "[xy]q?", "[xz]q?", "[0-9]q?", "[ace@]q?")) {
+      Pattern pattern = Pattern.compile(regex);
+      Matcher stringMatcher = pattern.matcher(text);
+      Utf8Matcher utf8Matcher = pattern.matcher(input);
+      List<List<Integer>> expected = new ArrayList<>();
+      List<List<Integer>> actual = new ArrayList<>();
+
+      while (stringMatcher.find()) {
+        expected.add(
+            List.of(
+                utf8Offset(text, stringMatcher.start()), utf8Offset(text, stringMatcher.end())));
+      }
+      while (utf8Matcher.find()) {
+        actual.add(List.of(utf8Matcher.start(), utf8Matcher.end()));
+      }
+
+      assertThat(pattern.find(input)).as("direct UTF-8 find for /%s/", regex).isTrue();
+      assertThat(actual).as("repeated UTF-8 find for /%s/", regex).isEqualTo(expected);
+
+      utf8Matcher.region(2, input.length());
+      assertThat(utf8Matcher.find()).as("region find for /%s/", regex).isTrue();
+      utf8Matcher.reset();
+      assertThat(findTrace(utf8Matcher)).as("reset find trace for /%s/", regex).isEqualTo(expected);
+    }
+  }
+
+  @Test
   void requiredNonAsciiClassRejectsAsciiInputAcrossUtf8EntryPoints() {
     Pattern pattern = Pattern.compile("[一-龥]{3,}");
     Utf8Input absent = Utf8Input.trusted("ordinary ASCII text".getBytes(UTF_8));


### PR DESCRIPTION
## Summary

- preclassify ASCII character-class prefix metadata once during `Pattern` compilation
- route UTF-8 prefix searches through the existing singleton, pair, range, and bitmap scanners
- preserve the existing `boolean[128]` path for Java `String` matching
- add systematic metadata, UTF-8 state-machine, diagnostics, and declarative benchmark coverage

The compact ranges and two 64-bit membership masks are derived from the same immutable ASCII
prefix bitmap. Tests verify exact membership equivalence for missing and empty classes, singleton,
adjacent and nonadjacent pairs, contiguous ranges, discontiguous classes, and the 63/64 bitmap
boundary. End-to-end tests cover direct `Pattern.find(Utf8Input)`, repeated `Utf8Matcher.find()`,
regions, reset, diagnostics, byte offsets, and the unchanged String path.

## Benchmark results

Environment: Apple M5 Max (`aarch64`), OpenJDK 26.0.1. Standard configuration is 2 forks,
2 x 500 ms warmup, and 5 x 500 ms measurement. Before is `5487784`; after is `de6f65a`.

| Workload | Before | After | Improvement |
|---|---:|---:|---:|
| Pair, first, 256 B | 34.17 ns | 12.42 ns | 2.75x |
| Range, first, 256 B | 36.07 ns | 12.71 ns | 2.84x |
| Pair, absent, 256 B | 35.93 ns | 15.37 ns | 2.34x |
| Range, absent, 256 B | 34.94 ns | 11.86 ns | 2.95x |
| Pair, scan-all, sparse, 32 KiB | 25.03 us | 17.63 us | 1.42x |
| Range, scan-all, sparse, 32 KiB | 24.19 us | 16.98 us | 1.42x |
| Pair, scan-all, dense, 32 KiB | 1.259 ms | 0.902 ms | 1.39x |
| Range, scan-all, dense, 32 KiB | 0.658 ms | 0.473 ms | 1.39x |

The 32 KiB absent and late controls changed by 0.6-2.2%, where input traversal dominates the
fixed classification cost.

Long confirmation (2 forks, 3 x 1 s warmup, 5 x 1 s measurement):

| Workload | Before | After | Improvement |
|---|---:|---:|---:|
| Pair, scan-all, dense, 32 KiB | 1.366 ms | 0.949 ms | 1.44x |
| Range, scan-all, dense, 32 KiB | 0.676 ms | 0.432 ms | 1.56x |

## Verification

Ran:

- `mvn -pl safere -Dtest=PatternInternalTest,Utf8MatcherStateMachineTest,Utf8DiagnosticsTest,Utf8InputScannerTest,Utf8LinearTimeTest test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere-benchmarks -Dtest=CrossEngineBenchmarkPlanTest test -q`
- `mvn spotless:check -q`
- `mvn verify -pl safere,safere-benchmarks -am -DskipTests -q`
- focused standard before/after benchmarks for the 12 new pair/range workloads
- focused long before/after benchmarks for the dense pair/range workloads

Not run: public API crosscheck, the external OpenJDK-derived benchmark suite, or the full benchmark
collection. The change is limited to internal UTF-8 prefix acceleration, and the focused matrix
covers its affected workloads.

Fixes #652
