### PR TITLE
Add SWAR scanning for multi-range ASCII classes

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -86,6 +86,23 @@
         "pair/first/late/32768/7",
         "range/first/absent/32768/7",
         "range/first/late/32768/7",
+        "range2/first/absent/64/0",
+        "range2/first/absent/256/0",
+        "range2/first/absent/1024/0",
+        "range2/first/absent/32768/0",
+        "range2/first/late/32768/0",
+        "range2/all/sparse/32768/0",
+        "range2/all/dense/32768/0",
+        "range2/first/prefixFalse/32768/0",
+        "range2/first/nonascii/32768/0",
+        "range2/first/late/32768/7",
+        "alnum3/first/absent/15/0",
+        "alnum3/first/absent/16/0",
+        "alnum3/first/absent/17/0",
+        "alnum3/first/absent/31/0",
+        "alnum3/first/absent/32/0",
+        "alnum3/first/absent/33/0",
+        "alnum3/first/absent/63/0",
         "alnum3/first/absent/64/0",
         "alnum3/first/absent/256/0",
         "alnum3/first/absent/1024/0",
@@ -100,6 +117,15 @@
         "alnum3/all/dense/32768/0",
         "alnum3/first/absent/32768/7",
         "alnum3/first/late/32768/7",
+        "alnum3/first/prefixFalse/32768/0",
+        "alnum3/first/nonascii/32768/0",
+        "mixed4/first/absent/15/0",
+        "mixed4/first/absent/16/0",
+        "mixed4/first/absent/17/0",
+        "mixed4/first/absent/31/0",
+        "mixed4/first/absent/32/0",
+        "mixed4/first/absent/33/0",
+        "mixed4/first/absent/63/0",
         "mixed4/first/absent/64/0",
         "mixed4/first/absent/256/0",
         "mixed4/first/absent/1024/0",
@@ -113,7 +139,9 @@
         "mixed4/all/sparse/32768/0",
         "mixed4/all/dense/32768/0",
         "mixed4/first/absent/32768/7",
-        "mixed4/first/late/32768/7"
+        "mixed4/first/late/32768/7",
+        "mixed4/first/prefixFalse/32768/0",
+        "mixed4/first/nonascii/32768/0"
       ]
     }
   },
@@ -412,6 +440,24 @@
       "shared": true
     },
     {
+      "id": "vectorScan.multi.prefixFalse.32768",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "_",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
+      "id": "vectorScan.multi.nonascii.32768",
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "é",
+        "length": 32768
+      },
+      "shared": true
+    },
+    {
       "id": "vectorScan.sparse.32768",
       "recipe": {
         "kind": "sparseMatchToLength",
@@ -437,6 +483,13 @@
       "id": "vectorScan.multi.absent.{length}",
       "axes": {
         "length": [
+          15,
+          16,
+          17,
+          31,
+          32,
+          33,
+          63,
           64,
           256,
           1024,

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(351);
+    assertThat(first).hasSize(360);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");

--- a/safere-vector-benchmarks/README.md
+++ b/safere-vector-benchmarks/README.md
@@ -43,8 +43,8 @@ trials and a reset `Utf8Matcher.find` loop for scan-all trials.
 
 The trial ID format is `shape/traversal/density/length/offset`, where:
 
-- `shape` is `singleton`, `pair`, `range`, `alnum3`, or `mixed4`;
+- `shape` is `singleton`, `pair`, `range`, `range2`, `alnum3`, or `mixed4`;
 - `traversal` is `first` or `all`;
-- `density` is `absent`, `late`, `sparse`, or `dense`;
+- `density` is `absent`, `late`, `sparse`, `dense`, `prefixFalse`, or `nonascii`;
 - `length` is the logical UTF-8 byte length; and
 - `offset` is the borrowed array window's starting offset.

--- a/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorScanBenchmark.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/vector/benchmark/Utf8VectorScanBenchmark.java
@@ -37,6 +37,7 @@ public class Utf8VectorScanBenchmark {
   private static final int[] SINGLETON_RANGES = {'x', 'x'};
   private static final int[] PAIR_RANGES = {'x', 'x', 'y', 'y'};
   private static final int[] RANGE_RANGES = {'0', '9'};
+  private static final int[] RANGE2_RANGES = {'0', '9', 'A', 'Z'};
   private static final int[] ALNUM3_RANGES = {'0', '9', 'A', 'Z', 'a', 'z'};
   private static final int[] MIXED4_RANGES = {'!', '!', '#', '#', '0', '9', 'A', 'Z'};
 
@@ -395,6 +396,20 @@ public class Utf8VectorScanBenchmark {
       @Override
       boolean matches(byte value) {
         return value >= '0' && value <= '9';
+      }
+    },
+    RANGE2(RANGE2_RANGES, "[0-9A-Z]", "multi.") {
+      @Override
+      VectorMask<Byte> matches(ByteVector values) {
+        VectorMask<Byte> digits =
+            values.compare(GE, (byte) '0').and(values.compare(LE, (byte) '9'));
+        VectorMask<Byte> upper = values.compare(GE, (byte) 'A').and(values.compare(LE, (byte) 'Z'));
+        return digits.or(upper);
+      }
+
+      @Override
+      boolean matches(byte value) {
+        return (value >= '0' && value <= '9') || (value >= 'A' && value <= 'Z');
       }
     },
     ALNUM3(ALNUM3_RANGES, "[0-9A-Za-z]", "multi.") {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -15,7 +15,10 @@ final class Utf8InputScanner implements InputScanner {
   private static final int REPLACEMENT_CHARACTER = 0xFFFD;
   private static final long BYTE_ONES = 0x0101_0101_0101_0101L;
   private static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
+  private static final long BYTE_LOW_BITS = ~BYTE_HIGH_BITS;
   private static final int BOYER_MOORE_HORSPOOL_BATCH_SIZE = 2;
+  private static final int MULTI_RANGE_SWAR_MINIMUM_LENGTH = 64;
+  private static final int MULTI_RANGE_SWAR_SCALAR_PROLOGUE_LENGTH = Long.BYTES;
   private static final int VECTOR_SCALAR_PROLOGUE_LENGTH = Integer.BYTES;
 
   /**
@@ -93,6 +96,25 @@ final class Utf8InputScanner implements InputScanner {
   public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
     int position = Math.max(0, start);
     if (!WorkCounterConfig.ENABLED) {
+      if (scanProvider == null
+          && ranges.length >= 4
+          && ranges.length <= 8
+          && ranges[0] >= 0
+          && ranges[ranges.length - 1] < 0x80
+          && length - position >= MULTI_RANGE_SWAR_MINIMUM_LENGTH
+          && (ranges.length != 4 || ranges[0] != ranges[1] || ranges[2] != ranges[3])) {
+        int scalarLimit = position + MULTI_RANGE_SWAR_SCALAR_PROLOGUE_LENGTH;
+        for (; position < scalarLimit; position++) {
+          int value = unsignedByteAt(position);
+          if ((value < Long.SIZE && (bitmap0 & (1L << value)) != 0)
+              || (value >= Long.SIZE
+                  && value < 128
+                  && (bitmap1 & (1L << (value - Long.SIZE))) != 0)) {
+            return position;
+          }
+        }
+        return indexOfMultipleByteRanges(ranges, bitmap0, bitmap1, position);
+      }
       int asciiResult = indexOfAsciiRanges(ranges, bitmap0, bitmap1, position);
       if (asciiResult >= -1) {
         return asciiResult;
@@ -162,6 +184,113 @@ final class Utf8InputScanner implements InputScanner {
       return indexOfBytePair((byte) ranges[0], (byte) ranges[2], start);
     }
     return -2;
+  }
+
+  private int indexOfMultipleByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
+    return switch (ranges.length) {
+      case 4 -> indexOfTwoByteRanges(ranges, bitmap0, bitmap1, start);
+      case 6 -> indexOfThreeByteRanges(ranges, bitmap0, bitmap1, start);
+      case 8 -> indexOfFourByteRanges(ranges, bitmap0, bitmap1, start);
+      default -> throw new AssertionError("unexpected range count");
+    };
+  }
+
+  private int indexOfTwoByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
+    long low0 = ranges[0] * BYTE_ONES;
+    long high0 = ranges[1] * BYTE_ONES;
+    long low1 = ranges[2] * BYTE_ONES;
+    long high1 = ranges[3] * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long values = word & BYTE_LOW_BITS;
+      long ascii = ~word & BYTE_HIGH_BITS;
+      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
+      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
+      if (matches != 0) {
+        return scalarRangeCheck(bitmap0, bitmap1, position, position + Long.BYTES);
+      }
+      position += Long.BYTES;
+    }
+    return scalarRangeCheck(bitmap0, bitmap1, position, length);
+  }
+
+  private int indexOfThreeByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
+    long low0 = ranges[0] * BYTE_ONES;
+    long high0 = ranges[1] * BYTE_ONES;
+    long low1 = ranges[2] * BYTE_ONES;
+    long high1 = ranges[3] * BYTE_ONES;
+    long low2 = ranges[4] * BYTE_ONES;
+    long high2 = ranges[5] * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long values = word & BYTE_LOW_BITS;
+      long ascii = ~word & BYTE_HIGH_BITS;
+      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
+      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
+      matches |= exactAsciiRangeMask(values, ascii, low2, high2);
+      if (matches != 0) {
+        return scalarRangeCheck(bitmap0, bitmap1, position, position + Long.BYTES);
+      }
+      position += Long.BYTES;
+    }
+    return scalarRangeCheck(bitmap0, bitmap1, position, length);
+  }
+
+  private int indexOfFourByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
+    long low0 = ranges[0] * BYTE_ONES;
+    long high0 = ranges[1] * BYTE_ONES;
+    long low1 = ranges[2] * BYTE_ONES;
+    long high1 = ranges[3] * BYTE_ONES;
+    long low2 = ranges[4] * BYTE_ONES;
+    long high2 = ranges[5] * BYTE_ONES;
+    long low3 = ranges[6] * BYTE_ONES;
+    long high3 = ranges[7] * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long values = word & BYTE_LOW_BITS;
+      long ascii = ~word & BYTE_HIGH_BITS;
+      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
+      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
+      matches |= exactAsciiRangeMask(values, ascii, low2, high2);
+      matches |= exactAsciiRangeMask(values, ascii, low3, high3);
+      if (matches != 0) {
+        return scalarRangeCheck(bitmap0, bitmap1, position, position + Long.BYTES);
+      }
+      position += Long.BYTES;
+    }
+    return scalarRangeCheck(bitmap0, bitmap1, position, length);
+  }
+
+  private int scalarRangeCheck(long bitmap0, long bitmap1, int position, int limit) {
+    for (; position < limit; position++) {
+      int value = unsignedByteAt(position);
+      if ((value < Long.SIZE && (bitmap0 & (1L << value)) != 0)
+          || (value >= Long.SIZE && value < 128 && (bitmap1 & (1L << (value - Long.SIZE))) != 0)) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
+  static long exactAsciiRangeMask(long word, int low, int high) {
+    long values = word & BYTE_LOW_BITS;
+    long ascii = ~word & BYTE_HIGH_BITS;
+    return exactAsciiRangeMask(values, ascii, low * BYTE_ONES, high * BYTE_ONES);
+  }
+
+  private static long exactAsciiRangeMask(
+      long values, long ascii, long repeatedLow, long repeatedHigh) {
+    // Setting each minuend's high bit makes both subtractions independent in every byte lane:
+    // each lane subtracts at most 127 from at least 128, so no borrow can cross a lane boundary.
+    long atLeastLow = ((values | BYTE_HIGH_BITS) - repeatedLow) & BYTE_HIGH_BITS;
+    long atMostHigh = ((repeatedHigh | BYTE_HIGH_BITS) - values) & BYTE_HIGH_BITS;
+    return ascii & atLeastLow & atMostHigh;
   }
 
   private int indexOfNonAsciiCodePointClass(int[] ranges, int start) {

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -177,6 +177,49 @@ class Utf8InputScannerTest {
   }
 
   @Test
+  void exactAsciiRangeMaskAgreesForEveryRangeAndByteValue() {
+    long byteOnes = 0x0101_0101_0101_0101L;
+    long byteHighBits = 0x8080_8080_8080_8080L;
+
+    for (int low = 0; low < 128; low++) {
+      for (int high = low; high < 128; high++) {
+        for (int value = 0; value < 256; value++) {
+          long word = value * byteOnes;
+          long expected = value >= low && value <= high ? byteHighBits : 0;
+          long actual = Utf8InputScanner.exactAsciiRangeMask(word, low, high);
+          if (actual != expected) {
+            fail(
+                "Incorrect range mask for [%s, %s] and byte %s: expected %s, actual %s",
+                low, high, value, Long.toHexString(expected), Long.toHexString(actual));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void exactAsciiRangeMaskKeepsByteLanesIndependent() {
+    Random random = new Random(20260805);
+    for (int trial = 0; trial < 100_000; trial++) {
+      int low = random.nextInt(128);
+      int high = low + random.nextInt(128 - low);
+      long word = 0;
+      long expected = 0;
+      for (int lane = 0; lane < Long.BYTES; lane++) {
+        int value = random.nextInt(256);
+        word |= (long) value << (lane * Byte.SIZE);
+        if (value >= low && value <= high) {
+          expected |= 0x80L << (lane * Byte.SIZE);
+        }
+      }
+
+      assertThat(Utf8InputScanner.exactAsciiRangeMask(word, low, high))
+          .as("range [%s, %s], word %s", low, high, Long.toHexString(word))
+          .isEqualTo(expected);
+    }
+  }
+
+  @Test
   void asciiCodePointClassSearchHonorsStartsAndSkipsNonAsciiScalars() {
     byte[] bytes = "5é😀a7".getBytes(UTF_8);
     int[] digits = {'0', '9'};


### PR DESCRIPTION
## Summary

- add an exact eight-byte SWAR scanner for normalized ASCII classes containing two through four ranges
- retain the existing scalar, singleton/pair, Vector-provider, and work-counter paths when the new specialization is not applicable
- expand the Vector scan workload matrix with two-range classes, short inputs, false-prefix candidates, non-ASCII input, offsets, densities, and unsupported larger classes
- add exhaustive per-byte range-mask tests and scanner coverage across alignments, match positions, and decline paths

The exact range mask sets each byte lane's high bit before subtraction. Each lane therefore subtracts at most 127 from at least 128, preventing borrow from crossing byte boundaries. A short scalar prologue handles nearby matches before the SWAR loop, and candidate words are resolved with an exact bitmap scan.

## Benchmark results

Standard x86-64 results for the complete SafeRE path on 32 KiB inputs, compared with `main`:

| Class | Workload | `main` | This PR | Change |
| --- | --- | ---: | ---: | ---: |
| `[0-9A-Za-z]` | absent | 15.748 us | 8.987 us | 1.75x faster |
| `[0-9A-Za-z]` | sparse scan-all | 61.839 us | 41.523 us | 1.49x faster |
| `[!#0-9A-Z]` | absent | 15.573 us | 11.362 us | 1.37x faster |
| `[!#0-9A-Z]` | sparse scan-all | 66.696 us | 54.168 us | 1.23x faster |

Long confirmation for dense scan-all workloads:

| Class | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| `[0-9A-Za-z]` | 880.866 us | 849.841 us | 3.5% faster |
| `[!#0-9A-Z]` | 1,147.382 us | 1,129.080 us | 1.6% faster |

The isolated low-level scanner benchmark regresses on dense scan-all input because every nearby
match repeats specialization dispatch: `[0-9A-Za-z]` moves from 48.779 us to 64.135 us (31% slower)
and `[!#0-9A-Z]` from 46.693 us to 89.266 us (91% slower). This regression does not carry through
to the complete matching path, where the long dense measurements above improve. Absent and sparse
low-level scans improve by 1.42x to 1.85x.

Benchmarks used `./run-vector-benchmarks.sh` with the standard configuration for routine evidence and `--long` for the dense confirmation. Measurements were collected on x86-64 with OpenJDK 26.0.2. AArch64 performance was not measured because native AArch64 hardware was unavailable; x86-64 is the project's primary target.

## Verification

Ran successfully:

- `mvn -pl safere test -q`
- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere -DskipTests verify -q`
- `mvn -f safere-vector-benchmarks/pom.xml -DskipTests spotless:check -q`
- `git diff --check`
- Codex review-fix loop against `main` (no P0-P2 findings)
- standard x86-64 absent, sparse, and dense Vector scan benchmark trials
- long x86-64 dense benchmark comparison against an untouched `main` worktree

Not run:

- AArch64 benchmarks
- full public API crosscheck validation
- cross-language or external OpenJDK-derived benchmark suites

Fixes #662
