### PR TITLE
Add declarative benchmark trial exclusions

### DIFF
--- a/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
+++ b/safere-benchmarks/DECLARATIVE_BENCHMARK_PLAN.md
@@ -79,6 +79,34 @@ A materially changed operation, input, result-consumption rule, lifecycle, or
 timing boundary requires a new workload ID. Reordering JSON or changing a
 display label does not.
 
+### Explicit trial exclusions
+
+A workload may declare known-unsafe engine trials with `trialExclusions`. Each
+rule names one or more exact execution-plan engine IDs, a nonblank reason, and
+optional axis selectors:
+
+```json
+"trialExclusions": [{
+  "engineIds": ["jdk-string"],
+  "when": {"size": [10000, 100000]},
+  "reason": "OpenJDK 26.0.2 throws StackOverflowError for this pattern at these sizes"
+}]
+```
+
+Conditions within `when` are conjunctive. An omitted axis is a wildcard, and
+an omitted or empty `when` selects every expansion of the workload for the
+named engines. Selector values use the same typed scalar or labeled
+`{"id": ..., "value": ...}` representation as the corresponding axis and
+must exactly equal a declared value.
+
+Engine IDs are exact; report-engine names, runners, and syntax profiles are not
+selectors. Rules may not overlap on an expanded workload/engine pair. Unknown
+engines, axes, and values, duplicate selectors, empty selections, and blank
+reasons are rejected. Explicit trial exclusions are resolved before general
+engine capability and syntax exclusions so the checked-in reason remains the
+auditable explanation. A workload cannot combine `trialExclusions` with
+`disabledReason`.
+
 ## Pattern profiles
 
 All workload patterns use Java regex syntax as their canonical representation.
@@ -164,6 +192,10 @@ contain an `exclusion` object with a stable kind and explanatory reason.
 Runners may implement generic regex operations only; an entry declared
 runnable that cannot be prepared is an error rather than a new runtime
 exclusion.
+
+Explicit trial rules materialize with exclusion kind
+`explicitTrialExclusion`. They remain in the complete execution-plan join but
+are omitted from runner trial lists.
 
 ## Bounded input recipes
 

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineBenchmarkPlan.java
@@ -59,8 +59,7 @@ final class CrossEngineBenchmarkPlan {
     return fromMaterialized(MaterializedExecutionPlan.load().entriesForRunner("java"));
   }
 
-  private static CrossEngineBenchmarkPlan fromMaterialized(
-      List<MaterializedExecutionPlan.Entry> entries) {
+  static CrossEngineBenchmarkPlan fromMaterialized(List<MaterializedExecutionPlan.Entry> entries) {
     Map<String, CrossEngineWorkload> workloads = new LinkedHashMap<>();
     Map<String, Trial> trials = new LinkedHashMap<>();
     List<MaterializedExecutionPlan.Entry> exclusions = new ArrayList<>();

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -111,6 +111,7 @@ final class DeclarativeBenchmarkPlan {
     }
 
     List<ExpandedWorkload> expandedWorkloads = expandWorkloads();
+    validateTrialExclusions(expandedWorkloads, engineIds);
     List<Trial> trials = new ArrayList<>();
     List<Exclusion> exclusions = new ArrayList<>();
     for (ExpandedWorkload workload : expandedWorkloads) {
@@ -143,6 +144,14 @@ final class DeclarativeBenchmarkPlan {
 
   private static Exclusion exclusion(
       ExpandedWorkload workload, EngineDeclaration engine, Set<Operation> implementedOperations) {
+    TrialExclusion trialExclusion = workload.trialExclusion(engine.id());
+    if (trialExclusion != null) {
+      return new Exclusion(
+          workload.id(),
+          engine.id(),
+          ExclusionKind.EXPLICIT_TRIAL_EXCLUSION,
+          trialExclusion.reason());
+    }
     if (!engine.adapterAvailable()) {
       return new Exclusion(
           workload.id(),
@@ -235,10 +244,35 @@ final class DeclarativeBenchmarkPlan {
                 expected,
                 workload.lifecycle(),
                 workload.measurement(),
-                workload.disabledReason()));
+                workload.disabledReason(),
+                workload.trialExclusions().stream()
+                    .filter(exclusion -> exclusion.matches(parameters))
+                    .toList()));
       }
     }
     return List.copyOf(result);
+  }
+
+  void validateTrialExclusions(List<ExpandedWorkload> workloads, Set<String> engineIds) {
+    Objects.requireNonNull(workloads);
+    Objects.requireNonNull(engineIds);
+    for (WorkloadDeclaration workload : this.workloads) {
+      for (TrialExclusion exclusion : workload.trialExclusions()) {
+        for (String engineId : exclusion.engineIds()) {
+          if (!engineIds.contains(engineId)) {
+            throw new IllegalArgumentException(
+                workload.idTemplate()
+                    + " trial exclusion references unknown engine ID: "
+                    + engineId);
+          }
+        }
+      }
+    }
+    for (ExpandedWorkload workload : workloads) {
+      for (String engineId : engineIds) {
+        workload.trialExclusion(engineId);
+      }
+    }
   }
 
   private void validateReferencesAndIdentities() {
@@ -322,7 +356,8 @@ final class DeclarativeBenchmarkPlan {
         "expected",
         "lifecycle",
         "measurement",
-        "disabledReason");
+        "disabledReason",
+        "trialExclusions");
     String id = workload.requiredString("id");
     Operation operation = Operation.fromJson(workload.requiredString("operation"));
     List<String> patterns = workload.requiredStringList("patterns");
@@ -351,6 +386,8 @@ final class DeclarativeBenchmarkPlan {
     MatcherLifecycle lifecycle = parseLifecycle(workload.optionalObject("lifecycle"));
     Measurement measurement = parseMeasurement(workload.requiredObject("measurement"));
     String disabledReason = workload.optionalString("disabledReason");
+    List<TrialExclusion> trialExclusions =
+        parseTrialExclusions(workload.optionalArray("trialExclusions"), id, axes);
 
     if (patterns.isEmpty()) {
       throw new IllegalArgumentException(id + " requires at least one pattern");
@@ -375,6 +412,10 @@ final class DeclarativeBenchmarkPlan {
     if (disabledReason != null && disabledReason.isBlank()) {
       throw new IllegalArgumentException(id + " disabledReason must not be blank");
     }
+    if (disabledReason != null && !trialExclusions.isEmpty()) {
+      throw new IllegalArgumentException(
+          id + " must not declare both disabledReason and trialExclusions");
+    }
     requirements.addAll(operation.requiredFeatures());
     requirements.addAll(lifecycle.requiredFeatures());
     operation.validate(id, patterns, inputs, consumption, lifecycle, measurement);
@@ -394,7 +435,84 @@ final class DeclarativeBenchmarkPlan {
         expected,
         lifecycle,
         measurement,
-        disabledReason);
+        disabledReason,
+        trialExclusions);
+  }
+
+  private static List<TrialExclusion> parseTrialExclusions(
+      JsonArray declarations, String workloadId, Map<String, List<ParameterValue>> axes) {
+    List<TrialExclusion> result = new ArrayList<>();
+    for (JsonElement element : declarations) {
+      JsonReader exclusion = JsonReader.object(workloadId + " trial exclusion", element);
+      exclusion.requireOnly("engineIds", "when", "reason");
+      List<String> engineIds = exclusion.requiredStringList("engineIds");
+      if (engineIds.isEmpty()) {
+        throw new IllegalArgumentException(
+            workloadId + " trial exclusion requires at least one engine ID");
+      }
+      Set<String> distinctEngineIds = new LinkedHashSet<>();
+      for (String engineId : engineIds) {
+        requireSimpleId(engineId, "benchmark engine");
+        if (!distinctEngineIds.add(engineId)) {
+          throw new IllegalArgumentException(
+              workloadId + " trial exclusion has duplicate engine ID: " + engineId);
+        }
+      }
+
+      Map<String, Set<ParameterValue>> selectors = new LinkedHashMap<>();
+      JsonObject when = exclusion.optionalObject("when");
+      if (when != null) {
+        for (Map.Entry<String, JsonElement> selector : when.entrySet()) {
+          String axis = selector.getKey();
+          List<ParameterValue> declaredValues = axes.get(axis);
+          if (declaredValues == null) {
+            throw new IllegalArgumentException(
+                workloadId + " trial exclusion references unknown axis: " + axis);
+          }
+          JsonArray values;
+          try {
+            values = selector.getValue().getAsJsonArray();
+          } catch (RuntimeException exception) {
+            throw new IllegalArgumentException(
+                workloadId + " trial exclusion selector must be an array: " + axis, exception);
+          }
+          if (values.isEmpty()) {
+            throw new IllegalArgumentException(
+                workloadId + " trial exclusion selector must not be empty: " + axis);
+          }
+          Set<ParameterValue> parsedValues = new LinkedHashSet<>();
+          for (JsonElement value : values) {
+            ParameterValue parsed = ParameterValue.parse(value, axis);
+            if (!parsedValues.add(parsed)) {
+              throw new IllegalArgumentException(
+                  workloadId
+                      + " trial exclusion has duplicate axis value: "
+                      + axis
+                      + "="
+                      + parsed.stableText());
+            }
+            if (!declaredValues.contains(parsed)) {
+              throw new IllegalArgumentException(
+                  workloadId
+                      + " trial exclusion selects undeclared axis value: "
+                      + axis
+                      + "="
+                      + parsed.stableText());
+            }
+          }
+          selectors.put(axis, Collections.unmodifiableSet(parsedValues));
+        }
+      }
+      String reason = exclusion.requiredString("reason");
+      if (reason.isBlank()) {
+        throw new IllegalArgumentException(
+            workloadId + " trial exclusion reason must not be blank");
+      }
+      result.add(
+          new TrialExclusion(
+              List.copyOf(distinctEngineIds), Collections.unmodifiableMap(selectors), reason));
+    }
+    return List.copyOf(result);
   }
 
   private static Map<String, List<ParameterValue>> parseAxes(JsonObject object) {
@@ -717,7 +835,8 @@ final class DeclarativeBenchmarkPlan {
       ExpectedResult expected,
       MatcherLifecycle lifecycle,
       Measurement measurement,
-      String disabledReason) {
+      String disabledReason,
+      List<TrialExclusion> trialExclusions) {
     WorkloadDeclaration {
       patternTemplates = List.copyOf(patternTemplates);
       inputTemplates = List.copyOf(inputTemplates);
@@ -726,6 +845,7 @@ final class DeclarativeBenchmarkPlan {
       flags = flags.clone();
       requirements = requirements.clone();
       inputRepresentations = inputRepresentations.clone();
+      trialExclusions = List.copyOf(trialExclusions);
     }
 
     @Override
@@ -759,7 +879,8 @@ final class DeclarativeBenchmarkPlan {
       ExpectedResult expected,
       MatcherLifecycle lifecycle,
       Measurement measurement,
-      String disabledReason) {
+      String disabledReason,
+      List<TrialExclusion> trialExclusions) {
     ExpandedWorkload {
       patterns = List.copyOf(patterns);
       inputIds = List.copyOf(inputIds);
@@ -768,6 +889,7 @@ final class DeclarativeBenchmarkPlan {
       flags = flags.clone();
       requirements = requirements.clone();
       inputRepresentations = inputRepresentations.clone();
+      trialExclusions = List.copyOf(trialExclusions);
     }
 
     @Override
@@ -783,6 +905,38 @@ final class DeclarativeBenchmarkPlan {
     @Override
     public EnumSet<InputRepresentation> inputRepresentations() {
       return inputRepresentations.clone();
+    }
+
+    TrialExclusion trialExclusion(String engineId) {
+      TrialExclusion result = null;
+      for (TrialExclusion exclusion : trialExclusions) {
+        if (!exclusion.engineIds().contains(engineId)) {
+          continue;
+        }
+        if (result != null) {
+          throw new IllegalArgumentException(
+              id + " has overlapping trial exclusions for engine " + engineId);
+        }
+        result = exclusion;
+      }
+      return result;
+    }
+  }
+
+  record TrialExclusion(
+      List<String> engineIds, Map<String, Set<ParameterValue>> when, String reason) {
+    TrialExclusion {
+      engineIds = List.copyOf(engineIds);
+      Map<String, Set<ParameterValue>> copied = new LinkedHashMap<>();
+      when.forEach(
+          (axis, values) ->
+              copied.put(axis, Collections.unmodifiableSet(new LinkedHashSet<>(values))));
+      when = Collections.unmodifiableMap(copied);
+    }
+
+    boolean matches(Map<String, ParameterValue> parameters) {
+      return when.entrySet().stream()
+          .allMatch(selector -> selector.getValue().contains(parameters.get(selector.getKey())));
     }
   }
 
@@ -2052,6 +2206,7 @@ final class DeclarativeBenchmarkPlan {
   }
 
   enum ExclusionKind {
+    EXPLICIT_TRIAL_EXCLUSION,
     WORKLOAD_DISABLED,
     UNSUPPORTED_FEATURE,
     UNSUPPORTED_FLAG,

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MaterializedExecutionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MaterializedExecutionPlan.java
@@ -178,7 +178,8 @@ final class MaterializedExecutionPlan {
         expected,
         lifecycle,
         measurement,
-        null);
+        null,
+        List.of());
   }
 
   private static Map<String, DeclarativeBenchmarkPlan.RecipeValue> parseArguments(

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
@@ -88,6 +88,11 @@ final class ResolvedBenchmarkPlan {
             }));
 
     List<DeclarativeBenchmarkPlan.ExpandedWorkload> workloads = plan.expandedWorkloads();
+    plan.validateTrialExclusions(
+        workloads,
+        engines.stream()
+            .map(Engine::id)
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new)));
     patternProfiles.validateReferences(
         workloads.stream()
             .flatMap(workload -> workload.patterns().stream())
@@ -353,6 +358,10 @@ final class ResolvedBenchmarkPlan {
       Engine engine,
       PatternProfiles patternProfiles,
       PatternProfiles replacementProfiles) {
+    DeclarativeBenchmarkPlan.TrialExclusion trialExclusion = workload.trialExclusion(engine.id());
+    if (trialExclusion != null) {
+      return new Exclusion("explicitTrialExclusion", trialExclusion.reason());
+    }
     if (workload.disabledReason() != null) {
       return new Exclusion("workloadDisabled", workload.disabledReason());
     }

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/DeclarativeBenchmarkPlanTest.java
@@ -585,6 +585,240 @@ class DeclarativeBenchmarkPlanTest {
   }
 
   @Test
+  void trialExclusionsSelectExactExpandedEnginePairs() {
+    DeclarativeBenchmarkPlan plan =
+        parse(
+            planJson(
+                """
+                [{
+                  "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
+                  "operation": "replaceAll",
+                  "patterns": ["x"],
+                  "inputs": ["literal.input"],
+                  "arguments": {"replacement": ""},
+                  "axes": {
+                    "matchLabel": ["match", "noMatch"],
+                    "size": [1000, 10000, 100000]
+                  },
+                  "trialExclusions": [{
+                    "engineIds": ["jdk-string"],
+                    "when": {"size": [10000, 100000]},
+                    "reason": "OpenJDK 26.0.2 throws StackOverflowError for the nested quantifiers"
+                  }],
+                  "resultConsumption": "string",
+                  "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                }]
+                """));
+
+    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
+        plan.expand(
+            List.of(
+                engine(
+                    "safere-string",
+                    DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                    DeclarativeBenchmarkPlan.Feature.REPLACE),
+                engine(
+                    "jdk-string",
+                    DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                    DeclarativeBenchmarkPlan.Feature.REPLACE)),
+            EnumSet.of(DeclarativeBenchmarkPlan.Operation.REPLACE_ALL));
+
+    assertThat(expanded.exclusions())
+        .extracting(
+            exclusion -> exclusion.workloadId() + "@" + exclusion.engineId(),
+            DeclarativeBenchmarkPlan.Exclusion::kind,
+            DeclarativeBenchmarkPlan.Exclusion::reason)
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple(
+                "RealWorldRegexBenchmark.runBenchmark.recitation.match.10000@jdk-string",
+                DeclarativeBenchmarkPlan.ExclusionKind.EXPLICIT_TRIAL_EXCLUSION,
+                "OpenJDK 26.0.2 throws StackOverflowError for the nested quantifiers"),
+            org.assertj.core.groups.Tuple.tuple(
+                "RealWorldRegexBenchmark.runBenchmark.recitation.match.100000@jdk-string",
+                DeclarativeBenchmarkPlan.ExclusionKind.EXPLICIT_TRIAL_EXCLUSION,
+                "OpenJDK 26.0.2 throws StackOverflowError for the nested quantifiers"),
+            org.assertj.core.groups.Tuple.tuple(
+                "RealWorldRegexBenchmark.runBenchmark.recitation.noMatch.10000@jdk-string",
+                DeclarativeBenchmarkPlan.ExclusionKind.EXPLICIT_TRIAL_EXCLUSION,
+                "OpenJDK 26.0.2 throws StackOverflowError for the nested quantifiers"),
+            org.assertj.core.groups.Tuple.tuple(
+                "RealWorldRegexBenchmark.runBenchmark.recitation.noMatch.100000@jdk-string",
+                DeclarativeBenchmarkPlan.ExclusionKind.EXPLICIT_TRIAL_EXCLUSION,
+                "OpenJDK 26.0.2 throws StackOverflowError for the nested quantifiers"));
+    assertThat(expanded.trials().stream().map(DeclarativeBenchmarkPlan.Trial::id))
+        .hasSize(8)
+        .contains(
+            "RealWorldRegexBenchmark.runBenchmark.recitation.match.1000@jdk-string",
+            "RealWorldRegexBenchmark.runBenchmark.recitation.noMatch.1000@jdk-string")
+        .filteredOn(id -> id.endsWith("@safere-string"))
+        .hasSize(6);
+  }
+
+  @Test
+  void trialExclusionsSupportConjunctiveLabeledSelectorsAndWorkloadWideRules() {
+    DeclarativeBenchmarkPlan plan =
+        parse(
+            planJson(
+                """
+                [{
+                  "id": "Synthetic.find.{case}.{size}",
+                  "operation": "find",
+                  "patterns": ["x"],
+                  "inputs": ["literal.input"],
+                  "axes": {
+                    "case": [{"id": "hit", "value": true}, {"id": "miss", "value": false}],
+                    "size": [8, 16]
+                  },
+                  "trialExclusions": [{
+                    "engineIds": ["first", "second"],
+                    "when": {"case": [{"id": "hit", "value": true}], "size": [16]},
+                    "reason": "conjunctive selector"
+                  }, {
+                    "engineIds": ["third"],
+                    "when": {},
+                    "reason": "all workload expansions"
+                  }],
+                  "resultConsumption": "boolean",
+                  "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                }]
+                """));
+
+    DeclarativeBenchmarkPlan.ExpandedPlan expanded =
+        plan.expand(
+            List.of(
+                engine(
+                    "first",
+                    DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                    DeclarativeBenchmarkPlan.Feature.FIND),
+                engine(
+                    "second",
+                    DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                    DeclarativeBenchmarkPlan.Feature.FIND),
+                engine(
+                    "third",
+                    DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                    DeclarativeBenchmarkPlan.Feature.FIND),
+                engine(
+                    "unexcluded",
+                    DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING,
+                    DeclarativeBenchmarkPlan.Feature.FIND)),
+            EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND));
+
+    assertThat(expanded.exclusions())
+        .extracting(exclusion -> exclusion.workloadId() + "@" + exclusion.engineId())
+        .containsExactly(
+            "Synthetic.find.hit.8@third",
+            "Synthetic.find.hit.16@first",
+            "Synthetic.find.hit.16@second",
+            "Synthetic.find.hit.16@third",
+            "Synthetic.find.miss.8@third",
+            "Synthetic.find.miss.16@third");
+  }
+
+  @Test
+  void trialExclusionsRejectInvalidSelectorsAndOverlaps() {
+    assertInvalidTrialExclusion("{}", "requires engineIds");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [], \"reason\": \"reason\"}", "requires at least one engine ID");
+    assertInvalidTrialExclusion("{\"engineIds\": [\"jdk-string\"]}", "requires reason");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\", \"jdk-string\"], \"reason\": \"reason\"}",
+        "duplicate engine ID");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"reason\": \"  \"}", "reason must not be blank");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"when\": {\"unknown\": [8]},"
+            + " \"reason\": \"reason\"}",
+        "references unknown axis");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"when\": {\"size\": []}," + " \"reason\": \"reason\"}",
+        "selector must not be empty");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"when\": {\"size\": [32]},"
+            + " \"reason\": \"reason\"}",
+        "selects undeclared axis value");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"when\": {\"size\": [8, 8]},"
+            + " \"reason\": \"reason\"}",
+        "duplicate axis value");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"reason\": \"reason\"," + " \"unknown\": true}",
+        "has unknown field: unknown");
+    assertThatThrownBy(
+            () ->
+                parse(
+                    planJson(
+                        """
+                        [{
+                          "id": "Synthetic.find",
+                          "operation": "find",
+                          "patterns": ["x"],
+                          "inputs": ["literal.input"],
+                          "trialExclusions": {},
+                          "resultConsumption": "boolean",
+                          "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                        }]
+                        """)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("trialExclusions must be an array");
+    assertInvalidTrialExclusion(
+        "{\"engineIds\": [\"jdk-string\"], \"when\": [], \"reason\": \"reason\"}",
+        "when must be an object");
+
+    assertThatThrownBy(
+            () ->
+                parse(
+                    planJson(
+                        """
+                        [{
+                          "id": "Synthetic.find",
+                          "operation": "find",
+                          "patterns": ["x"],
+                          "inputs": ["literal.input"],
+                          "trialExclusions": [{
+                            "engineIds": ["jdk-string"],
+                            "reason": "reason"
+                          }],
+                          "disabledReason": "disabled",
+                          "resultConsumption": "boolean",
+                          "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+                        }]
+                        """)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not declare both disabledReason and trialExclusions");
+
+    DeclarativeBenchmarkPlan unknownEngine =
+        planWithTrialExclusions("{\"engineIds\": [\"jdk-string\"], \"reason\": \"reason\"}");
+    assertThatThrownBy(
+            () ->
+                unknownEngine.expand(
+                    List.of(
+                        engine(
+                            "safere-string",
+                            DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING)),
+                    EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("references unknown engine ID: jdk-string");
+
+    DeclarativeBenchmarkPlan overlap =
+        planWithTrialExclusions(
+            "{\"engineIds\": [\"jdk-string\"], \"when\": {\"size\": [8]},"
+                + " \"reason\": \"first\"},"
+                + "{\"engineIds\": [\"jdk-string\"], \"reason\": \"second\"}");
+    assertThatThrownBy(
+            () ->
+                overlap.expand(
+                    List.of(
+                        engine(
+                            "jdk-string",
+                            DeclarativeBenchmarkPlan.InputRepresentation.JAVA_STRING)),
+                    EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Synthetic.find.8 has overlapping trial exclusions for engine jdk-string");
+  }
+
+  @Test
   void unsupportedFlagsHaveAMachineReadableExclusion() {
     DeclarativeBenchmarkPlan plan =
         parse(
@@ -1004,6 +1238,30 @@ class DeclarativeBenchmarkPlanTest {
 
   private static DeclarativeBenchmarkPlan parse(String json) {
     return DeclarativeBenchmarkPlan.parse(JsonParser.parseString(json).getAsJsonObject());
+  }
+
+  private static void assertInvalidTrialExclusion(String exclusion, String message) {
+    assertThatThrownBy(() -> planWithTrialExclusions(exclusion))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(message);
+  }
+
+  private static DeclarativeBenchmarkPlan planWithTrialExclusions(String exclusions) {
+    return parse(
+        planJson(
+            """
+            [{
+              "id": "Synthetic.find.{size}",
+              "operation": "find",
+              "patterns": ["x"],
+              "inputs": ["literal.input"],
+              "axes": {"size": [8, 16]},
+              "trialExclusions": [%s],
+              "resultConsumption": "boolean",
+              "measurement": {"mode": "averageTime", "timingUnit": "nanoseconds"}
+            }]
+            """
+                .formatted(exclusions)));
   }
 
   private static String planJson(String workloads) {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/ResolvedBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/ResolvedBenchmarkPlanTest.java
@@ -97,6 +97,61 @@ class ResolvedBenchmarkPlanTest {
         .isEqualTo("alternate-replacement");
   }
 
+  @Test
+  void explicitTrialExclusionsSurviveResolutionAndMaterializedConsumption() {
+    JsonObject data = normalizedData();
+    JsonObject find = data.getAsJsonArray("workloads").get(0).getAsJsonObject();
+    find.add(
+        "trialExclusions",
+        JsonParser.parseString(
+            """
+            [{
+              "engineIds": ["jdk-string"],
+              "reason": "OpenJDK 26.0.2 throws StackOverflowError for this trial"
+            }]
+            """));
+
+    JsonObject resolved =
+        ResolvedBenchmarkPlan.create(
+            data,
+            List.of(
+                engine(
+                    "safere-string",
+                    "alternate",
+                    EnumSet.of(DeclarativeBenchmarkPlan.Feature.FIND),
+                    EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND)),
+                engine(
+                    "jdk-string",
+                    "alternate",
+                    EnumSet.of(DeclarativeBenchmarkPlan.Feature.FIND),
+                    EnumSet.of(DeclarativeBenchmarkPlan.Operation.FIND))));
+
+    JsonObject exclusion = entry(resolved, "Synthetic.find@jdk-string");
+    assertThat(exclusion.get("status").getAsString()).isEqualTo("excluded");
+    assertThat(exclusion.getAsJsonObject("exclusion").get("kind").getAsString())
+        .isEqualTo("explicitTrialExclusion");
+    assertThat(exclusion.getAsJsonObject("exclusion").get("reason").getAsString())
+        .isEqualTo("OpenJDK 26.0.2 throws StackOverflowError for this trial");
+    assertThat(entry(resolved, "Synthetic.find@safere-string").get("status").getAsString())
+        .isEqualTo("runnable");
+
+    MaterializedExecutionPlan materialized = MaterializedExecutionPlan.parse(resolved);
+    assertThat(materialized.resolve("Synthetic.find@jdk-string").exclusion())
+        .isEqualTo(
+            new MaterializedExecutionPlan.Exclusion(
+                "explicitTrialExclusion",
+                "OpenJDK 26.0.2 throws StackOverflowError for this trial"));
+    CrossEngineBenchmarkPlan collection =
+        CrossEngineBenchmarkPlan.fromMaterialized(materialized.entriesForRunner("java"));
+    assertThat(collection.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS))
+        .extracting(CrossEngineBenchmarkPlan.Trial::id)
+        .contains("Synthetic.find@safere-string")
+        .doesNotContain("Synthetic.find@jdk-string");
+    assertThat(collection.exclusions())
+        .extracting(MaterializedExecutionPlan.Entry::id)
+        .contains("Synthetic.find@jdk-string");
+  }
+
   private static ResolvedBenchmarkPlan.Engine engine(
       String id,
       String profile,
@@ -105,7 +160,7 @@ class ResolvedBenchmarkPlanTest {
     return new ResolvedBenchmarkPlan.Engine(
         id,
         id,
-        "test",
+        "java",
         profile,
         profile,
         new DeclarativeBenchmarkPlan.EngineDeclaration(


### PR DESCRIPTION
## Summary

- add strict declarative `trialExclusions` selectors for exact engine IDs and expanded workload axes
- validate typed selector values, unknown engines, duplicate values, and overlapping rules
- preserve explicit exclusions through resolved-plan materialization, collection filtering, and reporting
- document the schema and cover the recitation exclusion matrix plus invalid forms

Fixes #672.

## Verification

Ran:

```text
mvn -pl safere-benchmarks spotless:apply verify -q
git diff --check
```

Also ran the noninteractive review/fix loop against `main`; it reported no P2-or-higher findings.

Confirmed separately on OpenJDK 26.0.2 that the PR #669 recitation inputs succeed at size 1,000 and throw `StackOverflowError` for both matching and nonmatching forms at sizes 10,000 and 100,000.

Not run:

- full SafeRE module test suite
- public API crosscheck suite
- benchmark measurements

PR #669 will add the checked-in recitation exclusion rule after rebasing onto this facility.
