### PR TITLE
Extract shared 8-bit ByteVectorScan and ByteSwarScan kernels from Utf8InputScanner

### DIFF
--- a/safere/src/main/java/org/safere/ByteSwarScan.java
+++ b/safere/src/main/java/org/safere/ByteSwarScan.java
@@ -1,0 +1,316 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.lang.invoke.MethodHandles.byteArrayViewVarHandle;
+import static java.nio.ByteOrder.nativeOrder;
+
+import java.lang.invoke.VarHandle;
+
+/** Stateless 64-bit SWAR kernels for scanning 1-byte sequences (UTF-8 and Latin-1 Strings). */
+final class ByteSwarScan {
+  static final long BYTE_ONES = 0x0101_0101_0101_0101L;
+  static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
+
+  /**
+   * Input sizes at which the SWAR candidate filter overtakes the skip loop. The filter always
+   * advances eight positions per step, while the skip loop can advance as far as the literal
+   * length, so the filter needs an input large enough to outweigh that per-step advantage. Both
+   * bounds were measured; see {@link #indexOfFiltered}.
+   */
+  static final int MIN_FILTER_LENGTH = 64;
+
+  static final int FILTER_LENGTH_FACTOR = 40;
+
+  private static final VarHandle LONG_VIEW = byteArrayViewVarHandle(long[].class, nativeOrder());
+
+  static long filterThreshold(int literalLength) {
+    return Math.max(MIN_FILTER_LENGTH, (long) literalLength * FILTER_LENGTH_FACTOR);
+  }
+
+  static int indexOfByte(byte[] bytes, int offset, int length, byte target, int start) {
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    long repeatedTarget = (target & 0xFFL) * BYTE_ONES;
+    while (position <= wordEnd) {
+      long difference = (long) LONG_VIEW.get(bytes, offset + position) ^ repeatedTarget;
+      if (((difference - BYTE_ONES) & ~difference & BYTE_HIGH_BITS) != 0) {
+        for (int index = 0; index < Long.BYTES; index++) {
+          if (bytes[offset + position + index] == target) {
+            return position + index;
+          }
+        }
+      }
+      position += Long.BYTES;
+    }
+    while (position < length) {
+      if (bytes[offset + position] == target) {
+        return position;
+      }
+      position++;
+    }
+    return -1;
+  }
+
+  static int indexOfBytePair(
+      byte[] bytes, int offset, int length, byte first, byte second, int start) {
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    long repeatedFirst = (first & 0xFFL) * BYTE_ONES;
+    long repeatedSecond = (second & 0xFFL) * BYTE_ONES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long firstDifference = word ^ repeatedFirst;
+      long secondDifference = word ^ repeatedSecond;
+      if (((((firstDifference - BYTE_ONES) & ~firstDifference)
+                  | ((secondDifference - BYTE_ONES) & ~secondDifference))
+              & BYTE_HIGH_BITS)
+          != 0) {
+        for (int index = 0; index < Long.BYTES; index++) {
+          byte value = bytes[offset + position + index];
+          if (value == first || value == second) {
+            return position + index;
+          }
+        }
+      }
+      position += Long.BYTES;
+    }
+    while (position < length) {
+      byte value = bytes[offset + position];
+      if (value == first || value == second) {
+        return position;
+      }
+      position++;
+    }
+    return -1;
+  }
+
+  /**
+   * Searches for a byte in the inclusive ASCII range {@code [low, high]}.
+   *
+   * <p>The word filter compares the common binary prefix of the range endpoints across eight bytes
+   * at once. Every byte in the range has that prefix, so the filter cannot miss a match. It may
+   * admit bytes outside the range when the endpoints do not cover their entire binary-prefix
+   * bucket; the scalar candidate check provides the exact answer.
+   */
+  static int indexOfByteRange(byte[] bytes, int offset, int length, int low, int high, int start) {
+    int differingBit = Integer.highestOneBit(low ^ high);
+    int commonMask = ~((differingBit << 1) - 1) & 0xFF;
+    long repeatedMask = (commonMask & 0xFFL) * BYTE_ONES;
+    long repeatedPrefix = (low & commonMask) * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long difference = (word & repeatedMask) ^ repeatedPrefix;
+      if (((difference - BYTE_ONES) & ~difference & BYTE_HIGH_BITS) != 0) {
+        for (int index = 0; index < Long.BYTES; index++) {
+          int value = bytes[offset + position + index] & 0xFF;
+          if (value >= low && value <= high) {
+            return position + index;
+          }
+        }
+      }
+      position += Long.BYTES;
+    }
+    while (position < length) {
+      int value = bytes[offset + position] & 0xFF;
+      if (value >= low && value <= high) {
+        return position;
+      }
+      position++;
+    }
+    return -1;
+  }
+
+  /**
+   * Searches for a multi-byte {@code literal} by locating candidate positions with a SWAR filter on
+   * the literal's first and last bytes, then verifying each candidate in full.
+   *
+   * <p>Two words are loaded per step, one aligned with the literal's first byte and one with its
+   * last byte. XOR-ing each against the corresponding broadcast byte turns matching positions into
+   * zero bytes, so the standard zero-byte test identifies positions where both the first and last
+   * byte agree. Requiring both bytes makes candidates far rarer than a single-byte filter would.
+   *
+   * <p>This examines eight positions per step with no data-dependent branching. A skip loop such as
+   * Boyer-Moore-Horspool can advance further per step, but each of its steps is a serialized load,
+   * table lookup, and add, which costs more than the wider branch-free step here.
+   *
+   * <p>The zero-byte test never misses a matching position, but it can flag a position that does
+   * not match, so every candidate is verified against the whole literal rather than trusting the
+   * filter for the first and last byte.
+   *
+   * <p>Verification is O(literal length) per candidate, so an adversarial input can drive this to
+   * O(input length * literal length). A work budget bounds that: on exhaustion this returns {@code
+   * -2} and the caller falls back to linear-time KMP.
+   *
+   * @return the index of the first match, {@code -1} if the literal is absent, or {@code -2} if the
+   *     work budget was exhausted before either could be established
+   */
+  static int indexOfFiltered(
+      byte[] bytes, int offset, int length, byte[] literal, int[] failure, int start) {
+    int last = literal.length - 1;
+    long repeatedFirst = (literal[0] & 0xFFL) * BYTE_ONES;
+    long repeatedLast = (literal[last] & 0xFFL) * BYTE_ONES;
+    int wordEnd = length - last - Long.BYTES;
+    long work = 0;
+    long workLimit = Utf8InputScanner.workLimit(length - start);
+    int position = start;
+    while (position <= wordEnd) {
+      long firstDifference = (long) LONG_VIEW.get(bytes, offset + position) ^ repeatedFirst;
+      long lastDifference = (long) LONG_VIEW.get(bytes, offset + position + last) ^ repeatedLast;
+      long candidates =
+          (firstDifference - BYTE_ONES)
+              & ~firstDifference
+              & (lastDifference - BYTE_ONES)
+              & ~lastDifference
+              & BYTE_HIGH_BITS;
+      if (candidates != 0) {
+        // Scanning the eight positions in address order keeps this independent of byte order and
+        // returns the leftmost match within the word.
+        int candidateCount = 0;
+        for (int index = 0; index < Long.BYTES; index++) {
+          int candidate = position + index;
+          if (bytes[offset + candidate] == literal[0]) {
+            if (matchesAt(bytes, offset, literal, candidate)) {
+              return candidate;
+            }
+            candidateCount++;
+          }
+        }
+        work = Utf8InputScanner.addCandidateWork(work, candidateCount, literal.length);
+      }
+      position += Long.BYTES;
+      work++;
+      if (work >= workLimit) {
+        return -2;
+      }
+    }
+    return Utf8InputScanner.indexOfLinear(bytes, offset, length, literal, failure, position);
+  }
+
+  private static boolean matchesAt(byte[] bytes, int offset, byte[] literal, int position) {
+    for (int index = 0; index < literal.length; index++) {
+      if (bytes[offset + position + index] != literal[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static long exactAsciiRangeMask(long word, int low, int high) {
+    long values = word & ~BYTE_HIGH_BITS;
+    long ascii = ~word & BYTE_HIGH_BITS;
+    return exactAsciiRangeMask(values, ascii, low * BYTE_ONES, high * BYTE_ONES);
+  }
+
+  static long exactAsciiRangeMask(long values, long ascii, long repeatedLow, long repeatedHigh) {
+    // Setting each minuend's high bit makes both subtractions independent in every byte lane:
+    // each lane subtracts at most 127 from at least 128, so no borrow can cross a lane boundary.
+    long atLeastLow = ((values | BYTE_HIGH_BITS) - repeatedLow) & BYTE_HIGH_BITS;
+    long atMostHigh = ((repeatedHigh | BYTE_HIGH_BITS) - values) & BYTE_HIGH_BITS;
+    return ascii & atLeastLow & atMostHigh;
+  }
+
+  static int indexOfMultipleByteRanges(
+      byte[] bytes, int offset, int length, int[] ranges, long bitmap0, long bitmap1, int start) {
+    return switch (ranges.length) {
+      case 4 -> indexOfTwoByteRanges(bytes, offset, length, ranges, bitmap0, bitmap1, start);
+      case 6 -> indexOfThreeByteRanges(bytes, offset, length, ranges, bitmap0, bitmap1, start);
+      case 8 -> indexOfFourByteRanges(bytes, offset, length, ranges, bitmap0, bitmap1, start);
+      default -> throw new AssertionError("unexpected range count");
+    };
+  }
+
+  private static int indexOfTwoByteRanges(
+      byte[] bytes, int offset, int length, int[] ranges, long bitmap0, long bitmap1, int start) {
+    long low0 = ranges[0] * BYTE_ONES;
+    long high0 = ranges[1] * BYTE_ONES;
+    long low1 = ranges[2] * BYTE_ONES;
+    long high1 = ranges[3] * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long values = word & ~BYTE_HIGH_BITS;
+      long ascii = ~word & BYTE_HIGH_BITS;
+      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
+      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
+      if (matches != 0) {
+        return scalarRangeCheck(bytes, offset, bitmap0, bitmap1, position, position + Long.BYTES);
+      }
+      position += Long.BYTES;
+    }
+    return scalarRangeCheck(bytes, offset, bitmap0, bitmap1, position, length);
+  }
+
+  private static int indexOfThreeByteRanges(
+      byte[] bytes, int offset, int length, int[] ranges, long bitmap0, long bitmap1, int start) {
+    long low0 = ranges[0] * BYTE_ONES;
+    long high0 = ranges[1] * BYTE_ONES;
+    long low1 = ranges[2] * BYTE_ONES;
+    long high1 = ranges[3] * BYTE_ONES;
+    long low2 = ranges[4] * BYTE_ONES;
+    long high2 = ranges[5] * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long values = word & ~BYTE_HIGH_BITS;
+      long ascii = ~word & BYTE_HIGH_BITS;
+      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
+      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
+      matches |= exactAsciiRangeMask(values, ascii, low2, high2);
+      if (matches != 0) {
+        return scalarRangeCheck(bytes, offset, bitmap0, bitmap1, position, position + Long.BYTES);
+      }
+      position += Long.BYTES;
+    }
+    return scalarRangeCheck(bytes, offset, bitmap0, bitmap1, position, length);
+  }
+
+  private static int indexOfFourByteRanges(
+      byte[] bytes, int offset, int length, int[] ranges, long bitmap0, long bitmap1, int start) {
+    long low0 = ranges[0] * BYTE_ONES;
+    long high0 = ranges[1] * BYTE_ONES;
+    long low1 = ranges[2] * BYTE_ONES;
+    long high1 = ranges[3] * BYTE_ONES;
+    long low2 = ranges[4] * BYTE_ONES;
+    long high2 = ranges[5] * BYTE_ONES;
+    long low3 = ranges[6] * BYTE_ONES;
+    long high3 = ranges[7] * BYTE_ONES;
+    int position = start;
+    int wordEnd = length - Long.BYTES;
+    while (position <= wordEnd) {
+      long word = (long) LONG_VIEW.get(bytes, offset + position);
+      long values = word & ~BYTE_HIGH_BITS;
+      long ascii = ~word & BYTE_HIGH_BITS;
+      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
+      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
+      matches |= exactAsciiRangeMask(values, ascii, low2, high2);
+      matches |= exactAsciiRangeMask(values, ascii, low3, high3);
+      if (matches != 0) {
+        return scalarRangeCheck(bytes, offset, bitmap0, bitmap1, position, position + Long.BYTES);
+      }
+      position += Long.BYTES;
+    }
+    return scalarRangeCheck(bytes, offset, bitmap0, bitmap1, position, length);
+  }
+
+  private static int scalarRangeCheck(
+      byte[] bytes, int offset, long bitmap0, long bitmap1, int position, int limit) {
+    for (; position < limit; position++) {
+      int value = bytes[offset + position] & 0xFF;
+      if ((value < Long.SIZE && (bitmap0 & (1L << value)) != 0)
+          || (value >= Long.SIZE && value < 128 && (bitmap1 & (1L << (value - Long.SIZE))) != 0)) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
+  private ByteSwarScan() {}
+}

--- a/safere/src/main/java/org/safere/ByteSwarScan.java
+++ b/safere/src/main/java/org/safere/ByteSwarScan.java
@@ -7,11 +7,12 @@ package org.safere;
 
 import static java.lang.invoke.MethodHandles.byteArrayViewVarHandle;
 import static java.nio.ByteOrder.nativeOrder;
+import static java.util.Objects.requireNonNull;
 
 import java.lang.invoke.VarHandle;
 
-/** Stateless 64-bit SWAR kernels for scanning 1-byte sequences (UTF-8 and Latin-1 Strings). */
-final class ByteSwarScan {
+/** Shared 64-bit SWAR kernels for scanning bounded 1-byte sequences. */
+abstract class ByteSwarScan {
   static final long BYTE_ONES = 0x0101_0101_0101_0101L;
   static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
 
@@ -27,11 +28,25 @@ final class ByteSwarScan {
 
   private static final VarHandle LONG_VIEW = byteArrayViewVarHandle(long[].class, nativeOrder());
 
+  final byte[] bytes;
+  final int offset;
+  final int length;
+
+  ByteSwarScan(byte[] bytes, int offset, int length) {
+    this.bytes = requireNonNull(bytes, "bytes");
+    if (offset < 0 || length < 0 || offset > bytes.length - length) {
+      throw new IndexOutOfBoundsException(
+          "offset=" + offset + ", length=" + length + ", arrayLength=" + bytes.length);
+    }
+    this.offset = offset;
+    this.length = length;
+  }
+
   static long filterThreshold(int literalLength) {
     return Math.max(MIN_FILTER_LENGTH, (long) literalLength * FILTER_LENGTH_FACTOR);
   }
 
-  static int indexOfByte(byte[] bytes, int offset, int length, byte target, int start) {
+  final int indexOfByte(byte target, int start) {
     int position = start;
     int wordEnd = length - Long.BYTES;
     long repeatedTarget = (target & 0xFFL) * BYTE_ONES;
@@ -311,6 +326,4 @@ final class ByteSwarScan {
     }
     return -1;
   }
-
-  private ByteSwarScan() {}
 }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -1,0 +1,79 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static jdk.incubator.vector.VectorOperators.GE;
+import static jdk.incubator.vector.VectorOperators.LE;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * Stateless SIMD kernels using the incubating Vector API for 1-byte sequences (UTF-8 and Latin-1).
+ */
+final class ByteVectorScan {
+  private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
+
+  public static int indexOfAsciiClass(
+      byte[] bytes, int offset, int length, int[] ranges, int start) {
+    if (ranges.length < 2 || ranges.length > 8 || (ranges.length & 1) != 0) {
+      return VectorScanProvider.UNSUPPORTED;
+    }
+    int position = Math.max(0, start);
+    int limit = position + SPECIES.loopBound(length - position);
+    for (; position < limit; position += SPECIES.length()) {
+      ByteVector values = ByteVector.fromArray(SPECIES, bytes, offset + position);
+      VectorMask<Byte> matches = matches(values, ranges);
+      if (matches.anyTrue()) {
+        return position + matches.firstTrue();
+      }
+    }
+    for (; position < length; position++) {
+      if (matches(bytes[offset + position], ranges)) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
+  private static VectorMask<Byte> matches(ByteVector values, int[] ranges) {
+    VectorMask<Byte> matches = matches(values, ranges[0], ranges[1]);
+    if (ranges.length >= 4) {
+      matches = matches.or(matches(values, ranges[2], ranges[3]));
+    }
+    if (ranges.length >= 6) {
+      matches = matches.or(matches(values, ranges[4], ranges[5]));
+    }
+    if (ranges.length == 8) {
+      matches = matches.or(matches(values, ranges[6], ranges[7]));
+    }
+    return matches;
+  }
+
+  private static VectorMask<Byte> matches(ByteVector values, int lowBound, int highBound) {
+    byte low = (byte) lowBound;
+    byte high = (byte) highBound;
+    if (low == high) {
+      return values.eq(low);
+    }
+    if (high == low + 1) {
+      return values.eq(low).or(values.eq(high));
+    }
+    return values.compare(GE, low).and(values.compare(LE, high));
+  }
+
+  private static boolean matches(byte value, int[] ranges) {
+    for (int index = 0; index < ranges.length; index += 2) {
+      if (value >= (byte) ranges[index] && value <= (byte) ranges[index + 1]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private ByteVectorScan() {}
+}

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -5,17 +5,9 @@
 
 package org.safere;
 
-import static jdk.incubator.vector.VectorOperators.GE;
-import static jdk.incubator.vector.VectorOperators.LE;
-
-import jdk.incubator.vector.ByteVector;
-import jdk.incubator.vector.VectorMask;
-import jdk.incubator.vector.VectorSpecies;
-
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
   private static final int MINIMUM_INPUT_LENGTH = 1024;
-  private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
 
   @Override
   public int minimumInputLength() {
@@ -24,58 +16,6 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
 
   @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
-    if (ranges.length < 2 || ranges.length > 8 || (ranges.length & 1) != 0) {
-      return UNSUPPORTED;
-    }
-    int position = Math.max(0, start);
-    int limit = position + SPECIES.loopBound(length - position);
-    for (; position < limit; position += SPECIES.length()) {
-      ByteVector values = ByteVector.fromArray(SPECIES, bytes, offset + position);
-      VectorMask<Byte> matches = matches(values, ranges);
-      if (matches.anyTrue()) {
-        return position + matches.firstTrue();
-      }
-    }
-    for (; position < length; position++) {
-      if (matches(bytes[offset + position], ranges)) {
-        return position;
-      }
-    }
-    return -1;
-  }
-
-  private static VectorMask<Byte> matches(ByteVector values, int[] ranges) {
-    VectorMask<Byte> matches = matches(values, ranges[0], ranges[1]);
-    if (ranges.length >= 4) {
-      matches = matches.or(matches(values, ranges[2], ranges[3]));
-    }
-    if (ranges.length >= 6) {
-      matches = matches.or(matches(values, ranges[4], ranges[5]));
-    }
-    if (ranges.length == 8) {
-      matches = matches.or(matches(values, ranges[6], ranges[7]));
-    }
-    return matches;
-  }
-
-  private static VectorMask<Byte> matches(ByteVector values, int lowBound, int highBound) {
-    byte low = (byte) lowBound;
-    byte high = (byte) highBound;
-    if (low == high) {
-      return values.eq(low);
-    }
-    if (high == low + 1) {
-      return values.eq(low).or(values.eq(high));
-    }
-    return values.compare(GE, low).and(values.compare(LE, high));
-  }
-
-  private static boolean matches(byte value, int[] ranges) {
-    for (int index = 0; index < ranges.length; index += 2) {
-      if (value >= (byte) ranges[index] && value <= (byte) ranges[index + 1]) {
-        return true;
-      }
-    }
-    return false;
+    return ByteVectorScan.indexOfAsciiClass(bytes, offset, length, ranges, start);
   }
 }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -13,23 +13,12 @@ import java.lang.invoke.VarHandle;
 
 final class Utf8InputScanner implements InputScanner {
   private static final int REPLACEMENT_CHARACTER = 0xFFFD;
-  private static final long BYTE_ONES = 0x0101_0101_0101_0101L;
   private static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
-  private static final long BYTE_LOW_BITS = ~BYTE_HIGH_BITS;
   private static final int BOYER_MOORE_HORSPOOL_BATCH_SIZE = 2;
   private static final int MULTI_RANGE_SWAR_MINIMUM_LENGTH = 64;
   private static final int MULTI_RANGE_SWAR_SCALAR_PROLOGUE_LENGTH = Long.BYTES;
   private static final int VECTOR_SCALAR_PROLOGUE_LENGTH = Integer.BYTES;
 
-  /**
-   * Input sizes at which the SWAR candidate filter overtakes the skip loop. The filter always
-   * advances eight positions per step, while the skip loop can advance as far as the literal
-   * length, so the filter needs an input large enough to outweigh that per-step advantage. Both
-   * bounds were measured; see {@link #indexOfFiltered}.
-   */
-  private static final int MIN_FILTER_LENGTH = 64;
-
-  private static final int FILTER_LENGTH_FACTOR = 40;
   private static final VarHandle LONG_VIEW = byteArrayViewVarHandle(long[].class, nativeOrder());
 
   private final byte[] bytes;
@@ -169,128 +158,27 @@ final class Utf8InputScanner implements InputScanner {
       int low = ranges[0];
       int high = ranges[1];
       if (low == high) {
-        return indexOfByte((byte) low, start);
+        return ByteSwarScan.indexOfByte(bytes, offset, length, (byte) low, start);
       }
       if (high == low + 1) {
-        return indexOfBytePair((byte) low, (byte) high, start);
+        return ByteSwarScan.indexOfBytePair(bytes, offset, length, (byte) low, (byte) high, start);
       }
-      return indexOfByteRange(low, high, start);
+      return ByteSwarScan.indexOfByteRange(bytes, offset, length, low, high, start);
     }
     if (ranges.length == 4
         && ranges[0] == ranges[1]
         && ranges[2] == ranges[3]
         && ranges[0] >= 0
         && ranges[3] < 0x80) {
-      return indexOfBytePair((byte) ranges[0], (byte) ranges[2], start);
+      return ByteSwarScan.indexOfBytePair(
+          bytes, offset, length, (byte) ranges[0], (byte) ranges[2], start);
     }
     return -2;
   }
 
   private int indexOfMultipleByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
-    return switch (ranges.length) {
-      case 4 -> indexOfTwoByteRanges(ranges, bitmap0, bitmap1, start);
-      case 6 -> indexOfThreeByteRanges(ranges, bitmap0, bitmap1, start);
-      case 8 -> indexOfFourByteRanges(ranges, bitmap0, bitmap1, start);
-      default -> throw new AssertionError("unexpected range count");
-    };
-  }
-
-  private int indexOfTwoByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
-    long low0 = ranges[0] * BYTE_ONES;
-    long high0 = ranges[1] * BYTE_ONES;
-    long low1 = ranges[2] * BYTE_ONES;
-    long high1 = ranges[3] * BYTE_ONES;
-    int position = start;
-    int wordEnd = length - Long.BYTES;
-    while (position <= wordEnd) {
-      long word = (long) LONG_VIEW.get(bytes, offset + position);
-      long values = word & BYTE_LOW_BITS;
-      long ascii = ~word & BYTE_HIGH_BITS;
-      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
-      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
-      if (matches != 0) {
-        return scalarRangeCheck(bitmap0, bitmap1, position, position + Long.BYTES);
-      }
-      position += Long.BYTES;
-    }
-    return scalarRangeCheck(bitmap0, bitmap1, position, length);
-  }
-
-  private int indexOfThreeByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
-    long low0 = ranges[0] * BYTE_ONES;
-    long high0 = ranges[1] * BYTE_ONES;
-    long low1 = ranges[2] * BYTE_ONES;
-    long high1 = ranges[3] * BYTE_ONES;
-    long low2 = ranges[4] * BYTE_ONES;
-    long high2 = ranges[5] * BYTE_ONES;
-    int position = start;
-    int wordEnd = length - Long.BYTES;
-    while (position <= wordEnd) {
-      long word = (long) LONG_VIEW.get(bytes, offset + position);
-      long values = word & BYTE_LOW_BITS;
-      long ascii = ~word & BYTE_HIGH_BITS;
-      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
-      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
-      matches |= exactAsciiRangeMask(values, ascii, low2, high2);
-      if (matches != 0) {
-        return scalarRangeCheck(bitmap0, bitmap1, position, position + Long.BYTES);
-      }
-      position += Long.BYTES;
-    }
-    return scalarRangeCheck(bitmap0, bitmap1, position, length);
-  }
-
-  private int indexOfFourByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
-    long low0 = ranges[0] * BYTE_ONES;
-    long high0 = ranges[1] * BYTE_ONES;
-    long low1 = ranges[2] * BYTE_ONES;
-    long high1 = ranges[3] * BYTE_ONES;
-    long low2 = ranges[4] * BYTE_ONES;
-    long high2 = ranges[5] * BYTE_ONES;
-    long low3 = ranges[6] * BYTE_ONES;
-    long high3 = ranges[7] * BYTE_ONES;
-    int position = start;
-    int wordEnd = length - Long.BYTES;
-    while (position <= wordEnd) {
-      long word = (long) LONG_VIEW.get(bytes, offset + position);
-      long values = word & BYTE_LOW_BITS;
-      long ascii = ~word & BYTE_HIGH_BITS;
-      long matches = exactAsciiRangeMask(values, ascii, low0, high0);
-      matches |= exactAsciiRangeMask(values, ascii, low1, high1);
-      matches |= exactAsciiRangeMask(values, ascii, low2, high2);
-      matches |= exactAsciiRangeMask(values, ascii, low3, high3);
-      if (matches != 0) {
-        return scalarRangeCheck(bitmap0, bitmap1, position, position + Long.BYTES);
-      }
-      position += Long.BYTES;
-    }
-    return scalarRangeCheck(bitmap0, bitmap1, position, length);
-  }
-
-  private int scalarRangeCheck(long bitmap0, long bitmap1, int position, int limit) {
-    for (; position < limit; position++) {
-      int value = unsignedByteAt(position);
-      if ((value < Long.SIZE && (bitmap0 & (1L << value)) != 0)
-          || (value >= Long.SIZE && value < 128 && (bitmap1 & (1L << (value - Long.SIZE))) != 0)) {
-        return position;
-      }
-    }
-    return -1;
-  }
-
-  static long exactAsciiRangeMask(long word, int low, int high) {
-    long values = word & BYTE_LOW_BITS;
-    long ascii = ~word & BYTE_HIGH_BITS;
-    return exactAsciiRangeMask(values, ascii, low * BYTE_ONES, high * BYTE_ONES);
-  }
-
-  private static long exactAsciiRangeMask(
-      long values, long ascii, long repeatedLow, long repeatedHigh) {
-    // Setting each minuend's high bit makes both subtractions independent in every byte lane:
-    // each lane subtracts at most 127 from at least 128, so no borrow can cross a lane boundary.
-    long atLeastLow = ((values | BYTE_HIGH_BITS) - repeatedLow) & BYTE_HIGH_BITS;
-    long atMostHigh = ((repeatedHigh | BYTE_HIGH_BITS) - values) & BYTE_HIGH_BITS;
-    return ascii & atLeastLow & atMostHigh;
+    return ByteSwarScan.indexOfMultipleByteRanges(
+        bytes, offset, length, ranges, bitmap0, bitmap1, start);
   }
 
   private int indexOfNonAsciiCodePointClass(int[] ranges, int start) {
@@ -330,7 +218,7 @@ final class Utf8InputScanner implements InputScanner {
     }
     if (!WorkCounterConfig.ENABLED) {
       if (literal.length == 1) {
-        return indexOfByte(literal[0], start);
+        return ByteSwarScan.indexOfByte(bytes, offset, length, literal[0], start);
       }
       if (shifts != null) {
         // Both searches beat the linear scan, but they win over different ranges. The skip loop
@@ -340,8 +228,8 @@ final class Utf8InputScanner implements InputScanner {
         // wins by a growing margin. The crossover scales with the literal length, since a longer
         // literal lets the skip loop advance further per step.
         int result =
-            remaining(start) >= filterThreshold(literal.length)
-                ? indexOfFiltered(literal, failure, start)
+            remaining(start) >= ByteSwarScan.filterThreshold(literal.length)
+                ? ByteSwarScan.indexOfFiltered(bytes, offset, length, literal, failure, start)
                 : boundedBoyerMooreHorspool(literal, shifts, start);
         // A match index or a trusted -1; only the -2 "work budget exhausted" sentinel falls
         // through to the linear-time scan below.
@@ -357,10 +245,6 @@ final class Utf8InputScanner implements InputScanner {
     return length - start;
   }
 
-  static long filterThreshold(int literalLength) {
-    return Math.max(MIN_FILTER_LENGTH, (long) literalLength * FILTER_LENGTH_FACTOR);
-  }
-
   static long workLimit(int remaining) {
     return Math.max(1L, (long) remaining * 2);
   }
@@ -371,6 +255,11 @@ final class Utf8InputScanner implements InputScanner {
 
   /** Knuth-Morris-Pratt scan, linear in the input length regardless of the literal. */
   private int indexOfLinear(byte[] literal, int[] failure, int start) {
+    return indexOfLinear(bytes, offset, length, literal, failure, start);
+  }
+
+  static int indexOfLinear(
+      byte[] bytes, int offset, int length, byte[] literal, int[] failure, int start) {
     int matched = 0;
     for (int position = start; position < length; position++) {
       if (WorkCounterConfig.ENABLED) {
@@ -413,13 +302,14 @@ final class Utf8InputScanner implements InputScanner {
       return indexOfAsciiClassScalar(asciiClass, start);
     }
     if (second < 0) {
-      return indexOfByte((byte) first, start);
+      return ByteSwarScan.indexOfByte(bytes, offset, length, (byte) first, start);
     }
     if (last == second) {
-      return indexOfBytePair((byte) first, (byte) second, start);
+      return ByteSwarScan.indexOfBytePair(
+          bytes, offset, length, (byte) first, (byte) second, start);
     }
     return contiguous
-        ? indexOfByteRange(first, last, start)
+        ? ByteSwarScan.indexOfByteRange(bytes, offset, length, first, last, start)
         : indexOfAsciiClassScalar(asciiClass, start);
   }
 
@@ -459,176 +349,6 @@ final class Utf8InputScanner implements InputScanner {
         position += shifts[bytes[offset + position] & 0xFF];
         work++;
       }
-    }
-    return -1;
-  }
-
-  /**
-   * Searches for a multi-byte {@code literal} by locating candidate positions with a SWAR filter on
-   * the literal's first and last bytes, then verifying each candidate in full.
-   *
-   * <p>Two words are loaded per step, one aligned with the literal's first byte and one with its
-   * last byte. XOR-ing each against the corresponding broadcast byte turns matching positions into
-   * zero bytes, so the standard zero-byte test identifies positions where both the first and last
-   * byte agree. Requiring both bytes makes candidates far rarer than a single-byte filter would.
-   *
-   * <p>This examines eight positions per step with no data-dependent branching. A skip loop such as
-   * Boyer-Moore-Horspool can advance further per step, but each of its steps is a serialized load,
-   * table lookup, and add, which costs more than the wider branch-free step here.
-   *
-   * <p>The zero-byte test never misses a matching position, but it can flag a position that does
-   * not match, so every candidate is verified against the whole literal rather than trusting the
-   * filter for the first and last byte.
-   *
-   * <p>Verification is O(literal length) per candidate, so an adversarial input can drive this to
-   * O(input length * literal length). A work budget bounds that: on exhaustion this returns {@code
-   * -2} and the caller falls back to linear-time KMP.
-   *
-   * @return the index of the first match, {@code -1} if the literal is absent, or {@code -2} if the
-   *     work budget was exhausted before either could be established
-   */
-  private int indexOfFiltered(byte[] literal, int[] failure, int start) {
-    int last = literal.length - 1;
-    long repeatedFirst = (literal[0] & 0xFFL) * BYTE_ONES;
-    long repeatedLast = (literal[last] & 0xFFL) * BYTE_ONES;
-    int wordEnd = length - last - Long.BYTES;
-    long work = 0;
-    long workLimit = workLimit(remaining(start));
-    int position = start;
-    while (position <= wordEnd) {
-      long firstDifference = (long) LONG_VIEW.get(bytes, offset + position) ^ repeatedFirst;
-      long lastDifference = (long) LONG_VIEW.get(bytes, offset + position + last) ^ repeatedLast;
-      long candidates =
-          (firstDifference - BYTE_ONES)
-              & ~firstDifference
-              & (lastDifference - BYTE_ONES)
-              & ~lastDifference
-              & BYTE_HIGH_BITS;
-      if (candidates != 0) {
-        // Scanning the eight positions in address order keeps this independent of byte order and
-        // returns the leftmost match within the word.
-        int candidateCount = 0;
-        for (int index = 0; index < Long.BYTES; index++) {
-          int candidate = position + index;
-          if (bytes[offset + candidate] == literal[0]) {
-            if (matchesAt(literal, candidate)) {
-              return candidate;
-            }
-            candidateCount++;
-          }
-        }
-        work = addCandidateWork(work, candidateCount, literal.length);
-      }
-      position += Long.BYTES;
-      work++;
-      if (work >= workLimit) {
-        return -2;
-      }
-    }
-    // Fewer than literal.length + Long.BYTES positions remain. Finishing with the linear scan
-    // keeps the tail linear rather than comparing the whole literal at each remaining position.
-    return indexOfLinear(literal, failure, position);
-  }
-
-  private boolean matchesAt(byte[] literal, int position) {
-    for (int index = 0; index < literal.length; index++) {
-      if (bytes[offset + position + index] != literal[index]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private int indexOfByte(byte target, int start) {
-    int position = start;
-    int wordEnd = length - Long.BYTES;
-    long repeatedTarget = (target & 0xFFL) * BYTE_ONES;
-    while (position <= wordEnd) {
-      long difference = (long) LONG_VIEW.get(bytes, offset + position) ^ repeatedTarget;
-      if (((difference - BYTE_ONES) & ~difference & BYTE_HIGH_BITS) != 0) {
-        for (int index = 0; index < Long.BYTES; index++) {
-          if (bytes[offset + position + index] == target) {
-            return position + index;
-          }
-        }
-      }
-      position += Long.BYTES;
-    }
-    while (position < length) {
-      if (bytes[offset + position] == target) {
-        return position;
-      }
-      position++;
-    }
-    return -1;
-  }
-
-  private int indexOfBytePair(byte first, byte second, int start) {
-    int position = start;
-    int wordEnd = length - Long.BYTES;
-    long repeatedFirst = (first & 0xFFL) * BYTE_ONES;
-    long repeatedSecond = (second & 0xFFL) * BYTE_ONES;
-    while (position <= wordEnd) {
-      long word = (long) LONG_VIEW.get(bytes, offset + position);
-      long firstDifference = word ^ repeatedFirst;
-      long secondDifference = word ^ repeatedSecond;
-      if (((((firstDifference - BYTE_ONES) & ~firstDifference)
-                  | ((secondDifference - BYTE_ONES) & ~secondDifference))
-              & BYTE_HIGH_BITS)
-          != 0) {
-        for (int index = 0; index < Long.BYTES; index++) {
-          byte value = bytes[offset + position + index];
-          if (value == first || value == second) {
-            return position + index;
-          }
-        }
-      }
-      position += Long.BYTES;
-    }
-    while (position < length) {
-      byte value = bytes[offset + position];
-      if (value == first || value == second) {
-        return position;
-      }
-      position++;
-    }
-    return -1;
-  }
-
-  /**
-   * Searches for a byte in the inclusive ASCII range {@code [low, high]}.
-   *
-   * <p>The word filter compares the common binary prefix of the range endpoints across eight bytes
-   * at once. Every byte in the range has that prefix, so the filter cannot miss a match. It may
-   * admit bytes outside the range when the endpoints do not cover their entire binary-prefix
-   * bucket; the scalar candidate check provides the exact answer.
-   */
-  private int indexOfByteRange(int low, int high, int start) {
-    int differingBit = Integer.highestOneBit(low ^ high);
-    int commonMask = ~((differingBit << 1) - 1) & 0xFF;
-    long repeatedMask = (commonMask & 0xFFL) * BYTE_ONES;
-    long repeatedPrefix = (low & commonMask) * BYTE_ONES;
-    int position = start;
-    int wordEnd = length - Long.BYTES;
-    while (position <= wordEnd) {
-      long word = (long) LONG_VIEW.get(bytes, offset + position);
-      long difference = (word & repeatedMask) ^ repeatedPrefix;
-      if (((difference - BYTE_ONES) & ~difference & BYTE_HIGH_BITS) != 0) {
-        for (int index = 0; index < Long.BYTES; index++) {
-          int value = unsignedByteAt(position + index);
-          if (value >= low && value <= high) {
-            return position + index;
-          }
-        }
-      }
-      position += Long.BYTES;
-    }
-    while (position < length) {
-      int value = unsignedByteAt(position);
-      if (value >= low && value <= high) {
-        return position;
-      }
-      position++;
     }
     return -1;
   }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -7,11 +7,10 @@ package org.safere;
 
 import static java.lang.invoke.MethodHandles.byteArrayViewVarHandle;
 import static java.nio.ByteOrder.nativeOrder;
-import static java.util.Objects.requireNonNull;
 
 import java.lang.invoke.VarHandle;
 
-final class Utf8InputScanner implements InputScanner {
+final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   private static final int REPLACEMENT_CHARACTER = 0xFFFD;
   private static final long BYTE_HIGH_BITS = 0x8080_8080_8080_8080L;
   private static final int BOYER_MOORE_HORSPOOL_BATCH_SIZE = 2;
@@ -21,9 +20,6 @@ final class Utf8InputScanner implements InputScanner {
 
   private static final VarHandle LONG_VIEW = byteArrayViewVarHandle(long[].class, nativeOrder());
 
-  private final byte[] bytes;
-  private final int offset;
-  private final int length;
   private final VectorScanProvider scanProvider;
 
   Utf8InputScanner(byte[] bytes) {
@@ -31,13 +27,7 @@ final class Utf8InputScanner implements InputScanner {
   }
 
   Utf8InputScanner(byte[] bytes, int offset, int length) {
-    this.bytes = requireNonNull(bytes, "bytes");
-    if (offset < 0 || length < 0 || offset > bytes.length - length) {
-      throw new IndexOutOfBoundsException(
-          "offset=" + offset + ", length=" + length + ", arrayLength=" + bytes.length);
-    }
-    this.offset = offset;
-    this.length = length;
+    super(bytes, offset, length);
     this.scanProvider = VectorScanProviders.providerForLength(length);
   }
 
@@ -158,7 +148,7 @@ final class Utf8InputScanner implements InputScanner {
       int low = ranges[0];
       int high = ranges[1];
       if (low == high) {
-        return ByteSwarScan.indexOfByte(bytes, offset, length, (byte) low, start);
+        return indexOfByte((byte) low, start);
       }
       if (high == low + 1) {
         return ByteSwarScan.indexOfBytePair(bytes, offset, length, (byte) low, (byte) high, start);
@@ -218,7 +208,7 @@ final class Utf8InputScanner implements InputScanner {
     }
     if (!WorkCounterConfig.ENABLED) {
       if (literal.length == 1) {
-        return ByteSwarScan.indexOfByte(bytes, offset, length, literal[0], start);
+        return indexOfByte(literal[0], start);
       }
       if (shifts != null) {
         // Both searches beat the linear scan, but they win over different ranges. The skip loop
@@ -302,7 +292,7 @@ final class Utf8InputScanner implements InputScanner {
       return indexOfAsciiClassScalar(asciiClass, start);
     }
     if (second < 0) {
-      return ByteSwarScan.indexOfByte(bytes, offset, length, (byte) first, start);
+      return indexOfByte((byte) first, start);
     }
     if (last == second) {
       return ByteSwarScan.indexOfBytePair(

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -186,7 +186,7 @@ class Utf8InputScannerTest {
         for (int value = 0; value < 256; value++) {
           long word = value * byteOnes;
           long expected = value >= low && value <= high ? byteHighBits : 0;
-          long actual = Utf8InputScanner.exactAsciiRangeMask(word, low, high);
+          long actual = ByteSwarScan.exactAsciiRangeMask(word, low, high);
           if (actual != expected) {
             fail(
                 "Incorrect range mask for [%s, %s] and byte %s: expected %s, actual %s",
@@ -213,7 +213,7 @@ class Utf8InputScannerTest {
         }
       }
 
-      assertThat(Utf8InputScanner.exactAsciiRangeMask(word, low, high))
+      assertThat(ByteSwarScan.exactAsciiRangeMask(word, low, high))
           .as("range [%s, %s], word %s", low, high, Long.toHexString(word))
           .isEqualTo(expected);
     }
@@ -316,7 +316,7 @@ class Utf8InputScannerTest {
 
   @Test
   void literalSearchSizeArithmeticDoesNotOverflowForLargeArrays() {
-    assertThat(Utf8InputScanner.filterThreshold(Integer.MAX_VALUE)).isEqualTo(85_899_345_880L);
+    assertThat(ByteSwarScan.filterThreshold(Integer.MAX_VALUE)).isEqualTo(85_899_345_880L);
     assertThat(Utf8InputScanner.workLimit(Integer.MAX_VALUE)).isEqualTo(4_294_967_294L);
   }
 


### PR DESCRIPTION
This is a pure refactoring, the point is that this code can be also be for latin1 in vector and SWAR fast paths for `String` that have access to its backing storage, if the `String` is latin1 (#656).

