### PR TITLE
Add UTF-8 keyword-alternation fast path

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.PatternSyntaxException;
 import org.safere.Pattern;
@@ -25,6 +26,7 @@ final class Utf8InputFuzzer {
   void arbitraryWindow(FuzzedDataProvider data) {
     assertLiteralSearchMatchesString("XXXXXX", "..XXXXXX");
     assertBoundarySensitiveRegionCaptures();
+    assertKeywordAlternationMatchesString(data);
     String repeatedLiteral =
         String.valueOf((char) data.consumeInt('A', 'Z')).repeat(data.consumeInt(2, 32));
     String suffix = new String(data.consumeBytes(data.consumeInt(0, 64)), StandardCharsets.UTF_8);
@@ -114,6 +116,38 @@ final class Utf8InputFuzzer {
             || utf8Matcher.end() > bytes.length)) {
       throw new AssertionError("UTF-8 literal search bounds differ from String search");
     }
+  }
+
+  private static void assertKeywordAlternationMatchesString(FuzzedDataProvider data) {
+    String keyword = data.pickValue(List.of("you", "your", "error", "timeout"));
+    String prefix = data.pickValue(List.of("", "plain ", "é ", "β-", "word_"));
+    String suffix = data.pickValue(List.of("", "!", " 中", "2", "_word"));
+    boolean greedy = data.consumeBoolean();
+    String regex =
+        greedy ? "(?is).*\\b(you|your|error|timeout)\\b.*" : "(?i)\\b(you|your|error|timeout)\\b";
+    String input =
+        prefix + data.pickValue(List.of(keyword, keyword.toUpperCase(Locale.ROOT))) + suffix;
+    Pattern pattern = Pattern.compile(regex);
+    org.safere.Matcher stringMatcher = pattern.matcher(input);
+    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+    Utf8Input utf8Input = Utf8Input.validated(bytes);
+    Utf8Matcher utf8Matcher = pattern.matcher(utf8Input);
+
+    boolean stringFound = stringMatcher.find();
+    if (utf8Matcher.find() != stringFound || pattern.find(utf8Input) != stringFound) {
+      throw new AssertionError("UTF-8 keyword alternation result differs from String search");
+    }
+    if (stringFound
+        && (utf8Matcher.start() != utf8Offset(input, stringMatcher.start())
+            || utf8Matcher.end() != utf8Offset(input, stringMatcher.end())
+            || utf8Matcher.start(1) != utf8Offset(input, stringMatcher.start(1))
+            || utf8Matcher.end(1) != utf8Offset(input, stringMatcher.end(1)))) {
+      throw new AssertionError("UTF-8 keyword alternation bounds differ from String search");
+    }
+  }
+
+  private static int utf8Offset(String input, int utf16Offset) {
+    return input.substring(0, utf16Offset).getBytes(StandardCharsets.UTF_8).length;
   }
 
   private static String decodeGroup(byte[] bytes, Utf8Matcher matcher) {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -123,8 +123,11 @@ final class Utf8InputFuzzer {
     String prefix = data.pickValue(List.of("", "plain ", "é ", "β-", "word_"));
     String suffix = data.pickValue(List.of("", "!", " 中", "2", "_word"));
     boolean greedy = data.consumeBoolean();
-    String regex =
-        greedy ? "(?is).*\\b(you|your|error|timeout)\\b.*" : "(?i)\\b(you|your|error|timeout)\\b";
+    String beforeBoundaryMode = data.pickValue(List.of("", "(?U)", "(?-U)"));
+    String afterBoundaryMode = data.pickValue(List.of("", "(?U)", "(?-U)"));
+    String core =
+        beforeBoundaryMode + "\\b(?i)(you|your|error|timeout)" + afterBoundaryMode + "\\b";
+    String regex = greedy ? "(?s).*" + core + ".*" : core;
     String input =
         prefix + data.pickValue(List.of(keyword, keyword.toUpperCase(Locale.ROOT))) + suffix;
     Pattern pattern = Pattern.compile(regex);

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1575,12 +1575,16 @@ public final class Matcher implements MatchResult {
     }
 
     Pattern.KeywordAlternation keywordAlternation = parentPattern.keywordAlternation();
-    if (options.keywordAlternationFastPath() && keywordAlternation != null) {
+    if (options.keywordAlternationFastPath()
+        && keywordAlternation != null
+        && (!regionActive || text == null)) {
       diagnosticBoundary(MatchStrategy.KEYWORD);
       if (keywordAlternation.captureGroup > 0) {
         diagnosticCapture(MatchStrategy.KEYWORD);
       }
-      return findKeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures());
+      return text != null
+          ? findKeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures())
+          : findUtf8KeywordAlternation(keywordAlternation, searchFrom, prog.numCaptures());
     }
 
     // Anchored start: if the pattern requires a match at the beginning of the text (e.g., ^
@@ -2169,7 +2173,7 @@ public final class Matcher implements MatchResult {
     return -1;
   }
 
-  private boolean findKeywordAlternation(
+  private boolean findUtf8KeywordAlternation(
       Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
     InputScanner scanner = activeScanner();
     int matchStart = Math.max(0, startPos);
@@ -2189,6 +2193,88 @@ public final class Matcher implements MatchResult {
       keywordGroups[2 * group + 1] = keywordEnd;
     }
     return applyFullMatchResult(keywordGroups);
+  }
+
+  private boolean findKeywordAlternation(
+      Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
+    if (keywordAlternation.greedyWholeInput) {
+      return findGreedyWholeInputKeywordAlternation(keywordAlternation, startPos, ncap);
+    }
+    for (int i = Math.max(0, startPos); i < text.length(); i++) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      char ch = text.charAt(i);
+      if (ch < 128
+          && keywordAlternation.firstAscii[asciiLower(ch)]
+          && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
+        for (String keyword : keywordAlternation.keywords) {
+          int end = i + keyword.length();
+          if (end <= text.length()
+              && regionMatchesAsciiIgnoreCase(text, i, keyword, 0, keyword.length())
+              && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
+            int[] keywordGroups = new int[2 * ncap];
+            Arrays.fill(keywordGroups, -1);
+            keywordGroups[0] = i;
+            keywordGroups[1] = end;
+            if (keywordAlternation.captureGroup > 0) {
+              int group = keywordAlternation.captureGroup;
+              keywordGroups[2 * group] = i;
+              keywordGroups[2 * group + 1] = end;
+            }
+            return applyFullMatchResult(keywordGroups);
+          }
+        }
+      }
+      int cp = text.codePointAt(i);
+      i += Character.charCount(cp) - 1;
+    }
+    return applyFailedMatchResult();
+  }
+
+  private boolean findGreedyWholeInputKeywordAlternation(
+      Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
+    int matchStart = Math.max(0, startPos);
+    for (int i = text.length() - 1; i >= matchStart; i--) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      char ch = text.charAt(i);
+      if (ch < 128
+          && keywordAlternation.firstAscii[asciiLower(ch)]
+          && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
+        for (String keyword : keywordAlternation.keywords) {
+          int end = i + keyword.length();
+          if (end <= text.length()
+              && regionMatchesAsciiIgnoreCase(text, i, keyword, 0, keyword.length())
+              && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
+            int[] keywordGroups = new int[2 * ncap];
+            Arrays.fill(keywordGroups, -1);
+            keywordGroups[0] = matchStart;
+            keywordGroups[1] = text.length();
+            if (keywordAlternation.captureGroup > 0) {
+              int group = keywordAlternation.captureGroup;
+              keywordGroups[2 * group] = i;
+              keywordGroups[2 * group + 1] = end;
+            }
+            return applyFullMatchResult(keywordGroups);
+          }
+        }
+      }
+    }
+    return applyFailedMatchResult();
+  }
+
+  private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {
+    boolean prevWord =
+        pos > 0 && isBoundaryWordChar(text.codePointBefore(pos), unicodeWordBoundary);
+    boolean nextWord =
+        pos < text.length() && isBoundaryWordChar(text.codePointAt(pos), unicodeWordBoundary);
+    return prevWord != nextWord;
+  }
+
+  private static boolean isBoundaryWordChar(int cp, boolean unicodeWordBoundary) {
+    return unicodeWordBoundary ? Nfa.isUnicodeWordChar(cp) : Nfa.isWordChar(cp);
   }
 
   private static int asciiLower(int ch) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1575,10 +1575,7 @@ public final class Matcher implements MatchResult {
     }
 
     Pattern.KeywordAlternation keywordAlternation = parentPattern.keywordAlternation();
-    if (options.keywordAlternationFastPath()
-        && !regionActive
-        && keywordAlternation != null
-        && text != null) {
+    if (options.keywordAlternationFastPath() && keywordAlternation != null) {
       diagnosticBoundary(MatchStrategy.KEYWORD);
       if (keywordAlternation.captureGroup > 0) {
         diagnosticCapture(MatchStrategy.KEYWORD);
@@ -2174,84 +2171,24 @@ public final class Matcher implements MatchResult {
 
   private boolean findKeywordAlternation(
       Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
-    if (keywordAlternation.greedyWholeInput) {
-      return findGreedyWholeInputKeywordAlternation(keywordAlternation, startPos, ncap);
-    }
-    for (int i = Math.max(0, startPos); i < text.length(); i++) {
-      if (WorkCounterConfig.ENABLED) {
-        WorkCounter.record();
-      }
-      char ch = text.charAt(i);
-      if (ch < 128
-          && keywordAlternation.firstAscii[asciiLower(ch)]
-          && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
-        for (String keyword : keywordAlternation.keywords) {
-          int end = i + keyword.length();
-          if (end <= text.length()
-              && regionMatchesAsciiIgnoreCase(text, i, keyword, 0, keyword.length())
-              && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
-            int[] keywordGroups = new int[2 * ncap];
-            Arrays.fill(keywordGroups, -1);
-            keywordGroups[0] = i;
-            keywordGroups[1] = end;
-            if (keywordAlternation.captureGroup > 0) {
-              int group = keywordAlternation.captureGroup;
-              keywordGroups[2 * group] = i;
-              keywordGroups[2 * group + 1] = end;
-            }
-            return applyFullMatchResult(keywordGroups);
-          }
-        }
-      }
-      int cp = text.codePointAt(i);
-      i += Character.charCount(cp) - 1;
-    }
-    return applyFailedMatchResult();
-  }
-
-  private boolean findGreedyWholeInputKeywordAlternation(
-      Pattern.KeywordAlternation keywordAlternation, int startPos, int ncap) {
+    InputScanner scanner = activeScanner();
     int matchStart = Math.max(0, startPos);
-    for (int i = text.length() - 1; i >= matchStart; i--) {
-      if (WorkCounterConfig.ENABLED) {
-        WorkCounter.record();
-      }
-      char ch = text.charAt(i);
-      if (ch < 128
-          && keywordAlternation.firstAscii[asciiLower(ch)]
-          && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
-        for (String keyword : keywordAlternation.keywords) {
-          int end = i + keyword.length();
-          if (end <= text.length()
-              && regionMatchesAsciiIgnoreCase(text, i, keyword, 0, keyword.length())
-              && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
-            int[] keywordGroups = new int[2 * ncap];
-            Arrays.fill(keywordGroups, -1);
-            keywordGroups[0] = matchStart;
-            keywordGroups[1] = text.length();
-            if (keywordAlternation.captureGroup > 0) {
-              int group = keywordAlternation.captureGroup;
-              keywordGroups[2 * group] = i;
-              keywordGroups[2 * group + 1] = end;
-            }
-            return applyFullMatchResult(keywordGroups);
-          }
-        }
-      }
+    long match = keywordAlternation.find(scanner, matchStart);
+    if (match < 0) {
+      return applyFailedMatchResult();
     }
-    return applyFailedMatchResult();
-  }
-
-  private boolean isWordBoundaryAt(int pos, boolean unicodeWordBoundary) {
-    boolean prevWord =
-        pos > 0 && isBoundaryWordChar(text.codePointBefore(pos), unicodeWordBoundary);
-    boolean nextWord =
-        pos < text.length() && isBoundaryWordChar(text.codePointAt(pos), unicodeWordBoundary);
-    return prevWord != nextWord;
-  }
-
-  private static boolean isBoundaryWordChar(int cp, boolean unicodeWordBoundary) {
-    return unicodeWordBoundary ? Nfa.isUnicodeWordChar(cp) : Nfa.isWordChar(cp);
+    int keywordStart = Pattern.KeywordAlternation.matchStart(match);
+    int keywordEnd = Pattern.KeywordAlternation.matchEnd(match);
+    int[] keywordGroups = new int[2 * ncap];
+    Arrays.fill(keywordGroups, -1);
+    keywordGroups[0] = keywordAlternation.greedyWholeInput ? matchStart : keywordStart;
+    keywordGroups[1] = keywordAlternation.greedyWholeInput ? scanner.length() : keywordEnd;
+    if (keywordAlternation.captureGroup > 0) {
+      int group = keywordAlternation.captureGroup;
+      keywordGroups[2 * group] = keywordStart;
+      keywordGroups[2 * group + 1] = keywordEnd;
+    }
+    return applyFullMatchResult(keywordGroups);
   }
 
   private static int asciiLower(int ch) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2595,9 +2595,13 @@ public final class Pattern implements Serializable {
       firstAscii[keyword.charAt(0)] = true;
     }
 
-    boolean unicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
+    boolean beforeUnicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
+    boolean afterUnicodeWordBoundary = (after.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
+    if (beforeUnicodeWordBoundary != afterUnicodeWordBoundary) {
+      return null;
+    }
     return new KeywordAlternation(
-        keywords, firstAscii, captureGroup, unicodeWordBoundary, greedyWholeInput);
+        keywords, firstAscii, captureGroup, beforeUnicodeWordBoundary, greedyWholeInput);
   }
 
   private static boolean isGreedyAnyCharStar(Regexp re) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -651,6 +651,9 @@ public final class Pattern implements Serializable {
     if (literalMatchUtf8 != null && !prefixFoldCase) {
       return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
     }
+    if (enginePathOptions.keywordAlternationFastPath() && keywordAlternation != null) {
+      return keywordAlternation.find(scanner, 0) >= 0;
+    }
     if (enginePathOptions.literalFastPaths()
         && requiredLiteralUtf8 != null
         && prefixUtf8 == null
@@ -715,6 +718,11 @@ public final class Pattern implements Serializable {
       boolean matched =
           scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
       diagnostics.boundary(MatchStrategy.LITERAL);
+      return matched;
+    }
+    if (enginePathOptions.keywordAlternationFastPath() && keywordAlternation != null) {
+      boolean matched = keywordAlternation.find(scanner, 0) >= 0;
+      diagnostics.boundary(MatchStrategy.KEYWORD);
       return matched;
     }
     if (enginePathOptions.literalFastPaths()
@@ -2149,6 +2157,82 @@ public final class Pattern implements Serializable {
       this.captureGroup = captureGroup;
       this.unicodeWordBoundary = unicodeWordBoundary;
       this.greedyWholeInput = greedyWholeInput;
+    }
+
+    long find(InputScanner scanner, int startPos) {
+      int matchStart = Math.max(0, startPos);
+      if (greedyWholeInput) {
+        for (int position = scanner.length() - 1; position >= matchStart; position--) {
+          long match = matchAt(scanner, position);
+          if (match >= 0) {
+            return match;
+          }
+        }
+        return -1;
+      }
+      int position = matchStart;
+      while (position < scanner.length()) {
+        long match = matchAt(scanner, position);
+        if (match >= 0) {
+          return match;
+        }
+        int ascii = scanner.asciiAt(position);
+        position =
+            ascii >= 0 ? position + 1 : InputScanner.position(scanner.decodeForward(position));
+      }
+      return -1;
+    }
+
+    private long matchAt(InputScanner scanner, int position) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      int first = scanner.asciiAt(position);
+      if (first < 0 || !firstAscii[asciiLower(first)] || !isWordBoundaryAt(scanner, position)) {
+        return -1;
+      }
+      for (String keyword : keywords) {
+        int end = position + keyword.length();
+        if (end <= scanner.length()
+            && matchesAsciiIgnoreCase(scanner, position, keyword)
+            && isWordBoundaryAt(scanner, end)) {
+          return ((long) position << 32) | (end & 0xFFFF_FFFFL);
+        }
+      }
+      return -1;
+    }
+
+    private boolean isWordBoundaryAt(InputScanner scanner, int position) {
+      boolean previousWord =
+          position > 0
+              && isBoundaryWordChar(scanner.codePointBefore(position), unicodeWordBoundary);
+      boolean nextWord =
+          position < scanner.length()
+              && isBoundaryWordChar(scanner.codePointAt(position), unicodeWordBoundary);
+      return previousWord != nextWord;
+    }
+
+    private static boolean matchesAsciiIgnoreCase(
+        InputScanner scanner, int position, String keyword) {
+      for (int index = 0; index < keyword.length(); index++) {
+        int input = scanner.asciiAt(position + index);
+        if (input < 0 || asciiLower(input) != keyword.charAt(index)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private static boolean isBoundaryWordChar(int codePoint, boolean unicodeWordBoundary) {
+      return unicodeWordBoundary ? Nfa.isUnicodeWordChar(codePoint) : Nfa.isWordChar(codePoint);
+    }
+
+    static int matchStart(long match) {
+      return (int) (match >>> 32);
+    }
+
+    static int matchEnd(long match) {
+      return (int) match;
     }
   }
 

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -562,6 +562,13 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("keyword alternation preserves independently scoped boundary modes")
+    void keywordAlternationPreservesIndependentlyScopedBoundaryModes() {
+      assertAllFindsMatchJdk("(?-U)\\b(?i)(foo|bar)(?U)\\b", "éfoo! fooé bar!");
+      assertAllFindsMatchJdk("(?U)\\b(?i)(foo|bar)(?-U)\\b", "éfoo! fooé bar!");
+    }
+
+    @Test
     @DisplayName("find() keyword alternation rejects partly case-sensitive scoped flags")
     void findKeywordAlternationRejectsPartlyCaseSensitiveScopedFlags() {
       assertAllFindsMatchJdk("\\b((?i:a)B|(?i:x)Y)\\b", "ab aB AB xy xY XY");

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -31,6 +31,17 @@ class SearchScalingRegressionTest {
         size -> pattern.matcher(Utf8Input.trusted("a".repeat(size).getBytes(UTF_8))).find());
   }
 
+  @Test
+  void greedyKeywordAlternationSuccessNearEndIsConstantWorkForUtf8Input() {
+    Pattern pattern = Pattern.compile("(?is).*\\b(you|your)\\b.*");
+    assertConstantWork(
+        size ->
+            pattern
+                .matcher(Utf8Input.trusted(("a".repeat(size) + " YOUR tail").getBytes(UTF_8)))
+                .find(),
+        "UTF-8 keyword search");
+  }
+
   private static void assertReverseDfaSuffixFailureIsConstantWork(IntPredicate find) {
     long work2000 =
         WorkCounter.countForTesting(
@@ -64,6 +75,17 @@ class SearchScalingRegressionTest {
     // Assert that scaling is sub-linear (effectively constant)
     assertThat(work10000)
         .as("Work scaling should be flat, not linear with input size increase")
+        .isLessThan(work2000 * 2);
+  }
+
+  private static void assertConstantWork(IntPredicate find, String description) {
+    long work2000 = WorkCounter.countForTesting(() -> assertThat(find.test(2_000)).isTrue());
+    long work10000 = WorkCounter.countForTesting(() -> assertThat(find.test(10_000)).isTrue());
+
+    assertThat(work2000).as("%s on short input", description).isPositive().isLessThan(200);
+    assertThat(work10000).as("%s on long input", description).isPositive().isLessThan(200);
+    assertThat(work10000)
+        .as("%s should not scale with the prefix", description)
         .isLessThan(work2000 * 2);
   }
 }

--- a/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
@@ -124,6 +124,36 @@ class Utf8DiagnosticsTest {
   }
 
   @Test
+  void keywordAlternationFindReportsUtf8FastPath() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern matcherPattern = Pattern.compile("(?is).*\\b(you|your)\\b.*");
+    Pattern booleanPattern = Pattern.compile("(?is).*\\b(you|your)\\b.*");
+    Utf8Input input = input("a long prefix ending with YOUR answer");
+
+    assertThat(matcherPattern.matcher(input).find()).isTrue();
+    assertThat(booleanPattern.find(input)).isTrue();
+
+    assertThat(operationsFor(matcherPattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.KEYWORD);
+              assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.KEYWORD);
+              assertThat(event.forwardDfaSearchCount()).isZero();
+              assertThat(event.reverseDfaSearchCount()).isZero();
+            });
+    assertThat(operationsFor(booleanPattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.KEYWORD);
+              assertThat(event.captureMode()).isEqualTo(CaptureMode.NONE);
+              assertThat(event.forwardDfaSearchCount()).isZero();
+              assertThat(event.reverseDfaSearchCount()).isZero();
+            });
+  }
+
+  @Test
   void patternBooleanFindReportsAccelerationAndDfaSearch() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile("é[ab]+c");

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -81,6 +81,37 @@ class Utf8MatcherStateMachineTest {
   }
 
   @Test
+  void keywordAlternationMatchesJdkAcrossUtf8Boundaries() {
+    assertKeywordAlternationMatch(
+        "(?is).*\\b(you|your)\\b.*",
+        "préface You spoke first.\nThen your example ended with YOU!",
+        0);
+    assertKeywordAlternationMatch(
+        "(?is).*\\b(you|your)\\b.*",
+        "é ignore YOU, then keep your answer",
+        "é ignore YOU, ".length());
+    assertKeywordAlternationMatch("(?isU).*\\b(you|your)\\b.*", "éyoué -- your!", 0);
+    assertKeywordAlternationMatch("(?isU).*\\b(you|your)\\b.*", "éyoué -- βyourβ", 0);
+  }
+
+  @Test
+  void keywordAlternationFindsAlternativesAndRejectsAdjacentWordCharacters() {
+    String input = "préface error warning2 _timeout failed!";
+    Utf8Matcher matcher = matcher("(?i)\\b(error|warning|timeout|failed)\\b", input);
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(utf8Slice(input, matcher.start(1), matcher.end(1))).isEqualTo("error");
+    assertThat(matcher.find()).isTrue();
+    assertThat(utf8Slice(input, matcher.start(1), matcher.end(1))).isEqualTo("failed");
+    assertThat(matcher.find()).isFalse();
+
+    Pattern absent = Pattern.compile("(?is).*\\b(you|your)\\b.*");
+    Utf8Input absentInput = Utf8Input.validated("é youth yours".getBytes(UTF_8));
+    assertThat(absent.matcher(absentInput).find()).isFalse();
+    assertThat(absent.find(absentInput)).isFalse();
+  }
+
+  @Test
   void emptyFindAdvancesByOneCodePoint() {
     Utf8Matcher matcher = matcher("", "😀");
     List<List<Integer>> bounds = new ArrayList<>();
@@ -364,6 +395,35 @@ class Utf8MatcherStateMachineTest {
 
   private static Utf8Matcher matcher(String pattern, String input) {
     return Pattern.compile(pattern).matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+  }
+
+  private static void assertKeywordAlternationMatch(String regex, String input, int regionStart) {
+    Pattern pattern = Pattern.compile(regex);
+    java.util.regex.Matcher jdkMatcher =
+        java.util.regex.Pattern.compile(regex).matcher(input).region(regionStart, input.length());
+    int byteRegionStart = utf8Offset(input, regionStart);
+    Utf8Input utf8Input = Utf8Input.validated(input.getBytes(UTF_8));
+    Utf8Matcher utf8Matcher =
+        pattern.matcher(utf8Input).region(byteRegionStart, utf8Input.length());
+
+    boolean jdkFound = jdkMatcher.find();
+    assertThat(pattern.find(utf8Input)).isEqualTo(jdkFound);
+    assertThat(utf8Matcher.find()).isEqualTo(jdkFound);
+    if (!jdkFound) {
+      return;
+    }
+    for (int group = 0; group <= jdkMatcher.groupCount(); group++) {
+      int expectedStart =
+          jdkMatcher.start(group) < 0 ? -1 : utf8Offset(input, jdkMatcher.start(group));
+      int expectedEnd = jdkMatcher.end(group) < 0 ? -1 : utf8Offset(input, jdkMatcher.end(group));
+      assertThat(utf8Matcher.start(group)).as("group %s start", group).isEqualTo(expectedStart);
+      assertThat(utf8Matcher.end(group)).as("group %s end", group).isEqualTo(expectedEnd);
+    }
+  }
+
+  private static String utf8Slice(String input, int start, int end) {
+    byte[] bytes = input.getBytes(UTF_8);
+    return new String(bytes, start, end - start, UTF_8);
   }
 
   private static List<List<Integer>> findTrace(Utf8Matcher matcher) {

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -95,6 +95,12 @@ class Utf8MatcherStateMachineTest {
   }
 
   @Test
+  void keywordAlternationPreservesIndependentUtf8BoundaryModes() {
+    assertKeywordAlternationMatch("(?-U)\\b(?i)(foo|bar)(?U)\\b", "éfoo! fooé bar!", 0);
+    assertKeywordAlternationMatch("(?U)\\b(?i)(foo|bar)(?-U)\\b", "éfoo! fooé bar!", 0);
+  }
+
+  @Test
   void keywordAlternationFindsAlternativesAndRejectsAdjacentWordCharacters() {
     String input = "préface error warning2 _timeout failed!";
     Utf8Matcher matcher = matcher("(?i)\\b(error|warning|timeout|failed)\\b", input);


### PR DESCRIPTION
## Summary

- add an input-scanner-native keyword-alternation search shared by String and UTF-8 matching
- enable the fast path for `Pattern.find(Utf8Input)`, stateful UTF-8 matchers, captures, and regions
- preserve ASCII case folding, Unicode-aware boundary handling when requested, and byte-relative UTF-8 offsets
- retain the original String-native loop so the existing String keyword-alternation fast path does not regress
- fall back to the general matcher when the opening and closing word boundaries use different scoped Unicode modes
- add correctness, path-selection, constant-work scaling, scoped-boundary, and fuzz regression coverage

Fixes #664

## Benchmark results

The final code at `729fa6c0473826bacf576e01151b8d09b7c578e6` was measured sequentially with the repository's `--long` JMH configuration for `RealWorldRegexBenchmark.runBenchmark.wildcardSearch.match`.

### UTF-8 improvement

| Input size | Issue baseline | Final PR | Improvement |
|---:|---:|---:|---:|
| 1K | 1,802.157 ns/op | 51.921 +/- 0.553 ns/op | 34.7x |
| 10K | 17,915.469 ns/op | 26.923 +/- 1.540 ns/op | 665x |
| 100K | 181,041.370 ns/op | 46.076 +/- 2.176 ns/op | 3,929x |

The issue baselines were measured at SafeRE commit `516a1ff76141bc83c3910426332c7824acdf007c`. Successful UTF-8 search remains effectively constant as the input grows because the greedy wrapper scans backward to the keyword near the end.

### String fast-path check

The same final `--long` run was compared with the existing measurements from current `main` (`c54a4ea`):

| Input size | `main` String | Final PR String | Difference |
|---:|---:|---:|---:|
| 1K | 54.310 ns/op | 55.340 +/- 1.334 ns/op | 1.9% slower |
| 10K | 39.323 ns/op | 39.360 +/- 0.959 ns/op | 0.1% slower |
| 100K | 51.463 ns/op | 52.043 +/- 1.476 ns/op | 1.1% slower |

These results keep the String path aligned with `main`. The final scoped-boundary correction does not add work to the normal one-mode hot path; patterns whose two boundaries use different Unicode modes bypass the accelerator and use the general engine.

## Verification

Ran successfully on the final code:

- `mvn -pl safere -Dtest=MatcherTest,Utf8MatcherStateMachineTest,PatternInternalTest,SearchScalingRegressionTest test -q`
- `mvn -pl safere-fuzz -am -Dtest=Utf8InputFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q`
  - 74,484,072 case-insensitive boundary cases passed
  - RE2 exhaustive suite: 10,404,136 tests, 532,510 skipped, 0 failures
- sequential `--long` String and UTF-8 benchmark confirmation at all three input sizes
- two final noninteractive Codex branch reviews against `main`; no actionable findings

No requested verification remains outstanding.
