### PR TITLE
Generalize fixed-offset start acceleration

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -27,6 +27,8 @@ final class Utf8InputFuzzer {
     assertLiteralSearchMatchesString("XXXXXX", "..XXXXXX");
     assertBoundarySensitiveRegionCaptures();
     assertKeywordAlternationMatchesString(data);
+    assertFixedOffsetAccelerationMatchesString(data);
+    assertMultiOffsetLiteralOccurrencesMatchString(data);
     String repeatedLiteral =
         String.valueOf((char) data.consumeInt('A', 'Z')).repeat(data.consumeInt(2, 32));
     String suffix = new String(data.consumeBytes(data.consumeInt(0, 64)), StandardCharsets.UTF_8);
@@ -146,6 +148,52 @@ final class Utf8InputFuzzer {
             || utf8Matcher.start(1) != utf8Offset(input, stringMatcher.start(1))
             || utf8Matcher.end(1) != utf8Offset(input, stringMatcher.end(1)))) {
       throw new AssertionError("UTF-8 keyword alternation bounds differ from String search");
+    }
+  }
+
+  private static void assertFixedOffsetAccelerationMatchesString(FuzzedDataProvider data) {
+    String leadingClass = data.pickValue(List.of("[aé]", "[a-ÿ]", "[a😀]", "[^x]"));
+    String leadingMember =
+        switch (leadingClass) {
+          case "[a😀]" -> "😀";
+          default -> "é";
+        };
+    String literal = data.pickValue(List.of("bc", "tag", "literal"));
+    String input =
+        data.pickValue(List.of("", "x", "😀")) + leadingMember + literal + " a" + literal;
+    Pattern pattern = Pattern.compile(leadingClass + literal);
+    org.safere.Matcher stringMatcher = pattern.matcher(input);
+    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+    Utf8Input utf8Input = Utf8Input.validated(bytes);
+    Utf8Matcher utf8Matcher = pattern.matcher(utf8Input);
+
+    boolean stringFound = stringMatcher.find();
+    if (utf8Matcher.find() != stringFound || pattern.find(utf8Input) != stringFound) {
+      throw new AssertionError("UTF-8 fixed-offset search result differs from String search");
+    }
+    if (stringFound
+        && (utf8Matcher.start() != utf8Offset(input, stringMatcher.start())
+            || utf8Matcher.end() != utf8Offset(input, stringMatcher.end())
+            || !Objects.equals(stringMatcher.group(), decodeGroup(bytes, utf8Matcher)))) {
+      throw new AssertionError("UTF-8 fixed-offset search bounds differ from String search");
+    }
+  }
+
+  private static void assertMultiOffsetLiteralOccurrencesMatchString(FuzzedDataProvider data) {
+    int longWidth = data.consumeInt(6, 16);
+    String literal = data.pickValue(List.of("z", "tag"));
+    String regex = "(aq|b[a-z]{" + longWidth + "})" + literal;
+    String body = "xax" + literal + "x".repeat(longWidth - literal.length() - 3);
+    String input = "b" + body + literal;
+    Pattern pattern = Pattern.compile(regex);
+    org.safere.Matcher stringMatcher = pattern.matcher(input);
+    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+    Utf8Input utf8Input = Utf8Input.validated(bytes);
+    Utf8Matcher utf8Matcher = pattern.matcher(utf8Input);
+
+    boolean stringFound = stringMatcher.find();
+    if (utf8Matcher.find() != stringFound || pattern.find(utf8Input) != stringFound) {
+      throw new AssertionError("UTF-8 multi-offset search result differs from String search");
     }
   }
 

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -38,6 +38,15 @@ interface InputScanner {
   /** Returns whether {@code pos} is a code-point boundary in this representation. */
   boolean isCodePointBoundary(int pos);
 
+  /** Moves backward by at most {@code count} Unicode code points from {@code pos}. */
+  default int retreatByCodePoints(int pos, int count) {
+    int result = pos;
+    for (int remaining = count; remaining > 0 && result > 0; remaining--) {
+      result = position(decodeBackward(result));
+    }
+    return result;
+  }
+
   /** Returns the code point starting at the given index. */
   default int codePointAt(int pos) {
     return codePoint(decodeForward(pos));

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2136,11 +2136,14 @@ public final class Matcher implements MatchResult {
 
   private int nextFixedOffsetCandidate(
       InputScanner scanner, Pattern.FixedOffsetLiteral fixedOffsetLiteral, int fromIndex) {
-    if (fixedOffsetLiteral.offset() > scanner.length() - fromIndex) {
+    int minOffset = fixedOffsetLiteral.minOffset();
+    if (minOffset > scanner.length() - fromIndex) {
       return -1;
     }
-    int literalFrom = fromIndex + fixedOffsetLiteral.offset();
+    int literalFrom = fromIndex + minOffset;
     boolean[] firstAscii = parentPattern.charClassPrefixAscii();
+    int[] discreteOffsets = fixedOffsetLiteral.discreteOffsets();
+
     while (literalFrom <= scanner.length()) {
       int literalStart;
       if (scanner instanceof Utf8InputScanner utf8Scanner) {
@@ -2163,12 +2166,28 @@ public final class Matcher implements MatchResult {
       if (literalStart < 0) {
         return -1;
       }
-      int candidateStart = literalStart - fixedOffsetLiteral.offset();
-      int first = scanner.asciiAt(candidateStart);
-      if (firstAscii == null || (first >= 0 && first < firstAscii.length && firstAscii[first])) {
-        return candidateStart;
+      if (discreteOffsets != null && firstAscii != null) {
+        boolean matchFound = false;
+        int earliestValid = -1;
+        for (int offset : discreteOffsets) {
+          int candidateStart = literalStart - offset;
+          if (candidateStart >= fromIndex) {
+            int first = scanner.asciiAt(candidateStart);
+            if (first >= 0 && first < firstAscii.length && firstAscii[first]) {
+              matchFound = true;
+              if (earliestValid < 0 || candidateStart < earliestValid) {
+                earliestValid = candidateStart;
+              }
+            }
+          }
+        }
+        if (matchFound) {
+          return earliestValid;
+        }
+        literalFrom = literalStart + 1;
+        continue;
       }
-      literalFrom = literalStart + 1;
+      return Math.max(fromIndex, literalStart - fixedOffsetLiteral.maxOffset());
     }
     return -1;
   }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1999,7 +1999,7 @@ public final class Matcher implements MatchResult {
       if (literalStart < 0) {
         return -1;
       }
-      if (discreteOffsets != null && firstAscii != null) {
+      if (discreteOffsets != null && discreteOffsets.length == 1 && firstAscii != null) {
         boolean matchFound = false;
         int earliestValid = -1;
         for (int offset : discreteOffsets) {
@@ -2020,7 +2020,8 @@ public final class Matcher implements MatchResult {
         literalFrom = literalStart + 1;
         continue;
       }
-      return Math.max(fromIndex, literalStart - fixedOffsetLiteral.maxOffset());
+      return Math.max(
+          fromIndex, scanner.retreatByCodePoints(literalStart, fixedOffsetLiteral.maxOffset()));
     }
     return -1;
   }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2395,7 +2395,9 @@ public final class Pattern implements Serializable {
         yield AsciiWidthRange.INVALID;
       }
       case CHAR_CLASS -> {
-        if (node.charClass != null && !node.charClass.isEmpty() && node.charClass.lo(0) < 128) {
+        if (node.charClass != null
+            && !node.charClass.isEmpty()
+            && node.charClass.hi(node.charClass.numRanges() - 1) < 128) {
           yield AsciiWidthRange.ONE;
         }
         yield AsciiWidthRange.INVALID;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -793,7 +793,8 @@ public final class Pattern implements Serializable {
   }
 
   private int nextFixedOffsetCandidate(Utf8InputScanner scanner, int searchFrom) {
-    int literalFrom = searchFrom + fixedOffsetLiteral.offset();
+    int literalFrom = searchFrom + fixedOffsetLiteral.minOffset();
+    int[] discreteOffsets = fixedOffsetLiteral.discreteOffsets();
     while (literalFrom <= scanner.length()) {
       int literalStart =
           scanner.indexOf(
@@ -804,13 +805,28 @@ public final class Pattern implements Serializable {
       if (literalStart < 0) {
         return -1;
       }
-      int candidateStart = literalStart - fixedOffsetLiteral.offset();
-      int first = scanner.asciiAt(candidateStart);
-      if (charClassPrefixAscii == null
-          || (first >= 0 && first < charClassPrefixAscii.length && charClassPrefixAscii[first])) {
-        return candidateStart;
+      if (discreteOffsets != null && discreteOffsets.length == 1 && charClassPrefixAscii != null) {
+        int earliestValid = -1;
+        for (int offset : discreteOffsets) {
+          int candidateStart = literalStart - offset;
+          if (candidateStart >= searchFrom) {
+            int first = scanner.asciiAt(candidateStart);
+            if (first >= 0
+                && first < charClassPrefixAscii.length
+                && charClassPrefixAscii[first]
+                && (earliestValid < 0 || candidateStart < earliestValid)) {
+              earliestValid = candidateStart;
+            }
+          }
+        }
+        if (earliestValid >= 0) {
+          return earliestValid;
+        }
+        literalFrom = literalStart + 1;
+        continue;
       }
-      literalFrom = literalStart + 1;
+      return Math.max(
+          searchFrom, scanner.retreatByCodePoints(literalStart, fixedOffsetLiteral.maxOffset()));
     }
     return -1;
   }
@@ -2241,67 +2257,53 @@ public final class Pattern implements Serializable {
     }
   }
 
-  /**
-   * Finds the longest case-sensitive ASCII literal after a fixed-width ASCII match prefix.
-   *
-   * <p>This deliberately recognizes only the simple concatenation shape produced by simplification.
-   * Stopping at the first variable-width or non-ASCII atom keeps byte and UTF-16 offsets identical
-   * and makes every derived start position exact.
-   */
+  /** Finds the longest case-sensitive ASCII literal after a bounded-width match prefix. */
   private static FixedOffsetLiteral extractFixedOffsetLiteral(Regexp re) {
     Regexp node = unwrapFixedOffsetNode(re);
     if (node.op != RegexpOp.CONCAT || node.subs == null) {
       return null;
     }
     FixedOffsetLiteral best = null;
-    int minOffset = 0;
-    int maxOffset = 0;
-    int[] discreteOffsets = new int[] {0};
+    AsciiWidthRange prefixWidth = AsciiWidthRange.ZERO;
 
-    for (int i = 0; i < node.subs.size(); i++) {
-      StringBuilder litSb = new StringBuilder();
-      for (int j = i; j < node.subs.size(); j++) {
-        String lit = fixedOffsetAsciiLiteral(node.subs.get(j));
-        if (lit == null) {
-          break;
+    for (int index = 0; index < node.subs.size(); ) {
+      String literalPart = fixedOffsetAsciiLiteral(node.subs.get(index));
+      if (literalPart != null) {
+        StringBuilder literal = new StringBuilder(literalPart);
+        int next = index + 1;
+        while (next < node.subs.size()) {
+          String nextPart = fixedOffsetAsciiLiteral(node.subs.get(next));
+          if (nextPart == null) {
+            break;
+          }
+          literal.append(nextPart);
+          next++;
         }
-        litSb.append(lit);
-      }
-      String literal = litSb.length() > 0 ? litSb.toString() : null;
-      if (i > 0 && (minOffset > 0 || maxOffset > 0)) {
-        int minLitLen = (discreteOffsets != null) ? 1 : 2;
-        if (literal != null
-            && literal.length() >= minLitLen
-            && (best == null || literal.length() > best.literal().length())) {
-          best = new FixedOffsetLiteral(literal, minOffset, maxOffset, discreteOffsets);
-        }
-      }
-      Regexp sub = node.subs.get(i);
-      AsciiWidthRange width = computeAsciiWidthRange(sub);
-      if (!width.isValid()) {
-        break;
-      }
-      minOffset += width.minWidth;
-      if (maxOffset != Integer.MAX_VALUE) {
-        if (width.maxWidth == Integer.MAX_VALUE || maxOffset > Integer.MAX_VALUE - width.maxWidth) {
-          maxOffset = Integer.MAX_VALUE;
-        } else {
-          maxOffset += width.maxWidth;
-        }
-      }
-      if (discreteOffsets != null
-          && width.discreteWidths != null
-          && discreteOffsets.length * width.discreteWidths.length <= 16) {
-        java.util.TreeSet<Integer> newDiscrete = new java.util.TreeSet<>();
-        for (int d1 : discreteOffsets) {
-          for (int d2 : width.discreteWidths) {
-            newDiscrete.add(d1 + d2);
+        if (index > 0 && (prefixWidth.minWidth > 0 || prefixWidth.maxWidth > 0)) {
+          int minimumLiteralLength = prefixWidth.discreteWidths != null ? 1 : 2;
+          if (literal.length() >= minimumLiteralLength
+              && (best == null || literal.length() > best.literal().length())) {
+            best =
+                new FixedOffsetLiteral(
+                    literal.toString(),
+                    prefixWidth.minWidth,
+                    prefixWidth.maxWidth,
+                    prefixWidth.discreteWidths);
           }
         }
-        discreteOffsets = newDiscrete.stream().mapToInt(Integer::intValue).toArray();
-      } else {
-        discreteOffsets = null;
+        prefixWidth = concatenateWidths(prefixWidth, AsciiWidthRange.exact(literal.length()));
+        if (!prefixWidth.isValid()) {
+          break;
+        }
+        index = next;
+        continue;
       }
+
+      prefixWidth = concatenateWidths(prefixWidth, computeAsciiWidthRange(node.subs.get(index)));
+      if (!prefixWidth.isValid()) {
+        break;
+      }
+      index++;
     }
     return best;
   }
@@ -2315,191 +2317,229 @@ public final class Pattern implements Serializable {
   }
 
   private static String fixedOffsetAsciiLiteral(Regexp re) {
-    Regexp node = unwrapFixedOffsetNode(re);
-    if ((node.flags & ParseFlags.FOLD_CASE) != 0) {
+    StringBuilder literal = new StringBuilder();
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.push(re);
+    while (!pending.isEmpty()) {
+      Regexp node = unwrapFixedOffsetNode(pending.pop());
+      if ((node.flags & ParseFlags.FOLD_CASE) != 0) {
+        return null;
+      }
+      if (node.op == RegexpOp.LITERAL && node.rune >= 0 && node.rune < 128) {
+        literal.append((char) node.rune);
+        continue;
+      }
+      if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
+        for (int rune : node.runes) {
+          if (rune < 0 || rune >= 128) {
+            return null;
+          }
+          literal.append((char) rune);
+        }
+        continue;
+      }
+      if (node.op == RegexpOp.CONCAT && node.subs != null) {
+        for (int index = node.subs.size() - 1; index >= 0; index--) {
+          pending.push(node.subs.get(index));
+        }
+        continue;
+      }
       return null;
     }
-    if (node.op == RegexpOp.LITERAL && node.rune >= 0 && node.rune < 128) {
-      return Character.toString(node.rune);
-    }
-    if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
-      for (int rune : node.runes) {
-        if (rune < 0 || rune >= 128) {
-          return null;
-        }
-      }
-      return new String(node.runes, 0, node.runes.length);
-    }
-    if (node.op == RegexpOp.CONCAT && node.subs != null) {
-      StringBuilder sb = new StringBuilder();
-      for (Regexp sub : node.subs) {
-        String s = fixedOffsetAsciiLiteral(sub);
-        if (s == null) {
-          return null;
-        }
-        sb.append(s);
-      }
-      return sb.isEmpty() ? null : sb.toString();
-    }
-    return null;
+    return literal.isEmpty() ? null : literal.toString();
   }
 
   private static AsciiWidthRange computeAsciiWidthRange(Regexp re) {
-    Regexp node = unwrapFixedOffsetNode(re);
-    if (node == null) {
+    return new AsciiWidthRangeWalker().walk(re, AsciiWidthRange.INVALID);
+  }
+
+  private static final class AsciiWidthRangeWalker extends Walker<AsciiWidthRange> {
+    @Override
+    protected AsciiWidthRange postVisit(
+        Regexp node,
+        AsciiWidthRange parentArg,
+        AsciiWidthRange preArg,
+        List<AsciiWidthRange> childArgs) {
+      return switch (node.op) {
+        case CAPTURE, NON_CAPTURE ->
+            childArgs.isEmpty() ? AsciiWidthRange.INVALID : childArgs.getFirst();
+        case EMPTY_MATCH,
+            BEGIN_LINE,
+            END_LINE,
+            BEGIN_TEXT,
+            END_TEXT,
+            WORD_BOUNDARY,
+            NO_WORD_BOUNDARY ->
+            AsciiWidthRange.ZERO;
+        case LITERAL ->
+            node.rune >= 0 && node.rune < 128 && (node.flags & ParseFlags.FOLD_CASE) == 0
+                ? AsciiWidthRange.ONE
+                : AsciiWidthRange.INVALID;
+        case LITERAL_STRING -> literalStringWidth(node);
+        case CHAR_CLASS -> characterClassWidth(node);
+        case REPEAT -> repeatWidth(node, childArgs);
+        case QUEST -> optionalWidth(childArgs);
+        case ALTERNATE -> alternateWidth(childArgs);
+        case CONCAT -> concatenateWidths(childArgs);
+        default -> AsciiWidthRange.INVALID;
+      };
+    }
+
+    @Override
+    protected AsciiWidthRange shortVisit(Regexp re, AsciiWidthRange parentArg) {
       return AsciiWidthRange.INVALID;
     }
-    return switch (node.op) {
-      case EMPTY_MATCH,
-          BEGIN_LINE,
-          END_LINE,
-          BEGIN_TEXT,
-          END_TEXT,
-          WORD_BOUNDARY,
-          NO_WORD_BOUNDARY ->
-          AsciiWidthRange.ZERO;
-      case LITERAL -> {
-        if (node.rune >= 0 && node.rune < 128 && (node.flags & ParseFlags.FOLD_CASE) == 0) {
-          yield AsciiWidthRange.ONE;
-        }
-        yield AsciiWidthRange.INVALID;
+
+    private static AsciiWidthRange literalStringWidth(Regexp node) {
+      if ((node.flags & ParseFlags.FOLD_CASE) != 0 || node.runes == null) {
+        return AsciiWidthRange.INVALID;
       }
-      case LITERAL_STRING -> {
-        if ((node.flags & ParseFlags.FOLD_CASE) == 0 && node.runes != null) {
-          for (int r : node.runes) {
-            if (r < 0 || r >= 128) {
-              yield AsciiWidthRange.INVALID;
-            }
-          }
-          yield AsciiWidthRange.exact(node.runes.length);
+      for (int rune : node.runes) {
+        if (rune < 0 || rune >= 128) {
+          return AsciiWidthRange.INVALID;
         }
-        yield AsciiWidthRange.INVALID;
       }
-      case CHAR_CLASS -> {
-        if (node.charClass != null
-            && !node.charClass.isEmpty()
-            && node.charClass.hi(node.charClass.numRanges() - 1) < 128) {
-          yield AsciiWidthRange.ONE;
-        }
-        yield AsciiWidthRange.INVALID;
+      return AsciiWidthRange.exact(node.runes.length);
+    }
+
+    private static AsciiWidthRange characterClassWidth(Regexp node) {
+      if (node.charClass == null || node.charClass.isEmpty()) {
+        return AsciiWidthRange.INVALID;
       }
-      case REPEAT -> {
-        if (node.max < 0) {
-          yield AsciiWidthRange.INVALID;
-        }
-        AsciiWidthRange sub = computeAsciiWidthRange(node.sub());
-        if (!sub.isValid() || node.min < 0) {
-          yield AsciiWidthRange.INVALID;
-        }
-        int minW = sub.minWidth * node.min;
-        int maxW = sub.maxWidth * node.max;
-        if (sub.isExact() && node.max - node.min <= 8) {
-          int[] discrete = new int[node.max - node.min + 1];
-          for (int i = 0; i < discrete.length; i++) {
-            discrete[i] = sub.minWidth * (node.min + i);
-          }
-          yield new AsciiWidthRange(minW, maxW, discrete);
-        }
-        yield new AsciiWidthRange(minW, maxW, null);
+      return node.charClass.hi(node.charClass.numRanges() - 1) < 128
+          ? AsciiWidthRange.ONE
+          : AsciiWidthRange.NON_DISCRETE_ONE;
+    }
+
+    private static AsciiWidthRange repeatWidth(Regexp node, List<AsciiWidthRange> childArgs) {
+      if (node.min < 0 || node.max < 0 || childArgs.isEmpty()) {
+        return AsciiWidthRange.INVALID;
       }
-      case QUEST -> {
-        AsciiWidthRange sub = computeAsciiWidthRange(node.sub());
-        if (!sub.isValid()) {
-          yield AsciiWidthRange.INVALID;
-        }
-        int minW = 0;
-        int maxW = sub.maxWidth;
-        if (sub.discreteWidths != null) {
-          java.util.TreeSet<Integer> discreteSet = new java.util.TreeSet<>();
-          discreteSet.add(0);
-          for (int d : sub.discreteWidths) {
-            discreteSet.add(d);
-          }
-          int[] discrete =
-              discreteSet.size() <= 16
-                  ? discreteSet.stream().mapToInt(Integer::intValue).toArray()
-                  : null;
-          yield new AsciiWidthRange(minW, maxW, discrete);
-        }
-        yield new AsciiWidthRange(minW, maxW, null);
+      AsciiWidthRange child = childArgs.getFirst();
+      if (!child.isValid()) {
+        return AsciiWidthRange.INVALID;
       }
-      case PLUS -> AsciiWidthRange.INVALID;
-      case ALTERNATE -> {
-        if (node.subs == null || node.subs.isEmpty()) {
-          yield AsciiWidthRange.INVALID;
-        }
-        int minW = Integer.MAX_VALUE;
-        int maxW = Integer.MIN_VALUE;
-        boolean allDiscrete = true;
-        java.util.TreeSet<Integer> discreteSet = new java.util.TreeSet<>();
-        for (Regexp sub : node.subs) {
-          AsciiWidthRange w = computeAsciiWidthRange(sub);
-          if (!w.isValid()) {
-            yield AsciiWidthRange.INVALID;
-          }
-          minW = Math.min(minW, w.minWidth);
-          maxW = Math.max(maxW, w.maxWidth);
-          if (w.discreteWidths != null && allDiscrete) {
-            for (int d : w.discreteWidths) {
-              discreteSet.add(d);
-            }
-          } else {
-            allDiscrete = false;
-          }
-        }
-        int[] discrete =
-            allDiscrete && discreteSet.size() <= 8
-                ? discreteSet.stream().mapToInt(Integer::intValue).toArray()
-                : null;
-        yield new AsciiWidthRange(minW, maxW, discrete);
+      int minWidth = multiplyWidth(child.minWidth, node.min);
+      int maxWidth = multiplyWidth(child.maxWidth, node.max);
+      if (minWidth < 0 || maxWidth < 0) {
+        return AsciiWidthRange.INVALID;
       }
-      case CONCAT -> {
-        if (node.subs == null || node.subs.isEmpty()) {
-          yield AsciiWidthRange.ZERO;
+      if (child.discreteWidths != null && child.isExact() && node.max - node.min <= 8) {
+        int[] discrete = new int[node.max - node.min + 1];
+        for (int index = 0; index < discrete.length; index++) {
+          int width = multiplyWidth(child.minWidth, node.min + index);
+          if (width < 0) {
+            return AsciiWidthRange.INVALID;
+          }
+          discrete[index] = width;
         }
-        int minW = 0;
-        int maxW = 0;
-        int[] discrete = new int[] {0};
-        for (Regexp sub : node.subs) {
-          AsciiWidthRange w = computeAsciiWidthRange(sub);
-          if (!w.isValid()) {
-            yield AsciiWidthRange.INVALID;
-          }
-          if (minW > Integer.MAX_VALUE - w.minWidth) {
-            yield AsciiWidthRange.INVALID;
-          }
-          minW += w.minWidth;
-          if (maxW != Integer.MAX_VALUE) {
-            if (w.maxWidth == Integer.MAX_VALUE || maxW > Integer.MAX_VALUE - w.maxWidth) {
-              maxW = Integer.MAX_VALUE;
-            } else {
-              maxW += w.maxWidth;
-            }
-          }
-          if (discrete != null
-              && w.discreteWidths != null
-              && discrete.length * w.discreteWidths.length <= 16) {
-            java.util.TreeSet<Integer> newDiscrete = new java.util.TreeSet<>();
-            for (int d1 : discrete) {
-              for (int d2 : w.discreteWidths) {
-                newDiscrete.add(d1 + d2);
-              }
-            }
-            discrete = newDiscrete.stream().mapToInt(Integer::intValue).toArray();
-          } else {
-            discrete = null;
-          }
-        }
-        yield new AsciiWidthRange(minW, maxW, discrete);
+        return new AsciiWidthRange(minWidth, maxWidth, discrete);
       }
-      default -> AsciiWidthRange.INVALID;
-    };
+      return new AsciiWidthRange(minWidth, maxWidth, null);
+    }
+
+    private static AsciiWidthRange optionalWidth(List<AsciiWidthRange> childArgs) {
+      if (childArgs.isEmpty() || !childArgs.getFirst().isValid()) {
+        return AsciiWidthRange.INVALID;
+      }
+      AsciiWidthRange child = childArgs.getFirst();
+      if (child.discreteWidths == null) {
+        return new AsciiWidthRange(0, child.maxWidth, null);
+      }
+      java.util.TreeSet<Integer> discrete = new java.util.TreeSet<>();
+      discrete.add(0);
+      for (int width : child.discreteWidths) {
+        discrete.add(width);
+      }
+      return new AsciiWidthRange(
+          0,
+          child.maxWidth,
+          discrete.size() <= 16 ? discrete.stream().mapToInt(Integer::intValue).toArray() : null);
+    }
+
+    private static AsciiWidthRange alternateWidth(List<AsciiWidthRange> childArgs) {
+      if (childArgs.isEmpty()) {
+        return AsciiWidthRange.INVALID;
+      }
+      int minWidth = Integer.MAX_VALUE;
+      int maxWidth = Integer.MIN_VALUE;
+      java.util.TreeSet<Integer> discrete = new java.util.TreeSet<>();
+      boolean allDiscrete = true;
+      for (AsciiWidthRange child : childArgs) {
+        if (!child.isValid()) {
+          return AsciiWidthRange.INVALID;
+        }
+        minWidth = Math.min(minWidth, child.minWidth);
+        maxWidth = Math.max(maxWidth, child.maxWidth);
+        if (allDiscrete && child.discreteWidths != null) {
+          for (int width : child.discreteWidths) {
+            discrete.add(width);
+          }
+        } else {
+          allDiscrete = false;
+        }
+      }
+      return new AsciiWidthRange(
+          minWidth,
+          maxWidth,
+          allDiscrete && discrete.size() <= 8
+              ? discrete.stream().mapToInt(Integer::intValue).toArray()
+              : null);
+    }
+  }
+
+  private static AsciiWidthRange concatenateWidths(List<AsciiWidthRange> widths) {
+    AsciiWidthRange result = AsciiWidthRange.ZERO;
+    for (AsciiWidthRange width : widths) {
+      result = concatenateWidths(result, width);
+      if (!result.isValid()) {
+        return result;
+      }
+    }
+    return result;
+  }
+
+  private static AsciiWidthRange concatenateWidths(AsciiWidthRange left, AsciiWidthRange right) {
+    if (!left.isValid() || !right.isValid()) {
+      return AsciiWidthRange.INVALID;
+    }
+    int minWidth = addWidth(left.minWidth, right.minWidth);
+    int maxWidth = addWidth(left.maxWidth, right.maxWidth);
+    if (minWidth < 0 || maxWidth < 0) {
+      return AsciiWidthRange.INVALID;
+    }
+    int[] discrete = null;
+    if (left.discreteWidths != null
+        && right.discreteWidths != null
+        && left.discreteWidths.length * right.discreteWidths.length <= 16) {
+      java.util.TreeSet<Integer> combined = new java.util.TreeSet<>();
+      for (int leftWidth : left.discreteWidths) {
+        for (int rightWidth : right.discreteWidths) {
+          int width = addWidth(leftWidth, rightWidth);
+          if (width < 0) {
+            return AsciiWidthRange.INVALID;
+          }
+          combined.add(width);
+        }
+      }
+      discrete = combined.stream().mapToInt(Integer::intValue).toArray();
+    }
+    return new AsciiWidthRange(minWidth, maxWidth, discrete);
+  }
+
+  private static int addWidth(int left, int right) {
+    return left > Integer.MAX_VALUE - right ? -1 : left + right;
+  }
+
+  private static int multiplyWidth(int width, int count) {
+    return width != 0 && count > Integer.MAX_VALUE / width ? -1 : width * count;
   }
 
   private static final class AsciiWidthRange {
     static final AsciiWidthRange INVALID = new AsciiWidthRange(-1, -1, null);
     static final AsciiWidthRange ZERO = new AsciiWidthRange(0, 0, new int[] {0});
     static final AsciiWidthRange ONE = new AsciiWidthRange(1, 1, new int[] {1});
+    static final AsciiWidthRange NON_DISCRETE_ONE = new AsciiWidthRange(1, 1, null);
 
     final int minWidth;
     final int maxWidth;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -491,10 +491,10 @@ public final class Pattern implements Serializable {
     boolean hasNullableAlt = hasAlt && hasNullableAlternation(re);
     boolean startsWithGcb = startsWithGraphemeClusterBoundary(metadataAst);
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
-    // Extract character-class prefix for acceleration when no literal prefix exists.
-    boolean[] ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     FixedOffsetLiteral fixedOffsetLiteral =
         prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
+    // Extract character-class prefix for acceleration when no literal prefix exists.
+    boolean[] ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     StartAcceleration startAcceleration =
         (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null)
             ? extractStartAcceleration(metadataAst)
@@ -2104,14 +2104,22 @@ public final class Pattern implements Serializable {
 
   static final class FixedOffsetLiteral {
     private final String literal;
-    private final int offset;
+    private final int minOffset;
+    private final int maxOffset;
+    private final int[] discreteOffsets;
     private final byte[] utf8;
     private final int[] failure;
     private final int[] shifts;
 
     FixedOffsetLiteral(String literal, int offset) {
+      this(literal, offset, offset, new int[] {offset});
+    }
+
+    FixedOffsetLiteral(String literal, int minOffset, int maxOffset, int[] discreteOffsets) {
       this.literal = literal;
-      this.offset = offset;
+      this.minOffset = minOffset;
+      this.maxOffset = maxOffset;
+      this.discreteOffsets = discreteOffsets;
       this.utf8 = literal.getBytes(java.nio.charset.StandardCharsets.UTF_8);
       this.failure = literalFailure(utf8);
       this.shifts = literalShifts(utf8);
@@ -2122,7 +2130,23 @@ public final class Pattern implements Serializable {
     }
 
     int offset() {
-      return offset;
+      return minOffset;
+    }
+
+    int minOffset() {
+      return minOffset;
+    }
+
+    int maxOffset() {
+      return maxOffset;
+    }
+
+    int[] discreteOffsets() {
+      return discreteOffsets;
+    }
+
+    boolean isExactOffset() {
+      return minOffset == maxOffset;
     }
 
     byte[] utf8() {
@@ -2249,19 +2273,54 @@ public final class Pattern implements Serializable {
       return null;
     }
     FixedOffsetLiteral best = null;
-    int offset = 0;
-    for (Regexp sub : node.subs) {
-      String literal = fixedOffsetAsciiLiteral(sub);
-      if (offset > 0
-          && literal != null
-          && (best == null || literal.length() > best.literal().length())) {
-        best = new FixedOffsetLiteral(literal, offset);
+    int minOffset = 0;
+    int maxOffset = 0;
+    int[] discreteOffsets = new int[] {0};
+
+    for (int i = 0; i < node.subs.size(); i++) {
+      StringBuilder litSb = new StringBuilder();
+      for (int j = i; j < node.subs.size(); j++) {
+        String lit = fixedOffsetAsciiLiteral(node.subs.get(j));
+        if (lit == null) {
+          break;
+        }
+        litSb.append(lit);
       }
-      int width = exactAsciiWidth(sub);
-      if (width < 0 || offset > Integer.MAX_VALUE - width) {
+      String literal = litSb.length() > 0 ? litSb.toString() : null;
+      if (i > 0 && (minOffset > 0 || maxOffset > 0)) {
+        int minLitLen = (discreteOffsets != null) ? 1 : 2;
+        if (literal != null
+            && literal.length() >= minLitLen
+            && (best == null || literal.length() > best.literal().length())) {
+          best = new FixedOffsetLiteral(literal, minOffset, maxOffset, discreteOffsets);
+        }
+      }
+      Regexp sub = node.subs.get(i);
+      AsciiWidthRange width = computeAsciiWidthRange(sub);
+      if (!width.isValid()) {
         break;
       }
-      offset += width;
+      minOffset += width.minWidth;
+      if (maxOffset != Integer.MAX_VALUE) {
+        if (width.maxWidth == Integer.MAX_VALUE || maxOffset > Integer.MAX_VALUE - width.maxWidth) {
+          maxOffset = Integer.MAX_VALUE;
+        } else {
+          maxOffset += width.maxWidth;
+        }
+      }
+      if (discreteOffsets != null
+          && width.discreteWidths != null
+          && discreteOffsets.length * width.discreteWidths.length <= 16) {
+        java.util.TreeSet<Integer> newDiscrete = new java.util.TreeSet<>();
+        for (int d1 : discreteOffsets) {
+          for (int d2 : width.discreteWidths) {
+            newDiscrete.add(d1 + d2);
+          }
+        }
+        discreteOffsets = newDiscrete.stream().mapToInt(Integer::intValue).toArray();
+      } else {
+        discreteOffsets = null;
+      }
     }
     return best;
   }
@@ -2282,71 +2341,204 @@ public final class Pattern implements Serializable {
     if (node.op == RegexpOp.LITERAL && node.rune >= 0 && node.rune < 128) {
       return Character.toString(node.rune);
     }
-    if (node.op != RegexpOp.LITERAL_STRING || node.runes == null || node.runes.length == 0) {
-      return null;
-    }
-    for (int rune : node.runes) {
-      if (rune < 0 || rune >= 128) {
-        return null;
+    if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
+      for (int rune : node.runes) {
+        if (rune < 0 || rune >= 128) {
+          return null;
+        }
       }
+      return new String(node.runes, 0, node.runes.length);
     }
-    return new String(node.runes, 0, node.runes.length);
+    if (node.op == RegexpOp.CONCAT && node.subs != null) {
+      StringBuilder sb = new StringBuilder();
+      for (Regexp sub : node.subs) {
+        String s = fixedOffsetAsciiLiteral(sub);
+        if (s == null) {
+          return null;
+        }
+        sb.append(s);
+      }
+      return sb.isEmpty() ? null : sb.toString();
+    }
+    return null;
   }
 
-  private static int exactAsciiWidth(Regexp re) {
-    record WidthNode(Regexp regexp, int multiplier) {}
-    Deque<WidthNode> pending = new ArrayDeque<>();
-    pending.push(new WidthNode(re, 1));
-    int width = 0;
-    while (!pending.isEmpty()) {
-      WidthNode current = pending.pop();
-      Regexp node = current.regexp();
-      int multiplier = current.multiplier();
-      if (node.op == RegexpOp.CAPTURE || node.op == RegexpOp.NON_CAPTURE) {
-        pending.push(new WidthNode(node.sub(), multiplier));
-        continue;
-      }
-      if (node.op == RegexpOp.CONCAT && node.subs != null) {
-        for (int index = node.subs.size() - 1; index >= 0; index--) {
-          pending.push(new WidthNode(node.subs.get(index), multiplier));
+  private static AsciiWidthRange computeAsciiWidthRange(Regexp re) {
+    Regexp node = unwrapFixedOffsetNode(re);
+    if (node == null) {
+      return AsciiWidthRange.INVALID;
+    }
+    return switch (node.op) {
+      case EMPTY_MATCH,
+          BEGIN_LINE,
+          END_LINE,
+          BEGIN_TEXT,
+          END_TEXT,
+          WORD_BOUNDARY,
+          NO_WORD_BOUNDARY ->
+          AsciiWidthRange.ZERO;
+      case LITERAL -> {
+        if (node.rune >= 0 && node.rune < 128 && (node.flags & ParseFlags.FOLD_CASE) == 0) {
+          yield AsciiWidthRange.ONE;
         }
-        continue;
+        yield AsciiWidthRange.INVALID;
       }
-      if (node.op == RegexpOp.REPEAT && node.min == node.max && node.min >= 0) {
-        if (node.min != 0 && multiplier > Integer.MAX_VALUE / node.min) {
-          return -1;
+      case LITERAL_STRING -> {
+        if ((node.flags & ParseFlags.FOLD_CASE) == 0 && node.runes != null) {
+          for (int r : node.runes) {
+            if (r < 0 || r >= 128) {
+              yield AsciiWidthRange.INVALID;
+            }
+          }
+          yield AsciiWidthRange.exact(node.runes.length);
         }
-        pending.push(new WidthNode(node.sub(), multiplier * node.min));
-        continue;
+        yield AsciiWidthRange.INVALID;
       }
-      int atomWidth;
-      if (node.op == RegexpOp.EMPTY_MATCH) {
-        atomWidth = 0;
-      } else if (node.op == RegexpOp.LITERAL) {
-        atomWidth = node.rune >= 0 && node.rune < 128 ? 1 : -1;
-      } else if (node.op == RegexpOp.LITERAL_STRING && node.runes != null) {
-        atomWidth = node.runes.length;
-        for (int rune : node.runes) {
-          if (rune < 0 || rune >= 128) {
-            return -1;
+      case CHAR_CLASS -> {
+        if (node.charClass != null && !node.charClass.isEmpty() && node.charClass.lo(0) < 128) {
+          yield AsciiWidthRange.ONE;
+        }
+        yield AsciiWidthRange.INVALID;
+      }
+      case REPEAT -> {
+        if (node.max < 0) {
+          yield AsciiWidthRange.INVALID;
+        }
+        AsciiWidthRange sub = computeAsciiWidthRange(node.sub());
+        if (!sub.isValid() || node.min < 0) {
+          yield AsciiWidthRange.INVALID;
+        }
+        int minW = sub.minWidth * node.min;
+        int maxW = sub.maxWidth * node.max;
+        if (sub.isExact() && node.max - node.min <= 8) {
+          int[] discrete = new int[node.max - node.min + 1];
+          for (int i = 0; i < discrete.length; i++) {
+            discrete[i] = sub.minWidth * (node.min + i);
+          }
+          yield new AsciiWidthRange(minW, maxW, discrete);
+        }
+        yield new AsciiWidthRange(minW, maxW, null);
+      }
+      case QUEST -> {
+        AsciiWidthRange sub = computeAsciiWidthRange(node.sub());
+        if (!sub.isValid()) {
+          yield AsciiWidthRange.INVALID;
+        }
+        int minW = 0;
+        int maxW = sub.maxWidth;
+        if (sub.discreteWidths != null) {
+          java.util.TreeSet<Integer> discreteSet = new java.util.TreeSet<>();
+          discreteSet.add(0);
+          for (int d : sub.discreteWidths) {
+            discreteSet.add(d);
+          }
+          int[] discrete =
+              discreteSet.size() <= 16
+                  ? discreteSet.stream().mapToInt(Integer::intValue).toArray()
+                  : null;
+          yield new AsciiWidthRange(minW, maxW, discrete);
+        }
+        yield new AsciiWidthRange(minW, maxW, null);
+      }
+      case PLUS -> AsciiWidthRange.INVALID;
+      case ALTERNATE -> {
+        if (node.subs == null || node.subs.isEmpty()) {
+          yield AsciiWidthRange.INVALID;
+        }
+        int minW = Integer.MAX_VALUE;
+        int maxW = Integer.MIN_VALUE;
+        boolean allDiscrete = true;
+        java.util.TreeSet<Integer> discreteSet = new java.util.TreeSet<>();
+        for (Regexp sub : node.subs) {
+          AsciiWidthRange w = computeAsciiWidthRange(sub);
+          if (!w.isValid()) {
+            yield AsciiWidthRange.INVALID;
+          }
+          minW = Math.min(minW, w.minWidth);
+          maxW = Math.max(maxW, w.maxWidth);
+          if (w.discreteWidths != null && allDiscrete) {
+            for (int d : w.discreteWidths) {
+              discreteSet.add(d);
+            }
+          } else {
+            allDiscrete = false;
           }
         }
-      } else if (node.op == RegexpOp.CHAR_CLASS
-          && node.charClass != null
-          && !node.charClass.isEmpty()
-          && node.charClass.hi(node.charClass.numRanges() - 1) < 128) {
-        atomWidth = 1;
-      } else {
-        return -1;
+        int[] discrete =
+            allDiscrete && discreteSet.size() <= 8
+                ? discreteSet.stream().mapToInt(Integer::intValue).toArray()
+                : null;
+        yield new AsciiWidthRange(minW, maxW, discrete);
       }
-      if (atomWidth < 0
-          || (atomWidth != 0 && multiplier > Integer.MAX_VALUE / atomWidth)
-          || width > Integer.MAX_VALUE - atomWidth * multiplier) {
-        return -1;
+      case CONCAT -> {
+        if (node.subs == null || node.subs.isEmpty()) {
+          yield AsciiWidthRange.ZERO;
+        }
+        int minW = 0;
+        int maxW = 0;
+        int[] discrete = new int[] {0};
+        for (Regexp sub : node.subs) {
+          AsciiWidthRange w = computeAsciiWidthRange(sub);
+          if (!w.isValid()) {
+            yield AsciiWidthRange.INVALID;
+          }
+          if (minW > Integer.MAX_VALUE - w.minWidth) {
+            yield AsciiWidthRange.INVALID;
+          }
+          minW += w.minWidth;
+          if (maxW != Integer.MAX_VALUE) {
+            if (w.maxWidth == Integer.MAX_VALUE || maxW > Integer.MAX_VALUE - w.maxWidth) {
+              maxW = Integer.MAX_VALUE;
+            } else {
+              maxW += w.maxWidth;
+            }
+          }
+          if (discrete != null
+              && w.discreteWidths != null
+              && discrete.length * w.discreteWidths.length <= 16) {
+            java.util.TreeSet<Integer> newDiscrete = new java.util.TreeSet<>();
+            for (int d1 : discrete) {
+              for (int d2 : w.discreteWidths) {
+                newDiscrete.add(d1 + d2);
+              }
+            }
+            discrete = newDiscrete.stream().mapToInt(Integer::intValue).toArray();
+          } else {
+            discrete = null;
+          }
+        }
+        yield new AsciiWidthRange(minW, maxW, discrete);
       }
-      width += atomWidth * multiplier;
+      default -> AsciiWidthRange.INVALID;
+    };
+  }
+
+  private static final class AsciiWidthRange {
+    static final AsciiWidthRange INVALID = new AsciiWidthRange(-1, -1, null);
+    static final AsciiWidthRange ZERO = new AsciiWidthRange(0, 0, new int[] {0});
+    static final AsciiWidthRange ONE = new AsciiWidthRange(1, 1, new int[] {1});
+
+    final int minWidth;
+    final int maxWidth;
+    final int[] discreteWidths;
+
+    AsciiWidthRange(int minWidth, int maxWidth, int[] discreteWidths) {
+      this.minWidth = minWidth;
+      this.maxWidth = maxWidth;
+      this.discreteWidths = discreteWidths;
     }
-    return width;
+
+    static AsciiWidthRange exact(int width) {
+      return new AsciiWidthRange(width, width, new int[] {width});
+    }
+
+    boolean isValid() {
+      return minWidth >= 0;
+    }
+
+    boolean isExact() {
+      return minWidth >= 0 && minWidth == maxWidth;
+    }
   }
 
   /**

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -88,6 +88,35 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("discrete multi-offset shifted start acceleration matches correctly")
+    void discreteMultiOffsetShiftedStartAcceleration() {
+      Pattern p = Pattern.compile("(^|[^#])(#!customTag)");
+      Matcher m = p.matcher("###!customTag #!customTag\n#!customTag");
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo(" #!customTag");
+      assertThat(m.start()).isEqualTo(13);
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("\n#!customTag");
+      assertThat(m.start()).isEqualTo(25);
+
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("bounded range shifted start acceleration matches correctly")
+    void boundedRangeShiftedStartAcceleration() {
+      Pattern p = Pattern.compile("\\s{0,8}renderElement\\(");
+      Matcher m = p.matcher("ignore text    renderElement(arg)");
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("    renderElement(");
+      assertThat(m.start()).isEqualTo(11);
+      assertThat(m.find()).isFalse();
+    }
+
+    @Test
     @DisplayName("lookingAt() respects lazy quantifier priority")
     void lookingAtRespectsLazyQuantifierPriority() {
       Matcher m = Pattern.compile("(a+?)").matcher("aaa");

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -117,6 +117,17 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("multi-offset acceleration preserves starts belonging to later literals")
+    void multiOffsetAccelerationPreservesEarlierStartFromLaterLiteral() {
+      Matcher matcher = Pattern.compile("(aq|b[a-z]{9})z").matcher("bxxaxzxxxxz");
+
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.group()).isEqualTo("bxxaxzxxxxz");
+      assertThat(matcher.start()).isZero();
+      assertThat(matcher.end()).isEqualTo(11);
+    }
+
+    @Test
     @DisplayName("lookingAt() respects lazy quantifier priority")
     void lookingAtRespectsLazyQuantifierPriority() {
       Matcher m = Pattern.compile("(a+?)").matcher("aaa");

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -242,7 +242,8 @@ class PatternInternalTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"\\d+/x", "[αβ]/x", "[ab](?i:x)", "literal-prefix"})
+  @ValueSource(
+      strings = {"\\d+/x", "[αβ]/x", "[ab](?i:x)", "literal-prefix", "(?:(?:a|.)a)", ".\\d{3}foo"})
   void variableWidthUnicodeAndOrdinaryPrefixesDoNotRecordFixedOffsetLiterals(String regex) {
     assertThat(Pattern.compile(regex).fixedOffsetLiteral()).isNull();
   }

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -247,6 +247,25 @@ class PatternInternalTest {
     assertThat(Pattern.compile(regex).fixedOffsetLiteral()).isNull();
   }
 
+  @Test
+  void discreteMultiOffsetLiteralsAreRecorded() {
+    Pattern.FixedOffsetLiteral fixed =
+        Pattern.compile("(^|[^#])(#!customTag)").fixedOffsetLiteral();
+    assertThat(fixed).isNotNull();
+    assertThat(fixed.literal()).isEqualTo("#!customTag");
+    assertThat(fixed.discreteOffsets()).containsExactly(0, 1);
+  }
+
+  @Test
+  void boundedRangeOffsetLiteralsAreRecorded() {
+    Pattern.FixedOffsetLiteral fixed =
+        Pattern.compile("\\s{0,8}renderElement\\(").fixedOffsetLiteral();
+    assertThat(fixed).isNotNull();
+    assertThat(fixed.literal()).isEqualTo("renderElement(");
+    assertThat(fixed.minOffset()).isEqualTo(0);
+    assertThat(fixed.maxOffset()).isEqualTo(8);
+  }
+
   @ParameterizedTest
   @CsvSource({
     "'.*(x|y).*',             xy, az",

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -263,18 +263,19 @@ class PatternInternalTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "\\d+/x",
-        "[αβ]/x",
-        "[ab](?i:x)",
-        "literal-prefix",
-        "(?:(?:a|.)a)",
-        ".\\d{3}foo",
-        "(^|[^#])(#!customTag)"
-      })
+  @ValueSource(strings = {"\\d+/x", "[ab](?i:x)", "literal-prefix"})
   void variableWidthUnicodeAndOrdinaryPrefixesDoNotRecordFixedOffsetLiterals(String regex) {
     assertThat(Pattern.compile(regex).fixedOffsetLiteral()).isNull();
+  }
+
+  @Test
+  void unicodeClassOffsetsAreRecordedAsNonDiscreteCodePointRanges() {
+    Pattern.FixedOffsetLiteral fixed = Pattern.compile("[αβ]/x").fixedOffsetLiteral();
+
+    assertThat(fixed).isNotNull();
+    assertThat(fixed.minOffset()).isEqualTo(1);
+    assertThat(fixed.maxOffset()).isEqualTo(1);
+    assertThat(fixed.discreteOffsets()).isNull();
   }
 
   @Test
@@ -283,6 +284,8 @@ class PatternInternalTest {
         Pattern.compile("(^|[a-z])(#!customTag)").fixedOffsetLiteral();
     assertThat(fixed).isNotNull();
     assertThat(fixed.literal()).isEqualTo("#!customTag");
+    assertThat(fixed.minOffset()).isZero();
+    assertThat(fixed.maxOffset()).isEqualTo(1);
     assertThat(fixed.discreteOffsets()).containsExactly(0, 1);
   }
 

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -243,7 +243,15 @@ class PatternInternalTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {"\\d+/x", "[αβ]/x", "[ab](?i:x)", "literal-prefix", "(?:(?:a|.)a)", ".\\d{3}foo"})
+      strings = {
+        "\\d+/x",
+        "[αβ]/x",
+        "[ab](?i:x)",
+        "literal-prefix",
+        "(?:(?:a|.)a)",
+        ".\\d{3}foo",
+        "(^|[^#])(#!customTag)"
+      })
   void variableWidthUnicodeAndOrdinaryPrefixesDoNotRecordFixedOffsetLiterals(String regex) {
     assertThat(Pattern.compile(regex).fixedOffsetLiteral()).isNull();
   }
@@ -251,7 +259,7 @@ class PatternInternalTest {
   @Test
   void discreteMultiOffsetLiteralsAreRecorded() {
     Pattern.FixedOffsetLiteral fixed =
-        Pattern.compile("(^|[^#])(#!customTag)").fixedOffsetLiteral();
+        Pattern.compile("(^|[a-z])(#!customTag)").fixedOffsetLiteral();
     assertThat(fixed).isNotNull();
     assertThat(fixed.literal()).isEqualTo("#!customTag");
     assertThat(fixed.discreteOffsets()).containsExactly(0, 1);

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -198,6 +198,27 @@ class PatternInternalTest {
   }
 
   @Test
+  void deeplyNestedFixedOffsetWidthExtractionIsStackSafe() {
+    Pattern p = Pattern.compile(nestedFixedOffsetPattern(2_000));
+
+    assertThat(p.fixedOffsetLiteral()).isNotNull();
+  }
+
+  @Test
+  void largeCapturedLiteralConcatenationRecordsMaximalSuffix() {
+    StringBuilder regex = new StringBuilder("[ab]");
+    for (int i = 0; i < 2_000; i++) {
+      regex.append("(x)");
+    }
+
+    Pattern.FixedOffsetLiteral fixed = Pattern.compile(regex.toString()).fixedOffsetLiteral();
+
+    assertThat(fixed).isNotNull();
+    assertThat(fixed.literal()).hasSize(2_000);
+    assertThat(fixed.minOffset()).isEqualTo(1);
+  }
+
+  @Test
   void caseInsensitiveAsciiLiteralUsesLiteralMatchMetadata() {
     Pattern p = Pattern.compile("(?i)i");
 
@@ -426,6 +447,19 @@ class PatternInternalTest {
     for (int i = 0; i < depth; i++) {
       regex.append(")x");
     }
+    return regex.toString();
+  }
+
+  private static String nestedFixedOffsetPattern(int depth) {
+    StringBuilder regex = new StringBuilder(depth * 3 + 6);
+    for (int i = 0; i < depth; i++) {
+      regex.append('(');
+    }
+    regex.append("[ab]");
+    for (int i = 0; i < depth; i++) {
+      regex.append(")x");
+    }
+    regex.append("ZZ");
     return regex.toString();
   }
 

--- a/safere/src/test/java/org/safere/Utf8EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/Utf8EnginePathEquivalenceTest.java
@@ -107,6 +107,23 @@ class Utf8EnginePathEquivalenceTest {
   }
 
   @Test
+  @DisplayName("UTF-8 convenience find supports generalized fixed offsets")
+  void utf8ConvenienceFindSupportsGeneralizedFixedOffsets() {
+    for (String regex : List.of("(^|a)bc", "(aq|b[a-z]{9})z")) {
+      String input =
+          switch (regex) {
+            case "(^|a)bc" -> "abc";
+            case "(aq|b[a-z]{9})z" -> "bxxaxzxxxxz";
+            default -> throw new AssertionError(regex);
+          };
+      Pattern pattern = Pattern.compile(regex);
+      Utf8Input utf8Input = Utf8Input.validated(input.getBytes(UTF_8));
+
+      assertThat(pattern.find(utf8Input)).as("/%s/ on %s", regex, input).isTrue();
+    }
+  }
+
+  @Test
   @DisplayName("malformed trusted input is equivalent across UTF-8 fallback engines")
   void malformedTrustedInputIsEquivalentAcrossFallbackEngines() {
     byte[] bytes = {'a', (byte) 0x80, (byte) 0xc2, 'b', (byte) 0xf0, (byte) 0x9f, 'c'};

--- a/safere/src/test/java/org/safere/Utf8EnginePathEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/Utf8EnginePathEquivalenceTest.java
@@ -89,7 +89,32 @@ class Utf8EnginePathEquivalenceTest {
             EnginePathOptions.builder()
                 .charClassMatchFastPaths(false)
                 .startAcceleration(false)
-                .build()));
+                .build()),
+        Arguments.of(
+            "mixed ASCII and non-ASCII class does not use byte-offset acceleration",
+            "[aé]bc",
+            "xébc abc",
+            EnginePathOptions.builder().startAcceleration(false).build()),
+        Arguments.of(
+            "non-ASCII range does not use byte-offset acceleration",
+            "[a-ÿ]bc",
+            "xébc abc",
+            EnginePathOptions.builder().startAcceleration(false).build()),
+        Arguments.of(
+            "supplementary class does not use byte-offset acceleration",
+            "[a😀]bc",
+            "x😀bc abc",
+            EnginePathOptions.builder().startAcceleration(false).build()),
+        Arguments.of(
+            "negated class does not use byte-offset acceleration",
+            "[^x]bc",
+            "xébc abc",
+            EnginePathOptions.builder().startAcceleration(false).build()),
+        Arguments.of(
+            "multi-offset acceleration preserves earlier starts from later literals",
+            "(aq|b[a-z]{9})z",
+            "bxxaxzxxxxz",
+            EnginePathOptions.builder().startAcceleration(false).build()));
   }
 
   @Test
@@ -107,12 +132,16 @@ class Utf8EnginePathEquivalenceTest {
   }
 
   @Test
-  @DisplayName("UTF-8 convenience find supports generalized fixed offsets")
+  @DisplayName("UTF-8 convenience find supports discrete and non-ASCII fixed offsets")
   void utf8ConvenienceFindSupportsGeneralizedFixedOffsets() {
-    for (String regex : List.of("(^|a)bc", "(aq|b[a-z]{9})z")) {
+    for (String regex :
+        List.of("(^|a)bc", "(^|[^#])(#!customTag)", "[aé]bc", "[a😀]bc", "(aq|b[a-z]{9})z")) {
       String input =
           switch (regex) {
             case "(^|a)bc" -> "abc";
+            case "(^|[^#])(#!customTag)" -> "é#!customTag";
+            case "[aé]bc" -> "ébc";
+            case "[a😀]bc" -> "😀bc";
             case "(aq|b[a-z]{9})z" -> "bxxaxzxxxxz";
             default -> throw new AssertionError(regex);
           };


### PR DESCRIPTION
Fixed-offset start acceleration previously required the prefix before an invariant literal to have a single, constant width (e.g. `\d{3}/\d{3}/\d{4}` where `/` is at exact offset 3). Any pattern containing leading alternations (such as line-start anchors `(^|[^#])(#!tag)`), optional atoms (`(?:\$|#)?literal`), or bounded repetitions was rejected by `exactAsciiWidth`, disabling literal start acceleration and falling back to byte-by-byte DFA scanning.

This change generalizes fixed-offset start acceleration to support:
1. Discrete multi-offsets: A bounded set of exact integer offsets (e.g., `{0, 1}` for `(^|[^#])` or `{2, 4}` for `(?:--|/\*)`).
2. Bounded ranges: Small repetition windows (e.g., `\s{0,8}directive`) for multi-character literals (`length >= 2`).
3. Multi-offset candidate pre-filtering: For discrete offsets, candidate start positions are checked against the leading character class (`firstAscii`) inside the literal scanning loop, skipping non-matching occurrences in SIMD time without invoking the forward DFA.

```
./run-java-benchmarks.sh --fastbuild CrossEngineScalingBenchmark.run -- \
  -p crossEngineScalingTrial=Issue488ReplaceAllBenchmark.altCapture.1000@safere-string,Issue488ReplaceAllBenchmark.altCapture.10000@safere-string,Issue488ReplaceAllBenchmark.altCapture.100000@safere-string
```

| Input Size | Base | Optimized | Delta | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| **1,000** | `3.946 ± 0.154 µs/op` | **`1.692 ± 0.156 µs/op`** | **-57.1%** | **2.33x faster** |
| **10,000** | `33.591 ± 1.117 µs/op` | **`11.518 ± 0.225 µs/op`** | **-65.7%** | **2.92x faster** |
| **100,000** | `335.942 ± 11.443 µs/op` | **`112.518 ± 10.271 µs/op`** | **-66.5%** | **2.99x faster** |
