### PR TITLE
Optimize replaceAll and replaceFirst execution paths in Matcher

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -418,6 +418,33 @@ final class FuzzSupport {
           () -> runJdkOracle("replaceFirst", null, () -> jdkMatcher.replaceFirst(replacement)));
     }
 
+    boolean hasReplacementMatchState() {
+      boolean safeRe;
+      try {
+        safeReMatcher.start();
+        safeRe = true;
+      } catch (IllegalStateException e) {
+        safeRe = false;
+      }
+      boolean jdk =
+          runJdkOracle(
+              "replacement match state",
+              safeRe,
+              () -> {
+                try {
+                  jdkMatcher.start();
+                  return true;
+                } catch (IllegalStateException e) {
+                  return false;
+                }
+              });
+      assertSame("replacement match state", safeRe, jdk);
+      if (safeRe) {
+        assertMatchState("replacement match state");
+      }
+      return safeRe;
+    }
+
     boolean appendReplacement(StringBuilder output, String replacement) {
       StringBuilder safeRe = new StringBuilder();
       StringBuilder jdk = new StringBuilder();

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ReplacementFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ReplacementFuzzer.java
@@ -21,10 +21,18 @@ final class ReplacementFuzzer {
       return;
     }
 
-    if (!pattern.matcher(input).replaceAll(replacement)
-        || !pattern.matcher(input).replaceFirst(replacement)) {
+    FuzzSupport.MatcherPair replaceAllMatcher = pattern.matcher(input);
+    if (!replaceAllMatcher.replaceAll(replacement)) {
       return;
     }
+    replaceAllMatcher.find();
+
+    FuzzSupport.MatcherPair replaceFirstMatcher = pattern.matcher(input);
+    if (!replaceFirstMatcher.replaceFirst(replacement)) {
+      return;
+    }
+    replaceFirstMatcher.hasReplacementMatchState();
+
     appendReplacementLoop(pattern, input, replacement, data.consumeBoolean());
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2843,6 +2843,11 @@ public final class Matcher implements MatchResult {
     Objects.requireNonNull(replacement, "replacement");
     reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    String literalResult = literalReplaceFastPath(template, 1);
+    if (literalResult != null) {
+      return literalResult;
+    }
+
     String fastResult = charClassReplaceFastPath(template, 1);
     if (fastResult != null) {
       return fastResult;
@@ -2858,8 +2863,15 @@ public final class Matcher implements MatchResult {
       return result;
     }
 
+    if (template.needsCaptures()) {
+      eagerFallbackCaptures = true;
+    }
+
     if (!find()) {
       return text;
+    }
+    if (template.needsCaptures()) {
+      parentPattern.recordInnerCaptureAccess();
     }
     diagnosticIncrementMatchCount();
     StringBuilder sb = new StringBuilder(text.length());
@@ -2934,7 +2946,6 @@ public final class Matcher implements MatchResult {
         // dollarAnchorEnd is safe if start-anchored because we skip the reverse DFA scan.
         || (parentPattern.prog().dollarAnchorEnd() && !parentPattern.prog().anchorStart())
         || parentPattern.literalMatch() != null
-        || parentPattern.canMatchEmpty()
         || parentPattern.hasNullableAlternation()
         || regionActive) {
       return null;
@@ -3052,6 +3063,12 @@ public final class Matcher implements MatchResult {
       builderAppendPos = matchEnd;
 
       cursor.pos = matchEnd;
+      if (matchStart == matchEnd) {
+        if (cursor.pos >= regionEnd) {
+          break;
+        }
+        cursor.pos++;
+      }
       matchesFound++;
       if (matchesFound < limit) {
         matchResult =
@@ -3115,7 +3132,9 @@ public final class Matcher implements MatchResult {
 
       int earlyEnd = fwdResult.pos();
       if (earlyEnd <= pos) {
-        return -1;
+        matchOffsets[0] = pos;
+        matchOffsets[1] = pos;
+        return 1;
       }
 
       int matchStart;
@@ -3246,6 +3265,11 @@ public final class Matcher implements MatchResult {
   private String replaceAllImpl(String replacement) {
     reset();
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
+    String literalResult = literalReplaceFastPath(template, Integer.MAX_VALUE);
+    if (literalResult != null) {
+      return literalResult;
+    }
+
     String fastResult = charClassReplaceFastPath(template, Integer.MAX_VALUE);
     if (fastResult != null) {
       return fastResult;
@@ -3261,8 +3285,15 @@ public final class Matcher implements MatchResult {
       return result;
     }
 
+    if (template.needsCaptures()) {
+      eagerFallbackCaptures = true;
+    }
+
     if (!find()) {
       return text;
+    }
+    if (template.needsCaptures()) {
+      parentPattern.recordInnerCaptureAccess();
     }
     diagnosticIncrementMatchCount();
     StringBuilder sb = new StringBuilder(text.length());
@@ -3323,6 +3354,90 @@ public final class Matcher implements MatchResult {
       appendReplacement(sb, replacement);
     } while (findAndRecordReplacementMatch());
     appendTail(sb);
+    return sb.toString();
+  }
+
+  private String literalReplaceFastPath(LazyTemplate template, int limit) {
+    if (!enginePathOptions().literalFastPaths()) {
+      return null;
+    }
+
+    String literal = parentPattern.literalMatch();
+    if (literal == null || literal.isEmpty() || text == null || parentPattern.prefixFoldCase()) {
+      return null;
+    }
+
+    String replacement = template.replacement;
+    boolean simpleReplacement = isSimpleReplacement(replacement);
+    if (!simpleReplacement && groupCount() > 0) {
+      return null; // Cannot handle complex replacements with captures yet
+    }
+
+    DiagnosticOperation activeDiagnostics = diagnosticOperation;
+    DiagnosticAccumulator accumulator =
+        activeDiagnostics == null ? null : activeDiagnostics.accumulator();
+    if (accumulator != null) {
+      accumulator.participate(MatchStrategy.LITERAL, StrategyRole.CANDIDATE_VERIFICATION);
+    }
+
+    StringBuilder sb = null;
+    int appendPosition = 0;
+    int searchFrom = 0;
+    int matchStart;
+    int matchesFound = 0;
+
+    int firstMatchStart = -1;
+    int firstMatchEnd = -1;
+
+    ReplacementSegment[] compiledTemplate = simpleReplacement ? null : template.get();
+
+    while (matchesFound < limit && (matchStart = text.indexOf(literal, searchFrom)) != -1) {
+      if (sb == null) {
+        sb = new StringBuilder(text.length());
+      }
+      sb.append(text, appendPosition, matchStart);
+
+      if (matchesFound == 0) {
+        firstMatchStart = matchStart;
+        firstMatchEnd = matchStart + literal.length();
+      }
+
+      if (simpleReplacement) {
+        sb.append(replacement);
+      } else {
+        groups[0] = matchStart;
+        groups[1] = matchStart + literal.length();
+        applyReplacementTemplate(sb, compiledTemplate);
+      }
+
+      appendPosition = matchStart + literal.length();
+      searchFrom = appendPosition;
+      matchesFound++;
+    }
+
+    if (sb == null) {
+      if (accumulator != null) {
+        accumulator.boundary(MatchStrategy.LITERAL);
+      }
+      applyFailedMatchResult();
+      return text;
+    }
+
+    this.appendPos = appendPosition;
+    sb.append(text, appendPosition, text.length());
+
+    if (limit == 1) {
+      applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
+    } else {
+      this.searchFrom = regionEnd;
+      applyFailedMatchResult();
+    }
+
+    if (accumulator != null) {
+      accumulator.boundary(MatchStrategy.LITERAL);
+      accumulator.matchCount(matchesFound);
+    }
+
     return sb.toString();
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -3063,13 +3063,14 @@ public final class Matcher implements MatchResult {
       builderAppendPos = matchEnd;
 
       cursor.pos = matchEnd;
+      matchesFound++;
       if (matchStart == matchEnd) {
         if (cursor.pos >= regionEnd) {
+          findExhaustedAfterTerminalEmptyMatch = true;
           break;
         }
         cursor.pos++;
       }
-      matchesFound++;
       if (matchesFound < limit) {
         matchResult =
             findNextDfaMatch(
@@ -3389,7 +3390,7 @@ public final class Matcher implements MatchResult {
     int firstMatchStart = -1;
     int firstMatchEnd = -1;
 
-    ReplacementSegment[] compiledTemplate = simpleReplacement ? null : template.get();
+    ReplacementSegment[] compiledTemplate = null;
 
     while (matchesFound < limit && (matchStart = text.indexOf(literal, searchFrom)) != -1) {
       if (sb == null) {
@@ -3400,6 +3401,10 @@ public final class Matcher implements MatchResult {
       if (matchesFound == 0) {
         firstMatchStart = matchStart;
         firstMatchEnd = matchStart + literal.length();
+        if (!simpleReplacement) {
+          applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
+          compiledTemplate = template.get();
+        }
       }
 
       if (simpleReplacement) {
@@ -3427,7 +3432,13 @@ public final class Matcher implements MatchResult {
     sb.append(text, appendPosition, text.length());
 
     if (limit == 1) {
-      applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
+      if (groupCount() == 0) {
+        applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
+      } else {
+        applyDeferredMatchResult(
+            firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
+        resolveCaptures();
+      }
     } else {
       this.searchFrom = regionEnd;
       applyFailedMatchResult();

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -208,6 +208,28 @@ class DiagnosticsTest {
   }
 
   @Test
+  void nullableDfaReplacementCountsTerminalEmptyMatch() {
+    Pattern.setDiagnostics(diagnostics);
+
+    for (String input : List.of("", "b", "bbb")) {
+      Pattern pattern = Pattern.compile("a?");
+      long expectedMatches = input.length() + 1L;
+
+      assertThat(pattern.matcher(input).replaceAll("x"))
+          .isEqualTo(java.util.regex.Pattern.compile("a?").matcher(input).replaceAll("x"));
+
+      assertThat(operationsFor(pattern))
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.operation()).isEqualTo(MatchOperation.REPLACE_ALL);
+                assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+                assertThat(event.matchCount()).isEqualTo(expectedMatches);
+              });
+    }
+  }
+
+  @Test
   void dfaSandwichReportsForwardAndReverseSearchCounts() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile("[ab]+c");

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -1332,20 +1332,22 @@ class MatcherTest {
     @ValueSource(strings = {"$", "\\"})
     @DisplayName("replaceAll() with no match does not validate malformed replacement")
     void replaceAllNoMatchDoesNotValidateMalformedReplacement(String replacement) {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("abc");
+      for (String regex : new String[] {"\\d+", "literal"}) {
+        Matcher matcher = Pattern.compile(regex).matcher("abc");
 
-      assertThat(m.replaceAll(replacement)).isEqualTo("abc");
+        assertThat(matcher.replaceAll(replacement)).as("pattern %s", regex).isEqualTo("abc");
+      }
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"$", "\\"})
     @DisplayName("replaceFirst() with no match does not validate malformed replacement")
     void replaceFirstNoMatchDoesNotValidateMalformedReplacement(String replacement) {
-      Pattern p = Pattern.compile("\\d+");
-      Matcher m = p.matcher("abc");
+      for (String regex : new String[] {"\\d+", "literal"}) {
+        Matcher matcher = Pattern.compile(regex).matcher("abc");
 
-      assertThat(m.replaceFirst(replacement)).isEqualTo("abc");
+        assertThat(matcher.replaceFirst(replacement)).as("pattern %s", regex).isEqualTo("abc");
+      }
     }
 
     @ParameterizedTest
@@ -1483,6 +1485,21 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("literal replaceFirst() retains numbered and named captures")
+    void literalReplaceFirstRetainsCaptures() {
+      Matcher matcher = Pattern.compile("(?<word>(foo))").matcher("foo bar");
+
+      assertThat(matcher.replaceFirst("X")).isEqualTo("X bar");
+
+      assertThat(matcher.group()).isEqualTo("foo");
+      assertThat(matcher.group(1)).isEqualTo("foo");
+      assertThat(matcher.group(2)).isEqualTo("foo");
+      assertThat(matcher.group("word")).isEqualTo("foo");
+      assertThat(matcher.start(1)).isZero();
+      assertThat(matcher.end(2)).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("anchored OnePass replaceFirst preserves the append position")
     void anchoredOnePassReplaceFirstPreservesAppendPosition() {
       Matcher m = Pattern.compile("^([a-z]+)$").matcher("abc\n");
@@ -1536,6 +1553,19 @@ class MatcherTest {
       assertThat(sb).hasToString("");
       assertThat(m.find()).isFalse();
       assertThatThrownBy(() -> m.toMatchResult().start()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "b", "bbb"})
+    @DisplayName("nullable DFA replaceAll() consumes its terminal empty match")
+    void nullableDfaReplaceAllConsumesTerminalEmptyMatch(String input) {
+      Matcher matcher = Pattern.compile("a?").matcher(input);
+      java.util.regex.Matcher jdkMatcher = java.util.regex.Pattern.compile("a?").matcher(input);
+
+      assertThat(matcher.replaceAll("X")).isEqualTo(jdkMatcher.replaceAll("X"));
+
+      assertThat(matcher.find()).isEqualTo(jdkMatcher.find()).isFalse();
+      assertThatThrownBy(matcher::start).isInstanceOf(IllegalStateException.class);
     }
 
     @Test


### PR DESCRIPTION
Improves performance of replacement loops by introducing dedicated fast paths and lifting wrapper restrictions.

* Add replacement fast path for literal patterns
* Generalized DFA fast path to handle zero match characters, and defend against stalls on empty matches, similar to non-replacement paths
* avoid redundant second NFA execution pass when replacement templates require capturing groups by setting eager capture demand early

```
$ ./run-java-benchmarks.sh --fastbuild CrossEngineBenchmark.run -- -p crossEngineTrial=ReplaceBenchmark.literalReplaceAll@safere-string,ReplaceBenchmark.emptyReplaceAll@safere-string
```

| Benchmark | Baseline (ns/op) | Experiment (ns/op) | Change |
| :--- | :--- | :--- | :--- | 
| `literalReplaceAll` | $289.639 \pm 10.256$ | $189.717 \pm 17.709$ | **34.5% Faster** |
| `emptyReplaceAll` | $113.108 \pm 30.723$ | $95.676 \pm 0.709$ | **15.4% Faster** |

