### PR TITLE
Consolidate singleCharClass and add ASCII fast-path for single character class matching

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -657,6 +657,22 @@
       "shared": true
     },
     {
+      "id": "charClassSearch.singleCharAbsent.{size}",
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "The quick brown fox jumps over the lazy dog without any numbers. ",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
       "id": "utf8Matching.requiredClassNonmatch.text",
       "recipe": {
         "kind": "repeatToLength",
@@ -9085,6 +9101,36 @@
         "constraints": [
           "prematerializedInput",
           "allocationProfile"
+        ]
+      }
+    },
+    {
+      "id": "SingleCharClassBenchmark.findDigitAbsent.{size}",
+      "operation": "find",
+      "patterns": [
+        "[0-9]"
+      ],
+      "inputs": [
+        "charClassSearch.singleCharAbsent.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString"
+      ],
+      "inputRepresentationReason": "Measures single character class find fast-path throughput over non-matching input strings.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
         ]
       }
     }

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -64,6 +64,10 @@ interface InputScanner {
     return (int) (decoded >> 32);
   }
 
+  default int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
+    return -1;
+  }
+
   static int position(long decoded) {
     return (int) decoded;
   }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -565,21 +565,20 @@ public final class Matcher implements MatchResult {
    * Fast path for {@code find()} when the pattern is exactly one character class. Scans code points
    * directly and returns the first matching code point as group 0.
    */
-  private boolean singleCharClassFindFastPath(int[] ranges, int fromIndex) {
-    long b0 = parentPattern.singleCharClassBitmap0();
-    long b1 = parentPattern.singleCharClassBitmap1();
-
-    int i = fromIndex;
-    int len = text.length();
-    while (i < len) {
-      if (WorkCounterConfig.ENABLED) {
-        WorkCounter.record();
+  private boolean singleCharClassFindFastPath(Pattern.CharClassScanInfo scanInfo, int fromIndex) {
+    if (scanInfo.isAscii && text != null) {
+      int idx = activeScanner().indexOfCharClass(scanInfo, fromIndex);
+      if (idx >= 0) {
+        return applyFullMatchResult(new int[] {idx, idx + 1});
       }
-      int cp = text.codePointAt(i);
-      if (charClassContains(ranges, b0, b1, cp)) {
-        return applyFullMatchResult(new int[] {i, i + Character.charCount(cp)});
-      }
-      i += Character.charCount(cp);
+      return applyFailedMatchResult();
+    }
+    int idx =
+        activeScanner()
+            .indexOfCodePointClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex);
+    if (idx >= 0) {
+      int cp = text.codePointAt(idx);
+      return applyFullMatchResult(new int[] {idx, idx + Character.charCount(cp)});
     }
     return applyFailedMatchResult();
   }
@@ -591,20 +590,6 @@ public final class Matcher implements MatchResult {
   private boolean containsRequiredMatchClass(int[] ranges, int fromIndex) {
     long b0 = parentPattern.requiredMatchClassBitmap0();
     long b1 = parentPattern.requiredMatchClassBitmap1();
-    if (text != null) {
-      int position = Math.max(0, fromIndex);
-      while (position < text.length()) {
-        if (WorkCounterConfig.ENABLED) {
-          WorkCounter.record();
-        }
-        int codePoint = text.codePointAt(position);
-        if (charClassContains(ranges, b0, b1, codePoint)) {
-          return true;
-        }
-        position += Character.charCount(codePoint);
-      }
-      return false;
-    }
     return activeScanner().indexOfCodePointClass(ranges, b0, b1, fromIndex) >= 0;
   }
 
@@ -1568,10 +1553,10 @@ public final class Matcher implements MatchResult {
       return applyFullMatchResult(new int[] {idx, idx + matchLength});
     }
 
-    int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
-    if (options.charClassMatchFastPaths() && singleCharClassRanges != null && text != null) {
+    Pattern.CharClassScanInfo singleCharClass = parentPattern.singleCharClassScanInfo();
+    if (options.charClassMatchFastPaths() && singleCharClass != null && text != null) {
       diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
-      return singleCharClassFindFastPath(singleCharClassRanges, searchFrom);
+      return singleCharClassFindFastPath(singleCharClass, searchFrom);
     }
 
     Pattern.KeywordAlternation keywordAlternation = parentPattern.keywordAlternation();
@@ -4317,23 +4302,23 @@ public final class Matcher implements MatchResult {
     }
 
     // Char class fast path
-    int[] singleCharClassRanges = parentPattern.singleCharClassRanges();
-    if (options.charClassMatchFastPaths() && singleCharClassRanges != null) {
-      long b0 = parentPattern.singleCharClassBitmap0();
-      long b1 = parentPattern.singleCharClassBitmap1();
-      int i = fromIndex;
-      int len = text.length();
-      while (i < len) {
-        if (WorkCounterConfig.ENABLED) {
-          WorkCounter.record();
+    Pattern.CharClassScanInfo singleCharClass = parentPattern.singleCharClassScanInfo();
+    if (options.charClassMatchFastPaths() && singleCharClass != null) {
+      if (singleCharClass.isAscii) {
+        int idx = scanner.indexOfCharClass(singleCharClass, fromIndex);
+        if (idx < 0) {
+          return -1L;
         }
-        int cp = text.codePointAt(i);
-        if (charClassContains(singleCharClassRanges, b0, b1, cp)) {
-          return packPositions(i, i + Character.charCount(cp));
-        }
-        i += Character.charCount(cp);
+        return packPositions(idx, idx + 1);
       }
-      return -1L;
+      int idx =
+          scanner.indexOfCodePointClass(
+              singleCharClass.ranges, singleCharClass.bitmap0, singleCharClass.bitmap1, fromIndex);
+      if (idx < 0) {
+        return -1L;
+      }
+      int cp = text.codePointAt(idx);
+      return packPositions(idx, idx + Character.charCount(cp));
     }
 
     int effectiveStart = fromIndex;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -180,10 +180,7 @@ public final class Pattern implements Serializable {
    * {@code \p{javaLetter}}. Non-null when {@code find()} can scan directly for one matching code
    * point and produce group 0 without invoking the engine cascade.
    */
-  private final transient int[] singleCharClassRanges;
-
-  private final transient long singleCharClassBitmap0;
-  private final transient long singleCharClassBitmap1;
+  private final transient CharClassScanInfo singleCharClassScanInfo;
 
   /**
    * Precomputed character class data for a mandatory character class. Non-null when matching can
@@ -301,9 +298,7 @@ public final class Pattern implements Serializable {
       long charClassMatchBitmap0,
       long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty,
-      int[] singleCharClassRanges,
-      long singleCharClassBitmap0,
-      long singleCharClassBitmap1,
+      CharClassScanInfo singleCharClass,
       int[] requiredMatchClassRanges,
       long requiredMatchClassBitmap0,
       long requiredMatchClassBitmap1,
@@ -367,9 +362,7 @@ public final class Pattern implements Serializable {
     this.charClassMatchBitmap0 = charClassMatchBitmap0;
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
     this.charClassMatchAllowEmpty = charClassMatchAllowEmpty;
-    this.singleCharClassRanges = singleCharClassRanges;
-    this.singleCharClassBitmap0 = singleCharClassBitmap0;
-    this.singleCharClassBitmap1 = singleCharClassBitmap1;
+    this.singleCharClassScanInfo = singleCharClass;
     this.requiredMatchClassRanges = requiredMatchClassRanges;
     this.requiredMatchClassBitmap0 = requiredMatchClassBitmap0;
     this.requiredMatchClassBitmap1 = requiredMatchClassBitmap1;
@@ -530,9 +523,7 @@ public final class Pattern implements Serializable {
         ccMatch != null ? ccMatch.bitmap0 : 0,
         ccMatch != null ? ccMatch.bitmap1 : 0,
         ccMatch != null && ccMatch.allowEmpty,
-        singleCharClass != null ? singleCharClass.ranges : null,
-        singleCharClass != null ? singleCharClass.bitmap0 : 0,
-        singleCharClass != null ? singleCharClass.bitmap1 : 0,
+        singleCharClass,
         requiredMatchClass != null ? requiredMatchClass.ranges : null,
         requiredMatchClass != null ? requiredMatchClass.bitmap0 : 0,
         requiredMatchClass != null ? requiredMatchClass.bitmap1 : 0,
@@ -1330,20 +1321,10 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Returns precomputed ranges when the pattern is exactly one character class, or {@code null}.
+   * Returns precomputed scan info when the pattern is exactly one character class, or {@code null}.
    */
-  int[] singleCharClassRanges() {
-    return singleCharClassRanges;
-  }
-
-  /** ASCII bitmap (code points 0–63) for the single-character-class fast path. */
-  long singleCharClassBitmap0() {
-    return singleCharClassBitmap0;
-  }
-
-  /** ASCII bitmap (code points 64–127) for the single-character-class fast path. */
-  long singleCharClassBitmap1() {
-    return singleCharClassBitmap1;
+  CharClassScanInfo singleCharClassScanInfo() {
+    return singleCharClassScanInfo;
   }
 
   /** Returns precomputed ranges for a required character class, or {@code null}. */
@@ -1594,7 +1575,7 @@ public final class Pattern implements Serializable {
     }
     addAstAnalysisFeatures(features);
 
-    if (charClassMatchRanges != null || singleCharClassRanges != null) {
+    if (charClassMatchRanges != null || singleCharClassScanInfo != null) {
       capabilities.add(PatternCapability.CHARACTER_CLASS_MATCH);
     }
     if (keywordAlternation != null) {
@@ -2803,11 +2784,13 @@ public final class Pattern implements Serializable {
     final int[] ranges;
     final long bitmap0;
     final long bitmap1;
+    final boolean isAscii;
 
-    CharClassScanInfo(int[] ranges, long bitmap0, long bitmap1) {
+    CharClassScanInfo(int[] ranges, long bitmap0, long bitmap1, boolean isAscii) {
       this.ranges = ranges;
       this.bitmap0 = bitmap0;
       this.bitmap1 = bitmap1;
+      this.isAscii = isAscii;
     }
   }
 
@@ -2845,7 +2828,7 @@ public final class Pattern implements Serializable {
     if (rangeCount == 0) {
       return null;
     }
-    return new CharClassScanInfo(Arrays.copyOf(ranges, rangeCount * 2), bitmap0, bitmap1);
+    return new CharClassScanInfo(Arrays.copyOf(ranges, rangeCount * 2), bitmap0, bitmap1, true);
   }
 
   /**
@@ -3120,7 +3103,8 @@ public final class Pattern implements Serializable {
         }
       }
     }
-    return new CharClassScanInfo(ranges, b0, b1);
+    boolean isAscii = numRanges > 0 && cc.hi(numRanges - 1) <= 127;
+    return new CharClassScanInfo(ranges, b0, b1, isAscii);
   }
 
   /**

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -48,6 +48,25 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
+  public int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
+    int position = Math.max(0, start);
+    int[] ranges = scanInfo.ranges;
+    long bitmap0 = scanInfo.bitmap0;
+    long bitmap1 = scanInfo.bitmap1;
+    while (position < text.length()) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
+      char ch = text.charAt(position);
+      if (InputScanner.classContains(ranges, bitmap0, bitmap1, ch)) {
+        return position;
+      }
+      position++;
+    }
+    return -1;
+  }
+
+  @Override
   public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
     int position = Math.max(0, start);
     while (position < text.length()) {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -805,4 +805,20 @@ final class Utf8InputScanner implements InputScanner {
     }
     return true;
   }
+
+  @Override
+  public int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
+    int pos = Math.max(0, start);
+    int[] ranges = scanInfo.ranges;
+    long b0 = scanInfo.bitmap0;
+    long b1 = scanInfo.bitmap1;
+    while (pos < length) {
+      int ascii = asciiAt(pos);
+      if (ascii >= 0 && InputScanner.classContains(ranges, b0, b1, ascii)) {
+        return pos;
+      }
+      pos++;
+    }
+    return -1;
+  }
 }


### PR DESCRIPTION
This was developed as part of #656, but is independent from it.

Currently this is performance neutral, the branch for ASCII seems to have been getting predicted and the separate loop doesn't help. The `indexOfCharClass` that was extracted could be more helpful in the future if it's vectorized, so this is mostly a refactoring/cleanup that paves the way for that.