### PR TITLE
Extend Vector scans to multi-range ASCII classes

### DIFF
--- a/run-vector-benchmarks.sh
+++ b/run-vector-benchmarks.sh
@@ -14,7 +14,7 @@ FASTBUILD=false
 END_TO_END=false
 PROVIDER="both"
 TRIAL_OVERRIDE=""
-METHODS="safeRe|swar|swarProvider|vector|vectorProvider|vectorCursor"
+METHODS="safeRe|swar|swarProvider|vector|vectorProvider|vectorBounds|vectorCursor"
 JMH_EXTRA_ARGS=()
 
 while [ "$#" -gt 0 ]; do
@@ -138,21 +138,21 @@ if [ -n "$TRIAL_OVERRIDE" ]; then
   TRIALS="$TRIAL_OVERRIDE"
 fi
 if [ "$END_TO_END" = true ]; then
-  FIRST_HIT_TRIALS=""
+  END_TO_END_TRIALS=""
   IFS=',' read -ra trial_list <<< "$TRIALS"
   for trial in "${trial_list[@]}"; do
-    if [[ "$trial" != singleton/* && "$trial" == */first/* ]]; then
-      if [ -n "$FIRST_HIT_TRIALS" ]; then
-        FIRST_HIT_TRIALS+=","
+    if [[ "$trial" != singleton/* ]]; then
+      if [ -n "$END_TO_END_TRIALS" ]; then
+        END_TO_END_TRIALS+=","
       fi
-      FIRST_HIT_TRIALS+="$trial"
+      END_TO_END_TRIALS+="$trial"
     fi
   done
-  if [ -z "$FIRST_HIT_TRIALS" ]; then
-    echo "ERROR: End-to-end provider benchmarks require at least one pair or range first-hit trial" >&2
+  if [ -z "$END_TO_END_TRIALS" ]; then
+    echo "ERROR: End-to-end provider benchmarks require at least one non-singleton trial" >&2
     exit 2
   fi
-  TRIALS="$FIRST_HIT_TRIALS"
+  TRIALS="$END_TO_END_TRIALS"
 fi
 
 run_benchmarks() {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -15,7 +15,9 @@
       "smokeTrials": [
         "singleton/first/absent/64/0",
         "pair/first/late/64/7",
-        "range/all/dense/32768/0"
+        "range/all/dense/32768/0",
+        "alnum3/first/absent/32768/0",
+        "mixed4/all/sparse/32768/0"
       ],
       "standardTrials": [
         "singleton/first/absent/15/0",
@@ -83,7 +85,35 @@
         "pair/first/absent/32768/7",
         "pair/first/late/32768/7",
         "range/first/absent/32768/7",
-        "range/first/late/32768/7"
+        "range/first/late/32768/7",
+        "alnum3/first/absent/64/0",
+        "alnum3/first/absent/256/0",
+        "alnum3/first/absent/1024/0",
+        "alnum3/first/absent/32768/0",
+        "alnum3/first/absent/1048576/0",
+        "alnum3/first/late/32768/0",
+        "alnum3/first/sparse/32768/0",
+        "alnum3/first/dense/32768/0",
+        "alnum3/all/absent/32768/0",
+        "alnum3/all/late/32768/0",
+        "alnum3/all/sparse/32768/0",
+        "alnum3/all/dense/32768/0",
+        "alnum3/first/absent/32768/7",
+        "alnum3/first/late/32768/7",
+        "mixed4/first/absent/64/0",
+        "mixed4/first/absent/256/0",
+        "mixed4/first/absent/1024/0",
+        "mixed4/first/absent/32768/0",
+        "mixed4/first/absent/1048576/0",
+        "mixed4/first/late/32768/0",
+        "mixed4/first/sparse/32768/0",
+        "mixed4/first/dense/32768/0",
+        "mixed4/all/absent/32768/0",
+        "mixed4/all/late/32768/0",
+        "mixed4/all/sparse/32768/0",
+        "mixed4/all/dense/32768/0",
+        "mixed4/first/absent/32768/7",
+        "mixed4/first/late/32768/7"
       ]
     }
   },
@@ -399,6 +429,56 @@
       "recipe": {
         "kind": "repeatToLength",
         "unit": "bxy5",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "vectorScan.multi.absent.{length}",
+      "axes": {
+        "length": [
+          64,
+          256,
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "~",
+        "length": "{length}"
+      },
+      "shared": true
+    },
+    {
+      "id": "vectorScan.multi.late.32768",
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "~",
+        "suffix": "!#5Aa",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "vectorScan.multi.sparse.32768",
+      "recipe": {
+        "kind": "sparseMatchToLength",
+        "match": "!#5Aa",
+        "nonMatch": "~",
+        "nonMatchRepeats": 127,
+        "delimiterAlphabet": "~",
+        "seed": 20260801,
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "vectorScan.multi.dense.32768",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "~!#5Aa",
         "length": 32768
       },
       "shared": true

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(337);
+    assertThat(first).hasSize(345);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");

--- a/safere-vector-benchmarks/README.md
+++ b/safere-vector-benchmarks/README.md
@@ -15,12 +15,12 @@ Use `--long` for confirmation runs and `--trials` to select comma-separated tria
 `safere-benchmarks/benchmark-data.json`. The runner passes `--add-modules=jdk.incubator.vector` to
 both the host JVM and JMH forks. All inputs and trial lists come from the shared benchmark data.
 Use `--methods` with a pipe-separated list to select benchmark implementations, for example
-`--methods 'swar|vectorCursor'`.
-Use `--end-to-end` to run complete `Pattern.find(Utf8Input)` comparisons in separate SWAR and
-Vector JVMs. Use `--provider swar` or `--provider vector` to run only one side. The latter exercises
-the production multi-release JAR selection path and immutable startup selection. End-to-end runs
-use pair and range trials; singleton regexes are compiled to the literal scanner and therefore do
-not exercise the character-class provider.
+`--methods 'swar|vectorBounds|vectorCursor'`.
+Use `--end-to-end` to run complete `Pattern.find(Utf8Input)` and repeated `Utf8Matcher.find()`
+comparisons in separate SWAR and Vector JVMs. Use `--provider swar` or `--provider vector` to run
+only one side. The latter exercises the production multi-release JAR selection path and immutable
+startup selection. End-to-end runs exclude singleton regexes because they are compiled to the
+literal scanner and therefore do not exercise the character-class provider.
 
 The Vector implementation, activation property, supported scans, and tuning thresholds are
 experimental and may change incompatibly or be removed in any SafeRE release.
@@ -31,12 +31,14 @@ independently of the production multi-release selection mechanism.
 
 The `vectorCursor` benchmark drains all matching lanes from each vector mask before advancing. It
 models a scan-all cursor that retains rather than discards the remaining matches in a loaded vector.
+The `vectorBounds` benchmark broadcasts every range bound before entering the input loop and then
+compares loaded input vectors with those retained bound vectors.
 The `safeRe` benchmark runs the corresponding complete UTF-8 `Pattern.find` operation for first-hit
 trials and a reset `Utf8Matcher.find` loop for scan-all trials.
 
 The trial ID format is `shape/traversal/density/length/offset`, where:
 
-- `shape` is `singleton`, `pair`, or `range`;
+- `shape` is `singleton`, `pair`, `range`, `alnum3`, or `mixed4`;
 - `traversal` is `first` or `all`;
 - `density` is `absent`, `late`, `sparse`, or `dense`;
 - `length` is the logical UTF-8 byte length; and

--- a/safere-vector-benchmarks/src/main/java/org/safere/Utf8ScannerBenchmarkAccess.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/Utf8ScannerBenchmarkAccess.java
@@ -16,6 +16,19 @@ public final class Utf8ScannerBenchmarkAccess {
 
   /** Returns the first byte position in the supplied code-point ranges. */
   public int indexOfCodePointClass(int[] ranges, int start) {
-    return scanner.indexOfCodePointClass(ranges, 0, 0, start);
+    return scanner.indexOfCodePointClass(
+        ranges, asciiBitmap(ranges, 0, 63), asciiBitmap(ranges, 64, 127), start);
+  }
+
+  private static long asciiBitmap(int[] ranges, int first, int last) {
+    long bitmap = 0;
+    for (int index = 0; index < ranges.length; index += 2) {
+      int low = Math.max(first, ranges[index]);
+      int high = Math.min(last, ranges[index + 1]);
+      for (int value = low; value <= high; value++) {
+        bitmap |= 1L << (value - first);
+      }
+    }
+    return bitmap;
   }
 }

--- a/safere-vector-benchmarks/src/main/java/org/safere/Utf8ScannerBenchmarkAccess.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/Utf8ScannerBenchmarkAccess.java
@@ -8,16 +8,21 @@ package org.safere;
 /** Benchmark-only access to the current UTF-8 scanner implementation. */
 public final class Utf8ScannerBenchmarkAccess {
   private final Utf8InputScanner scanner;
+  private final int[] ranges;
+  private final long bitmap0;
+  private final long bitmap1;
 
-  /** Creates a scanner over the requested borrowed-array window. */
-  public Utf8ScannerBenchmarkAccess(byte[] bytes, int offset, int length) {
+  /** Creates a scanner over the requested borrowed-array window and code-point ranges. */
+  public Utf8ScannerBenchmarkAccess(byte[] bytes, int offset, int length, int[] ranges) {
     scanner = new Utf8InputScanner(bytes, offset, length);
+    this.ranges = ranges;
+    bitmap0 = asciiBitmap(ranges, 0, 63);
+    bitmap1 = asciiBitmap(ranges, 64, 127);
   }
 
-  /** Returns the first byte position in the supplied code-point ranges. */
-  public int indexOfCodePointClass(int[] ranges, int start) {
-    return scanner.indexOfCodePointClass(
-        ranges, asciiBitmap(ranges, 0, 63), asciiBitmap(ranges, 64, 127), start);
+  /** Returns the first byte position in the configured code-point ranges. */
+  public int indexOfCodePointClass(int start) {
+    return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, start);
   }
 
   private static long asciiBitmap(int[] ranges, int first, int last) {

--- a/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorEndToEndProviderBenchmark.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorEndToEndProviderBenchmark.java
@@ -20,6 +20,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.safere.Pattern;
 import org.safere.Utf8Input;
+import org.safere.Utf8Matcher;
 
 /** Measures complete UTF-8 find operations with the provider selected at JVM startup. */
 @BenchmarkMode(Mode.AverageTime)
@@ -36,15 +37,22 @@ public class Utf8VectorEndToEndProviderBenchmark {
 
   private Pattern pattern;
   private Utf8Input input;
+  private Utf8Matcher matcher;
+  private boolean scanAll;
+  private int expected;
 
   /** Materializes input and verifies the selected provider and complete result. */
   @Setup(Level.Trial)
   public void setup() {
     String[] fields = vectorScanTrial.split("/", -1);
-    if (fields.length != 5 || !fields[1].equals("first")) {
-      throw new IllegalArgumentException(
-          "Expected first-hit Vector scan trial: " + vectorScanTrial);
+    if (fields.length != 5) {
+      throw new IllegalArgumentException("Malformed Vector scan trial: " + vectorScanTrial);
     }
+    scanAll = fields[1].equals("all");
+    if (!scanAll && !fields[1].equals("first")) {
+      throw new IllegalArgumentException("Unknown traversal: " + fields[1]);
+    }
+    String inputProfile = "";
     String regex =
         switch (fields[0].toLowerCase(Locale.ROOT)) {
           case "singleton" ->
@@ -52,6 +60,14 @@ public class Utf8VectorEndToEndProviderBenchmark {
                   "Singleton patterns use literal scanning, not the character-class provider");
           case "pair" -> "[xy]";
           case "range" -> "[0-9]";
+          case "alnum3" -> {
+            inputProfile = "multi.";
+            yield "[0-9A-Za-z]";
+          }
+          case "mixed4" -> {
+            inputProfile = "multi.";
+            yield "[!#0-9A-Z]";
+          }
           default -> throw new IllegalArgumentException("Unknown shape: " + fields[0]);
         };
     int length = Integer.parseInt(fields[3]);
@@ -62,22 +78,65 @@ public class Utf8VectorEndToEndProviderBenchmark {
       throw new IllegalStateException(
           "Expected provider " + scanProvider + " but JVM selected " + configuredProvider);
     }
-    byte[] source = VectorScanConfiguration.input(fields[2], length);
+    byte[] source = VectorScanConfiguration.input(inputProfile, fields[2], length);
     byte[] storage = new byte[offset + source.length + ByteVector.SPECIES_PREFERRED.length()];
     Arrays.fill(storage, (byte) 0x7f);
     System.arraycopy(source, 0, storage, offset, source.length);
 
     pattern = Pattern.compile(regex);
     input = Utf8Input.trusted(storage, offset, length);
-    boolean expected = !fields[2].equals("absent");
-    if (pattern.find(input) != expected) {
+    matcher = pattern.matcher(input);
+    expected = expectedResult(fields[0], source);
+    if (runSafeRe() != expected) {
       throw new AssertionError("Unexpected result for " + vectorScanTrial);
     }
   }
 
   /** Runs the complete direct UTF-8 find operation. */
   @Benchmark
-  public boolean safeReFind() {
-    return pattern.find(input);
+  public int safeReFind() {
+    return runSafeRe();
+  }
+
+  private int runSafeRe() {
+    if (!scanAll) {
+      return pattern.find(input) ? 1 : 0;
+    }
+    matcher.reset();
+    int checksum = 0;
+    while (matcher.find()) {
+      checksum += matcher.start();
+    }
+    return checksum;
+  }
+
+  private int expectedResult(String shape, byte[] source) {
+    int checksum = 0;
+    for (int position = 0; position < source.length; position++) {
+      if (matches(shape, source[position])) {
+        if (!scanAll) {
+          return 1;
+        }
+        checksum += position;
+      }
+    }
+    return checksum;
+  }
+
+  private static boolean matches(String shape, byte value) {
+    return switch (shape) {
+      case "pair" -> value == 'x' || value == 'y';
+      case "range" -> value >= '0' && value <= '9';
+      case "alnum3" ->
+          (value >= '0' && value <= '9')
+              || (value >= 'A' && value <= 'Z')
+              || (value >= 'a' && value <= 'z');
+      case "mixed4" ->
+          value == '!'
+              || value == '#'
+              || (value >= '0' && value <= '9')
+              || (value >= 'A' && value <= 'Z');
+      default -> throw new IllegalArgumentException("Unknown shape: " + shape);
+    };
   }
 }

--- a/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorScanBenchmark.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorScanBenchmark.java
@@ -37,6 +37,8 @@ public class Utf8VectorScanBenchmark {
   private static final int[] SINGLETON_RANGES = {'x', 'x'};
   private static final int[] PAIR_RANGES = {'x', 'x', 'y', 'y'};
   private static final int[] RANGE_RANGES = {'0', '9'};
+  private static final int[] ALNUM3_RANGES = {'0', '9', 'A', 'Z', 'a', 'z'};
+  private static final int[] MIXED4_RANGES = {'!', '!', '#', '#', '0', '9', 'A', 'Z'};
 
   /** Data-declared trial in shape/traversal/density/length/offset form. */
   @Param({})
@@ -50,6 +52,8 @@ public class Utf8VectorScanBenchmark {
   private Utf8ScannerBenchmarkAccess swarScanner;
   private ScanProvider swarProvider;
   private ScanProvider vectorProvider;
+  private ByteVector[] lowerBounds;
+  private ByteVector[] upperBounds;
   private Pattern safeRePattern;
   private Utf8Input safeReInput;
   private Utf8Matcher safeReMatcher;
@@ -75,13 +79,20 @@ public class Utf8VectorScanBenchmark {
         };
     length = Integer.parseInt(fields[3]);
     offset = Integer.parseInt(fields[4]);
-    byte[] input = VectorScanConfiguration.input(fields[2], length);
+    byte[] input = VectorScanConfiguration.input(shape.inputProfile, fields[2], length);
     storage = new byte[offset + input.length + SPECIES.length()];
     Arrays.fill(storage, (byte) 0x7f);
     System.arraycopy(input, 0, storage, offset, input.length);
     swarScanner = new Utf8ScannerBenchmarkAccess(storage, offset, length);
     swarProvider = new SwarProvider();
     vectorProvider = new VectorProvider();
+    int rangeCount = shape.ranges.length / 2;
+    lowerBounds = new ByteVector[rangeCount];
+    upperBounds = new ByteVector[rangeCount];
+    for (int range = 0; range < rangeCount; range++) {
+      lowerBounds[range] = ByteVector.broadcast(SPECIES, (byte) shape.ranges[range * 2]);
+      upperBounds[range] = ByteVector.broadcast(SPECIES, (byte) shape.ranges[range * 2 + 1]);
+    }
     safeRePattern = Pattern.compile(shape.pattern);
     safeReInput = Utf8Input.trusted(storage, offset, length);
     safeReMatcher = safeRePattern.matcher(safeReInput);
@@ -89,10 +100,12 @@ public class Utf8VectorScanBenchmark {
     int swarProviderResult = runSwarProvider();
     int vectorResult = runVector();
     int vectorProviderResult = runVectorProvider();
+    int vectorBoundsResult = runVectorBounds();
     int vectorCursorResult = runVectorCursor();
     if (swarResult != swarProviderResult
         || swarResult != vectorResult
         || swarResult != vectorProviderResult
+        || swarResult != vectorBoundsResult
         || swarResult != vectorCursorResult) {
       throw new AssertionError(
           "Scanner disagreement for "
@@ -105,6 +118,8 @@ public class Utf8VectorScanBenchmark {
               + vectorResult
               + ", Vector provider="
               + vectorProviderResult
+              + ", Vector bounds="
+              + vectorBoundsResult
               + ", Vector cursor="
               + vectorCursorResult);
     }
@@ -143,6 +158,12 @@ public class Utf8VectorScanBenchmark {
   @Benchmark
   public int vectorProvider() {
     return runVectorProvider();
+  }
+
+  /** Runs ByteVector with range bounds broadcast once outside the input loop. */
+  @Benchmark
+  public int vectorBounds() {
+    return runVectorBounds();
   }
 
   /** Runs a ByteVector implementation that retains and drains each complete match mask. */
@@ -237,6 +258,23 @@ public class Utf8VectorScanBenchmark {
     return checksum;
   }
 
+  private int runVectorBounds() {
+    if (!scanAll) {
+      return indexOfVectorBounds(0);
+    }
+    int checksum = 0;
+    int start = 0;
+    while (start < length) {
+      int found = indexOfVectorBounds(start);
+      if (found < 0) {
+        break;
+      }
+      checksum += found;
+      start = found + 1;
+    }
+    return checksum;
+  }
+
   private int runVectorCursor() {
     if (!scanAll) {
       return indexOfVector(0);
@@ -271,6 +309,30 @@ public class Utf8VectorScanBenchmark {
     for (; position < limit; position += SPECIES.length()) {
       ByteVector values = ByteVector.fromArray(SPECIES, storage, offset + position);
       VectorMask<Byte> matches = shape.matches(values);
+      if (matches.anyTrue()) {
+        return position + matches.firstTrue();
+      }
+    }
+    for (; position < length; position++) {
+      if (shape.matches(storage[offset + position])) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
+  private int indexOfVectorBounds(int start) {
+    int position = Math.max(0, start);
+    int limit = position + SPECIES.loopBound(length - position);
+    for (; position < limit; position += SPECIES.length()) {
+      ByteVector values = ByteVector.fromArray(SPECIES, storage, offset + position);
+      VectorMask<Byte> matches =
+          values.compare(GE, lowerBounds[0]).and(values.compare(LE, upperBounds[0]));
+      for (int range = 1; range < lowerBounds.length; range++) {
+        matches =
+            matches.or(
+                values.compare(GE, lowerBounds[range]).and(values.compare(LE, upperBounds[range])));
+      }
       if (matches.anyTrue()) {
         return position + matches.firstTrue();
       }
@@ -334,14 +396,55 @@ public class Utf8VectorScanBenchmark {
       boolean matches(byte value) {
         return value >= '0' && value <= '9';
       }
+    },
+    ALNUM3(ALNUM3_RANGES, "[0-9A-Za-z]", "multi.") {
+      @Override
+      VectorMask<Byte> matches(ByteVector values) {
+        VectorMask<Byte> digits =
+            values.compare(GE, (byte) '0').and(values.compare(LE, (byte) '9'));
+        VectorMask<Byte> upper = values.compare(GE, (byte) 'A').and(values.compare(LE, (byte) 'Z'));
+        VectorMask<Byte> lower = values.compare(GE, (byte) 'a').and(values.compare(LE, (byte) 'z'));
+        return digits.or(upper).or(lower);
+      }
+
+      @Override
+      boolean matches(byte value) {
+        return (value >= '0' && value <= '9')
+            || (value >= 'A' && value <= 'Z')
+            || (value >= 'a' && value <= 'z');
+      }
+    },
+    MIXED4(MIXED4_RANGES, "[!#0-9A-Z]", "multi.") {
+      @Override
+      VectorMask<Byte> matches(ByteVector values) {
+        VectorMask<Byte> singletons = values.eq((byte) '!').or(values.eq((byte) '#'));
+        VectorMask<Byte> digits =
+            values.compare(GE, (byte) '0').and(values.compare(LE, (byte) '9'));
+        VectorMask<Byte> upper = values.compare(GE, (byte) 'A').and(values.compare(LE, (byte) 'Z'));
+        return singletons.or(digits).or(upper);
+      }
+
+      @Override
+      boolean matches(byte value) {
+        return value == '!'
+            || value == '#'
+            || (value >= '0' && value <= '9')
+            || (value >= 'A' && value <= 'Z');
+      }
     };
 
     private final int[] ranges;
     private final String pattern;
+    private final String inputProfile;
 
     Shape(int[] ranges, String pattern) {
+      this(ranges, pattern, "");
+    }
+
+    Shape(int[] ranges, String pattern, String inputProfile) {
       this.ranges = ranges;
       this.pattern = pattern;
+      this.inputProfile = inputProfile;
     }
 
     abstract VectorMask<Byte> matches(ByteVector values);

--- a/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorScanBenchmark.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorScanBenchmark.java
@@ -83,7 +83,7 @@ public class Utf8VectorScanBenchmark {
     storage = new byte[offset + input.length + SPECIES.length()];
     Arrays.fill(storage, (byte) 0x7f);
     System.arraycopy(input, 0, storage, offset, input.length);
-    swarScanner = new Utf8ScannerBenchmarkAccess(storage, offset, length);
+    swarScanner = new Utf8ScannerBenchmarkAccess(storage, offset, length, shape.ranges);
     swarProvider = new SwarProvider();
     vectorProvider = new VectorProvider();
     int rangeCount = shape.ranges.length / 2;
@@ -192,12 +192,12 @@ public class Utf8VectorScanBenchmark {
 
   private int runSwar() {
     if (!scanAll) {
-      return swarScanner.indexOfCodePointClass(shape.ranges, 0);
+      return swarScanner.indexOfCodePointClass(0);
     }
     int checksum = 0;
     int start = 0;
     while (start < length) {
-      int found = swarScanner.indexOfCodePointClass(shape.ranges, start);
+      int found = swarScanner.indexOfCodePointClass(start);
       if (found < 0) {
         break;
       }
@@ -352,7 +352,7 @@ public class Utf8VectorScanBenchmark {
   private final class SwarProvider implements ScanProvider {
     @Override
     public int indexOf(int start) {
-      return swarScanner.indexOfCodePointClass(shape.ranges, start);
+      return swarScanner.indexOfCodePointClass(start);
     }
   }
 

--- a/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/VectorScanConfiguration.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/VectorScanConfiguration.java
@@ -36,9 +36,9 @@ final class VectorScanConfiguration {
     return List.copyOf(result);
   }
 
-  static byte[] input(String density, int length) {
+  static byte[] input(String profile, String density, int length) {
     JsonObject manifest = manifest();
-    String inputId = "vectorScan." + density + "." + length;
+    String inputId = "vectorScan." + profile + density + "." + length;
     String file =
         manifest.getAsJsonObject("inputs").getAsJsonObject(inputId).get("file").getAsString();
     try {

--- a/safere/src/main/java-jdk26/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java-jdk26/org/safere/IncubatorVectorScanProvider.java
@@ -15,7 +15,6 @@ import jdk.incubator.vector.VectorSpecies;
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
   private static final int MINIMUM_INPUT_LENGTH = 1024;
-  private static final int SCALAR_PROLOGUE_LENGTH = Integer.BYTES;
   private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
 
   @Override
@@ -25,13 +24,10 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
 
   @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
-    int position = Math.max(0, start);
-    int scalarLimit = Math.min(length, position + SCALAR_PROLOGUE_LENGTH);
-    for (; position < scalarLimit; position++) {
-      if (matches(bytes[offset + position], ranges)) {
-        return position;
-      }
+    if (ranges.length < 2 || ranges.length > 8 || (ranges.length & 1) != 0) {
+      return UNSUPPORTED;
     }
+    int position = Math.max(0, start);
     int limit = position + SPECIES.loopBound(length - position);
     for (; position < limit; position += SPECIES.length()) {
       ByteVector values = ByteVector.fromArray(SPECIES, bytes, offset + position);
@@ -49,11 +45,22 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   }
 
   private static VectorMask<Byte> matches(ByteVector values, int[] ranges) {
-    if (ranges.length == 4) {
-      return values.eq((byte) ranges[0]).or(values.eq((byte) ranges[2]));
+    VectorMask<Byte> matches = matches(values, ranges[0], ranges[1]);
+    if (ranges.length >= 4) {
+      matches = matches.or(matches(values, ranges[2], ranges[3]));
     }
-    byte low = (byte) ranges[0];
-    byte high = (byte) ranges[1];
+    if (ranges.length >= 6) {
+      matches = matches.or(matches(values, ranges[4], ranges[5]));
+    }
+    if (ranges.length == 8) {
+      matches = matches.or(matches(values, ranges[6], ranges[7]));
+    }
+    return matches;
+  }
+
+  private static VectorMask<Byte> matches(ByteVector values, int lowBound, int highBound) {
+    byte low = (byte) lowBound;
+    byte high = (byte) highBound;
     if (low == high) {
       return values.eq(low);
     }
@@ -64,9 +71,11 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   }
 
   private static boolean matches(byte value, int[] ranges) {
-    if (ranges.length == 4) {
-      return value == (byte) ranges[0] || value == (byte) ranges[2];
+    for (int index = 0; index < ranges.length; index += 2) {
+      if (value >= (byte) ranges[index] && value <= (byte) ranges[index + 1]) {
+        return true;
+      }
     }
-    return value >= (byte) ranges[0] && value <= (byte) ranges[1];
+    return false;
   }
 }

--- a/safere/src/main/java-jdk26/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java-jdk26/org/safere/IncubatorVectorScanProvider.java
@@ -5,8 +5,7 @@
 
 package org.safere;
 
-import static jdk.incubator.vector.VectorOperators.GE;
-import static jdk.incubator.vector.VectorOperators.LE;
+import static jdk.incubator.vector.VectorOperators.ULE;
 
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorMask;
@@ -67,7 +66,9 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
     if (high == low + 1) {
       return values.eq(low).or(values.eq(high));
     }
-    return values.compare(GE, low).and(values.compare(LE, high));
+    ByteVector lowVector = ByteVector.broadcast(SPECIES, low);
+    ByteVector rangeVector = ByteVector.broadcast(SPECIES, (byte) (high - low));
+    return values.sub(lowVector).compare(ULE, rangeVector);
   }
 
   private static boolean matches(byte value, int[] ranges) {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -16,6 +16,7 @@ final class Utf8InputScanner implements InputScanner {
   private static final long BYTE_ONES = 0x0101_0101_0101_0101L;
   private static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
   private static final int BOYER_MOORE_HORSPOOL_BATCH_SIZE = 2;
+  private static final int VECTOR_SCALAR_PROLOGUE_LENGTH = Integer.BYTES;
 
   /**
    * Input sizes at which the SWAR candidate filter overtakes the skip loop. The filter always
@@ -92,7 +93,7 @@ final class Utf8InputScanner implements InputScanner {
   public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
     int position = Math.max(0, start);
     if (!WorkCounterConfig.ENABLED) {
-      int asciiResult = indexOfAsciiRanges(ranges, position);
+      int asciiResult = indexOfAsciiRanges(ranges, bitmap0, bitmap1, position);
       if (asciiResult >= -1) {
         return asciiResult;
       }
@@ -126,11 +127,23 @@ final class Utf8InputScanner implements InputScanner {
    * @return the match position, {@code -1} when the class is absent, or {@code -2} when the class
    *     requires the general code-point scan
    */
-  private int indexOfAsciiRanges(int[] ranges, int start) {
-    if (ranges.length == 2 && ranges[0] >= 0 && ranges[1] < 0x80) {
+  private int indexOfAsciiRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
+    if (ranges.length >= 2 && ranges[0] >= 0 && ranges[ranges.length - 1] < 0x80) {
       if (scanProvider != null && length - start >= scanProvider.minimumInputLength()) {
-        return scanProvider.indexOfAsciiClass(bytes, offset, length, ranges, start);
+        int position = start;
+        int scalarLimit = Math.min(length, position + VECTOR_SCALAR_PROLOGUE_LENGTH);
+        for (; position < scalarLimit; position++) {
+          if (InputScanner.classContains(ranges, bitmap0, bitmap1, unsignedByteAt(position))) {
+            return position;
+          }
+        }
+        int result = scanProvider.indexOfAsciiClass(bytes, offset, length, ranges, position);
+        if (result != VectorScanProvider.UNSUPPORTED) {
+          return result;
+        }
       }
+    }
+    if (ranges.length == 2 && ranges[0] >= 0 && ranges[1] < 0x80) {
       int low = ranges[0];
       int high = ranges[1];
       if (low == high) {
@@ -146,9 +159,6 @@ final class Utf8InputScanner implements InputScanner {
         && ranges[2] == ranges[3]
         && ranges[0] >= 0
         && ranges[3] < 0x80) {
-      if (scanProvider != null && length - start >= scanProvider.minimumInputLength()) {
-        return scanProvider.indexOfAsciiClass(bytes, offset, length, ranges, start);
-      }
       return indexOfBytePair((byte) ranges[0], (byte) ranges[2], start);
     }
     return -2;

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -7,7 +7,10 @@ package org.safere;
 
 /** Internal provider for experimental Vector API scan operations. */
 interface VectorScanProvider {
+  int UNSUPPORTED = -2;
+
   int minimumInputLength();
 
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 }

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -145,6 +145,38 @@ class Utf8InputScannerTest {
   }
 
   @Test
+  void asciiCodePointClassSearchCoversMultiRangeProviderAndDeclinePaths() {
+    List<int[]> classes =
+        List.of(
+            new int[] {'0', '9', 'A', 'Z'},
+            new int[] {'0', '9', 'A', 'Z', 'a', 'z'},
+            new int[] {'!', '!', '#', '#', '0', '9', 'A', 'Z'},
+            new int[] {'!', '!', '#', '#', '0', '9', 'A', 'Z', 'a', 'z'});
+    int length = 2048;
+    int[] positions = {0, 1, 3, 4, 15, 16, 17, 1023, 1024, 2031, 2047};
+
+    for (int[] ranges : classes) {
+      long bitmap0 = asciiBitmap(ranges, 0, 63);
+      long bitmap1 = asciiBitmap(ranges, 64, 127);
+      for (int offset = 0; offset < Long.BYTES * 2; offset++) {
+        for (int expected : positions) {
+          byte[] storage = new byte[offset + length + Long.BYTES];
+          Arrays.fill(storage, (byte) '~');
+          storage[offset + expected] = (byte) ranges[ranges.length - 1];
+          Utf8InputScanner scanner = new Utf8InputScanner(storage, offset, length);
+
+          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, 0))
+              .as("ranges %s, offset %s, position %s", Arrays.toString(ranges), offset, expected)
+              .isEqualTo(expected);
+          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, expected + 1))
+              .as("absent tail for ranges %s, offset %s", Arrays.toString(ranges), offset)
+              .isEqualTo(-1);
+        }
+      }
+    }
+  }
+
+  @Test
   void asciiCodePointClassSearchHonorsStartsAndSkipsNonAsciiScalars() {
     byte[] bytes = "5é😀a7".getBytes(UTF_8);
     int[] digits = {'0', '9'};


### PR DESCRIPTION
## Summary

- offer all normalized ASCII character classes to the experimental Vector provider and let the
  provider decline unsupported shapes cheaply
- support one through four ASCII ranges with direct Vector comparisons while retaining a bounded
  bitmap scalar prologue for dense matches
- extend the Vector benchmark corpus and harness with three-range alphanumeric, mixed four-range,
  retained-bound, and repeated scan-all coverage
- add alignment, tail, and unsupported five-range fallback tests

Refs #660

## AArch64 benchmark results

JDK 26.0.1 on AArch64. Times are nanoseconds per operation; lower is better.

Long end-to-end first-hit confirmation:

| Trial | SWAR | Vector | Improvement |
| --- | ---: | ---: | ---: |
| `[0-9A-Za-z]`, absent, 32 KiB | 9,263.056 | 1,551.326 | 5.97x |
| `[0-9A-Za-z]`, late, 32 KiB, offset 7 | 9,884.072 | 1,557.448 | 6.35x |
| `[!#0-9A-Z]`, absent, 32 KiB | 9,103.980 | 1,554.491 | 5.86x |
| `[!#0-9A-Z]`, late, 32 KiB, offset 7 | 10,144.201 | 1,570.777 | 6.46x |

Standard end-to-end repeated scan-all measurements:

| Trial | SWAR | Vector | Improvement |
| --- | ---: | ---: | ---: |
| `[0-9A-Za-z]`, sparse, 32 KiB | 38,548.046 | 16,601.162 | 2.32x |
| `[0-9A-Za-z]`, dense, 32 KiB | 622,112.729 | 530,954.750 | 1.17x |
| `[!#0-9A-Z]`, sparse, 32 KiB | 45,281.047 | 21,474.850 | 2.11x |
| `[!#0-9A-Z]`, dense, 32 KiB | 736,524.573 | 647,962.667 | 1.14x |

The benchmark-only retained bound-vector layout was slower than direct scalar-bound comparisons on
this platform, so the production implementation uses direct comparisons.

## Verification

Completed:

- `mvn -pl safere test -q`
- `mvn -pl safere test -Pvector-tests -q`
- `mvn -pl safere-benchmarks test -q`
- `mvn package -DskipTests -Dpmd.skip=true -Dspotless.check.skip=true -q -f safere-vector-benchmarks/pom.xml`
- `mvn spotless:check -pl safere -q`
- `mvn spotless:check -f safere-vector-benchmarks/pom.xml -q`
- `git diff --check`
- `./run-vector-benchmarks.sh --long --fastbuild --end-to-end` for the four first-hit trials above
- standard end-to-end Vector benchmarks for the four repeated scan-all trials above
- Codex branch review against `main`; no P0-P2 findings

Not run:

- x86-64 Vector benchmarks; confirm that the new three- and four-range implementations are
  profitable on that architecture
- full native/external benchmark collection, which is outside this experimental Vector-only change
- public API crosscheck suite
