### PR TITLE
Add benchmark report writing skill

### DIFF
--- a/.agents/skills/write-benchmark-report/SKILL.md
+++ b/.agents/skills/write-benchmark-report/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: write-benchmark-report
+description: "Collect, analyze, write, validate, and publish reproducible SafeRE benchmark reports and BENCHMARKS.md updates. Use when asked to launch a benchmark collection, review benchmark results, choose and support headline comparisons, explain benchmark categories or surprising ratios, archive raw benchmark evidence, or prepare a benchmark-report change for review."
+---
+
+# Write Benchmark Report
+
+Produce a self-contained, evidence-backed SafeRE benchmark report whose claims can be recalculated
+from checked-in raw data. Treat benchmark execution, interpretation, writing, and publication as one
+workflow.
+
+## Establish Scope
+
+1. Read the repository `AGENTS.md` Benchmarking section, the current `BENCHMARKS.md`, the benchmark
+   collection documentation in `README.md`, and the collection scripts before acting.
+2. Inspect the current workload declarations and report plan. Do not preserve historical categories,
+   methods, or competitors when the suite has changed.
+3. Resolve what "full" means before running:
+   - Default project collection: Java engines plus the external OpenJDK-derived suite.
+   - Add C++ RE2, PCRE2 JIT, Go, Rust, and .NET only when cross-language context is requested.
+   - Skip the external suite only when the user explicitly narrows scope. Call the resulting
+     collection incomplete and remove stale external results from the new report.
+4. Inspect prerequisites without installing anything. Ask the project owner to install missing
+   compilers, SDKs, runtimes, external checkouts, or libraries.
+5. Record the exact SafeRE commit before the run. Prefer a clean tree. If the tree is dirty, stop
+   unless the intended benchmark source is unambiguous and can be recorded honestly.
+
+Tell the user the planned suites, engines, commands, expected exclusions, and launch/hand-off approach
+before starting when they ask for a plan first.
+
+## Collect Results
+
+Use the project wrappers as the only source of benchmark settings. Never invoke JMH through Maven
+execution and never run benchmark processes in parallel.
+
+Use one of:
+
+```bash
+./collect-benchmark-results.sh
+./collect-benchmark-results.sh --long
+./collect-benchmark-results.sh --cross-language
+./collect-benchmark-results.sh --cross-language --skip-openjdk-regex
+```
+
+Use standard mode for routine publication evidence. Use `--long` to confirm close, surprising, or
+important comparisons; do not silently mix standard and long point estimates in one aggregate.
+
+Launch the collection in a durable background execution or session with output captured. Watch only
+long enough to establish that prerequisites and builds succeeded and the script reached the first
+actual benchmark run. Then stop polling to conserve tokens unless the user explicitly asks for
+continuous oversight. Tell the user that the collection is still running and provide its output
+directory plus the session, process, or log identifier needed to inspect it later. Never describe a
+successfully started collection as completed.
+
+Before analyzing results—whether later in the same conversation or after the user returns—check the
+process exit status and verify that the output directory contains the expected artifacts for every
+selected suite. Preserve the exact command and whether standard, long, smoke, cross-language, and
+external-suite modes were used. If the run failed, preserve its output, diagnose the failure, and
+continue only when doing so does not compromise comparability.
+
+## Normalize And Audit
+
+Prefer `normalized-results.jsonl` for calculations and retain the original harness output as the
+authority. When the collector does not emit normalized JSONL, generate it with
+`safere-benchmarks/scripts/compare-benchmarks.py` from the captured JMH and engine JSONL files.
+
+Before writing conclusions:
+
+1. Validate JSON and JSONL syntax.
+2. Verify that normalized `(engine, benchmark)` identities are unique.
+3. Compare the declared report plan with actual results. Distinguish:
+   - complete comparable membership;
+   - declared but missing measurements;
+   - explicit capability or syntax exclusions.
+4. Inventory operations, parameters, sizes, match outcomes, representations, and engines for every
+   proposed aggregate.
+5. Inspect confidence intervals and rerun important noisy or close cases with `--long` when needed.
+6. Trace surprising results to individual rows before speculating about causes. Inspect workload
+   definitions and implementation paths; profile before proposing an optimization.
+7. File a GitHub issue for a newly discovered bug or material performance-path gap. Include exact
+   rows, scaling, likely path selection, and correctness constraints. Do not let the report change
+   silently conceal it.
+
+## Compute Comparisons
+
+For every aggregate, define membership, parameter coverage, and weighting in the report.
+
+Use the geometric mean of per-row ratios:
+
+```text
+ratio = SafeRE time / competitor time
+```
+
+- A ratio below `1.0` means SafeRE is faster.
+- A ratio above `1.0` means SafeRE takes longer.
+- Give every declared row equal weight unless the report explicitly defines another defensible
+  weighting.
+- Calculate each competitor on its actual pairwise shared membership when coverage differs.
+- Keep controlled same-runtime comparisons separate from cross-runtime context.
+- Keep semantically different operations such as matching, compilation, replacement, memory, cold
+  start, and adversarial scaling separate unless the combined question is explicitly meaningful.
+
+State comparisons directly. Prefer "SafeRE is 13% slower" or "SafeRE takes 2.03× as long" over
+ambiguous phrases such as "1.13× slower." Include the raw ratio and row count in aggregate tables.
+
+Run sensitivity analyses when a few extreme rows may drive a headline. Report both the complete
+aggregate and a clearly labeled diagnostic exclusion; never replace the complete result with a
+more favorable subset. Break representation comparisons down by pattern, match outcome, and size
+before attributing them to encoding or implementation choices.
+
+## Choose The Headline
+
+Choose the broadest representative controlled category, not automatically the category with the
+largest SafeRE advantage. For the current suite this will often be the Real-world matrix because it
+covers many patterns, successful and failed searches, and multiple input sizes. Re-evaluate this
+choice whenever workload structure changes.
+
+Use smaller focused categories as supporting checks. Explain where they agree with or qualify the
+headline. A headline such as a broad SafeRE/JDK lead must not imply that SafeRE wins every pattern
+when focused categories or individual rows show otherwise.
+
+Describe every major report category in a compact table with:
+
+- composition and row count;
+- operation and parameter coverage;
+- weighting;
+- the question the category answers.
+
+## Write `BENCHMARKS.md`
+
+Lead with outcomes. Use this order when it fits the evidence:
+
+1. Executive summary led by the primary category and its sensitivity result.
+2. Environment and reproducibility.
+3. Benchmark-category definitions.
+4. Same-runtime aggregates, then explicitly contextual cross-runtime aggregates.
+5. Primary-category analysis and inspectable supporting tables.
+6. Smaller supporting categories.
+7. Representation-specific results such as String versus pre-existing UTF-8.
+8. Compilation, replacement, captures, scaling, adversarial behavior, memory, and SafeRE-only
+   functionality.
+9. Interpretation of tradeoffs and limitations.
+
+Include:
+
+- the full benchmarked SafeRE SHA and that commit's UTC date/time using `Z` notation;
+- SafeRE, JDK, JMH, runtime, compiler, engine/library, OS, CPU, and memory versions as applicable;
+- the exact collection command and benchmark mode;
+- timing configuration, forks/processes, confidence-interval convention, input representation, and
+  conversion boundaries;
+- every material exclusion and actual row count;
+- a prominent link to published raw and normalized artifacts.
+
+Do not add a separate results timestamp unless explicitly requested. Do not include test counts,
+personal names, stale external-suite results, or claims supported only by ignored local files.
+
+Use neutral language and explain likely architectural reasons only when evidence supports them.
+Acknowledge SafeRE costs such as compilation time, memory, or slower short paths alongside its
+linear-time and fast-path benefits. Avoid universal rankings.
+
+## Publish Evidence
+
+Keep ordinary timestamped runs under ignored `benchmark-results/`. Publish the reviewed collection
+under:
+
+```text
+benchmark-results/published/<full-SafeRE-commit>/
+```
+
+Preserve the complete result directory, including raw JMH/native output, engine JSONL, resolved
+plan, memory output, normalized JSONL, and generated tables. Do not clean whitespace or otherwise
+rewrite raw output.
+
+Add a publication `README.md` that records:
+
+- benchmarked commit and UTC commit time;
+- exact command and mode;
+- included and skipped suites;
+- artifact roles and normalized schema;
+- a statement that raw output is authoritative.
+
+Add `SHA256SUMS` for every other file in the publication directory. Configure `.gitignore` so local
+runs remain ignored while `benchmark-results/published/**` is trackable. Mark bulky raw and
+generated artifacts non-diffable in `.gitattributes`; keep the publication README and checksums
+reviewable.
+
+## Validate The Report And Publication
+
+Perform all applicable checks:
+
+```bash
+python3 -m unittest discover -s safere-benchmarks/scripts -p 'test_*.py'
+bash -n collect-benchmark-results.sh
+git diff --check
+```
+
+Also:
+
+- parse every JSON/JSONL artifact;
+- regenerate normalized JSONL from raw inputs and require byte-identical output;
+- verify normalized identity uniqueness;
+- run `sha256sum --check SHA256SUMS` from the publication directory;
+- check Markdown tables for consistent column counts;
+- recalculate every reported aggregate and inspectable pattern-level ratio from the published data;
+- verify that local timestamped results remain ignored and published results are trackable;
+- verify that only intended source, documentation, and publication files changed.
+
+Do not rerun the full benchmark collection merely because report prose or normalization tooling
+changed. State that derived artifacts were regenerated from preserved raw output. Run matching
+implementation tests only when matching code changed.
+
+## Hand Off
+
+Summarize:
+
+- the primary headline and its most important qualification;
+- collection scope and explicitly skipped suites;
+- artifact location;
+- validations run and not run;
+- discovered issues filed;
+- changed files.
+
+Do not commit, push, open a PR, or post benchmark claims externally unless the user explicitly asks.

--- a/.agents/skills/write-benchmark-report/agents/openai.yaml
+++ b/.agents/skills/write-benchmark-report/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write Benchmark Report"
+  short_description: "Create reproducible SafeRE benchmark reports"
+  default_prompt: "Use $write-benchmark-report to collect results and write a reproducible SafeRE benchmark report."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,12 @@ Benchmark classes have no `@Fork`, `@Warmup`, or `@Measurement` annotations
 
 # Full collection; includes the external OpenJDK-derived suite by default
 ./collect-benchmark-results.sh
+
+# Longer confirmation collection
+./collect-benchmark-results.sh --long
+
+# Add cross-runtime engines
+./collect-benchmark-results.sh --cross-language
 ```
 
 Arguments after the mode flag are passed directly to JMH as benchmark regex
@@ -348,8 +354,8 @@ generic runners and trials:
   `./collect-benchmark-results.sh` collects SafeRE, JDK, RE2/J, and RE2-FFM
   results from SafeRE's suite, then SafeRE/JDK results from the external
   OpenJDK-derived suite. Use `./collect-benchmark-results.sh --cross-language`
-  only when broader C++ RE2, Go `regexp`, and Rust `regex` context is explicitly
-  needed.
+  only when broader C++ RE2, PCRE2 JIT, Go `regexp`, Rust `regex`, and .NET
+  non-backtracking context is explicitly needed.
 - **OpenJDK-derived benchmarks stay external.** Their GPL-2.0-only repository
   must be checked out separately and must not be vendored or added to SafeRE's
   Maven modules. The collection script runs them as a separate result set
@@ -360,6 +366,13 @@ generic runners and trials:
 - **NEVER run benchmarks in parallel.** All benchmark runs must run
   sequentially, one at a time. Parallel runs compete for CPU, cache, and memory
   bandwidth, producing inaccurate results.
+- **A collection does not require continuous monitoring.** Launch long
+  collections in a durable session with captured output. Verify that
+  prerequisites and builds succeed and that the first actual benchmark starts,
+  then stop polling unless the user explicitly asks for continuous oversight.
+  Before analyzing the results, verify the final exit status and the expected
+  artifacts for every selected suite. Do not describe a successfully started
+  collection as completed.
 - **Do not commit optimizations that do not improve benchmark results.**
   Every optimization must be validated with before/after benchmarks.
 - **`benchmark-data.json` is the only checked-in workload source.** Benchmark
@@ -396,9 +409,13 @@ When reporting an aggregate comparison:
 - Compute the **geometric mean of speed ratios** rather than an arithmetic mean
   of ratios. Use `SafeRE time / competitor time`, so values below 1.0 mean
   SafeRE is faster.
-- Report the raw geomean and a readable interpretation such as "N× faster" or
-  "N× slower." Explain when a small number of extreme cases materially
-  influences the aggregate.
+- Compute each competitor aggregate over its actual pairwise shared membership
+  when engine coverage differs. Report the row count and material exclusions;
+  do not present a partial-coverage aggregate as an overall engine comparison.
+- Report the raw geomean and a readable interpretation. For ratios below 1.0,
+  use "N× faster." For ratios above 1.0, use a percentage such as "13% slower"
+  or the unambiguous "takes 2.03× as long," not "1.13× slower." Explain when a
+  small number of extreme cases materially influences the aggregate.
 
 **Why geometric mean:** It is the only mean consistent under inversion
 (geomean(A/B) = 1/geomean(B/A)), treats multiplicative improvements
@@ -406,16 +423,23 @@ symmetrically, and is the standard in systems benchmarking (SPEC, DaCapo,
 Renaissance). Do not use arithmetic mean of ratios — it is biased by outliers
 and inconsistent under inversion.
 
-`BENCHMARKS.md` must be self-contained for checked-in benchmark claims. Raw
-outputs may remain local, but do not make an ignored or machine-local artifact
-the only place where a reported result or supporting table can be inspected.
+`BENCHMARKS.md` must be self-contained for checked-in benchmark claims. For a
+published benchmark report, check in the reviewed collection under
+`benchmark-results/published/<full-SafeRE-commit>/`, including complete raw
+outputs, normalized results, the resolved plan, a publication README, and
+SHA-256 checksums. Keep ordinary timestamped runs ignored. The report must link
+prominently to the published artifacts, and its claims must be reproducible
+from them; neither the report nor an ignored or machine-local artifact may be
+the sole inspectable evidence.
 
 When updating `BENCHMARKS.md`, update the external OpenJDK-derived benchmark
 section from the same collection. Keep its results and aggregates separate from
 SafeRE's native suite, and record the SafeRE commit, external benchmark
 repository commit, pinned OpenJDK source commit, SafeRE version, and JDK
-version. Do not leave the previous external results in place after publishing a
-new full collection.
+version. If the user explicitly narrows the collection to skip that suite,
+identify the report as incomplete and remove stale external results rather than
+retaining results from a different collection. Do not leave the previous
+external results in place after publishing a new full collection.
 
 ### Writing About Benchmark Results
 
@@ -424,10 +448,11 @@ new full collection.
   implementations. Every engine makes deliberate design tradeoffs.
 - **State facts and ratios.** Write "SafeRE is 50× faster than RE2/J"
   rather than "SafeRE crushes RE2/J."
-- **Explain *why* differences exist.** Attribute performance gaps to
-  specific design decisions (e.g., "RE2/J lacks a DFA engine" or "JDK
-  defers compilation work to match time") rather than implying one
-  implementation is poorly written.
+- **Explain supported causes.** Attribute performance gaps to specific design
+  decisions only when workload inspection, implementation tracing, or profiling
+  supports the explanation. Label inferences as such, and profile before
+  proposing an optimization. Do not present speculation as a measured cause or
+  imply that another implementation is poorly written.
 - **Acknowledge tradeoffs.** When SafeRE is slower, explain what it gains
   in return (e.g., linear-time guarantees). When it's faster, note what
   the other engine optimizes for instead.


### PR DESCRIPTION
## Summary

- add a `write-benchmark-report` skill for collecting, analyzing, validating, and publishing reproducible benchmark reports
- document raw-result publication, pairwise coverage, unambiguous ratio wording, and evidence requirements
- align repository guidance with the complete cross-runtime engine set and durable benchmark launch workflow

## Verification

- `python3 /home/eaftan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/write-benchmark-report`
- `git diff main...HEAD --check`
- Codex review-fix loop against `main`: no actionable correctness issues

No Maven tests were run because this change only adds agent instructions and documentation.
