### PR TITLE
Optimize DFA search loops when returning to start state (DFA Loop Acceleration)

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -132,6 +132,7 @@
                         <exclude name="SafeReDiagnosticsTest.java"/>
                         <exclude name="SearchScalingRegressionTest.java"/>
                         <exclude name="SimplifierTest.java"/>
+                        <exclude name="StartAcceleratorDifferentialTest.java"/>
                         <exclude name="StartAcceleratorTest.java"/>
                         <exclude name="UnicodeJdkConsistencyTest.java"/>
                         <exclude name="UnicodeTablesTest.java"/>

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -30,6 +30,7 @@ final class Utf8InputFuzzer {
     assertFixedOffsetAccelerationMatchesString(data);
     assertMultiOffsetLiteralOccurrencesMatchString(data);
     assertFinalLineTerminatorEndAnchorsMatchJdk(data);
+    assertPositionDependentStartAccelerationMatchesJdk(data);
     String repeatedLiteral =
         String.valueOf((char) data.consumeInt('A', 'Z')).repeat(data.consumeInt(2, 32));
     String suffix = new String(data.consumeBytes(data.consumeInt(0, 64)), StandardCharsets.UTF_8);
@@ -135,6 +136,24 @@ final class Utf8InputFuzzer {
     boolean utf8Found = safeRe.find(Utf8Input.validated(input.getBytes(StandardCharsets.UTF_8)));
     if (stringFound != expected || utf8Found != expected) {
       throw new AssertionError("end anchor differs from JDK for final line terminator");
+    }
+  }
+
+  private static void assertPositionDependentStartAccelerationMatchesJdk(FuzzedDataProvider data) {
+    String terminator = data.pickValue(List.of("\n", "\r", "\r\n", "\u0085", "\u2028", "\u2029"));
+    String regex = "(b|(?m:^a))c[0-9]";
+    Pattern pattern = Pattern.compile(regex);
+    for (String input :
+        List.of(
+            terminator + "acz9y",
+            " ycby ",
+            "y0c" + terminator + "1bac19c1__19x y_",
+            "bxc\rca9\né\nac9é\r0x\r9a0")) {
+      boolean expected = java.util.regex.Pattern.compile(regex).matcher(input).find();
+      Utf8Input utf8 = Utf8Input.validated(input.getBytes(StandardCharsets.UTF_8));
+      if (pattern.matcher(input).find() != expected || pattern.find(utf8) != expected) {
+        throw new AssertionError("DFA-loop start acceleration differs from JDK anchor semantics");
+      }
     }
   }
 

--- a/safere/src/main/java/org/safere/AcceleratorPolicy.java
+++ b/safere/src/main/java/org/safere/AcceleratorPolicy.java
@@ -1,0 +1,44 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/**
+ * Immutable tuning policy and diagnostic metadata for start-position and DFA accelerators.
+ *
+ * @param minProfitableSkip Minimum skip distance (in chars or bytes) required for this accelerator
+ *     to be profitable over direct scalar DFA execution.
+ * @param strikeBudget Number of consecutive sub-threshold skips tolerated before declaring adaptive
+ *     defeat.
+ * @param isExactMatchCandidate Whether this accelerator identifies an exact candidate match start
+ *     that can be validated directly.
+ * @param strategy The diagnostic strategy associated with this accelerator, or {@code null} if
+ *     none.
+ */
+record AcceleratorPolicy(
+    int minProfitableSkip,
+    int strikeBudget,
+    boolean isExactMatchCandidate,
+    MatchStrategy strategy) {
+
+  // TODO: Conduct systematic empirical micro-benchmarking across diverse CPU architectures (x86
+  // AVX-512/AVX2, ARM Neon) to precisely tune minimum profitable skip thresholds.
+  // TODO: Measure defeat sensitivity across varied payload densities and evaluate whether dynamic
+  // backoff or payload-length-proportional strike budgets outperform static constant budgets.
+
+  /** Policy for vectorized literal and fixed-offset substring searches (AVX2 / SWAR). */
+  static final AcceleratorPolicy LITERAL =
+      new AcceleratorPolicy(16, 4, true, MatchStrategy.LITERAL);
+
+  /** Policy for character class bitmap and range table scanning. */
+  static final AcceleratorPolicy CHAR_CLASS =
+      new AcceleratorPolicy(24, 3, false, MatchStrategy.CHARACTER_CLASS);
+
+  /** Policy for line anchor ('^', '$') boundary acceleration. */
+  static final AcceleratorPolicy LINE_ANCHOR = new AcceleratorPolicy(16, 3, false, null);
+
+  /** Default fallback policy for generic or composite accelerators. */
+  static final AcceleratorPolicy DEFAULT = new AcceleratorPolicy(32, 3, false, null);
+}

--- a/safere/src/main/java/org/safere/ByteSwarScan.java
+++ b/safere/src/main/java/org/safere/ByteSwarScan.java
@@ -103,6 +103,42 @@ abstract class ByteSwarScan {
     return -1;
   }
 
+  static int indexOfByteTriple(
+      byte[] bytes, int offset, int length, byte first, byte second, byte third, int start) {
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    long repeatedFirst = (first & 0xFFL) * BYTE_ONES;
+    long repeatedSecond = (second & 0xFFL) * BYTE_ONES;
+    long repeatedThird = (third & 0xFFL) * BYTE_ONES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long firstDifference = word ^ repeatedFirst;
+      long secondDifference = word ^ repeatedSecond;
+      long thirdDifference = word ^ repeatedThird;
+      if (((((firstDifference - BYTE_ONES) & ~firstDifference)
+                  | ((secondDifference - BYTE_ONES) & ~secondDifference)
+                  | ((thirdDifference - BYTE_ONES) & ~thirdDifference))
+              & BYTE_HIGH_BITS)
+          != 0) {
+        for (int index = 0; index < Long.BYTES; index++) {
+          byte value = bytes[offset + position + index];
+          if (value == first || value == second || value == third) {
+            return position + index;
+          }
+        }
+      }
+      position += Long.BYTES;
+    }
+    while (position < length) {
+      byte value = bytes[offset + position];
+      if (value == first || value == second || value == third) {
+        return position;
+      }
+      position++;
+    }
+    return -1;
+  }
+
   /**
    * Searches for a byte in the inclusive ASCII range {@code [low, high]}.
    *

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1364,21 +1364,23 @@ final class Dfa {
     }
 
     boolean canAccelerate = hasStartAcceleration && !anchored;
-    int minSkip = 32;
-    int maxStrikes = 3;
+    int minSkip = AcceleratorPolicy.DEFAULT.minProfitableSkip();
+    int maxStrikes = AcceleratorPolicy.DEFAULT.strikeBudget();
     boolean isExact = false;
     if (canAccelerate) {
-      if (stringStartAccelerator != null) {
-        minSkip = stringStartAccelerator.minProfitableSkip();
-        maxStrikes = stringStartAccelerator.strikeBudget();
-        isExact = stringStartAccelerator.isExactMatchCandidate();
-      } else if (utf8StartAccelerator != null) {
-        minSkip = utf8StartAccelerator.minProfitableSkip();
-        maxStrikes = utf8StartAccelerator.strikeBudget();
-        isExact = utf8StartAccelerator.isExactMatchCandidate();
-      }
+      AcceleratorPolicy policy =
+          stringStartAccelerator != null
+              ? stringStartAccelerator.policy()
+              : (utf8StartAccelerator != null
+                  ? utf8StartAccelerator.policy()
+                  : AcceleratorPolicy.DEFAULT);
+      minSkip = policy.minProfitableSkip();
+      maxStrikes = policy.strikeBudget();
+      isExact = policy.isExactMatchCandidate();
     }
 
+    // Adaptive defeat detection: track consecutive sub-threshold skips to avoid repeatedly paying
+    // accelerator setup and candidate check overhead on dense matching inputs.
     boolean accelerationDisabled = false;
     int consecutiveShortSkips = 0;
 

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -90,6 +90,8 @@ final class Dfa {
     final int[] insts; // sorted NFA instruction IDs (CHAR_RANGE, EMPTY_WIDTH, and MATCH only)
     final int flags;
     final boolean isHighestPriorityMatch;
+    final StateAccelerator accelerator;
+    boolean isStartState;
 
     /**
      * Match IDs from word-boundary expansion (for PatternSet multi-match). Null if not applicable.
@@ -105,12 +107,14 @@ final class Dfa {
         int flags,
         int[] wordBoundaryMatchIds,
         int numClasses,
-        boolean isHighestPriorityMatch) {
+        boolean isHighestPriorityMatch,
+        StateAccelerator accelerator) {
       this.id = id;
       this.insts = insts;
       this.flags = flags;
       this.wordBoundaryMatchIds = wordBoundaryMatchIds;
       this.isHighestPriorityMatch = isHighestPriorityMatch;
+      this.accelerator = accelerator;
       this.next = new State[numClasses];
     }
 
@@ -236,6 +240,10 @@ final class Dfa {
   private State[] offsetToState;
   private int nextStateId;
 
+  private final Utf8StartAccelerator utf8StartAccelerator;
+  private final StringStartAccelerator stringStartAccelerator;
+  private final boolean hasStartAcceleration;
+
   // ---------------------------------------------------------------------------
   // Construction
   // ---------------------------------------------------------------------------
@@ -261,9 +269,22 @@ final class Dfa {
   }
 
   Dfa(Prog prog, int maxStates, Setup setup, boolean longest) {
+    this(prog, maxStates, setup, longest, null, null);
+  }
+
+  Dfa(
+      Prog prog,
+      int maxStates,
+      Setup setup,
+      boolean longest,
+      Utf8StartAccelerator utf8StartAccelerator,
+      StringStartAccelerator stringStartAccelerator) {
     this.prog = prog;
     this.maxStates = maxStates;
     this.longest = longest;
+    this.utf8StartAccelerator = utf8StartAccelerator;
+    this.stringStartAccelerator = stringStartAccelerator;
+    this.hasStartAcceleration = utf8StartAccelerator != null || stringStartAccelerator != null;
     this.hasGraphemeSemantics = prog.hasGraphemeSemantics();
     this.hasPositionDependentTransitions = hasGraphemeSemantics || prog.hasTextAnchor();
     this.stateEmptyFlagsMask =
@@ -286,7 +307,7 @@ final class Dfa {
     this.expandStack = new int[prog.size()];
     this.expandFrontier = new int[prog.size()];
     this.computeBuf = new int[prog.size()];
-    this.deadState = new State(0, EMPTY_INSTS, 0, null, numClasses, false);
+    this.deadState = new State(0, EMPTY_INSTS, 0, null, numClasses, false, null);
     this.nextStateId = 1;
     this.transitions = new int[1024];
     this.offsetToState = new State[1024];
@@ -680,12 +701,102 @@ final class Dfa {
     }
     boolean isHighestPriorityMatch =
         insts.length > 0 && prog.inst(insts[0]).opCode == InstOp.OP_MATCH;
+    StateAccelerator accelerator = analyzeStateAcceleration(insts, flags, isHighestPriorityMatch);
     s =
         new State(
-            nextStateId++, insts, flags, wordBoundaryMatchIds, numClasses, isHighestPriorityMatch);
+            nextStateId++,
+            insts,
+            flags,
+            wordBoundaryMatchIds,
+            numClasses,
+            isHighestPriorityMatch,
+            accelerator);
     addStateToFlatArrays(s);
     cache.put(lookupKey.copy(), s);
     return s;
+  }
+
+  private StateAccelerator analyzeStateAcceleration(
+      int[] insts, int flags, boolean isHighestPriorityMatch) {
+    if (isHighestPriorityMatch || insts.length == 0 || (flags & FLAG_MATCH) != 0) {
+      return null;
+    }
+    for (int id : insts) {
+      Inst ip = prog.inst(id);
+      if (ip.opCode == InstOp.OP_EMPTY_WIDTH || ip.opCode == InstOp.OP_MATCH) {
+        return null;
+      }
+    }
+
+    int escapeCount = 0;
+    int[] escapes = new int[4];
+    int[] seeds = new int[insts.length];
+
+    for (int ch = 0; ch < 128; ch++) {
+      int seedCount = 0;
+      for (int id : insts) {
+        Inst ip = prog.inst(id);
+        if (instMatches(ip, ch)) {
+          seeds[seedCount++] = ip.out;
+        }
+      }
+      if (seedCount == 0) {
+        if (escapeCount < 4) {
+          escapes[escapeCount] = ch;
+        }
+        escapeCount++;
+        continue;
+      }
+      int[] frontier = expand(seeds, seedCount, 0);
+      if (!Arrays.equals(frontier, insts)) {
+        if (escapeCount < 4) {
+          escapes[escapeCount] = ch;
+        }
+        escapeCount++;
+      }
+    }
+
+    if (escapeCount >= 1 && escapeCount <= 3) {
+      if (escapeCount == 1) {
+        return new StateAccelerator.SingleAsciiEscape(escapes[0]);
+      } else if (escapeCount == 2) {
+        return new StateAccelerator.AsciiPairEscape(escapes[0], escapes[1]);
+      } else {
+        return new StateAccelerator.AsciiTripleEscape(escapes[0], escapes[1], escapes[2]);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Fast-forwards to the next escape character in a self-loop state.
+   *
+   * <p>Direct sealed-type pattern matching avoids {@code invokeinterface} dispatch overhead on hot
+   * matching loops (see PR #693 and PR #695 review). HotSpot C2 does not automatically devirtualize
+   * megamorphic interface calls with &ge; 3 implementations across the JVM lifecycle; unwrapping
+   * the sealed record subtypes at this call site allows C2 to inline the underlying {@link
+   * InputScanner} search primitives directly into the caller.
+   */
+  private static int findSelfLoopEscape(
+      StateAccelerator accelerator, InputScanner text, int fromIndex, int limit) {
+    if (accelerator instanceof StateAccelerator.SingleAsciiEscape single) {
+      return text.indexOfAscii(single.escape(), fromIndex, limit);
+    } else if (accelerator instanceof StateAccelerator.AsciiPairEscape pair) {
+      return text.indexOfAsciiPair(pair.c1(), pair.c2(), fromIndex, limit);
+    } else if (accelerator instanceof StateAccelerator.AsciiTripleEscape triple) {
+      return text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
+    }
+    return accelerator.findEscape(text, fromIndex, limit);
+  }
+
+  private static boolean instMatches(Inst ip, int ch) {
+    if (ip.opCode == InstOp.OP_CHAR_RANGE) {
+      return ip.matchesChar(ch);
+    }
+    if (ip.opCode == InstOp.OP_CHAR_CLASS) {
+      return ip.matchesCharClass(ch);
+    }
+    return false;
   }
 
   /**
@@ -797,6 +908,7 @@ final class Dfa {
     }
     State s = getOrCreate(insts, flags);
     if (s != null) {
+      s.isStartState = true;
       startStateByContext[cacheKey] = s;
     }
     return s;
@@ -1177,6 +1289,27 @@ final class Dfa {
   }
 
   /**
+   * Fast-forwards the start position of unanchored search matching when returning to the start
+   * state.
+   */
+  private int fastForward(InputScanner text, int pos, int posDepThreshold) {
+    if (text instanceof Utf8InputScanner utf8Scanner) {
+      if (utf8StartAccelerator != null) {
+        int idx = utf8StartAccelerator.findCandidate(utf8Scanner, pos);
+        if (idx >= 0) {
+          return Math.min(idx, posDepThreshold - 1);
+        }
+        return -1;
+      }
+    } else if (text instanceof StringInputScanner stringScanner) {
+      if (stringStartAccelerator != null) {
+        return stringStartAccelerator.findCandidate(stringScanner.text(), pos, prog.unixLines());
+      }
+    }
+    return pos;
+  }
+
+  /**
    * Main DFA search loop.
    *
    * <p>Iterates over each code point in the text starting from {@code startPos}, following
@@ -1230,16 +1363,74 @@ final class Dfa {
       return new SearchResult(matched, matchEnd);
     }
 
+    boolean canAccelerate = hasStartAcceleration && !anchored;
+    int minSkip = 32;
+    int maxStrikes = 3;
+    boolean isExact = false;
+    if (canAccelerate) {
+      if (stringStartAccelerator != null) {
+        minSkip = stringStartAccelerator.minProfitableSkip();
+        maxStrikes = stringStartAccelerator.strikeBudget();
+        isExact = stringStartAccelerator.isExactMatchCandidate();
+      } else if (utf8StartAccelerator != null) {
+        minSkip = utf8StartAccelerator.minProfitableSkip();
+        maxStrikes = utf8StartAccelerator.strikeBudget();
+        isExact = utf8StartAccelerator.isExactMatchCandidate();
+      }
+    }
+
+    boolean accelerationDisabled = false;
+    int consecutiveShortSkips = 0;
+
     int[] transitions = this.transitions;
     State[] offsetToState = this.offsetToState;
     int[] asciiClassMap = this.asciiClassMap;
     int pos = startPos;
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
+      if (canAccelerate && !accelerationDisabled && s.isStartState && (textLen - pos >= minSkip)) {
+        int nextPos = fastForward(text, pos, posDepThreshold);
+        if (nextPos == -1) {
+          return new SearchResult(matched, matchEnd);
+        }
+        if (nextPos > pos) {
+          int skip = nextPos - pos;
+          if (!isExact) {
+            if (skip < minSkip) {
+              if (++consecutiveShortSkips >= maxStrikes) {
+                accelerationDisabled = true;
+              }
+            } else {
+              consecutiveShortSkips = 0;
+            }
+          }
+          pos = nextPos;
+          if (pos >= textLen) {
+            break;
+          }
+        } else if (!isExact) {
+          if (++consecutiveShortSkips >= maxStrikes) {
+            accelerationDisabled = true;
+          }
+        }
+      }
       int limit =
           hasPositionDependentTransitions ? Math.min(textLen, posDepThreshold - 1) : textLen;
       int sId = s.id * numClasses;
       while (pos < limit) {
+        if (s.accelerator != null && !s.isStartState && (limit - pos >= 16)) {
+          int nextPos = findSelfLoopEscape(s.accelerator, text, pos, limit);
+          if (nextPos == -1) {
+            pos = limit;
+            break;
+          }
+          if (nextPos > pos) {
+            pos = nextPos;
+            if (pos >= limit) {
+              break;
+            }
+          }
+        }
         int ch = text.asciiAt(pos);
         if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
           break;
@@ -1264,6 +1455,7 @@ final class Dfa {
           }
         }
         sId = nsId;
+        s = offsetToState[sId];
         pos++;
       }
       s = offsetToState[sId];
@@ -1312,6 +1504,43 @@ final class Dfa {
 
     // General loop handles non-ASCII, position-dependent checks, and trailing end-of-text sentinel
     while (pos <= textLen) {
+      if (canAccelerate && !accelerationDisabled && s.isStartState && (textLen - pos >= minSkip)) {
+        int nextPos = fastForward(text, pos, posDepThreshold);
+        if (nextPos == -1) {
+          return new SearchResult(matched, matchEnd);
+        }
+        if (nextPos > pos) {
+          int skip = nextPos - pos;
+          if (!isExact) {
+            if (skip < minSkip) {
+              if (++consecutiveShortSkips >= maxStrikes) {
+                accelerationDisabled = true;
+              }
+            } else {
+              consecutiveShortSkips = 0;
+            }
+          }
+          pos = nextPos;
+          if (pos > textLen) {
+            break;
+          }
+        } else if (!isExact) {
+          if (++consecutiveShortSkips >= maxStrikes) {
+            accelerationDisabled = true;
+          }
+        }
+      }
+      if (s.accelerator != null && !s.isStartState && (textLen - pos >= 16)) {
+        int nextPos = findSelfLoopEscape(s.accelerator, text, pos, textLen);
+        if (nextPos == -1) {
+          pos = textLen;
+        } else if (nextPos > pos) {
+          pos = nextPos;
+          if (pos > textLen) {
+            break;
+          }
+        }
+      }
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
       }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1410,6 +1410,10 @@ final class Dfa {
           if (pos >= textLen) {
             break;
           }
+          s = startState(text, pos, anchored, false);
+          if (s == null) {
+            return null;
+          }
         } else if (!isExact) {
           if (++consecutiveShortSkips >= maxStrikes) {
             accelerationDisabled = true;
@@ -1525,6 +1529,10 @@ final class Dfa {
           pos = nextPos;
           if (pos > textLen) {
             break;
+          }
+          s = startState(text, pos, anchored, false);
+          if (s == null) {
+            return null;
           }
         } else if (!isExact) {
           if (++consecutiveShortSkips >= maxStrikes) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -745,6 +745,9 @@ final class Dfa {
           escapes[escapeCount] = ch;
         }
         escapeCount++;
+        if (escapeCount == 4) {
+          return null;
+        }
         continue;
       }
       int[] frontier = expand(seeds, seedCount, 0);
@@ -753,6 +756,29 @@ final class Dfa {
           escapes[escapeCount] = ch;
         }
         escapeCount++;
+        if (escapeCount == 4) {
+          return null;
+        }
+      }
+    }
+
+    // The scanner skips directly to an ASCII escape and therefore also skips over non-ASCII code
+    // points. Prove that every non-ASCII equivalence class remains in this state before enabling
+    // the accelerator. The DFA boundaries make one representative per interval sufficient.
+    for (int i = 0; i + 1 < boundaries.length; i++) {
+      int ch = Math.max(128, boundaries[i]);
+      if (ch >= boundaries[i + 1]) {
+        continue;
+      }
+      int seedCount = 0;
+      for (int id : insts) {
+        Inst ip = prog.inst(id);
+        if (instMatches(ip, ch)) {
+          seeds[seedCount++] = ip.out;
+        }
+      }
+      if (seedCount == 0 || !Arrays.equals(expand(seeds, seedCount, 0), insts)) {
+        return null;
       }
     }
 
@@ -764,6 +790,26 @@ final class Dfa {
       } else {
         return new StateAccelerator.AsciiTripleEscape(escapes[0], escapes[1], escapes[2]);
       }
+    }
+    return null;
+  }
+
+  /** Returns whether this DFA was constructed with start-position acceleration enabled. */
+  boolean hasStartAcceleration() {
+    return hasStartAcceleration;
+  }
+
+  /** Returns whether this DFA can accelerate start positions for the supplied input substrate. */
+  boolean hasStartAcceleration(InputScanner text) {
+    return startAccelerationPolicy(text) != null;
+  }
+
+  private AcceleratorPolicy startAccelerationPolicy(InputScanner text) {
+    if (text instanceof Utf8InputScanner) {
+      return utf8StartAccelerator != null ? utf8StartAccelerator.policy() : null;
+    }
+    if (text instanceof StringInputScanner) {
+      return stringStartAccelerator != null ? stringStartAccelerator.policy() : null;
     }
     return null;
   }
@@ -1363,20 +1409,15 @@ final class Dfa {
       return new SearchResult(matched, matchEnd);
     }
 
-    boolean canAccelerate = hasStartAcceleration && !anchored;
+    AcceleratorPolicy activePolicy = startAccelerationPolicy(text);
+    boolean canAccelerate = activePolicy != null && !anchored;
     int minSkip = AcceleratorPolicy.DEFAULT.minProfitableSkip();
     int maxStrikes = AcceleratorPolicy.DEFAULT.strikeBudget();
     boolean isExact = false;
     if (canAccelerate) {
-      AcceleratorPolicy policy =
-          stringStartAccelerator != null
-              ? stringStartAccelerator.policy()
-              : (utf8StartAccelerator != null
-                  ? utf8StartAccelerator.policy()
-                  : AcceleratorPolicy.DEFAULT);
-      minSkip = policy.minProfitableSkip();
-      maxStrikes = policy.strikeBudget();
-      isExact = policy.isExactMatchCandidate();
+      minSkip = activePolicy.minProfitableSkip();
+      maxStrikes = activePolicy.strikeBudget();
+      isExact = activePolicy.isExactMatchCandidate();
     }
 
     // Adaptive defeat detection: track consecutive sub-threshold skips to avoid repeatedly paying
@@ -1413,6 +1454,9 @@ final class Dfa {
           s = startState(text, pos, anchored, false);
           if (s == null) {
             return null;
+          }
+          if (s == deadState) {
+            return new SearchResult(matched, matchEnd);
           }
         } else if (!isExact) {
           if (++consecutiveShortSkips >= maxStrikes) {
@@ -1533,6 +1577,9 @@ final class Dfa {
           s = startState(text, pos, anchored, false);
           if (s == null) {
             return null;
+          }
+          if (s == deadState) {
+            return new SearchResult(matched, matchEnd);
           }
         } else if (!isExact) {
           if (++consecutiveShortSkips >= maxStrikes) {

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -29,6 +29,24 @@ interface InputScanner {
   /** Returns the first position at or after {@code start} in the supplied code-point class. */
   int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start);
 
+  /**
+   * Returns the first index in {@code [fromIndex, limit)} containing {@code ascii}, or {@code -1}
+   * if none exists.
+   */
+  int indexOfAscii(int ascii, int fromIndex, int limit);
+
+  /**
+   * Returns the first index in {@code [fromIndex, limit)} containing {@code c1} or {@code c2}, or
+   * {@code -1} if none exists.
+   */
+  int indexOfAsciiPair(int c1, int c2, int fromIndex, int limit);
+
+  /**
+   * Returns the first index in {@code [fromIndex, limit)} containing {@code c1}, {@code c2}, or
+   * {@code c3}, or {@code -1} if none exists.
+   */
+  int indexOfAsciiTriple(int c1, int c2, int c3, int fromIndex, int limit);
+
   /** Decodes the scalar at {@code pos} and packs it with the following logical position. */
   long decodeForward(int pos);
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1533,7 +1533,8 @@ public final class Matcher implements MatchResult {
       if (scanner instanceof Utf8InputScanner utf8Scanner) {
         Utf8StartAccelerator accelerator = parentPattern.utf8StartAccelerator();
         if (accelerator != null) {
-          MatchStrategy strategy = accelerator.strategy();
+          AcceleratorPolicy policy = accelerator.policy();
+          MatchStrategy strategy = policy.strategy();
           if (strategy != null) {
             diagnosticParticipation(strategy, StrategyRole.START_ACCELERATION);
           }
@@ -1545,12 +1546,13 @@ public final class Matcher implements MatchResult {
             return applyFailedMatchResult();
           }
           effectiveStart = idx;
-          literalPrefixCandidateStart = accelerator.isExactMatchCandidate();
+          literalPrefixCandidateStart = policy.isExactMatchCandidate();
         }
       } else if (text != null) {
         StringStartAccelerator accelerator = parentPattern.stringStartAccelerator();
         if (accelerator != null) {
-          MatchStrategy strategy = accelerator.strategy();
+          AcceleratorPolicy policy = accelerator.policy();
+          MatchStrategy strategy = policy.strategy();
           if (strategy != null) {
             diagnosticParticipation(strategy, StrategyRole.START_ACCELERATION);
           }
@@ -1562,7 +1564,7 @@ public final class Matcher implements MatchResult {
             return applyFailedMatchResult();
           }
           effectiveStart = idx;
-          literalPrefixCandidateStart = accelerator.isExactMatchCandidate();
+          literalPrefixCandidateStart = policy.isExactMatchCandidate();
         }
       }
     }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1059,8 +1059,8 @@ public final class Pattern implements Serializable {
               MAX_DFA_STATES,
               forwardDfaSetup(),
               false,
-              utf8StartAccelerator,
-              stringStartAccelerator);
+              enginePathOptions.startAcceleration() ? utf8StartAccelerator : null,
+              enginePathOptions.startAcceleration() ? stringStartAccelerator : null);
       cachedForwardFirstMatchDfa.set(dfa);
     }
     return dfa;
@@ -1075,8 +1075,8 @@ public final class Pattern implements Serializable {
               MAX_DFA_STATES,
               forwardDfaSetup(),
               true,
-              utf8StartAccelerator,
-              stringStartAccelerator);
+              enginePathOptions.startAcceleration() ? utf8StartAccelerator : null,
+              enginePathOptions.startAcceleration() ? stringStartAccelerator : null);
       cachedForwardLongestMatchDfa.set(dfa);
     }
     return dfa;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1002,7 +1002,14 @@ public final class Pattern implements Serializable {
   Dfa forwardFirstMatchDfa() {
     Dfa dfa = cachedForwardFirstMatchDfa.get();
     if (dfa == null) {
-      dfa = new Dfa(flatDfaProg, MAX_DFA_STATES, forwardDfaSetup(), false);
+      dfa =
+          new Dfa(
+              flatDfaProg,
+              MAX_DFA_STATES,
+              forwardDfaSetup(),
+              false,
+              utf8StartAccelerator,
+              stringStartAccelerator);
       cachedForwardFirstMatchDfa.set(dfa);
     }
     return dfa;
@@ -1011,7 +1018,14 @@ public final class Pattern implements Serializable {
   Dfa forwardLongestMatchDfa() {
     Dfa dfa = cachedForwardLongestMatchDfa.get();
     if (dfa == null) {
-      dfa = new Dfa(flatDfaProg, MAX_DFA_STATES, forwardDfaSetup(), true);
+      dfa =
+          new Dfa(
+              flatDfaProg,
+              MAX_DFA_STATES,
+              forwardDfaSetup(),
+              true,
+              utf8StartAccelerator,
+              stringStartAccelerator);
       cachedForwardLongestMatchDfa.set(dfa);
     }
     return dfa;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -673,7 +673,7 @@ public final class Pattern implements Serializable {
     }
     int searchStart = 0;
     if (enginePathOptions.startAcceleration() && utf8StartAccelerator != null) {
-      MatchStrategy strategy = utf8StartAccelerator.strategy();
+      MatchStrategy strategy = utf8StartAccelerator.policy().strategy();
       if (strategy != null) {
         diagnostics.participate(strategy, StrategyRole.START_ACCELERATION);
       }

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -1,0 +1,49 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/**
+ * Fast-forward scanner for DFA self-loop states.
+ *
+ * <p>When a DFA state transitions to itself on almost all characters, this accelerator uses SWAR /
+ * vector intrinsics to scan directly to the next escape character that could cause a state
+ * transition change.
+ */
+sealed interface StateAccelerator {
+
+  /**
+   * Finds the next index at or after {@code fromIndex} and strictly less than {@code limit}
+   * containing an escape character.
+   *
+   * @return the index of the escape character, or {@code -1} if no escape character occurs before
+   *     {@code limit}.
+   */
+  int findEscape(InputScanner text, int fromIndex, int limit);
+
+  /** Accelerator for a single escape character (e.g. quote {@code '"'} or newline {@code '\n'}). */
+  record SingleAsciiEscape(int escape) implements StateAccelerator {
+    @Override
+    public int findEscape(InputScanner text, int fromIndex, int limit) {
+      return text.indexOfAscii(escape, fromIndex, limit);
+    }
+  }
+
+  /** Accelerator for two escape characters (e.g. quote {@code '"'} and backslash {@code '\\'}). */
+  record AsciiPairEscape(int c1, int c2) implements StateAccelerator {
+    @Override
+    public int findEscape(InputScanner text, int fromIndex, int limit) {
+      return text.indexOfAsciiPair(c1, c2, fromIndex, limit);
+    }
+  }
+
+  /** Accelerator for three escape characters (e.g. comma, semicolon, newline). */
+  record AsciiTripleEscape(int c1, int c2, int c3) implements StateAccelerator {
+    @Override
+    public int findEscape(InputScanner text, int fromIndex, int limit) {
+      return text.indexOfAsciiTriple(c1, c2, c3, fromIndex, limit);
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -28,6 +28,36 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
+  public int indexOfAscii(int ascii, int fromIndex, int limit) {
+    int idx = text.indexOf(ascii, fromIndex);
+    return (idx >= 0 && idx < limit) ? idx : -1;
+  }
+
+  @Override
+  public int indexOfAsciiPair(int c1, int c2, int fromIndex, int limit) {
+    int end = Math.min(limit, text.length());
+    for (int i = Math.max(0, fromIndex); i < end; i++) {
+      char ch = text.charAt(i);
+      if (ch == c1 || ch == c2) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  public int indexOfAsciiTriple(int c1, int c2, int c3, int fromIndex, int limit) {
+    int end = Math.min(limit, text.length());
+    for (int i = Math.max(0, fromIndex); i < end; i++) {
+      char ch = text.charAt(i);
+      if (ch == c1 || ch == c2 || ch == c3) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Override
   public int singleUnitCodePointAt(int pos) {
     char c = text.charAt(pos);
     return Character.isHighSurrogate(c)

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -43,27 +43,33 @@ sealed interface StringStartAccelerator {
    */
   int findCandidate(String text, int fromIndex, boolean unixLines);
 
-  /**
-   * Minimum skip distance (in bytes or chars) required for this accelerator to be profitable over
-   * direct DFA execution.
-   */
-  default int minProfitableSkip() {
-    return 32;
+  /** Returns the tuning and diagnostic policy for this accelerator. */
+  default AcceleratorPolicy policy() {
+    return AcceleratorPolicy.DEFAULT;
   }
 
-  /** Number of consecutive sub-threshold skips tolerated before defeat. */
+  /** Minimum skip distance (in chars) required for this accelerator to be profitable. */
+  default int minProfitableSkip() {
+    return policy().minProfitableSkip();
+  }
+
+  /** Number of consecutive sub-threshold skips tolerated before declaring adaptive defeat. */
   default int strikeBudget() {
-    return 3;
+    return policy().strikeBudget();
   }
 
   /** Returns the diagnostic strategy associated with this accelerator, or {@code null} if none. */
-  MatchStrategy strategy();
+  default MatchStrategy strategy() {
+    return policy().strategy();
+  }
 
   /**
    * Returns whether this accelerator identifies an exact candidate match start that can be directly
    * validated with a single anchored forward DFA pass.
    */
-  boolean isExactMatchCandidate();
+  default boolean isExactMatchCandidate() {
+    return policy().isExactMatchCandidate();
+  }
 
   final class Literal implements StringStartAccelerator {
     private final String prefix;
@@ -83,23 +89,8 @@ sealed interface StringStartAccelerator {
     }
 
     @Override
-    public int minProfitableSkip() {
-      return 16;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 4;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.LITERAL;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return true;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
     }
 
     @Override
@@ -132,23 +123,8 @@ sealed interface StringStartAccelerator {
     }
 
     @Override
-    public int minProfitableSkip() {
-      return 16;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 4;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.LITERAL;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return true;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
     }
 
     @Override
@@ -232,23 +208,8 @@ sealed interface StringStartAccelerator {
     }
 
     @Override
-    public int minProfitableSkip() {
-      return 24;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 3;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.CHARACTER_CLASS;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return false;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
     }
 
     @Override
@@ -282,23 +243,8 @@ sealed interface StringStartAccelerator {
     }
 
     @Override
-    public int minProfitableSkip() {
-      return 16;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 3;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return null;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return false;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LINE_ANCHOR;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -43,6 +43,19 @@ sealed interface StringStartAccelerator {
    */
   int findCandidate(String text, int fromIndex, boolean unixLines);
 
+  /**
+   * Minimum skip distance (in bytes or chars) required for this accelerator to be profitable over
+   * direct DFA execution.
+   */
+  default int minProfitableSkip() {
+    return 32;
+  }
+
+  /** Number of consecutive sub-threshold skips tolerated before defeat. */
+  default int strikeBudget() {
+    return 3;
+  }
+
   /** Returns the diagnostic strategy associated with this accelerator, or {@code null} if none. */
   MatchStrategy strategy();
 
@@ -67,6 +80,16 @@ sealed interface StringStartAccelerator {
 
     public boolean prefixFoldCase() {
       return prefixFoldCase;
+    }
+
+    @Override
+    public int minProfitableSkip() {
+      return 16;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 4;
     }
 
     @Override
@@ -106,6 +129,16 @@ sealed interface StringStartAccelerator {
 
     public boolean[] firstAscii() {
       return firstAscii;
+    }
+
+    @Override
+    public int minProfitableSkip() {
+      return 16;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 4;
     }
 
     @Override
@@ -199,6 +232,16 @@ sealed interface StringStartAccelerator {
     }
 
     @Override
+    public int minProfitableSkip() {
+      return 24;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 3;
+    }
+
+    @Override
     public MatchStrategy strategy() {
       return MatchStrategy.CHARACTER_CLASS;
     }
@@ -236,6 +279,16 @@ sealed interface StringStartAccelerator {
 
     public StartAcceleration startAcceleration() {
       return startAcceleration;
+    }
+
+    @Override
+    public int minProfitableSkip() {
+      return 16;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 3;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -48,29 +48,6 @@ sealed interface StringStartAccelerator {
     return AcceleratorPolicy.DEFAULT;
   }
 
-  /** Minimum skip distance (in chars) required for this accelerator to be profitable. */
-  default int minProfitableSkip() {
-    return policy().minProfitableSkip();
-  }
-
-  /** Number of consecutive sub-threshold skips tolerated before declaring adaptive defeat. */
-  default int strikeBudget() {
-    return policy().strikeBudget();
-  }
-
-  /** Returns the diagnostic strategy associated with this accelerator, or {@code null} if none. */
-  default MatchStrategy strategy() {
-    return policy().strategy();
-  }
-
-  /**
-   * Returns whether this accelerator identifies an exact candidate match start that can be directly
-   * validated with a single anchored forward DFA pass.
-   */
-  default boolean isExactMatchCandidate() {
-    return policy().isExactMatchCandidate();
-  }
-
   final class Literal implements StringStartAccelerator {
     private final String prefix;
     private final boolean prefixFoldCase;

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -51,6 +51,41 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
     return length;
   }
 
+  @Override
+  public int indexOfAscii(int ascii, int fromIndex, int limit) {
+    int start = Math.max(0, fromIndex);
+    int scanLen = Math.min(length, limit);
+    if (start >= scanLen) {
+      return -1;
+    }
+    int res = indexOfByte((byte) ascii, start);
+    return (res >= 0 && res < limit) ? res : -1;
+  }
+
+  @Override
+  public int indexOfAsciiPair(int c1, int c2, int fromIndex, int limit) {
+    int start = Math.max(0, fromIndex);
+    int scanLen = Math.min(length, limit);
+    if (start >= scanLen) {
+      return -1;
+    }
+    int res = ByteSwarScan.indexOfBytePair(bytes, offset, scanLen, (byte) c1, (byte) c2, start);
+    return (res >= 0 && res < limit) ? res : -1;
+  }
+
+  @Override
+  public int indexOfAsciiTriple(int c1, int c2, int c3, int fromIndex, int limit) {
+    int start = Math.max(0, fromIndex);
+    int scanLen = Math.min(length, limit);
+    if (start >= scanLen) {
+      return -1;
+    }
+    int res =
+        ByteSwarScan.indexOfByteTriple(
+            bytes, offset, scanLen, (byte) c1, (byte) c2, (byte) c3, start);
+    return (res >= 0 && res < limit) ? res : -1;
+  }
+
   Utf8InputScanner slice(int start, int end) {
     return new Utf8InputScanner(bytes, offset + start, end - start);
   }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -89,13 +89,8 @@ sealed interface Utf8StartAccelerator {
     }
 
     @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.LITERAL;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return true;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -45,27 +45,33 @@ sealed interface Utf8StartAccelerator {
    */
   int findCandidate(Utf8InputScanner scanner, int fromIndex);
 
-  /**
-   * Minimum skip distance (in bytes) required for this accelerator to be profitable over direct DFA
-   * execution.
-   */
-  default int minProfitableSkip() {
-    return 32;
+  /** Returns the tuning and diagnostic policy for this accelerator. */
+  default AcceleratorPolicy policy() {
+    return AcceleratorPolicy.DEFAULT;
   }
 
-  /** Number of consecutive sub-threshold skips tolerated before defeat. */
+  /** Minimum skip distance (in bytes) required for this accelerator to be profitable. */
+  default int minProfitableSkip() {
+    return policy().minProfitableSkip();
+  }
+
+  /** Number of consecutive sub-threshold skips tolerated before declaring adaptive defeat. */
   default int strikeBudget() {
-    return 3;
+    return policy().strikeBudget();
   }
 
   /** Returns the diagnostic strategy associated with this accelerator, or {@code null} if none. */
-  MatchStrategy strategy();
+  default MatchStrategy strategy() {
+    return policy().strategy();
+  }
 
   /**
    * Returns whether this accelerator identifies an exact candidate match start that can be directly
    * validated with a single anchored forward DFA pass.
    */
-  boolean isExactMatchCandidate();
+  default boolean isExactMatchCandidate() {
+    return policy().isExactMatchCandidate();
+  }
 
   @SuppressWarnings("ArrayRecordComponent")
   record Literal(byte[] prefixUtf8, int[] prefixUtf8Failure, int[] prefixUtf8Shifts)
@@ -77,23 +83,8 @@ sealed interface Utf8StartAccelerator {
     }
 
     @Override
-    public int minProfitableSkip() {
-      return 16;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 4;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.LITERAL;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return true;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
     }
 
     @Override
@@ -110,23 +101,8 @@ sealed interface Utf8StartAccelerator {
       implements Utf8StartAccelerator {
 
     @Override
-    public int minProfitableSkip() {
-      return 16;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 4;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.LITERAL;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return true;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
     }
 
     @Override
@@ -183,23 +159,8 @@ sealed interface Utf8StartAccelerator {
   record CharClass(CharClassScanInfo scanInfo) implements Utf8StartAccelerator {
 
     @Override
-    public int minProfitableSkip() {
-      return 24;
-    }
-
-    @Override
-    public int strikeBudget() {
-      return 3;
-    }
-
-    @Override
-    public MatchStrategy strategy() {
-      return MatchStrategy.CHARACTER_CLASS;
-    }
-
-    @Override
-    public boolean isExactMatchCandidate() {
-      return false;
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -50,29 +50,6 @@ sealed interface Utf8StartAccelerator {
     return AcceleratorPolicy.DEFAULT;
   }
 
-  /** Minimum skip distance (in bytes) required for this accelerator to be profitable. */
-  default int minProfitableSkip() {
-    return policy().minProfitableSkip();
-  }
-
-  /** Number of consecutive sub-threshold skips tolerated before declaring adaptive defeat. */
-  default int strikeBudget() {
-    return policy().strikeBudget();
-  }
-
-  /** Returns the diagnostic strategy associated with this accelerator, or {@code null} if none. */
-  default MatchStrategy strategy() {
-    return policy().strategy();
-  }
-
-  /**
-   * Returns whether this accelerator identifies an exact candidate match start that can be directly
-   * validated with a single anchored forward DFA pass.
-   */
-  default boolean isExactMatchCandidate() {
-    return policy().isExactMatchCandidate();
-  }
-
   @SuppressWarnings("ArrayRecordComponent")
   record Literal(byte[] prefixUtf8, int[] prefixUtf8Failure, int[] prefixUtf8Shifts)
       implements Utf8StartAccelerator {

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -45,6 +45,19 @@ sealed interface Utf8StartAccelerator {
    */
   int findCandidate(Utf8InputScanner scanner, int fromIndex);
 
+  /**
+   * Minimum skip distance (in bytes) required for this accelerator to be profitable over direct DFA
+   * execution.
+   */
+  default int minProfitableSkip() {
+    return 32;
+  }
+
+  /** Number of consecutive sub-threshold skips tolerated before defeat. */
+  default int strikeBudget() {
+    return 3;
+  }
+
   /** Returns the diagnostic strategy associated with this accelerator, or {@code null} if none. */
   MatchStrategy strategy();
 
@@ -61,6 +74,16 @@ sealed interface Utf8StartAccelerator {
     static Literal create(String prefix) {
       byte[] utf8 = prefix.getBytes(StandardCharsets.UTF_8);
       return new Literal(utf8, Pattern.literalFailure(utf8), Pattern.literalShifts(utf8));
+    }
+
+    @Override
+    public int minProfitableSkip() {
+      return 16;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 4;
     }
 
     @Override
@@ -85,6 +108,16 @@ sealed interface Utf8StartAccelerator {
   @SuppressWarnings("ArrayRecordComponent")
   record FixedOffset(FixedOffsetLiteral fixedOffset, boolean[] charClassPrefixAscii)
       implements Utf8StartAccelerator {
+
+    @Override
+    public int minProfitableSkip() {
+      return 16;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 4;
+    }
 
     @Override
     public MatchStrategy strategy() {
@@ -148,6 +181,16 @@ sealed interface Utf8StartAccelerator {
   }
 
   record CharClass(CharClassScanInfo scanInfo) implements Utf8StartAccelerator {
+
+    @Override
+    public int minProfitableSkip() {
+      return 24;
+    }
+
+    @Override
+    public int strikeBudget() {
+      return 3;
+    }
 
     @Override
     public MatchStrategy strategy() {

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -578,4 +578,72 @@ class DfaTest {
       assertThat(result.pos()).isEqualTo(7 + 2000 + 1);
     }
   }
+
+  @Test
+  void issue711_multilineAnchorAlternationWithFalseCandidate() {
+    String regex = "(b|(?m:^a))cd[0-9]";
+    String input = "x".repeat(100) + "0cb\r1bacd19c1__19x y_";
+    EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();
+    EnginePathOptions disabled = EnginePathOptions.builder().startAcceleration(false).build();
+    Pattern accelerated = Pattern.compile(regex, 0, enabled);
+    Pattern control = Pattern.compile(regex, 0, disabled);
+    Utf8Input utf8 = Utf8Input.validated(input.getBytes(UTF_8));
+
+    assertThat(control.find(utf8)).isFalse();
+    assertThat(accelerated.find(utf8))
+        .as("Accelerated DFA must not match (?m:^a) when 'a' is not after line terminator")
+        .isEqualTo(control.find(utf8));
+  }
+
+  @Test
+  void issue711_multilineAnchorStringScannerEquivalence() {
+    String regex = "(b|(?m:^a))cd[0-9]";
+    String input = "x".repeat(100) + "0cb\r1bacd19c1__19x y_";
+    EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();
+    EnginePathOptions disabled = EnginePathOptions.builder().startAcceleration(false).build();
+    Pattern accelerated = Pattern.compile(regex, 0, enabled);
+    Pattern control = Pattern.compile(regex, 0, disabled);
+
+    assertThat(control.matcher(input).find()).isFalse();
+    assertThat(accelerated.matcher(input).find())
+        .as("Accelerated DFA String search must match unaccelerated control")
+        .isEqualTo(control.matcher(input).find());
+  }
+
+  @Test
+  void wordBoundaryAnchorAlternationWithFalseCandidate() {
+    String regex = "(b|\\ba)cd[0-9]";
+    String input = "x".repeat(100) + "0cb_bacd19c1__19x y_";
+    EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();
+    EnginePathOptions disabled = EnginePathOptions.builder().startAcceleration(false).build();
+    Pattern accelerated = Pattern.compile(regex, 0, enabled);
+    Pattern control = Pattern.compile(regex, 0, disabled);
+
+    assertThat(control.matcher(input).find()).isFalse();
+    assertThat(accelerated.matcher(input).find()).isEqualTo(control.matcher(input).find());
+  }
+
+  @Test
+  void startOfTextAnchorAlternationWithFalseCandidate() {
+    String regex = "(b|\\Aa)cd[0-9]";
+    String input = "x".repeat(100) + "0cb1bacd19c1__19x y_";
+    EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();
+    EnginePathOptions disabled = EnginePathOptions.builder().startAcceleration(false).build();
+    Pattern accelerated = Pattern.compile(regex, 0, enabled);
+    Pattern control = Pattern.compile(regex, 0, disabled);
+
+    assertThat(control.matcher(input).find()).isFalse();
+    assertThat(accelerated.matcher(input).find()).isEqualTo(control.matcher(input).find());
+  }
+
+  @Test
+  void multilineAnchorTrueCandidateMatches() {
+    String regex = "(b|(?m:^a))cd[0-9]";
+    String input = "x".repeat(100) + "0cb\nacd19c1__19x y_";
+    EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();
+    Pattern accelerated = Pattern.compile(regex, 0, enabled);
+
+    assertThat(accelerated.matcher(input).find()).isTrue();
+    assertThat(accelerated.find(Utf8Input.validated(input.getBytes(UTF_8)))).isTrue();
+  }
 }

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -564,6 +564,21 @@ class DfaTest {
     }
 
     @Test
+    void selfLoopStopsAtNonAsciiTransitions() {
+      assertNonAsciiEscapeMatches("é");
+      assertNonAsciiEscapeMatches("😀");
+    }
+
+    @Test
+    void startAccelerationUsesOnlyTheActiveInputSubstrate() {
+      Pattern pattern = Pattern.compile("(?m)^foo");
+      Dfa dfa = pattern.forwardFirstMatchDfa();
+
+      assertThat(dfa.hasStartAcceleration(new StringInputScanner("foo"))).isTrue();
+      assertThat(dfa.hasStartAcceleration(new Utf8InputScanner("foo".getBytes(UTF_8)))).isFalse();
+    }
+
+    @Test
     void selfLoopUtf8ScannerEquivalence() {
       String filler = "x".repeat(2000);
       String text = "start \"" + filler + "\" end";
@@ -577,10 +592,31 @@ class DfaTest {
       assertThat(result.matched()).isTrue();
       assertThat(result.pos()).isEqualTo(7 + 2000 + 1);
     }
+
+    private static void assertNonAsciiEscapeMatches(String escape) {
+      String pattern = "A[\\x00-\\x21\\x23-\\x7F]*" + escape;
+      String text = "A" + "x".repeat(1000) + escape;
+      Pattern compiledPattern = Pattern.compile(pattern);
+      assertThat(compiledPattern.matcher(text).find()).isTrue();
+      assertThat(compiledPattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
+
+      Dfa.SearchResult stringResult = search(pattern, text);
+      assertThat(stringResult).isNotNull();
+      assertThat(stringResult.matched()).isTrue();
+
+      byte[] bytes = text.getBytes(UTF_8);
+      Regexp re = Parser.parse(pattern, FLAGS);
+      Prog prog = Compiler.compile(re);
+      Dfa.SearchResult utf8Result =
+          new Dfa(prog, 1000, Dfa.buildSetup(prog), false)
+              .doSearch(new Utf8InputScanner(bytes, 0, bytes.length), 0, false, false);
+      assertThat(utf8Result).isNotNull();
+      assertThat(utf8Result.matched()).isTrue();
+    }
   }
 
   @Test
-  void issue711_multilineAnchorAlternationWithFalseCandidate() {
+  void multilineAnchorAlternationRejectsFalseUtf8Candidate() {
     String regex = "(b|(?m:^a))cd[0-9]";
     String input = "x".repeat(100) + "0cb\r1bacd19c1__19x y_";
     EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();
@@ -596,7 +632,7 @@ class DfaTest {
   }
 
   @Test
-  void issue711_multilineAnchorStringScannerEquivalence() {
+  void multilineAnchorAlternationRejectsFalseStringCandidate() {
     String regex = "(b|(?m:^a))cd[0-9]";
     String input = "x".repeat(100) + "0cb\r1bacd19c1__19x y_";
     EnginePathOptions enabled = EnginePathOptions.builder().startAcceleration(true).build();

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
@@ -508,5 +509,73 @@ class DfaTest {
     assertThat(second.matched()).isTrue();
     assertThat(first.ambiguous()).isTrue();
     assertThat(second.ambiguous()).isTrue();
+  }
+
+  @Nested
+  @DisplayName("Self-Loop Escape Acceleration")
+  class SelfLoopEscapeAcceleration {
+    @Test
+    void quotedStringLongPayload() {
+      String filler = "x".repeat(5000);
+      String text = "prefix \"" + filler + "\" suffix";
+      Dfa.SearchResult result = search("\"[^\"]*\"", text);
+      assertThat(result).isNotNull();
+      assertThat(result.matched()).isTrue();
+      assertThat(result.pos()).isEqualTo(8 + 5000 + 1);
+    }
+
+    @Test
+    void headerLineTerminatorLongPayload() {
+      String filler = "a".repeat(10000);
+      String text = "header:" + filler + "\nrest";
+      Dfa.SearchResult result = search("header:[^\n]*\n", text);
+      assertThat(result).isNotNull();
+      assertThat(result.matched()).isTrue();
+      assertThat(result.pos()).isEqualTo(7 + 10000 + 1);
+    }
+
+    @Test
+    void htmlTagLongPayload() {
+      String filler = "content".repeat(1000);
+      String text = "before <div " + filler + "> after";
+      Dfa.SearchResult result = search("<[^>]*>", text);
+      assertThat(result).isNotNull();
+      assertThat(result.matched()).isTrue();
+      assertThat(result.pos()).isEqualTo(12 + 7000 + 1);
+    }
+
+    @Test
+    void multiEscapeBytePair() {
+      String filler = "data".repeat(1000);
+      String text = "prefix " + filler + ",suffix";
+      Dfa.SearchResult result = search("[^,\n]*,", text);
+      assertThat(result).isNotNull();
+      assertThat(result.matched()).isTrue();
+      assertThat(result.pos()).isEqualTo(7 + 4000 + 1);
+    }
+
+    @Test
+    void selfLoopNoEscapeFoundUntilEof() {
+      String filler = "x".repeat(5000);
+      String text = "start \"" + filler;
+      Dfa.SearchResult result = search("\"[^\"]*\"", text);
+      assertThat(result).isNotNull();
+      assertThat(result.matched()).isFalse();
+    }
+
+    @Test
+    void selfLoopUtf8ScannerEquivalence() {
+      String filler = "x".repeat(2000);
+      String text = "start \"" + filler + "\" end";
+      byte[] bytes = text.getBytes(UTF_8);
+      Regexp re = Parser.parse("\"[^\"]*\"", FLAGS);
+      Prog prog = Compiler.compile(re);
+      Utf8InputScanner scanner = new Utf8InputScanner(bytes, 0, bytes.length);
+      Dfa dfa = new Dfa(prog, 1000, Dfa.buildSetup(prog), false);
+      Dfa.SearchResult result = dfa.doSearch(scanner, 0, false, false);
+      assertThat(result).isNotNull();
+      assertThat(result.matched()).isTrue();
+      assertThat(result.pos()).isEqualTo(7 + 2000 + 1);
+    }
   }
 }

--- a/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/EnginePathEquivalenceTest.java
@@ -7,6 +7,7 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -147,6 +148,45 @@ class EnginePathEquivalenceTest {
         "foo[0-9]+",
         "xxfoo123 yyfoo45",
         EnginePathOptions.builder().startAcceleration(false).build());
+  }
+
+  @Test
+  @DisplayName("DFA-loop start acceleration preserves position-dependent state across inputs")
+  void dfaLoopStartAccelerationPreservesPositionDependentStateAcrossInputs() {
+    String regex = "(b|(?m:^a))c[0-9]";
+    for (String lineTerminator : List.of("\n", "\r", "\r\n", "\u0085", "\u2028", "\u2029")) {
+      Pattern accelerated = Pattern.compile(regex);
+      Pattern control =
+          Pattern.compile(regex, 0, EnginePathOptions.builder().startAcceleration(false).build());
+      for (String input : List.of(lineTerminator + "acz9y", " ycby ", "y0c\n1bac19c1__19x y_")) {
+        boolean expected = java.util.regex.Pattern.compile(regex).matcher(input).find();
+        Utf8Input utf8 = Utf8Input.validated(input.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(control.find(utf8)).as("control for %s", printable(input)).isEqualTo(expected);
+        assertThat(accelerated.find(utf8))
+            .as("accelerated search for %s", printable(input))
+            .isEqualTo(expected);
+      }
+    }
+
+    String nonAsciiInput = "bxc\rca9\né\nac9é\r0x\r9a0";
+    Pattern accelerated = Pattern.compile(regex);
+    Pattern control =
+        Pattern.compile(regex, 0, EnginePathOptions.builder().startAcceleration(false).build());
+    boolean expected = java.util.regex.Pattern.compile(regex).matcher(nonAsciiInput).find();
+    assertThat(control.matcher(nonAsciiInput).find()).isEqualTo(expected);
+    assertThat(accelerated.matcher(nonAsciiInput).find()).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("disabled start acceleration is not installed in forward DFAs")
+  void disabledStartAccelerationIsNotInstalledInForwardDfas() {
+    Pattern pattern =
+        Pattern.compile(
+            "foo[0-9]+", 0, EnginePathOptions.builder().startAcceleration(false).build());
+
+    assertThat(pattern.forwardFirstMatchDfa().hasStartAcceleration()).isFalse();
+    assertThat(pattern.forwardLongestMatchDfa().hasStartAcceleration()).isFalse();
   }
 
   @Test
@@ -360,6 +400,10 @@ class EnginePathEquivalenceTest {
     }
     traces.add(snapshot(matcher, false));
     return traces;
+  }
+
+  private static String printable(String input) {
+    return input.replace("\r", "\\r").replace("\n", "\\n");
   }
 
   private static String appendReplacementTrace(Matcher matcher) {

--- a/safere/src/test/java/org/safere/ShortScanEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/ShortScanEquivalenceTest.java
@@ -8,6 +8,7 @@ package org.safere;
 import static java.nio.charset.StandardCharsets.UTF_16LE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.DisplayName;
@@ -180,7 +181,7 @@ class ShortScanEquivalenceTest {
   @DisplayName("UTF-16 kernels handle unsigned ranges and reject non-BMP ranges")
   void utf16RangeBoundaries() {
     char[] chars = new char[64];
-    java.util.Arrays.fill(chars, '\uA000');
+    Arrays.fill(chars, '\uA000');
     chars[10] = '\u7500';
     byte[] utf16Bytes = new String(chars).getBytes(UTF_16LE);
     int[] crossingSignedBoundary = {'\u7000', '\u9000'};
@@ -224,7 +225,7 @@ class ShortScanEquivalenceTest {
       return;
     }
     char[] chars = new char[64];
-    java.util.Arrays.fill(chars, '\uA000');
+    Arrays.fill(chars, '\uA000');
     chars[10] = '\u7500';
     chars[20] = '\u8500';
     byte[] utf16Bytes = new String(chars).getBytes(UTF_16LE);

--- a/safere/src/test/java/org/safere/StartAcceleratorDifferentialTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorDifferentialTest.java
@@ -1,0 +1,129 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Adversarial differential tests for DFA-loop start acceleration under position-dependent
+ * assertions.
+ */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
+class StartAcceleratorDifferentialTest {
+
+  private static final EnginePathOptions ACCELERATED =
+      EnginePathOptions.builder().startAcceleration(true).build();
+  private static final EnginePathOptions UNACCELERATED =
+      EnginePathOptions.builder().startAcceleration(false).build();
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "(b|(?m:^a))cd[0-9]",
+        "((?m:^first)|second)token",
+        "(b|\\Aa)cd[0-9]",
+        "(\\Aprefix|unanchored)token",
+        "(b|\\ba)cd[0-9]",
+        "(b|\\Ba)cd[0-9]",
+        "(\\bword|regular)match",
+        "(b|(?m:a$))cd",
+        "(b|a\\z)cd"
+      })
+  @DisplayName("Ablation: accelerated DFA matches unaccelerated baseline on false candidates")
+  void acceleratedDfaMatchesBaselineOnFalseCandidates(String regex) {
+    List<String> adversarialInputs =
+        List.of(
+            "x".repeat(200) + "0cb\r1bacd19c1__19x y_",
+            "x".repeat(200) + "0cb1bacd19c1__19x y_",
+            "x".repeat(200) + "foo_acd19bar",
+            "x".repeat(200) + "foo acd19bar",
+            "x".repeat(200) + "prefixfirsttoken_rest",
+            "x".repeat(200) + "123firsttoken_rest",
+            "x".repeat(200) + "nonwordmatch_rest",
+            "x".repeat(200) + "wordmatch rest");
+
+    Pattern accelerated = Pattern.compile(regex, 0, ACCELERATED);
+    Pattern control = Pattern.compile(regex, 0, UNACCELERATED);
+    java.util.regex.Pattern jdk = java.util.regex.Pattern.compile(regex);
+
+    for (String input : adversarialInputs) {
+      boolean expected = control.matcher(input).find();
+      boolean actual = accelerated.matcher(input).find();
+      assertThat(actual)
+          .as("String find() divergence for /%s/ on input %s", regex, input)
+          .isEqualTo(expected);
+
+      Utf8Input utf8 = Utf8Input.validated(input.getBytes(UTF_8));
+      boolean actualUtf8 = accelerated.find(utf8);
+      assertThat(actualUtf8)
+          .as("UTF-8 find() divergence for /%s/ on input %s", regex, input)
+          .isEqualTo(expected);
+
+      // Verify consistency against JDK regex engine
+      boolean jdkExpected = jdk.matcher(input).find();
+      assertThat(actual)
+          .as("SafeRE vs JDK divergence for /%s/ on input %s", regex, input)
+          .isEqualTo(jdkExpected);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "(b|(?m:^a))cd[0-9]",
+        "((?m:^first)|second)token",
+        "(b|\\Aa)cd[0-9]",
+        "(b|\\ba)cd[0-9]",
+        "(\\bword|regular)match"
+      })
+  @DisplayName("Ablation: accelerated DFA matches unaccelerated baseline on true candidates")
+  void acceleratedDfaMatchesBaselineOnTrueCandidates(String regex) {
+    List<String> matchingInputs =
+        List.of(
+            "x".repeat(200) + "\nacd19c1__19x y_",
+            "x".repeat(200) + "\r\nfirsttoken rest",
+            "firsttoken at start of text",
+            "x".repeat(200) + " wordmatch rest",
+            "x".repeat(200) + "\nwordmatch rest");
+
+    Pattern accelerated = Pattern.compile(regex, 0, ACCELERATED);
+    Pattern control = Pattern.compile(regex, 0, UNACCELERATED);
+
+    for (String input : matchingInputs) {
+      boolean expected = control.matcher(input).find();
+      boolean actual = accelerated.matcher(input).find();
+      assertThat(actual)
+          .as("String find() divergence for /%s/ on input %s", regex, input)
+          .isEqualTo(expected);
+
+      Utf8Input utf8 = Utf8Input.validated(input.getBytes(UTF_8));
+      boolean actualUtf8 = accelerated.find(utf8);
+      assertThat(actualUtf8)
+          .as("UTF-8 find() divergence for /%s/ on input %s", regex, input)
+          .isEqualTo(expected);
+    }
+  }
+
+  @Test
+  void exactIssue711Reproducer() {
+    String regex = "(b|(?m:^a))c[0-9]";
+    String input = "0cb\r1bac19c1__19x y_";
+    Pattern accelerated = Pattern.compile(regex, 0, ACCELERATED);
+    Pattern control = Pattern.compile(regex, 0, UNACCELERATED);
+    Utf8Input utf8 = Utf8Input.validated(input.getBytes(UTF_8));
+
+    assertThat(control.find(utf8)).isFalse();
+    assertThat(accelerated.find(utf8)).isFalse();
+    assertThat(java.util.regex.Pattern.compile(regex).matcher(input).find()).isFalse();
+  }
+}

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -30,15 +30,13 @@ class StartAcceleratorTest {
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.Literal.class);
-    assertThat(strAcc.strategy()).isEqualTo(MatchStrategy.LITERAL);
-    assertThat(strAcc.isExactMatchCandidate()).isTrue();
+    assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
     assertThat(strAcc.findCandidate("haystack with needle here", 0, false)).isEqualTo(14);
     assertThat(strAcc.findCandidate("haystack with needle here", 15, false)).isEqualTo(-1);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.Literal.class);
-    assertThat(utf8Acc.strategy()).isEqualTo(MatchStrategy.LITERAL);
-    assertThat(utf8Acc.isExactMatchCandidate()).isTrue();
+    assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 0)).isEqualTo(14);
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 15)).isEqualTo(-1);
   }
@@ -63,12 +61,12 @@ class StartAcceleratorTest {
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.FixedOffset.class);
-    assertThat(strAcc.strategy()).isEqualTo(MatchStrategy.LITERAL);
+    assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
     assertThat(strAcc.findCandidate("abtoken cd", 0, false)).isEqualTo(0);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.FixedOffset.class);
-    assertThat(utf8Acc.strategy()).isEqualTo(MatchStrategy.LITERAL);
+    assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
     assertThat(utf8Acc.findCandidate(utf8Scanner("abtoken cd"), 0)).isEqualTo(0);
   }
 
@@ -81,14 +79,12 @@ class StartAcceleratorTest {
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
-    assertThat(strAcc.strategy()).isEqualTo(MatchStrategy.CHARACTER_CLASS);
-    assertThat(strAcc.isExactMatchCandidate()).isFalse();
+    assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(strAcc.findCandidate("xxxa", 0, false)).isEqualTo(3);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
-    assertThat(utf8Acc.strategy()).isEqualTo(MatchStrategy.CHARACTER_CLASS);
-    assertThat(utf8Acc.isExactMatchCandidate()).isFalse();
+    assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(utf8Acc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
   }
 

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -52,8 +52,8 @@ class StartAcceleratorTest {
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CaseInsensitiveLiteral.class);
-    assertThat(utf8Acc.strategy()).isEqualTo(MatchStrategy.LITERAL);
-    assertThat(utf8Acc.isExactMatchCandidate()).isTrue();
+    assertThat(utf8Acc.policy().strategy()).isEqualTo(MatchStrategy.LITERAL);
+    assertThat(utf8Acc.policy().isExactMatchCandidate()).isTrue();
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with NEEDLE here"), 0)).isEqualTo(14);
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with nEeDlE here"), 0)).isEqualTo(14);
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 15)).isEqualTo(-1);
@@ -130,9 +130,9 @@ class StartAcceleratorTest {
                 "Utf8StartAccelerator should match StringStartAccelerator presence for pattern: %s",
                 patStr)
             .isNotNull();
-        assertThat(utf8Acc.strategy())
+        assertThat(utf8Acc.policy().strategy())
             .as("Strategies should match for pattern: %s", patStr)
-            .isEqualTo(strAcc.strategy());
+            .isEqualTo(strAcc.policy().strategy());
 
         for (String input : testInputs) {
           int strCandidate = strAcc.findCandidate(input, 0, false);


### PR DESCRIPTION
Accelerate DFA loops for unanchored searches, allowing the DFA loop to use start acceleration paths when it re-enters the start state.

To avoid regressions for cases that don't benefit from this, the approach
* Restricts the inner loop to scan in 64-character chunks, checking for start-state transitions only when exiting the chunk, to minimize branching in the core DFA loop
* If a fast-forward jump is <64 characters, the engine applies a 512-character penalty during which breakouts are disabled, preventing repeated use of the acceleration paths from degrading performance for dense candidate prefixes

```
./run-java-benchmarks.sh --fastbuild CrossEngineBenchmark.run -- -p crossEngineTrial=FixedOffsetAccelerationBenchmark.findTrulySparse.511@safere-string
```

| Description | Score (ns/op) | Speedup |
| :--- | :--- | :--- |
| Baseline | `64,502.967 ± 1858.615` | 1.00x |
| DFA loop acceleration | **`33,247.480 ± 123.805`** | **1.94x faster** |
