### PR TITLE
More real world benchmarks

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1674,6 +1674,42 @@
       "shared": true
     },
     {
+      "id": "realWorldRegex.recitation.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "[",
+        "unit": "1.2.3,",
+        "suffix": "4.5.6]",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.recitation.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "[",
+        "unit": "1.2.3,",
+        "suffix": "4.5.6",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
       "id": "scrubber.withoutDirectives",
       "recipe": {
         "kind": "repeat",
@@ -3424,6 +3460,38 @@
         "constraints": [
           "prematerializedInput"
         ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
+      "operation": "replaceAll",
+      "patterns": [
+        "\\s*[\\[［]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,、]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]］]"
+      ],
+      "inputs": [
+        "realWorldRegex.recitation.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "replacement": ""
       },
       "axes": {
         "matchLabel": [


### PR DESCRIPTION
This benchmark is similar to a real world case where SafeRE is slower than RE2-FFM.

I'm seeing SafeRE performance around ~2x of RE2 on some real world workloads, the performance gap seems to be largely from longer >10k character inputs where the JNI/FFM overhead is negligible and RE2 has faster scanning performance.

For this specific benchmark case I measured SafeRE as ~2.2x slower, 49ns/op vs. 22ns/op for RE2-FFM.

```
./run-java-benchmarks.sh --fastbuild CrossEngineBenchmark.run -- -p crossEngineTrial=RealWorldRegexBenchmark.runBenchmark.recitation.noMatch.10000@safere-string,RealWorldRegexBenchmark.runBenchmark.recitation.noMatch.10000@re2-ffm-string-conversion
```