### PR TITLE
Refactor to encapsulate reject prefilters

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -125,6 +125,7 @@
                         <exclude name="ProgTest.java"/>
                         <exclude name="RegexpOpTest.java"/>
                         <exclude name="RegexpTest.java"/>
+                        <exclude name="RejectPrefilterTest.java"/>
                         <exclude name="SafeReDiagnosticsTest.java"/>
                         <exclude name="SearchScalingRegressionTest.java"/>
                         <exclude name="SimplifierTest.java"/>

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -97,6 +97,7 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean fullTextRegionContext;
   private boolean findExhaustedAfterTerminalEmptyMatch;
+  private boolean disjointRequiredLiteralsChecked;
   private int modCount;
   private DiagnosticOperation diagnosticOperation;
   private boolean diagnosticCaptureSearch;
@@ -419,6 +420,7 @@ public final class Matcher implements MatchResult {
     resetReplacementState();
     clearCurrentResult();
     eagerFallbackCaptures = false;
+    disjointRequiredLiteralsChecked = false;
   }
 
   private PreparedMatchRunner preparedMatchRunner;
@@ -430,10 +432,12 @@ public final class Matcher implements MatchResult {
     resetSearchStateForRegionStart();
     resetReplacementState();
     clearCurrentResult();
+    disjointRequiredLiteralsChecked = false;
   }
 
   private void invalidatePatternCaches() {
     preparedMatchRunner = null;
+    disjointRequiredLiteralsChecked = false;
     cachedForwardFirstMatchDfa = null;
     cachedForwardLongestMatchDfa = null;
     cachedReverseDfa = null;
@@ -887,6 +891,24 @@ public final class Matcher implements MatchResult {
       diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
       diagnosticBoundary(rejectPrefilter.strategy());
       return applyFailedMatchResult();
+    }
+    Pattern.DisjointRequiredLiterals disjoint = parentPattern.disjointRequiredLiterals();
+    if (enginePathOptions().literalFastPaths() && disjoint != null && text != null) {
+      boolean found = false;
+      for (String lit : disjoint.literals()) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(text.length());
+        }
+        if (text.indexOf(lit) >= 0) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(MatchStrategy.LITERAL);
+        return applyFailedMatchResult();
+      }
     }
 
     Prog prog = parentPattern.prog();
@@ -1460,6 +1482,31 @@ public final class Matcher implements MatchResult {
       if (rejectPrefilter.canReject(scanner, text, searchFrom, options)) {
         diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
         diagnosticBoundary(rejectPrefilter.strategy());
+        return applyFailedMatchResult();
+      }
+    }
+    Pattern.DisjointRequiredLiterals disjointRequiredLiterals =
+        parentPattern.disjointRequiredLiterals();
+    if (options.literalFastPaths()
+        && disjointRequiredLiterals != null
+        && !disjointRequiredLiteralsChecked
+        && !hasAcceleratedSearchPath
+        && !prog.anchorStart()
+        && text != null) {
+      disjointRequiredLiteralsChecked = true;
+      boolean found = false;
+      for (String lit : disjointRequiredLiterals.literals()) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(Math.max(0, text.length() - searchFrom));
+        }
+        if (text.indexOf(lit, searchFrom) >= 0) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(MatchStrategy.LITERAL);
         return applyFailedMatchResult();
       }
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.safere.Pattern.DisjointRequiredLiterals;
 
 /**
  * An engine that performs match operations on a {@linkplain CharSequence character sequence} by
@@ -98,7 +97,6 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean fullTextRegionContext;
   private boolean findExhaustedAfterTerminalEmptyMatch;
-  private boolean disjointRequiredLiteralsChecked;
   private int modCount;
   private DiagnosticOperation diagnosticOperation;
   private boolean diagnosticCaptureSearch;
@@ -421,7 +419,6 @@ public final class Matcher implements MatchResult {
     resetReplacementState();
     clearCurrentResult();
     eagerFallbackCaptures = false;
-    disjointRequiredLiteralsChecked = false;
   }
 
   private PreparedMatchRunner preparedMatchRunner;
@@ -433,12 +430,10 @@ public final class Matcher implements MatchResult {
     resetSearchStateForRegionStart();
     resetReplacementState();
     clearCurrentResult();
-    disjointRequiredLiteralsChecked = false;
   }
 
   private void invalidatePatternCaches() {
     preparedMatchRunner = null;
-    disjointRequiredLiteralsChecked = false;
     cachedForwardFirstMatchDfa = null;
     cachedForwardLongestMatchDfa = null;
     cachedReverseDfa = null;
@@ -591,16 +586,6 @@ public final class Matcher implements MatchResult {
       return applyFullMatchResult(new int[] {idx, idx + Character.charCount(cp)});
     }
     return applyFailedMatchResult();
-  }
-
-  private boolean containsRequiredMatchClass(int[] ranges) {
-    return containsRequiredMatchClass(ranges, 0);
-  }
-
-  private boolean containsRequiredMatchClass(int[] ranges, int fromIndex) {
-    long b0 = parentPattern.requiredMatchClassBitmap0();
-    long b1 = parentPattern.requiredMatchClassBitmap1();
-    return activeScanner().indexOfCodePointClass(ranges, b0, b1, fromIndex) >= 0;
   }
 
   /**
@@ -895,13 +880,12 @@ public final class Matcher implements MatchResult {
   private boolean matchesCore() {
     capturesResolved = true;
 
-    int[] requiredRanges = parentPattern.requiredMatchClassRanges();
-    if (enginePathOptions().charClassMatchFastPaths()
-        && requiredRanges != null
+    RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
+    if (rejectPrefilter != null
         && text != null
-        && !containsRequiredMatchClass(requiredRanges)) {
-      diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
-      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
+        && rejectPrefilter.canReject(activeScanner(), text, 0, enginePathOptions())) {
+      diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
+      diagnosticBoundary(rejectPrefilter.strategy());
       return applyFailedMatchResult();
     }
 
@@ -1469,53 +1453,15 @@ public final class Matcher implements MatchResult {
             || (prog.anchorEnd()
                 && scanner.length() >= MIN_REVERSE_FIRST_LEN
                 && canUseReverseDfa());
-    String requiredLiteral = parentPattern.requiredLiteral();
-    if (options.literalFastPaths()
-        && requiredLiteral != null
-        && !hasAcceleratedSearchPath
+    RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
+    if (!hasAcceleratedSearchPath
+        && rejectPrefilter != null
         && (text != null || scanner instanceof Utf8InputScanner)) {
-      int idx =
-          scanner instanceof Utf8InputScanner utf8Scanner
-              ? utf8Scanner.indexOf(
-                  parentPattern.requiredLiteralUtf8(),
-                  parentPattern.requiredLiteralFailure(),
-                  parentPattern.requiredLiteralShifts(),
-                  searchFrom)
-              : indexOfRequiredLiteral(requiredLiteral);
-      if (idx < 0) {
+      if (rejectPrefilter.canReject(scanner, text, searchFrom, options)) {
+        diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(rejectPrefilter.strategy());
         return applyFailedMatchResult();
       }
-    }
-    DisjointRequiredLiterals disjointRequiredLiterals = parentPattern.disjointRequiredLiterals();
-    if (options.literalFastPaths()
-        && disjointRequiredLiterals != null
-        && !disjointRequiredLiteralsChecked
-        && !hasAcceleratedSearchPath
-        && !prog.anchorStart()
-        && text != null) {
-      disjointRequiredLiteralsChecked = true;
-      boolean found = false;
-      for (String lit : disjointRequiredLiterals.literals()) {
-        if (indexOfRequiredLiteral(lit) >= 0) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
-        diagnosticBoundary(MatchStrategy.LITERAL);
-        return applyFailedMatchResult();
-      }
-    }
-
-    int[] requiredRanges = parentPattern.requiredMatchClassRanges();
-    if (options.charClassMatchFastPaths()
-        && requiredRanges != null
-        && !hasAcceleratedSearchPath
-        && !containsRequiredMatchClass(requiredRanges, searchFrom)) {
-      diagnosticParticipation(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
-      diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
-      return applyFailedMatchResult();
     }
 
     // Prefix acceleration: if the pattern starts with a literal prefix, skip ahead to where
@@ -1984,13 +1930,6 @@ public final class Matcher implements MatchResult {
     } else {
       return applyDeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false);
     }
-  }
-
-  private int indexOfRequiredLiteral(String requiredLiteral) {
-    if (WorkCounterConfig.ENABLED) {
-      WorkCounter.record(Math.max(0, text.length() - searchFrom));
-    }
-    return text.indexOf(requiredLiteral, searchFrom);
   }
 
   private int nextFixedOffsetCandidate(

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -885,11 +885,13 @@ public final class Matcher implements MatchResult {
     capturesResolved = true;
 
     RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
-    if (rejectPrefilter != null
-        && text != null
-        && rejectPrefilter.canReject(activeScanner(), text, 0, enginePathOptions())) {
-      diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
-      diagnosticBoundary(rejectPrefilter.strategy());
+    MatchStrategy rejectionStrategy =
+        rejectPrefilter != null && text != null
+            ? rejectPrefilter.rejectionStrategy(activeScanner(), text, 0, enginePathOptions())
+            : null;
+    if (rejectionStrategy != null) {
+      diagnosticParticipation(rejectionStrategy, StrategyRole.REJECT_PREFILTER);
+      diagnosticBoundary(rejectionStrategy);
       return applyFailedMatchResult();
     }
     Pattern.DisjointRequiredLiterals disjoint = parentPattern.disjointRequiredLiterals();
@@ -1479,9 +1481,11 @@ public final class Matcher implements MatchResult {
     if (!hasAcceleratedSearchPath
         && rejectPrefilter != null
         && (text != null || scanner instanceof Utf8InputScanner)) {
-      if (rejectPrefilter.canReject(scanner, text, searchFrom, options)) {
-        diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
-        diagnosticBoundary(rejectPrefilter.strategy());
+      MatchStrategy rejectionStrategy =
+          rejectPrefilter.rejectionStrategy(scanner, text, searchFrom, options);
+      if (rejectionStrategy != null) {
+        diagnosticParticipation(rejectionStrategy, StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(rejectionStrategy);
         return applyFailedMatchResult();
       }
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -885,10 +885,15 @@ public final class Matcher implements MatchResult {
     capturesResolved = true;
 
     RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
-    MatchStrategy rejectionStrategy =
-        rejectPrefilter != null && text != null
-            ? rejectPrefilter.rejectionStrategy(activeScanner(), text, 0, enginePathOptions())
-            : null;
+    MatchStrategy rejectionStrategy = null;
+    if (rejectPrefilter != null && text != null) {
+      rejectionStrategy =
+          rejectPrefilter instanceof RejectPrefilter.Composite composite
+              ? composite.rejectionStrategy(activeScanner(), text, 0, enginePathOptions())
+              : rejectPrefilter.canReject(activeScanner(), text, 0, enginePathOptions())
+                  ? rejectPrefilter.strategy()
+                  : null;
+    }
     if (rejectionStrategy != null) {
       diagnosticParticipation(rejectionStrategy, StrategyRole.REJECT_PREFILTER);
       diagnosticBoundary(rejectionStrategy);
@@ -1482,7 +1487,11 @@ public final class Matcher implements MatchResult {
         && rejectPrefilter != null
         && (text != null || scanner instanceof Utf8InputScanner)) {
       MatchStrategy rejectionStrategy =
-          rejectPrefilter.rejectionStrategy(scanner, text, searchFrom, options);
+          rejectPrefilter instanceof RejectPrefilter.Composite composite
+              ? composite.rejectionStrategy(scanner, text, searchFrom, options)
+              : rejectPrefilter.canReject(scanner, text, searchFrom, options)
+                  ? rejectPrefilter.strategy()
+                  : null;
       if (rejectionStrategy != null) {
         diagnosticParticipation(rejectionStrategy, StrategyRole.REJECT_PREFILTER);
         diagnosticBoundary(rejectionStrategy);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -632,11 +632,24 @@ public final class Pattern implements Serializable {
     if (enginePathOptions.keywordAlternationFastPath() && keywordAlternation != null) {
       return keywordAlternation.find(scanner, 0) >= 0;
     }
-    if (rejectPrefilter != null
-        && prefixUtf8 == null
-        && charClassPrefixAscii == null
-        && rejectPrefilter.canReject(scanner, 0, enginePathOptions)) {
-      return false;
+    if (rejectPrefilter != null && prefixUtf8 == null && charClassPrefixAscii == null) {
+      boolean rejected;
+      if (rejectPrefilter instanceof RejectPrefilter.Literal literal) {
+        rejected =
+            enginePathOptions.literalFastPaths()
+                && scanner.indexOf(literal.utf8(), literal.failure(), literal.shifts(), 0) < 0;
+      } else if (rejectPrefilter instanceof RejectPrefilter.CharClass charClass) {
+        rejected =
+            enginePathOptions.charClassMatchFastPaths()
+                && scanner.indexOfCodePointClass(
+                        charClass.ranges(), charClass.bitmap0(), charClass.bitmap1(), 0)
+                    < 0;
+      } else {
+        rejected = rejectPrefilter.canReject(scanner, 0, enginePathOptions);
+      }
+      if (rejected) {
+        return false;
+      }
     }
     int searchStart = 0;
     if (prefixUtf8 != null && !prefixFoldCase) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -186,34 +186,15 @@ public final class Pattern implements Serializable {
    */
   private final transient CharClassScanInfo singleCharClassScanInfo;
 
-  /**
-   * Precomputed character class data for a mandatory character class. Non-null when matching can
-   * reject by scanning for an absent required code point before invoking the full engine cascade.
-   * This is intentionally a negative-only accelerator: if the class is present, normal matching
-   * still determines the result.
-   */
-  private final transient int[] requiredMatchClassRanges;
-
-  private final transient long requiredMatchClassBitmap0;
-  private final transient long requiredMatchClassBitmap1;
+  /** Whole-input rejection AST metadata for Tier 0 acceleration. */
+  private final transient RejectDescriptor rejectDescriptor;
 
   /**
-   * A case-sensitive literal substring that every match must contain. This is a negative-only
-   * accelerator: an absent literal rejects the search, while a present literal still goes through
-   * the normal engine to determine match boundaries and captures.
+   * Whole-input rejection filter for Tier 0 acceleration. Non-null when matching can quickly
+   * reject by verifying that mandatory literal content or character classes appear anywhere in the
+   * input before running automata.
    */
-  private final transient String requiredLiteral;
-
-  private final transient byte[] requiredLiteralUtf8;
-  private final transient int[] requiredLiteralFailure;
-  private final transient int[] requiredLiteralShifts;
-
-  /**
-   * A small disjoint set of case-sensitive literal substrings for alternation patterns where every
-   * branch requires at least one literal substring. If none of these literals are present in the
-   * input, the search is rejected immediately.
-   */
-  private final transient DisjointRequiredLiterals disjointRequiredLiterals;
+  private final transient RejectPrefilter rejectPrefilter;
 
   /**
    * Lazily computed OnePass analysis results. Holds the OnePass automaton (if eligible) and derived
@@ -323,11 +304,7 @@ public final class Pattern implements Serializable {
       long charClassMatchBitmap1,
       boolean charClassMatchAllowEmpty,
       CharClassScanInfo singleCharClass,
-      int[] requiredMatchClassRanges,
-      long requiredMatchClassBitmap0,
-      long requiredMatchClassBitmap1,
-      String requiredLiteral,
-      DisjointRequiredLiterals disjointRequiredLiterals,
+      RejectDescriptor rejectDescriptor,
       EnginePathOptions enginePathOptions) {
     this.patternId = nextPatternId();
     this.pattern = pattern;
@@ -388,19 +365,8 @@ public final class Pattern implements Serializable {
     this.charClassMatchBitmap1 = charClassMatchBitmap1;
     this.charClassMatchAllowEmpty = charClassMatchAllowEmpty;
     this.singleCharClassScanInfo = singleCharClass;
-    this.requiredMatchClassRanges = requiredMatchClassRanges;
-    this.requiredMatchClassBitmap0 = requiredMatchClassBitmap0;
-    this.requiredMatchClassBitmap1 = requiredMatchClassBitmap1;
-    this.requiredLiteral = requiredLiteral;
-    this.requiredLiteralUtf8 =
-        requiredLiteral == null
-            ? null
-            : requiredLiteral.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-    this.requiredLiteralFailure =
-        requiredLiteralUtf8 == null ? null : literalFailure(requiredLiteralUtf8);
-    this.requiredLiteralShifts =
-        requiredLiteralUtf8 == null ? null : literalShifts(requiredLiteralUtf8);
-    this.disjointRequiredLiterals = disjointRequiredLiterals;
+    this.rejectDescriptor = rejectDescriptor != null ? rejectDescriptor : RejectDescriptor.NONE;
+    this.rejectPrefilter = RejectPrefilter.create(this.rejectDescriptor);
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
     onePassAnalysis();
@@ -522,13 +488,8 @@ public final class Pattern implements Serializable {
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
-    CharClassScanInfo requiredMatchClass =
-        extractRequiredMatchClass(metadataAst, prefix == null && ccPrefixAscii == null);
-    String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
-    DisjointRequiredLiterals disjointRequiredLiterals =
-        (prefix == null && requiredLiteral == null)
-            ? DisjointRequiredLiterals.create(extractDisjointRequiredLiterals(metadataAst))
-            : null;
+    RejectDescriptor rejectDescriptor =
+        extractRejectDescriptor(metadataAst, prefix, ccPrefixAscii);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -554,11 +515,7 @@ public final class Pattern implements Serializable {
         ccMatch != null ? ccMatch.bitmap1 : 0,
         ccMatch != null && ccMatch.allowEmpty,
         singleCharClass,
-        requiredMatchClass != null ? requiredMatchClass.ranges : null,
-        requiredMatchClass != null ? requiredMatchClass.bitmap0 : 0,
-        requiredMatchClass != null ? requiredMatchClass.bitmap1 : 0,
-        requiredLiteral,
-        disjointRequiredLiterals,
+        rejectDescriptor,
         enginePathOptions);
   }
 
@@ -676,20 +633,10 @@ public final class Pattern implements Serializable {
     if (enginePathOptions.keywordAlternationFastPath() && keywordAlternation != null) {
       return keywordAlternation.find(scanner, 0) >= 0;
     }
-    if (enginePathOptions.literalFastPaths()
-        && requiredLiteralUtf8 != null
-        && prefixUtf8 == null
-        && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
-            < 0) {
-      return false;
-    }
-    if (enginePathOptions.charClassMatchFastPaths()
-        && requiredMatchClassRanges != null
+    if (rejectPrefilter != null
         && prefixUtf8 == null
         && charClassPrefixAscii == null
-        && scanner.indexOfCodePointClass(
-                requiredMatchClassRanges, requiredMatchClassBitmap0, requiredMatchClassBitmap1, 0)
-            < 0) {
+        && rejectPrefilter.canReject(scanner, 0, enginePathOptions)) {
       return false;
     }
     int searchStart = 0;
@@ -747,24 +694,10 @@ public final class Pattern implements Serializable {
       diagnostics.boundary(MatchStrategy.KEYWORD);
       return matched;
     }
-    if (enginePathOptions.literalFastPaths()
-        && requiredLiteralUtf8 != null
-        && prefixUtf8 == null
-        && scanner.indexOf(requiredLiteralUtf8, requiredLiteralFailure, requiredLiteralShifts, 0)
-            < 0) {
-      diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
-      diagnostics.boundary(MatchStrategy.LITERAL);
-      return false;
-    }
-    if (enginePathOptions.charClassMatchFastPaths()
-        && requiredMatchClassRanges != null
+    if (rejectPrefilter != null
         && prefixUtf8 == null
         && charClassPrefixAscii == null
-        && scanner.indexOfCodePointClass(
-                requiredMatchClassRanges, requiredMatchClassBitmap0, requiredMatchClassBitmap1, 0)
-            < 0) {
-      diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
-      diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
+        && rejectPrefilter.canRejectWithDiagnostics(scanner, 0, enginePathOptions, diagnostics)) {
       return false;
     }
     int searchStart = 0;
@@ -862,7 +795,7 @@ public final class Pattern implements Serializable {
     return -1;
   }
 
-  private static int[] literalFailure(byte[] literal) {
+  static int[] literalFailure(byte[] literal) {
     int[] failure = new int[literal.length];
     int matched = 0;
     for (int index = 1; index < literal.length; index++) {
@@ -877,7 +810,7 @@ public final class Pattern implements Serializable {
     return failure;
   }
 
-  private static int[] literalShifts(byte[] literal) {
+  static int[] literalShifts(byte[] literal) {
     if (literal.length < 2) {
       return null;
     }
@@ -1374,43 +1307,24 @@ public final class Pattern implements Serializable {
     return singleCharClassScanInfo;
   }
 
-  /** Returns precomputed ranges for a required character class, or {@code null}. */
-  int[] requiredMatchClassRanges() {
-    return requiredMatchClassRanges;
+  /** Returns AST metadata for whole-input rejection, or {@link RejectDescriptor#NONE}. */
+  RejectDescriptor rejectDescriptor() {
+    return rejectDescriptor;
   }
 
-  /** ASCII bitmap (code points 0–63) for the required-character-class fast path. */
-  long requiredMatchClassBitmap0() {
-    return requiredMatchClassBitmap0;
-  }
-
-  /** ASCII bitmap (code points 64–127) for the required-character-class fast path. */
-  long requiredMatchClassBitmap1() {
-    return requiredMatchClassBitmap1;
-  }
-
-  String requiredLiteral() {
-    return requiredLiteral;
-  }
-
-  byte[] requiredLiteralUtf8() {
-    return requiredLiteralUtf8;
-  }
-
-  int[] requiredLiteralFailure() {
-    return requiredLiteralFailure;
-  }
-
-  int[] requiredLiteralShifts() {
-    return requiredLiteralShifts;
+  /** Returns whole-input rejection prefilter, or {@code null}. */
+  RejectPrefilter rejectPrefilter() {
+    return rejectPrefilter;
   }
 
   DisjointRequiredLiterals disjointRequiredLiterals() {
-    return disjointRequiredLiterals;
+    return rejectDescriptor.disjointRequiredLiterals();
   }
 
   String[] requiredDisjointLiterals() {
-    return disjointRequiredLiterals != null ? disjointRequiredLiterals.literals() : null;
+    return rejectDescriptor.disjointRequiredLiterals() != null
+        ? rejectDescriptor.disjointRequiredLiterals().literals()
+        : null;
   }
 
   /**
@@ -3201,6 +3115,22 @@ public final class Pattern implements Serializable {
       return null;
     }
     return buildCharClassScanInfo(cc);
+  }
+
+  /** Extracts whole-input rejection metadata from the AST. */
+  private static RejectDescriptor extractRejectDescriptor(
+      Regexp metadataAst, String prefix, boolean[] ccPrefixAscii) {
+    String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
+    CharClassScanInfo requiredMatchClass =
+        extractRequiredMatchClass(metadataAst, prefix == null && ccPrefixAscii == null);
+    DisjointRequiredLiterals disjointRequiredLiterals =
+        (prefix == null && requiredLiteral == null)
+            ? DisjointRequiredLiterals.create(extractDisjointRequiredLiterals(metadataAst))
+            : null;
+    if (requiredLiteral == null && requiredMatchClass == null && disjointRequiredLiterals == null) {
+      return null;
+    }
+    return new RejectDescriptor(requiredLiteral, requiredMatchClass, disjointRequiredLiterals);
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -190,9 +190,9 @@ public final class Pattern implements Serializable {
   private final transient RejectDescriptor rejectDescriptor;
 
   /**
-   * Whole-input rejection filter for Tier 0 acceleration. Non-null when matching can quickly
-   * reject by verifying that mandatory literal content or character classes appear anywhere in the
-   * input before running automata.
+   * Whole-input rejection filter for Tier 0 acceleration. Non-null when matching can quickly reject
+   * by verifying that mandatory literal content or character classes appear anywhere in the input
+   * before running automata.
    */
   private final transient RejectPrefilter rejectPrefilter;
 
@@ -488,8 +488,7 @@ public final class Pattern implements Serializable {
     // Detect "repeated character class" pattern for matches() fast path.
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
-    RejectDescriptor rejectDescriptor =
-        extractRejectDescriptor(metadataAst, prefix, ccPrefixAscii);
+    RejectDescriptor rejectDescriptor = extractRejectDescriptor(metadataAst, prefix, ccPrefixAscii);
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,

--- a/safere/src/main/java/org/safere/RejectDescriptor.java
+++ b/safere/src/main/java/org/safere/RejectDescriptor.java
@@ -9,8 +9,8 @@ import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.DisjointRequiredLiterals;
 
 /**
- * Metadata extracted from a regular expression AST describing mandatory content that any match
- * must contain across the entire input (Tier 0 whole-input rejection).
+ * Metadata extracted from a regular expression AST describing mandatory content that any match must
+ * contain across the entire input (Tier 0 whole-input rejection).
  */
 record RejectDescriptor(
     String requiredLiteral,
@@ -20,8 +20,6 @@ record RejectDescriptor(
   static final RejectDescriptor NONE = new RejectDescriptor(null, null, null);
 
   boolean hasRejectionFilter() {
-    return requiredLiteral != null
-        || requiredCharClass != null
-        || disjointRequiredLiterals != null;
+    return requiredLiteral != null || requiredCharClass != null || disjointRequiredLiterals != null;
   }
 }

--- a/safere/src/main/java/org/safere/RejectDescriptor.java
+++ b/safere/src/main/java/org/safere/RejectDescriptor.java
@@ -17,6 +17,10 @@ record RejectDescriptor(
     CharClassScanInfo requiredCharClass,
     DisjointRequiredLiterals disjointRequiredLiterals) {
 
+  RejectDescriptor(String requiredLiteral, CharClassScanInfo requiredCharClass) {
+    this(requiredLiteral, requiredCharClass, null);
+  }
+
   static final RejectDescriptor NONE = new RejectDescriptor(null, null, null);
 
   boolean hasRejectionFilter() {

--- a/safere/src/main/java/org/safere/RejectDescriptor.java
+++ b/safere/src/main/java/org/safere/RejectDescriptor.java
@@ -1,0 +1,27 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import org.safere.Pattern.CharClassScanInfo;
+import org.safere.Pattern.DisjointRequiredLiterals;
+
+/**
+ * Metadata extracted from a regular expression AST describing mandatory content that any match
+ * must contain across the entire input (Tier 0 whole-input rejection).
+ */
+record RejectDescriptor(
+    String requiredLiteral,
+    CharClassScanInfo requiredCharClass,
+    DisjointRequiredLiterals disjointRequiredLiterals) {
+
+  static final RejectDescriptor NONE = new RejectDescriptor(null, null, null);
+
+  boolean hasRejectionFilter() {
+    return requiredLiteral != null
+        || requiredCharClass != null
+        || disjointRequiredLiterals != null;
+  }
+}

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -24,6 +24,12 @@ sealed interface RejectPrefilter
   /** Returns whether the input starting from {@code searchFrom} can be rejected. */
   boolean canReject(InputScanner scanner, String text, int searchFrom, EnginePathOptions options);
 
+  /** Returns the strategy that rejected the input, or {@code null} if it cannot be rejected. */
+  default MatchStrategy rejectionStrategy(
+      InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
+    return canReject(scanner, text, searchFrom, options) ? strategy() : null;
+  }
+
   /** Returns whether the UTF-8 input starting from {@code searchFrom} can be rejected. */
   boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options);
 
@@ -180,6 +186,18 @@ sealed interface RejectPrefilter
         }
       }
       return false;
+    }
+
+    @Override
+    public MatchStrategy rejectionStrategy(
+        InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
+      for (RejectPrefilter filter : filters) {
+        MatchStrategy strategy = filter.rejectionStrategy(scanner, text, searchFrom, options);
+        if (strategy != null) {
+          return strategy;
+        }
+      }
+      return null;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -6,8 +6,6 @@
 package org.safere;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.DisjointRequiredLiterals;
 
@@ -45,7 +43,7 @@ sealed interface RejectPrefilter
   MatchStrategy strategy();
 
   static RejectPrefilter create(RejectDescriptor descriptor) {
-    if (descriptor == null || !descriptor.hasRejectionFilter()) {
+    if (descriptor == null) {
       return null;
     }
     RejectPrefilter litFilter =
@@ -54,29 +52,10 @@ sealed interface RejectPrefilter
         descriptor.requiredCharClass() != null
             ? CharClass.create(descriptor.requiredCharClass())
             : null;
-    RejectPrefilter disjointFilter =
-        descriptor.disjointRequiredLiterals() != null
-            ? DisjointLiterals.create(descriptor.disjointRequiredLiterals())
-            : null;
-
-    List<RejectPrefilter> active = new ArrayList<>(3);
-    if (litFilter != null) {
-      active.add(litFilter);
+    if (litFilter != null && ccFilter != null) {
+      return new Composite(new RejectPrefilter[] {litFilter, ccFilter});
     }
-    if (ccFilter != null) {
-      active.add(ccFilter);
-    }
-    if (disjointFilter != null) {
-      active.add(disjointFilter);
-    }
-
-    if (active.isEmpty()) {
-      return null;
-    }
-    if (active.size() == 1) {
-      return active.get(0);
-    }
-    return new Composite(active.toArray(new RejectPrefilter[0]));
+    return litFilter != null ? litFilter : ccFilter;
   }
 
   @SuppressWarnings("ArrayRecordComponent")
@@ -153,62 +132,35 @@ sealed interface RejectPrefilter
   }
 
   @SuppressWarnings("ArrayRecordComponent")
-  record DisjointLiterals(
-      String[] literals, byte[][] utf8Literals, int[][] failures, int[][] shifts)
-      implements RejectPrefilter {
+  record DisjointLiterals(String[] literals) implements RejectPrefilter {
 
     static DisjointLiterals create(DisjointRequiredLiterals disjoint) {
-      String[] literals = disjoint.literals();
-      byte[][] utf8Literals = new byte[literals.length][];
-      int[][] failures = new int[literals.length][];
-      int[][] shifts = new int[literals.length][];
-      for (int i = 0; i < literals.length; i++) {
-        utf8Literals[i] = literals[i].getBytes(StandardCharsets.UTF_8);
-        failures[i] = Pattern.literalFailure(utf8Literals[i]);
-        shifts[i] = Pattern.literalShifts(utf8Literals[i]);
+      if (disjoint == null || disjoint.literals() == null || disjoint.literals().length == 0) {
+        return null;
       }
-      return new DisjointLiterals(literals, utf8Literals, failures, shifts);
+      return new DisjointLiterals(disjoint.literals());
     }
 
     @Override
     public boolean canReject(
         InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
-      if (!options.literalFastPaths()) {
+      if (!options.literalFastPaths() || text == null) {
         return false;
       }
-      if (scanner instanceof Utf8InputScanner utf8Scanner) {
-        for (int i = 0; i < utf8Literals.length; i++) {
-          if (utf8Scanner.indexOf(utf8Literals[i], failures[i], shifts[i], searchFrom) >= 0) {
-            return false;
-          }
+      for (String literal : literals) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(Math.max(0, text.length() - searchFrom));
         }
-        return true;
-      }
-      if (text != null) {
-        for (String literal : literals) {
-          if (WorkCounterConfig.ENABLED) {
-            WorkCounter.record(Math.max(0, text.length() - searchFrom));
-          }
-          if (text.indexOf(literal, searchFrom) >= 0) {
-            return false;
-          }
-        }
-        return true;
-      }
-      return false;
-    }
-
-    @Override
-    public boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options) {
-      if (!options.literalFastPaths()) {
-        return false;
-      }
-      for (int i = 0; i < utf8Literals.length; i++) {
-        if (scanner.indexOf(utf8Literals[i], failures[i], shifts[i], searchFrom) >= 0) {
+        if (text.indexOf(literal, searchFrom) >= 0) {
           return false;
         }
       }
       return true;
+    }
+
+    @Override
+    public boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options) {
+      return false;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -24,17 +24,10 @@ sealed interface RejectPrefilter
         RejectPrefilter.Composite {
 
   /** Returns whether the input starting from {@code searchFrom} can be rejected. */
-  boolean canReject(
-      InputScanner scanner,
-      String text,
-      int searchFrom,
-      EnginePathOptions options);
+  boolean canReject(InputScanner scanner, String text, int searchFrom, EnginePathOptions options);
 
   /** Returns whether the UTF-8 input starting from {@code searchFrom} can be rejected. */
-  boolean canReject(
-      Utf8InputScanner scanner,
-      int searchFrom,
-      EnginePathOptions options);
+  boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options);
 
   default boolean canRejectWithDiagnostics(
       Utf8InputScanner scanner,
@@ -56,9 +49,7 @@ sealed interface RejectPrefilter
       return null;
     }
     RejectPrefilter litFilter =
-        descriptor.requiredLiteral() != null
-            ? Literal.create(descriptor.requiredLiteral())
-            : null;
+        descriptor.requiredLiteral() != null ? Literal.create(descriptor.requiredLiteral()) : null;
     RejectPrefilter ccFilter =
         descriptor.requiredCharClass() != null
             ? CharClass.create(descriptor.requiredCharClass())
@@ -89,11 +80,7 @@ sealed interface RejectPrefilter
   }
 
   @SuppressWarnings("ArrayRecordComponent")
-  record Literal(
-      String literal,
-      byte[] utf8,
-      int[] failure,
-      int[] shifts)
+  record Literal(String literal, byte[] utf8, int[] failure, int[] shifts)
       implements RejectPrefilter {
 
     static Literal create(String literal) {
@@ -105,10 +92,7 @@ sealed interface RejectPrefilter
 
     @Override
     public boolean canReject(
-        InputScanner scanner,
-        String text,
-        int searchFrom,
-        EnginePathOptions options) {
+        InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
       if (!options.literalFastPaths()) {
         return false;
       }
@@ -125,10 +109,7 @@ sealed interface RejectPrefilter
     }
 
     @Override
-    public boolean canReject(
-        Utf8InputScanner scanner,
-        int searchFrom,
-        EnginePathOptions options) {
+    public boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options) {
       if (!options.literalFastPaths()) {
         return false;
       }
@@ -142,11 +123,7 @@ sealed interface RejectPrefilter
   }
 
   @SuppressWarnings("ArrayRecordComponent")
-  record CharClass(
-      int[] ranges,
-      long bitmap0,
-      long bitmap1)
-      implements RejectPrefilter {
+  record CharClass(int[] ranges, long bitmap0, long bitmap1) implements RejectPrefilter {
 
     static CharClass create(CharClassScanInfo scanInfo) {
       return new CharClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1);
@@ -154,10 +131,7 @@ sealed interface RejectPrefilter
 
     @Override
     public boolean canReject(
-        InputScanner scanner,
-        String text,
-        int searchFrom,
-        EnginePathOptions options) {
+        InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
       if (!options.charClassMatchFastPaths()) {
         return false;
       }
@@ -165,10 +139,7 @@ sealed interface RejectPrefilter
     }
 
     @Override
-    public boolean canReject(
-        Utf8InputScanner scanner,
-        int searchFrom,
-        EnginePathOptions options) {
+    public boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options) {
       if (!options.charClassMatchFastPaths()) {
         return false;
       }
@@ -183,10 +154,7 @@ sealed interface RejectPrefilter
 
   @SuppressWarnings("ArrayRecordComponent")
   record DisjointLiterals(
-      String[] literals,
-      byte[][] utf8Literals,
-      int[][] failures,
-      int[][] shifts)
+      String[] literals, byte[][] utf8Literals, int[][] failures, int[][] shifts)
       implements RejectPrefilter {
 
     static DisjointLiterals create(DisjointRequiredLiterals disjoint) {
@@ -204,10 +172,7 @@ sealed interface RejectPrefilter
 
     @Override
     public boolean canReject(
-        InputScanner scanner,
-        String text,
-        int searchFrom,
-        EnginePathOptions options) {
+        InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
       if (!options.literalFastPaths()) {
         return false;
       }
@@ -234,10 +199,7 @@ sealed interface RejectPrefilter
     }
 
     @Override
-    public boolean canReject(
-        Utf8InputScanner scanner,
-        int searchFrom,
-        EnginePathOptions options) {
+    public boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options) {
       if (!options.literalFastPaths()) {
         return false;
       }
@@ -259,10 +221,7 @@ sealed interface RejectPrefilter
   record Composite(RejectPrefilter[] filters) implements RejectPrefilter {
     @Override
     public boolean canReject(
-        InputScanner scanner,
-        String text,
-        int searchFrom,
-        EnginePathOptions options) {
+        InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
       for (RejectPrefilter filter : filters) {
         if (filter.canReject(scanner, text, searchFrom, options)) {
           return true;
@@ -272,10 +231,7 @@ sealed interface RejectPrefilter
     }
 
     @Override
-    public boolean canReject(
-        Utf8InputScanner scanner,
-        int searchFrom,
-        EnginePathOptions options) {
+    public boolean canReject(Utf8InputScanner scanner, int searchFrom, EnginePathOptions options) {
       for (RejectPrefilter filter : filters) {
         if (filter.canReject(scanner, searchFrom, options)) {
           return true;

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -1,0 +1,306 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.safere.Pattern.CharClassScanInfo;
+import org.safere.Pattern.DisjointRequiredLiterals;
+
+/**
+ * Whole-input rejection filter (Tier 0 acceleration).
+ *
+ * <p>Rejects match attempts in O(1) / fast linear scan before invoking automata when mandatory
+ * tokens or character classes are absent anywhere in the input.
+ */
+sealed interface RejectPrefilter
+    permits RejectPrefilter.Literal,
+        RejectPrefilter.CharClass,
+        RejectPrefilter.DisjointLiterals,
+        RejectPrefilter.Composite {
+
+  /** Returns whether the input starting from {@code searchFrom} can be rejected. */
+  boolean canReject(
+      InputScanner scanner,
+      String text,
+      int searchFrom,
+      EnginePathOptions options);
+
+  /** Returns whether the UTF-8 input starting from {@code searchFrom} can be rejected. */
+  boolean canReject(
+      Utf8InputScanner scanner,
+      int searchFrom,
+      EnginePathOptions options);
+
+  default boolean canRejectWithDiagnostics(
+      Utf8InputScanner scanner,
+      int searchFrom,
+      EnginePathOptions options,
+      DiagnosticAccumulator diagnostics) {
+    if (canReject(scanner, searchFrom, options)) {
+      diagnostics.participate(strategy(), StrategyRole.REJECT_PREFILTER);
+      diagnostics.boundary(strategy());
+      return true;
+    }
+    return false;
+  }
+
+  MatchStrategy strategy();
+
+  static RejectPrefilter create(RejectDescriptor descriptor) {
+    if (descriptor == null || !descriptor.hasRejectionFilter()) {
+      return null;
+    }
+    RejectPrefilter litFilter =
+        descriptor.requiredLiteral() != null
+            ? Literal.create(descriptor.requiredLiteral())
+            : null;
+    RejectPrefilter ccFilter =
+        descriptor.requiredCharClass() != null
+            ? CharClass.create(descriptor.requiredCharClass())
+            : null;
+    RejectPrefilter disjointFilter =
+        descriptor.disjointRequiredLiterals() != null
+            ? DisjointLiterals.create(descriptor.disjointRequiredLiterals())
+            : null;
+
+    List<RejectPrefilter> active = new ArrayList<>(3);
+    if (litFilter != null) {
+      active.add(litFilter);
+    }
+    if (ccFilter != null) {
+      active.add(ccFilter);
+    }
+    if (disjointFilter != null) {
+      active.add(disjointFilter);
+    }
+
+    if (active.isEmpty()) {
+      return null;
+    }
+    if (active.size() == 1) {
+      return active.get(0);
+    }
+    return new Composite(active.toArray(new RejectPrefilter[0]));
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  record Literal(
+      String literal,
+      byte[] utf8,
+      int[] failure,
+      int[] shifts)
+      implements RejectPrefilter {
+
+    static Literal create(String literal) {
+      byte[] utf8 = literal.getBytes(StandardCharsets.UTF_8);
+      int[] failure = Pattern.literalFailure(utf8);
+      int[] shifts = Pattern.literalShifts(utf8);
+      return new Literal(literal, utf8, failure, shifts);
+    }
+
+    @Override
+    public boolean canReject(
+        InputScanner scanner,
+        String text,
+        int searchFrom,
+        EnginePathOptions options) {
+      if (!options.literalFastPaths()) {
+        return false;
+      }
+      if (scanner instanceof Utf8InputScanner utf8Scanner) {
+        return utf8Scanner.indexOf(utf8, failure, shifts, searchFrom) < 0;
+      }
+      if (text != null) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(Math.max(0, text.length() - searchFrom));
+        }
+        return text.indexOf(literal, searchFrom) < 0;
+      }
+      return false;
+    }
+
+    @Override
+    public boolean canReject(
+        Utf8InputScanner scanner,
+        int searchFrom,
+        EnginePathOptions options) {
+      if (!options.literalFastPaths()) {
+        return false;
+      }
+      return scanner.indexOf(utf8, failure, shifts, searchFrom) < 0;
+    }
+
+    @Override
+    public MatchStrategy strategy() {
+      return MatchStrategy.LITERAL;
+    }
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  record CharClass(
+      int[] ranges,
+      long bitmap0,
+      long bitmap1)
+      implements RejectPrefilter {
+
+    static CharClass create(CharClassScanInfo scanInfo) {
+      return new CharClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1);
+    }
+
+    @Override
+    public boolean canReject(
+        InputScanner scanner,
+        String text,
+        int searchFrom,
+        EnginePathOptions options) {
+      if (!options.charClassMatchFastPaths()) {
+        return false;
+      }
+      return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, searchFrom) < 0;
+    }
+
+    @Override
+    public boolean canReject(
+        Utf8InputScanner scanner,
+        int searchFrom,
+        EnginePathOptions options) {
+      if (!options.charClassMatchFastPaths()) {
+        return false;
+      }
+      return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, searchFrom) < 0;
+    }
+
+    @Override
+    public MatchStrategy strategy() {
+      return MatchStrategy.CHARACTER_CLASS;
+    }
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  record DisjointLiterals(
+      String[] literals,
+      byte[][] utf8Literals,
+      int[][] failures,
+      int[][] shifts)
+      implements RejectPrefilter {
+
+    static DisjointLiterals create(DisjointRequiredLiterals disjoint) {
+      String[] literals = disjoint.literals();
+      byte[][] utf8Literals = new byte[literals.length][];
+      int[][] failures = new int[literals.length][];
+      int[][] shifts = new int[literals.length][];
+      for (int i = 0; i < literals.length; i++) {
+        utf8Literals[i] = literals[i].getBytes(StandardCharsets.UTF_8);
+        failures[i] = Pattern.literalFailure(utf8Literals[i]);
+        shifts[i] = Pattern.literalShifts(utf8Literals[i]);
+      }
+      return new DisjointLiterals(literals, utf8Literals, failures, shifts);
+    }
+
+    @Override
+    public boolean canReject(
+        InputScanner scanner,
+        String text,
+        int searchFrom,
+        EnginePathOptions options) {
+      if (!options.literalFastPaths()) {
+        return false;
+      }
+      if (scanner instanceof Utf8InputScanner utf8Scanner) {
+        for (int i = 0; i < utf8Literals.length; i++) {
+          if (utf8Scanner.indexOf(utf8Literals[i], failures[i], shifts[i], searchFrom) >= 0) {
+            return false;
+          }
+        }
+        return true;
+      }
+      if (text != null) {
+        for (String literal : literals) {
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record(Math.max(0, text.length() - searchFrom));
+          }
+          if (text.indexOf(literal, searchFrom) >= 0) {
+            return false;
+          }
+        }
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public boolean canReject(
+        Utf8InputScanner scanner,
+        int searchFrom,
+        EnginePathOptions options) {
+      if (!options.literalFastPaths()) {
+        return false;
+      }
+      for (int i = 0; i < utf8Literals.length; i++) {
+        if (scanner.indexOf(utf8Literals[i], failures[i], shifts[i], searchFrom) >= 0) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public MatchStrategy strategy() {
+      return MatchStrategy.LITERAL;
+    }
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  record Composite(RejectPrefilter[] filters) implements RejectPrefilter {
+    @Override
+    public boolean canReject(
+        InputScanner scanner,
+        String text,
+        int searchFrom,
+        EnginePathOptions options) {
+      for (RejectPrefilter filter : filters) {
+        if (filter.canReject(scanner, text, searchFrom, options)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public boolean canReject(
+        Utf8InputScanner scanner,
+        int searchFrom,
+        EnginePathOptions options) {
+      for (RejectPrefilter filter : filters) {
+        if (filter.canReject(scanner, searchFrom, options)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public boolean canRejectWithDiagnostics(
+        Utf8InputScanner scanner,
+        int searchFrom,
+        EnginePathOptions options,
+        DiagnosticAccumulator diagnostics) {
+      for (RejectPrefilter filter : filters) {
+        if (filter.canRejectWithDiagnostics(scanner, searchFrom, options, diagnostics)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public MatchStrategy strategy() {
+      return filters[0].strategy();
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -159,6 +159,16 @@ class DiagnosticsTest {
   }
 
   @Test
+  void compositeRejectPrefilterReportsTheChildThatRejected() {
+    Pattern.setDiagnostics(diagnostics);
+
+    for (MatchOperation operation : List.of(MatchOperation.FIND, MatchOperation.MATCHES)) {
+      assertCompositeRejection(operation, "needle", MatchStrategy.CHARACTER_CLASS);
+      assertCompositeRejection(operation, "x", MatchStrategy.LITERAL);
+    }
+  }
+
+  @Test
   void ordinaryReplacementLoopSuppressesNestedFindEvents() {
     Pattern.setDiagnostics(diagnostics);
     EnginePathOptions exactOnly =
@@ -624,6 +634,30 @@ class DiagnosticsTest {
     return diagnostics.operations.stream()
         .filter(event -> event.pattern().patternId() == patternId)
         .toList();
+  }
+
+  private void assertCompositeRejection(
+      MatchOperation operation, String input, MatchStrategy expectedStrategy) {
+    Pattern pattern = Pattern.compile(".*x.*needle.*");
+    Matcher matcher = pattern.matcher(input);
+
+    boolean matched =
+        switch (operation) {
+          case FIND -> matcher.find();
+          case MATCHES -> matcher.matches();
+          default -> throw new AssertionError("unsupported operation: " + operation);
+        };
+
+    assertThat(matched).isFalse();
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(
+            event -> {
+              assertThat(event.boundaryStrategy()).isEqualTo(expectedStrategy);
+              assertThat(event.auxiliaryStrategies())
+                  .containsExactly(
+                      new StrategyParticipation(expectedStrategy, StrategyRole.REJECT_PREFILTER));
+            });
   }
 
   private static final class RecordingDiagnostics extends SafeReMatchDiagnostics {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -231,7 +231,7 @@ class PatternInternalTest {
   void dotStarAroundWhitespaceRecordsRequiredWhitespaceClass() {
     Pattern p = Pattern.compile(".*\\s+.*");
 
-    assertThat(p.requiredMatchClassRanges()).isNotNull();
+    assertThat(p.rejectDescriptor().requiredCharClass()).isNotNull();
   }
 
   @ParameterizedTest
@@ -311,7 +311,7 @@ class PatternInternalTest {
       String regex, String members, String nonMembers) {
     Pattern p = Pattern.compile(regex);
 
-    assertThat(p.requiredMatchClassRanges()).isNotNull();
+    assertThat(p.rejectDescriptor().requiredCharClass()).isNotNull();
     members
         .codePoints()
         .forEach(codePoint -> assertThat(requiredClassContains(p, codePoint)).isTrue());
@@ -323,7 +323,7 @@ class PatternInternalTest {
   @ParameterizedTest
   @ValueSource(strings = {".*(x|).*", ".*(?:x|y)?.*", ".*(?:x|y){0,3}.*", ".*(?:x|y|.*).*"})
   void nullableAlternativesDoNotRecordRequiredCharacterClasses(String regex) {
-    assertThat(Pattern.compile(regex).requiredMatchClassRanges()).isNull();
+    assertThat(Pattern.compile(regex).rejectDescriptor().requiredCharClass()).isNull();
   }
 
   @ParameterizedTest
@@ -335,7 +335,7 @@ class PatternInternalTest {
     "'.*前置.*かなり長い必要語.*', かなり長い必要語"
   })
   void mandatoryCaseSensitiveLiteralsAreRecorded(String regex, String expected) {
-    assertThat(Pattern.compile(regex).requiredLiteral()).isEqualTo(expected);
+    assertThat(Pattern.compile(regex).rejectDescriptor().requiredLiteral()).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -348,7 +348,7 @@ class PatternInternalTest {
         "needle.*"
       })
   void optionalCaseInsensitiveAndAlreadyPrefixedLiteralsAreNotRecorded(String regex) {
-    assertThat(Pattern.compile(regex).requiredLiteral()).isNull();
+    assertThat(Pattern.compile(regex).rejectDescriptor().requiredLiteral()).isNull();
   }
 
   @Test
@@ -423,22 +423,20 @@ class PatternInternalTest {
   void boundaryPrefixedLiteralRecordsRequiredClass() {
     Pattern p = Pattern.compile("\\b{g}z");
 
-    assertThat(p.requiredMatchClassRanges()).isNotNull();
+    assertThat(p.rejectDescriptor().requiredCharClass()).isNotNull();
   }
 
   @Test
   void pureNullablePatternsDoNotRecordRequiredCharacterClasses() {
     Pattern p = Pattern.compile(".*");
 
-    assertThat(p.requiredMatchClassRanges()).isNull();
+    assertThat(p.rejectDescriptor().requiredCharClass()).isNull();
   }
 
   private static boolean requiredClassContains(Pattern pattern, int codePoint) {
-    return InputScanner.classContains(
-        pattern.requiredMatchClassRanges(),
-        pattern.requiredMatchClassBitmap0(),
-        pattern.requiredMatchClassBitmap1(),
-        codePoint);
+    Pattern.CharClassScanInfo info = pattern.rejectDescriptor().requiredCharClass();
+    return info != null
+        && InputScanner.classContains(info.ranges, info.bitmap0, info.bitmap1, codePoint);
   }
 
   private static Pattern.CharClassScanInfo assertAsciiScanInfo(

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -355,7 +355,7 @@ class PatternInternalTest {
   void disjointRequiredLiteralsAreRecordedForAlternations() {
     Pattern p = Pattern.compile(".*(?:apple|banana|cherry).*");
     assertThat(p.requiredDisjointLiterals()).containsExactly("apple", "banana", "cherry");
-    assertThat(p.requiredLiteral()).isNull();
+    assertThat(p.rejectDescriptor().requiredLiteral()).isNull();
 
     Pattern p2 = Pattern.compile("(foo.*|bar.*|baz.*)");
     assertThat(p2.requiredDisjointLiterals()).containsExactly("foo", "bar", "baz");
@@ -414,7 +414,7 @@ class PatternInternalTest {
       })
   void invalidOrNullableAlternationsDoNotRecordDisjointLiterals(String regex) {
     Pattern p = Pattern.compile(regex);
-    if (p.prefix() == null && p.requiredLiteral() == null) {
+    if (p.prefix() == null && p.rejectDescriptor().requiredLiteral() == null) {
       assertThat(p.requiredDisjointLiterals()).isNull();
     }
   }

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -143,12 +143,10 @@ class RejectPrefilterTest {
     RejectDescriptor desc = new RejectDescriptor(null, null, disjoint);
     assertThat(desc.hasRejectionFilter()).isTrue();
 
-    RejectPrefilter prefilter = RejectPrefilter.create(desc);
-    assertThat(prefilter).isInstanceOf(RejectPrefilter.DisjointLiterals.class);
-    RejectPrefilter.DisjointLiterals disjointPrefilter =
-        (RejectPrefilter.DisjointLiterals) prefilter;
-    assertThat(disjointPrefilter.strategy()).isEqualTo(MatchStrategy.LITERAL);
-    assertThat(disjointPrefilter.literals()).isEqualTo(literals);
+    RejectPrefilter.DisjointLiterals prefilter = RejectPrefilter.DisjointLiterals.create(disjoint);
+    assertThat(prefilter).isNotNull();
+    assertThat(prefilter.strategy()).isEqualTo(MatchStrategy.LITERAL);
+    assertThat(prefilter.literals()).isEqualTo(literals);
 
     EnginePathOptions options = EnginePathOptions.allEnabled();
 
@@ -157,13 +155,13 @@ class RejectPrefilterTest {
     assertThat(prefilter.canReject(null, "I like apple pie", 0, options)).isFalse();
     assertThat(prefilter.canReject(null, "I like grape juice", 0, options)).isTrue();
 
-    // UTF-8 input
+    // UTF-8 input (disjoint literals prefilter is String-only to avoid redundant UTF-8 scans)
     assertThat(prefilter.canReject(utf8Scanner("I like orange juice"), 0, options)).isFalse();
-    assertThat(prefilter.canReject(utf8Scanner("I like grape juice"), 0, options)).isTrue();
+    assertThat(prefilter.canReject(utf8Scanner("I like grape juice"), 0, options)).isFalse();
 
     // Disabled option
     EnginePathOptions disabled = EnginePathOptions.builder().literalFastPaths(false).build();
-    assertThat(prefilter.canReject(utf8Scanner("I like grape juice"), 0, disabled)).isFalse();
+    assertThat(prefilter.canReject(null, "I like grape juice", 0, disabled)).isFalse();
   }
 
   private static Utf8InputScanner utf8Scanner(String text) {

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -1,0 +1,144 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.safere.Pattern.CharClassScanInfo;
+
+class RejectPrefilterTest {
+
+  @Test
+  void nullAndNoneDescriptorsProduceNullPrefilter() {
+    assertThat(RejectPrefilter.create(null)).isNull();
+    assertThat(RejectPrefilter.create(RejectDescriptor.NONE)).isNull();
+    assertThat(RejectDescriptor.NONE.hasRejectionFilter()).isFalse();
+  }
+
+  @Test
+  void literalRejectPrefilterRejectsMissingLiteral() {
+    RejectDescriptor desc = new RejectDescriptor("needle", null);
+    assertThat(desc.hasRejectionFilter()).isTrue();
+
+    RejectPrefilter prefilter = RejectPrefilter.create(desc);
+    assertThat(prefilter).isInstanceOf(RejectPrefilter.Literal.class);
+    RejectPrefilter.Literal lit = (RejectPrefilter.Literal) prefilter;
+    assertThat(lit.strategy()).isEqualTo(MatchStrategy.LITERAL);
+    assertThat(lit.literal()).isEqualTo("needle");
+    assertThat(lit.utf8()).isEqualTo("needle".getBytes(UTF_8));
+    assertThat(lit.failure()).isNotNull();
+    assertThat(lit.shifts()).isNotNull();
+
+    EnginePathOptions options = EnginePathOptions.allEnabled();
+
+    // String input
+    assertThat(prefilter.canReject(null, "haystack with needle in it", 0, options)).isFalse();
+    assertThat(prefilter.canReject(null, "haystack without keyword in it", 0, options)).isTrue();
+    assertThat(prefilter.canReject(null, "needle is at start", 7, options)).isTrue();
+
+    // UTF-8 scanner
+    Utf8InputScanner matchingScanner = utf8Scanner("haystack with needle in it");
+    Utf8InputScanner nonMatchingScanner = utf8Scanner("haystack without keyword in it");
+    assertThat(prefilter.canReject(matchingScanner, 0, options)).isFalse();
+    assertThat(prefilter.canReject(nonMatchingScanner, 0, options)).isTrue();
+
+    // Disabled option
+    EnginePathOptions disabled =
+        EnginePathOptions.builder().literalFastPaths(false).build();
+    assertThat(prefilter.canReject(nonMatchingScanner, 0, disabled)).isFalse();
+  }
+
+  @Test
+  void charClassRejectPrefilterRejectsMissingClass() {
+    // Digit class [0-9]
+    int[] ranges = new int[] {'0', '9'};
+    long b0 = 0x03FF000000000000L; // digits 0-9
+    long b1 = 0L;
+    CharClassScanInfo scanInfo = new CharClassScanInfo(ranges, b0, b1, true);
+
+    RejectDescriptor desc = new RejectDescriptor(null, scanInfo);
+    assertThat(desc.hasRejectionFilter()).isTrue();
+
+    RejectPrefilter prefilter = RejectPrefilter.create(desc);
+    assertThat(prefilter).isInstanceOf(RejectPrefilter.CharClass.class);
+    RejectPrefilter.CharClass cc = (RejectPrefilter.CharClass) prefilter;
+    assertThat(cc.strategy()).isEqualTo(MatchStrategy.CHARACTER_CLASS);
+    assertThat(cc.ranges()).isEqualTo(ranges);
+    assertThat(cc.bitmap0()).isEqualTo(b0);
+    assertThat(cc.bitmap1()).isEqualTo(b1);
+
+    EnginePathOptions options = EnginePathOptions.allEnabled();
+
+    Utf8InputScanner matchingScanner = utf8Scanner("item-42-test");
+    Utf8InputScanner nonMatchingScanner = utf8Scanner("item-no-digits");
+    assertThat(prefilter.canReject(matchingScanner, 0, options)).isFalse();
+    assertThat(prefilter.canReject(nonMatchingScanner, 0, options)).isTrue();
+
+    // Disabled option
+    EnginePathOptions disabled =
+        EnginePathOptions.builder().charClassMatchFastPaths(false).build();
+    assertThat(prefilter.canReject(nonMatchingScanner, 0, disabled)).isFalse();
+  }
+
+  @Test
+  void compositeRejectPrefilterRejectsIfAnyFilterRejects() {
+    int[] ranges = new int[] {'0', '9'};
+    long b0 = 0x03FF000000000000L;
+    long b1 = 0L;
+    CharClassScanInfo scanInfo = new CharClassScanInfo(ranges, b0, b1, true);
+
+    RejectDescriptor desc = new RejectDescriptor("token", scanInfo);
+    RejectPrefilter prefilter = RejectPrefilter.create(desc);
+
+    assertThat(prefilter).isInstanceOf(RejectPrefilter.Composite.class);
+    RejectPrefilter.Composite composite = (RejectPrefilter.Composite) prefilter;
+    assertThat(composite.filters()).hasSize(2);
+
+    EnginePathOptions options = EnginePathOptions.allEnabled();
+
+    // Has both token and digits -> not rejected
+    assertThat(prefilter.canReject(utf8Scanner("prefix token 123 suffix"), 0, options)).isFalse();
+
+    // Missing token -> rejected
+    assertThat(prefilter.canReject(utf8Scanner("prefix missing 123 suffix"), 0, options)).isTrue();
+
+    // Missing digits -> rejected
+    assertThat(prefilter.canReject(utf8Scanner("prefix token no-digits suffix"), 0, options))
+        .isTrue();
+  }
+
+  @Test
+  void diagnosticsAccumulateOnRejection() {
+    RejectDescriptor desc = new RejectDescriptor("needle", null);
+    RejectPrefilter prefilter = RejectPrefilter.create(desc);
+
+    DiagnosticAccumulator accumulator = new DiagnosticAccumulator();
+    Utf8InputScanner scanner = utf8Scanner("no match here");
+
+    boolean rejected =
+        prefilter.canRejectWithDiagnostics(scanner, 0, EnginePathOptions.allEnabled(), accumulator);
+    assertThat(rejected).isTrue();
+
+    Pattern pattern = Pattern.compile("needle");
+    OperationDiagnostics event =
+        accumulator.toEvent(
+            pattern.descriptor(),
+            MatchOperation.FIND,
+            MatchOutcome.NO_MATCH,
+            CaptureMode.NONE,
+            scanner.length());
+    assertThat(event.auxiliaryStrategies())
+        .contains(new StrategyParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER));
+    assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+  }
+
+  private static Utf8InputScanner utf8Scanner(String text) {
+    byte[] bytes = text.getBytes(UTF_8);
+    return new Utf8InputScanner(bytes, 0, bytes.length);
+  }
+}

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -49,8 +49,7 @@ class RejectPrefilterTest {
     assertThat(prefilter.canReject(nonMatchingScanner, 0, options)).isTrue();
 
     // Disabled option
-    EnginePathOptions disabled =
-        EnginePathOptions.builder().literalFastPaths(false).build();
+    EnginePathOptions disabled = EnginePathOptions.builder().literalFastPaths(false).build();
     assertThat(prefilter.canReject(nonMatchingScanner, 0, disabled)).isFalse();
   }
 
@@ -81,8 +80,7 @@ class RejectPrefilterTest {
     assertThat(prefilter.canReject(nonMatchingScanner, 0, options)).isTrue();
 
     // Disabled option
-    EnginePathOptions disabled =
-        EnginePathOptions.builder().charClassMatchFastPaths(false).build();
+    EnginePathOptions disabled = EnginePathOptions.builder().charClassMatchFastPaths(false).build();
     assertThat(prefilter.canReject(nonMatchingScanner, 0, disabled)).isFalse();
   }
 
@@ -136,6 +134,36 @@ class RejectPrefilterTest {
     assertThat(event.auxiliaryStrategies())
         .contains(new StrategyParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER));
     assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+  }
+
+  @Test
+  void disjointLiteralsRejectPrefilterRejectsWhenAllMissing() {
+    String[] literals = new String[] {"apple", "banana", "orange"};
+    Pattern.DisjointRequiredLiterals disjoint = new Pattern.DisjointRequiredLiterals(literals);
+    RejectDescriptor desc = new RejectDescriptor(null, null, disjoint);
+    assertThat(desc.hasRejectionFilter()).isTrue();
+
+    RejectPrefilter prefilter = RejectPrefilter.create(desc);
+    assertThat(prefilter).isInstanceOf(RejectPrefilter.DisjointLiterals.class);
+    RejectPrefilter.DisjointLiterals disjointPrefilter =
+        (RejectPrefilter.DisjointLiterals) prefilter;
+    assertThat(disjointPrefilter.strategy()).isEqualTo(MatchStrategy.LITERAL);
+    assertThat(disjointPrefilter.literals()).isEqualTo(literals);
+
+    EnginePathOptions options = EnginePathOptions.allEnabled();
+
+    // String input
+    assertThat(prefilter.canReject(null, "I like banana smoothie", 0, options)).isFalse();
+    assertThat(prefilter.canReject(null, "I like apple pie", 0, options)).isFalse();
+    assertThat(prefilter.canReject(null, "I like grape juice", 0, options)).isTrue();
+
+    // UTF-8 input
+    assertThat(prefilter.canReject(utf8Scanner("I like orange juice"), 0, options)).isFalse();
+    assertThat(prefilter.canReject(utf8Scanner("I like grape juice"), 0, options)).isTrue();
+
+    // Disabled option
+    EnginePathOptions disabled = EnginePathOptions.builder().literalFastPaths(false).build();
+    assertThat(prefilter.canReject(utf8Scanner("I like grape juice"), 0, disabled)).isFalse();
   }
 
   private static Utf8InputScanner utf8Scanner(String text) {

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.safere.Pattern.CharClassScanInfo;
 
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class RejectPrefilterTest {
 
   @Test


### PR DESCRIPTION
This is a similar refactoring to https://github.com/eaftan/safere/pull/693 but for reject prefilters. This will make adding additional strategies like https://github.com/eaftan/safere/pull/694 simpler, and lays groundwork for future optimizations like Teddy SIMD or aho-corasick prefilters.