### PR TITLE
Use AsciiBitmap for ASCII character class metadata and accelerators, and other small improvements

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -102,6 +102,7 @@
                              annotated with @DisabledForCrosscheck in the original source. -->
                         <exclude name="AnchorOptTest.java"/>
                         <exclude name="AnchoredDfaCachingTest.java"/>
+                        <exclude name="AsciiBitmapTest.java"/>
                         <exclude name="BitStateTest.java"/>
                         <exclude name="CharClassTest.java"/>
                         <exclude name="CompilerTest.java"/>

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Pattern.java
@@ -282,7 +282,7 @@ public final class Pattern implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Object readResolve() throws ObjectStreamException {
-      return Pattern.compile(regex, flags);
+      return compile(regex, flags);
     }
   }
 }

--- a/safere/src/main/java/org/safere/AsciiBitmap.java
+++ b/safere/src/main/java/org/safere/AsciiBitmap.java
@@ -52,6 +52,22 @@ record AsciiBitmap(long bitmap0, long bitmap1) {
     return new AsciiBitmap(this.bitmap0 | other.bitmap0, this.bitmap1 | other.bitmap1);
   }
 
+  /** Returns a 128-element boolean lookup array for maximum scalar loop throughput. */
+  boolean[] toBooleanArray() {
+    boolean[] array = new boolean[128];
+    for (int i = 0; i < 64; i++) {
+      if ((bitmap0 & (1L << i)) != 0) {
+        array[i] = true;
+      }
+    }
+    for (int i = 0; i < 64; i++) {
+      if ((bitmap1 & (1L << i)) != 0) {
+        array[64 + i] = true;
+      }
+    }
+    return array;
+  }
+
   static final class Builder {
     private long b0;
     private long b1;

--- a/safere/src/main/java/org/safere/AsciiBitmap.java
+++ b/safere/src/main/java/org/safere/AsciiBitmap.java
@@ -1,0 +1,79 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/**
+ * Immutable 128-bit bitmap representing a set of ASCII code points (0–127).
+ *
+ * <p>Bits 0–63 are stored in {@code bitmap0}; bits 64–127 are stored in {@code bitmap1}.
+ */
+record AsciiBitmap(long bitmap0, long bitmap1) {
+
+  static final AsciiBitmap EMPTY = new AsciiBitmap(0L, 0L);
+
+  static AsciiBitmap of(int cp) {
+    if (cp >= 0 && cp < 64) {
+      return new AsciiBitmap(1L << cp, 0L);
+    }
+    if (cp >= 64 && cp < 128) {
+      return new AsciiBitmap(0L, 1L << (cp - 64));
+    }
+    return EMPTY;
+  }
+
+  boolean contains(int cp) {
+    return (cp >>> 7 == 0) && containsAscii(cp);
+  }
+
+  /**
+   * Unchecked ASCII membership test.
+   *
+   * <p>Only safe when the caller has already verified that {@code 0 <= cp <= 127}.
+   */
+  boolean containsAscii(int cp) {
+    return (((cp & 64) == 0 ? bitmap0 : bitmap1) & (1L << cp)) != 0;
+  }
+
+  int cardinality() {
+    return Long.bitCount(bitmap0) + Long.bitCount(bitmap1);
+  }
+
+  boolean isEmpty() {
+    return bitmap0 == 0L && bitmap1 == 0L;
+  }
+
+  AsciiBitmap union(AsciiBitmap other) {
+    if (other == null || other.isEmpty()) {
+      return this;
+    }
+    return new AsciiBitmap(this.bitmap0 | other.bitmap0, this.bitmap1 | other.bitmap1);
+  }
+
+  static final class Builder {
+    private long b0;
+    private long b1;
+
+    Builder add(int cp) {
+      if (cp >= 0 && cp < 64) {
+        b0 |= (1L << cp);
+      } else if (cp >= 64 && cp < 128) {
+        b1 |= (1L << (cp - 64));
+      }
+      return this;
+    }
+
+    Builder addRange(int lo, int hi) {
+      for (int cp = Math.max(0, lo); cp <= Math.min(127, hi); cp++) {
+        add(cp);
+      }
+      return this;
+    }
+
+    AsciiBitmap build() {
+      return (b0 == 0L && b1 == 0L) ? EMPTY : new AsciiBitmap(b0, b1);
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -97,7 +97,6 @@ public final class Matcher implements MatchResult {
   private int regionEnd;
   private boolean fullTextRegionContext;
   private boolean findExhaustedAfterTerminalEmptyMatch;
-  private boolean disjointRequiredLiteralsChecked;
   private int modCount;
   private DiagnosticOperation diagnosticOperation;
   private boolean diagnosticCaptureSearch;
@@ -420,7 +419,6 @@ public final class Matcher implements MatchResult {
     resetReplacementState();
     clearCurrentResult();
     eagerFallbackCaptures = false;
-    disjointRequiredLiteralsChecked = false;
   }
 
   private PreparedMatchRunner preparedMatchRunner;
@@ -432,12 +430,10 @@ public final class Matcher implements MatchResult {
     resetSearchStateForRegionStart();
     resetReplacementState();
     clearCurrentResult();
-    disjointRequiredLiteralsChecked = false;
   }
 
   private void invalidatePatternCaches() {
     preparedMatchRunner = null;
-    disjointRequiredLiteralsChecked = false;
     cachedForwardFirstMatchDfa = null;
     cachedForwardLongestMatchDfa = null;
     cachedReverseDfa = null;
@@ -576,7 +572,7 @@ public final class Matcher implements MatchResult {
    * directly and returns the first matching code point as group 0.
    */
   private boolean singleCharClassFindFastPath(Pattern.CharClassScanInfo scanInfo, int fromIndex) {
-    if (scanInfo.isAscii && text != null) {
+    if (scanInfo.isAscii) {
       int idx = activeScanner().indexOfCharClass(scanInfo, fromIndex);
       if (idx >= 0) {
         return applyFullMatchResult(new int[] {idx, idx + 1});
@@ -587,8 +583,11 @@ public final class Matcher implements MatchResult {
         activeScanner()
             .indexOfCodePointClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex);
     if (idx >= 0) {
-      int cp = text.codePointAt(idx);
-      return applyFullMatchResult(new int[] {idx, idx + Character.charCount(cp)});
+      int end =
+          text != null
+              ? idx + Character.charCount(text.codePointAt(idx))
+              : InputScanner.position(activeScanner().decodeForward(idx));
+      return applyFullMatchResult(new int[] {idx, end});
     }
     return applyFailedMatchResult();
   }
@@ -899,24 +898,6 @@ public final class Matcher implements MatchResult {
       diagnosticParticipation(rejectionStrategy, StrategyRole.REJECT_PREFILTER);
       diagnosticBoundary(rejectionStrategy);
       return applyFailedMatchResult();
-    }
-    Pattern.DisjointRequiredLiterals disjoint = parentPattern.disjointRequiredLiterals();
-    if (enginePathOptions().literalFastPaths() && disjoint != null && text != null) {
-      boolean found = false;
-      for (String lit : disjoint.literals()) {
-        if (WorkCounterConfig.ENABLED) {
-          WorkCounter.record(text.length());
-        }
-        if (text.indexOf(lit) >= 0) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
-        diagnosticBoundary(MatchStrategy.LITERAL);
-        return applyFailedMatchResult();
-      }
     }
 
     Prog prog = parentPattern.prog();
@@ -1499,31 +1480,6 @@ public final class Matcher implements MatchResult {
         return applyFailedMatchResult();
       }
     }
-    Pattern.DisjointRequiredLiterals disjointRequiredLiterals =
-        parentPattern.disjointRequiredLiterals();
-    if (options.literalFastPaths()
-        && disjointRequiredLiterals != null
-        && !disjointRequiredLiteralsChecked
-        && !hasAcceleratedSearchPath
-        && !prog.anchorStart()
-        && text != null) {
-      disjointRequiredLiteralsChecked = true;
-      boolean found = false;
-      for (String lit : disjointRequiredLiterals.literals()) {
-        if (WorkCounterConfig.ENABLED) {
-          WorkCounter.record(Math.max(0, text.length() - searchFrom));
-        }
-        if (text.indexOf(lit, searchFrom) >= 0) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
-        diagnosticBoundary(MatchStrategy.LITERAL);
-        return applyFailedMatchResult();
-      }
-    }
 
     // Prefix acceleration: if the pattern has a start accelerator (literal, fixed-offset,
     // character-class, or line-anchor), skip ahead to candidate match positions.
@@ -1966,8 +1922,7 @@ public final class Matcher implements MatchResult {
         WorkCounter.record();
       }
       char ch = text.charAt(i);
-      if (ch < 128
-          && keywordAlternation.firstAscii[asciiLower(ch)]
+      if (keywordAlternation.firstAscii.contains(asciiLower(ch))
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();
@@ -2001,8 +1956,7 @@ public final class Matcher implements MatchResult {
         WorkCounter.record();
       }
       char ch = text.charAt(i);
-      if (ch < 128
-          && keywordAlternation.firstAscii[asciiLower(ch)]
+      if (keywordAlternation.firstAscii.contains(asciiLower(ch))
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();
@@ -4390,9 +4344,7 @@ public final class Matcher implements MatchResult {
     // Single char class runner
     Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
     Pattern.CharClassMatchInfo charClassMatch = matchDescriptor.charClassMatch();
-    if (options.charClassMatchFastPaths()
-        && (singleCharClass != null || charClassMatch != null)
-        && text != null) {
+    if (options.charClassMatchFastPaths() && (singleCharClass != null || charClassMatch != null)) {
       return new SingleCharClassPreparedRunner(singleCharClass, charClassMatch, prog.anchorStart());
     }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1923,7 +1923,7 @@ public final class Matcher implements MatchResult {
       }
       char ch = text.charAt(i);
       if (ch < 128
-          && keywordAlternation.firstAsciiTable[ch]
+          && keywordAlternation.firstAsciiTable[asciiLower(ch)]
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();
@@ -1958,7 +1958,7 @@ public final class Matcher implements MatchResult {
       }
       char ch = text.charAt(i);
       if (ch < 128
-          && keywordAlternation.firstAsciiTable[ch]
+          && keywordAlternation.firstAsciiTable[asciiLower(ch)]
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1922,7 +1922,8 @@ public final class Matcher implements MatchResult {
         WorkCounter.record();
       }
       char ch = text.charAt(i);
-      if (keywordAlternation.firstAscii.contains(ch)
+      if (ch < 128
+          && keywordAlternation.firstAsciiTable[ch]
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();
@@ -1956,7 +1957,8 @@ public final class Matcher implements MatchResult {
         WorkCounter.record();
       }
       char ch = text.charAt(i);
-      if (keywordAlternation.firstAscii.contains(ch)
+      if (ch < 128
+          && keywordAlternation.firstAsciiTable[ch]
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1922,7 +1922,7 @@ public final class Matcher implements MatchResult {
         WorkCounter.record();
       }
       char ch = text.charAt(i);
-      if (keywordAlternation.firstAscii.contains(asciiLower(ch))
+      if (keywordAlternation.firstAscii.contains(ch)
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();
@@ -1956,7 +1956,7 @@ public final class Matcher implements MatchResult {
         WorkCounter.record();
       }
       char ch = text.charAt(i);
-      if (keywordAlternation.firstAscii.contains(asciiLower(ch))
+      if (keywordAlternation.firstAscii.contains(ch)
           && isWordBoundaryAt(i, keywordAlternation.unicodeWordBoundary)) {
         for (String keyword : keywordAlternation.keywords) {
           int end = i + keyword.length();

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1997,6 +1997,7 @@ public final class Pattern implements Serializable {
   static final class KeywordAlternation {
     final String[] keywords;
     final AsciiBitmap firstAscii;
+    final boolean[] firstAsciiTable;
     final int captureGroup;
     final boolean unicodeWordBoundary;
     final boolean greedyWholeInput;
@@ -2009,6 +2010,7 @@ public final class Pattern implements Serializable {
         boolean greedyWholeInput) {
       this.keywords = keywords;
       this.firstAscii = firstAscii;
+      this.firstAsciiTable = firstAscii.toBooleanArray();
       this.captureGroup = captureGroup;
       this.unicodeWordBoundary = unicodeWordBoundary;
       this.greedyWholeInput = greedyWholeInput;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2048,7 +2048,9 @@ public final class Pattern implements Serializable {
         WorkCounter.record();
       }
       int first = scanner.asciiAt(position);
-      if (first < 0 || !firstAscii.containsAscii(first) || !isWordBoundaryAt(scanner, position)) {
+      if (first < 0
+          || !firstAscii.containsAscii(asciiLower(first))
+          || !isWordBoundaryAt(scanner, position)) {
         return -1;
       }
       for (String keyword : keywords) {
@@ -2644,13 +2646,7 @@ public final class Pattern implements Serializable {
         return null;
       }
       keywords[i] = keyword;
-      char c = keyword.charAt(0);
-      firstAscii.add(c);
-      if (c >= 'a' && c <= 'z') {
-        firstAscii.add(c - 32);
-      } else if (c >= 'A' && c <= 'Z') {
-        firstAscii.add(c + 32);
-      }
+      firstAscii.add(keyword.charAt(0));
     }
 
     boolean beforeUnicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -151,7 +151,7 @@ public final class Pattern implements Serializable {
   private final transient boolean canMatchEmpty;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
-  private final transient boolean[] charClassPrefixAscii;
+  private final transient AsciiBitmap charClassPrefixAscii;
   private final transient FixedOffsetLiteral fixedOffsetLiteral;
   private final transient Utf8StartAccelerator utf8StartAccelerator;
   private final transient StringStartAccelerator stringStartAccelerator;
@@ -475,7 +475,7 @@ public final class Pattern implements Serializable {
     boolean prefixFoldCase = prefixResult.foldCase();
     FixedOffsetLiteral fixedOffsetLiteral =
         prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
-    boolean[] ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
+    AsciiBitmap ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     StartAcceleration startAcceleration =
         (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null)
             ? extractStartAcceleration(metadataAst)
@@ -1168,7 +1168,7 @@ public final class Pattern implements Serializable {
    * the pattern has no character-class prefix. Used for prefix acceleration in {@link
    * Matcher#doFind()} when no literal prefix exists.
    */
-  boolean[] charClassPrefixAscii() {
+  AsciiBitmap charClassPrefixAscii() {
     return charClassPrefixAscii;
   }
 
@@ -1924,9 +1924,9 @@ public final class Pattern implements Serializable {
   static final class StartAcceleration {
     final boolean requireLineStart;
     final boolean allowLineStart;
-    final boolean[] asciiStart;
+    final AsciiBitmap asciiStart;
 
-    StartAcceleration(boolean requireLineStart, boolean allowLineStart, boolean[] asciiStart) {
+    StartAcceleration(boolean requireLineStart, boolean allowLineStart, AsciiBitmap asciiStart) {
       this.requireLineStart = requireLineStart;
       this.allowLineStart = allowLineStart;
       this.asciiStart = asciiStart;
@@ -1996,14 +1996,14 @@ public final class Pattern implements Serializable {
   /** Fast-path data for {@code (?i)\b(keyword|...)\b} and its greedy whole-input form. */
   static final class KeywordAlternation {
     final String[] keywords;
-    final boolean[] firstAscii;
+    final AsciiBitmap firstAscii;
     final int captureGroup;
     final boolean unicodeWordBoundary;
     final boolean greedyWholeInput;
 
     KeywordAlternation(
         String[] keywords,
-        boolean[] firstAscii,
+        AsciiBitmap firstAscii,
         int captureGroup,
         boolean unicodeWordBoundary,
         boolean greedyWholeInput) {
@@ -2043,7 +2043,9 @@ public final class Pattern implements Serializable {
         WorkCounter.record();
       }
       int first = scanner.asciiAt(position);
-      if (first < 0 || !firstAscii[asciiLower(first)] || !isWordBoundaryAt(scanner, position)) {
+      if (first < 0
+          || !firstAscii.contains(asciiLower(first))
+          || !isWordBoundaryAt(scanner, position)) {
         return -1;
       }
       for (String keyword : keywords) {
@@ -2474,8 +2476,8 @@ public final class Pattern implements Serializable {
    *
    * @return a {@code boolean[128]} ASCII bitmap, or {@code null} if no suitable prefix exists
    */
-  private static boolean[] extractCharClassPrefixAscii(Regexp re) {
-    boolean[] bitmap = new boolean[128];
+  private static AsciiBitmap extractCharClassPrefixAscii(Regexp re) {
+    AsciiBitmap.Builder bitmap = new AsciiBitmap.Builder();
     Deque<Regexp> work = new ArrayDeque<>();
     work.add(re);
 
@@ -2530,25 +2532,25 @@ public final class Pattern implements Serializable {
       }
     }
 
-    return bitmap;
+    return bitmap.build();
   }
 
-  private static boolean addLiteralPrefixAscii(int r, int flags, boolean[] bitmap) {
+  private static boolean addLiteralPrefixAscii(int r, int flags, AsciiBitmap.Builder bitmap) {
     if (r >= 128) {
       return false;
     }
-    bitmap[r] = true;
+    bitmap.add(r);
     if ((flags & ParseFlags.FOLD_CASE) != 0) {
       if (r >= 'a' && r <= 'z') {
-        bitmap[r - 32] = true;
+        bitmap.add(r - 32);
       } else if (r >= 'A' && r <= 'Z') {
-        bitmap[r + 32] = true;
+        bitmap.add(r + 32);
       }
     }
     return true;
   }
 
-  private static boolean addCharClassPrefixAscii(CharClass cc, boolean[] bitmap) {
+  private static boolean addCharClassPrefixAscii(CharClass cc, AsciiBitmap.Builder bitmap) {
     if (cc == null || cc.isEmpty()) {
       return false;
     }
@@ -2558,9 +2560,7 @@ public final class Pattern implements Serializable {
       }
     }
     for (int i = 0; i < cc.numRanges(); i++) {
-      for (int cp = cc.lo(i); cp <= cc.hi(i); cp++) {
-        bitmap[cp] = true;
-      }
+      bitmap.addRange(cc.lo(i), cc.hi(i));
     }
     return true;
   }
@@ -2574,7 +2574,7 @@ public final class Pattern implements Serializable {
     if (node.op == RegexpOp.CONCAT && node.nsub() > 0) {
       Regexp first = unwrapCaptures(node.subs.get(0));
       if (first != null && first.op == RegexpOp.BEGIN_LINE) {
-        boolean[] requiredStart = null;
+        AsciiBitmap requiredStart = null;
         if (node.nsub() > 1) {
           requiredStart = requiredFirstAscii(node.subs.get(1));
         }
@@ -2634,14 +2634,14 @@ public final class Pattern implements Serializable {
     }
 
     String[] keywords = new String[middle.subs.size()];
-    boolean[] firstAscii = new boolean[128];
+    AsciiBitmap.Builder firstAscii = new AsciiBitmap.Builder();
     for (int i = 0; i < middle.subs.size(); i++) {
       String keyword = extractAsciiCaseInsensitiveLiteral(middle.subs.get(i));
       if (keyword == null || keyword.isEmpty()) {
         return null;
       }
       keywords[i] = keyword;
-      firstAscii[keyword.charAt(0)] = true;
+      firstAscii.add(keyword.charAt(0));
     }
 
     boolean beforeUnicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;
@@ -2650,7 +2650,7 @@ public final class Pattern implements Serializable {
       return null;
     }
     return new KeywordAlternation(
-        keywords, firstAscii, captureGroup, beforeUnicodeWordBoundary, greedyWholeInput);
+        keywords, firstAscii.build(), captureGroup, beforeUnicodeWordBoundary, greedyWholeInput);
   }
 
   private static boolean isGreedyAnyCharStar(Regexp re) {
@@ -2795,7 +2795,7 @@ public final class Pattern implements Serializable {
     return node;
   }
 
-  private static boolean[] requiredFirstAscii(Regexp re) {
+  private static AsciiBitmap requiredFirstAscii(Regexp re) {
     Regexp node = firstMeaningfulNode(re);
     if (node == null) {
       return null;
@@ -2807,20 +2807,20 @@ public final class Pattern implements Serializable {
       return null;
     }
 
-    boolean[] bitmap = new boolean[128];
+    AsciiBitmap.Builder bitmap = new AsciiBitmap.Builder();
     if (node.op == RegexpOp.LITERAL) {
       if ((node.flags & ParseFlags.FOLD_CASE) != 0 || node.rune >= 128) {
         return null;
       }
-      bitmap[node.rune] = true;
-      return bitmap;
+      bitmap.add(node.rune);
+      return bitmap.build();
     }
     if (node.op == RegexpOp.LITERAL_STRING && node.runes != null && node.runes.length > 0) {
       if ((node.flags & ParseFlags.FOLD_CASE) != 0 || node.runes[0] >= 128) {
         return null;
       }
-      bitmap[node.runes[0]] = true;
-      return bitmap;
+      bitmap.add(node.runes[0]);
+      return bitmap.build();
     }
     if (node.op == RegexpOp.CHAR_CLASS && node.charClass != null) {
       CharClass cc = node.charClass;
@@ -2833,11 +2833,9 @@ public final class Pattern implements Serializable {
         }
       }
       for (int i = 0; i < cc.numRanges(); i++) {
-        for (int cp = cc.lo(i); cp <= cc.hi(i); cp++) {
-          bitmap[cp] = true;
-        }
+        bitmap.addRange(cc.lo(i), cc.hi(i));
       }
-      return bitmap;
+      return bitmap.build();
     }
     return null;
   }
@@ -2862,41 +2860,33 @@ public final class Pattern implements Serializable {
     }
   }
 
-  static CharClassScanInfo buildAsciiClassScanInfo(boolean[] asciiClass) {
-    if (asciiClass == null) {
+  static CharClassScanInfo buildAsciiClassScanInfo(AsciiBitmap asciiClass) {
+    if (asciiClass == null || asciiClass.isEmpty()) {
       return null;
     }
-    int[] ranges = new int[asciiClass.length * 2];
+    int[] ranges = new int[128 * 2];
     int rangeCount = 0;
-    long bitmap0 = 0;
-    long bitmap1 = 0;
     int value = 0;
-    while (value < asciiClass.length) {
-      if (!asciiClass[value]) {
+    while (value < 128) {
+      if (!asciiClass.containsAscii(value)) {
         value++;
         continue;
       }
       int low = value;
-      while (value + 1 < asciiClass.length && asciiClass[value + 1]) {
+      while (value + 1 < 128 && asciiClass.containsAscii(value + 1)) {
         value++;
       }
       int high = value;
       ranges[rangeCount * 2] = low;
       ranges[rangeCount * 2 + 1] = high;
       rangeCount++;
-      for (int member = low; member <= high; member++) {
-        if (member < Long.SIZE) {
-          bitmap0 |= 1L << member;
-        } else {
-          bitmap1 |= 1L << (member - Long.SIZE);
-        }
-      }
       value++;
     }
     if (rangeCount == 0) {
       return null;
     }
-    return new CharClassScanInfo(Arrays.copyOf(ranges, rangeCount * 2), bitmap0, bitmap1, true);
+    return new CharClassScanInfo(
+        Arrays.copyOf(ranges, rangeCount * 2), asciiClass.bitmap0(), asciiClass.bitmap1(), true);
   }
 
   /**
@@ -3000,7 +2990,7 @@ public final class Pattern implements Serializable {
 
   /** Extracts whole-input rejection metadata from the AST. */
   private static RejectDescriptor extractRejectDescriptor(
-      Regexp metadataAst, String prefix, boolean[] ccPrefixAscii) {
+      Regexp metadataAst, String prefix, AsciiBitmap ccPrefixAscii) {
     String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
     CharClassScanInfo requiredMatchClass =
         extractRequiredMatchClass(metadataAst, prefix == null && ccPrefixAscii == null);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2043,9 +2043,7 @@ public final class Pattern implements Serializable {
         WorkCounter.record();
       }
       int first = scanner.asciiAt(position);
-      if (first < 0
-          || !firstAscii.contains(asciiLower(first))
-          || !isWordBoundaryAt(scanner, position)) {
+      if (first < 0 || !firstAscii.containsAscii(first) || !isWordBoundaryAt(scanner, position)) {
         return -1;
       }
       for (String keyword : keywords) {
@@ -2641,7 +2639,13 @@ public final class Pattern implements Serializable {
         return null;
       }
       keywords[i] = keyword;
-      firstAscii.add(keyword.charAt(0));
+      char c = keyword.charAt(0);
+      firstAscii.add(c);
+      if (c >= 'a' && c <= 'z') {
+        firstAscii.add(c - 32);
+      } else if (c >= 'A' && c <= 'Z') {
+        firstAscii.add(c + 32);
+      }
     }
 
     boolean beforeUnicodeWordBoundary = (before.flags & ParseFlags.UNICODE_CHAR_CLASS) != 0;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -449,7 +449,10 @@ public final class Pattern implements Serializable {
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
     RejectDescriptor rejectDescriptor =
         extractRejectDescriptor(
-            metadataAst, startDescriptor.prefix(), startDescriptor.charClassPrefixAscii());
+            metadataAst,
+            startDescriptor.prefix(),
+            startDescriptor.charClassPrefixAscii(),
+            compiled.anchorStart());
     // OnePass analysis and DFA setup are deferred to first use (lazy initialization).
     return new Pattern(
         regex,
@@ -2996,12 +2999,12 @@ public final class Pattern implements Serializable {
 
   /** Extracts whole-input rejection metadata from the AST. */
   private static RejectDescriptor extractRejectDescriptor(
-      Regexp metadataAst, String prefix, AsciiBitmap ccPrefixAscii) {
+      Regexp metadataAst, String prefix, AsciiBitmap ccPrefixAscii, boolean anchorStart) {
     String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
     CharClassScanInfo requiredMatchClass =
         extractRequiredMatchClass(metadataAst, prefix == null && ccPrefixAscii == null);
     DisjointRequiredLiterals disjointRequiredLiterals =
-        (prefix == null && requiredLiteral == null)
+        (!anchorStart && prefix == null && requiredLiteral == null)
             ? DisjointRequiredLiterals.create(extractDisjointRequiredLiterals(metadataAst))
             : null;
     if (requiredLiteral == null && requiredMatchClass == null && disjointRequiredLiterals == null) {

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -170,7 +170,7 @@ sealed interface RejectPrefilter
     @Override
     public boolean canReject(
         InputScanner scanner, String text, int searchFrom, EnginePathOptions options) {
-      if (!options.literalFastPaths() || text == null) {
+      if (!options.literalFastPaths() || text == null || searchFrom > 0) {
         return false;
       }
       for (String literal : literals) {

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -58,10 +58,30 @@ sealed interface RejectPrefilter
         descriptor.requiredCharClass() != null
             ? CharClass.create(descriptor.requiredCharClass())
             : null;
-    if (litFilter != null && ccFilter != null) {
-      return new Composite(new RejectPrefilter[] {litFilter, ccFilter});
+    RejectPrefilter disjointFilter =
+        descriptor.disjointRequiredLiterals() != null
+            ? DisjointLiterals.create(descriptor.disjointRequiredLiterals())
+            : null;
+    int count =
+        (litFilter != null ? 1 : 0) + (ccFilter != null ? 1 : 0) + (disjointFilter != null ? 1 : 0);
+    if (count == 0) {
+      return null;
     }
-    return litFilter != null ? litFilter : ccFilter;
+    if (count == 1) {
+      return litFilter != null ? litFilter : (ccFilter != null ? ccFilter : disjointFilter);
+    }
+    RejectPrefilter[] filters = new RejectPrefilter[count];
+    int idx = 0;
+    if (litFilter != null) {
+      filters[idx++] = litFilter;
+    }
+    if (ccFilter != null) {
+      filters[idx++] = ccFilter;
+    }
+    if (disjointFilter != null) {
+      filters[idx++] = disjointFilter;
+    }
+    return new Composite(filters);
   }
 
   @SuppressWarnings("ArrayRecordComponent")

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -79,7 +79,7 @@ sealed interface RejectPrefilter
       filters[idx++] = ccFilter;
     }
     if (disjointFilter != null) {
-      filters[idx++] = disjointFilter;
+      filters[idx] = disjointFilter;
     }
     return new Composite(filters);
   }

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -12,12 +12,11 @@ import org.safere.Pattern.StartAcceleration;
  * Immutable descriptor capturing pre-computed start-position metadata extracted from a regular
  * expression AST.
  */
-@SuppressWarnings("ArrayRecordComponent")
 record StartDescriptor(
     String prefix,
     boolean prefixFoldCase,
     FixedOffsetLiteral fixedOffsetLiteral,
-    boolean[] charClassPrefixAscii,
+    AsciiBitmap charClassPrefixAscii,
     StartAcceleration lineAnchor) {
 
   static final StartDescriptor NONE = new StartDescriptor(null, false, null, null, null);

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -189,9 +189,11 @@ sealed interface StringStartAccelerator {
 
   final class CharClass implements StringStartAccelerator {
     private final AsciiBitmap asciiMap;
+    private final boolean[] asciiTable;
 
     CharClass(AsciiBitmap asciiMap) {
       this.asciiMap = asciiMap;
+      this.asciiTable = asciiMap.toBooleanArray();
     }
 
     public AsciiBitmap asciiMap() {
@@ -210,16 +212,16 @@ sealed interface StringStartAccelerator {
 
     @Override
     public int findCandidate(String text, int fromIndex, boolean unixLines) {
-      return indexOfCharClass(text, asciiMap, fromIndex);
+      return indexOfCharClass(text, asciiTable, fromIndex);
     }
 
-    private static int indexOfCharClass(String text, AsciiBitmap asciiMap, int fromIndex) {
+    private static int indexOfCharClass(String text, boolean[] asciiTable, int fromIndex) {
       for (int i = fromIndex; i < text.length(); i++) {
         if (WorkCounterConfig.ENABLED) {
           WorkCounter.record();
         }
         char ch = text.charAt(i);
-        if (asciiMap.contains(ch)) {
+        if (ch < 128 && asciiTable[ch]) {
           return i;
         }
       }

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -93,9 +93,9 @@ sealed interface StringStartAccelerator {
 
   final class FixedOffset implements StringStartAccelerator {
     private final FixedOffsetLiteral fixedOffset;
-    private final boolean[] firstAscii;
+    private final AsciiBitmap firstAscii;
 
-    FixedOffset(FixedOffsetLiteral fixedOffset, boolean[] firstAscii) {
+    FixedOffset(FixedOffsetLiteral fixedOffset, AsciiBitmap firstAscii) {
       this.fixedOffset = fixedOffset;
       this.firstAscii = firstAscii;
     }
@@ -104,7 +104,7 @@ sealed interface StringStartAccelerator {
       return fixedOffset;
     }
 
-    public boolean[] firstAscii() {
+    public AsciiBitmap firstAscii() {
       return firstAscii;
     }
 
@@ -124,7 +124,7 @@ sealed interface StringStartAccelerator {
     }
 
     private static int nextFixedOffsetCandidate(
-        String text, FixedOffsetLiteral fixedOffsetLiteral, boolean[] firstAscii, int fromIndex) {
+        String text, FixedOffsetLiteral fixedOffsetLiteral, AsciiBitmap firstAscii, int fromIndex) {
       int minOffset = fixedOffsetLiteral.minOffset();
       if (minOffset > text.length() - fromIndex) {
         return -1;
@@ -151,7 +151,7 @@ sealed interface StringStartAccelerator {
             int candidateStart = literalStart - offset;
             if (candidateStart >= fromIndex) {
               int first = candidateStart < text.length() ? text.charAt(candidateStart) : -1;
-              if (first >= 0 && first < firstAscii.length && firstAscii[first]) {
+              if (first >= 0 && firstAscii.contains(first)) {
                 matchFound = true;
                 if (earliestValid < 0 || candidateStart < earliestValid) {
                   earliestValid = candidateStart;
@@ -188,13 +188,13 @@ sealed interface StringStartAccelerator {
   }
 
   final class CharClass implements StringStartAccelerator {
-    private final boolean[] asciiMap;
+    private final AsciiBitmap asciiMap;
 
-    CharClass(boolean[] asciiMap) {
+    CharClass(AsciiBitmap asciiMap) {
       this.asciiMap = asciiMap;
     }
 
-    public boolean[] asciiMap() {
+    public AsciiBitmap asciiMap() {
       return asciiMap;
     }
 
@@ -213,13 +213,13 @@ sealed interface StringStartAccelerator {
       return indexOfCharClass(text, asciiMap, fromIndex);
     }
 
-    private static int indexOfCharClass(String text, boolean[] asciiMap, int fromIndex) {
+    private static int indexOfCharClass(String text, AsciiBitmap asciiMap, int fromIndex) {
       for (int i = fromIndex; i < text.length(); i++) {
         if (WorkCounterConfig.ENABLED) {
           WorkCounter.record();
         }
         char ch = text.charAt(i);
-        if (ch < 128 && asciiMap[ch]) {
+        if (asciiMap.contains(ch)) {
           return i;
         }
       }
@@ -279,12 +279,12 @@ sealed interface StringStartAccelerator {
       return (acceleration.allowLineStart && lineStart) || asciiStart;
     }
 
-    private static boolean matchesAsciiStart(String text, int pos, boolean[] asciiStart) {
+    private static boolean matchesAsciiStart(String text, int pos, AsciiBitmap asciiStart) {
       if (asciiStart == null || pos >= text.length()) {
         return false;
       }
       char ch = text.charAt(pos);
-      return ch < 128 && asciiStart[ch];
+      return asciiStart.contains(ch);
     }
 
     private static boolean isBeginLine(String text, int pos, boolean unixLines) {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -518,17 +518,6 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
 
   @Override
   public int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
-    int pos = Math.max(0, start);
-    int[] ranges = scanInfo.ranges;
-    long b0 = scanInfo.bitmap0;
-    long b1 = scanInfo.bitmap1;
-    while (pos < length) {
-      int ascii = asciiAt(pos);
-      if (ascii >= 0 && InputScanner.classContains(ranges, b0, b1, ascii)) {
-        return pos;
-      }
-      pos++;
-    }
-    return -1;
+    return indexOfCodePointClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, start);
   }
 }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -82,8 +82,7 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-  @SuppressWarnings("ArrayRecordComponent")
-  record FixedOffset(FixedOffsetLiteral fixedOffset, boolean[] charClassPrefixAscii)
+  record FixedOffset(FixedOffsetLiteral fixedOffset, AsciiBitmap charClassPrefixAscii)
       implements Utf8StartAccelerator {
 
     @Override
@@ -104,7 +103,7 @@ sealed interface Utf8StartAccelerator {
     private static int nextFixedOffsetCandidate(
         Utf8InputScanner scanner,
         FixedOffsetLiteral fixedOffsetLiteral,
-        boolean[] charClassPrefixAscii,
+        AsciiBitmap charClassPrefixAscii,
         int searchFrom) {
       int literalFrom = searchFrom + fixedOffsetLiteral.minOffset();
       int[] discreteOffsets = fixedOffsetLiteral.discreteOffsets();
@@ -126,9 +125,7 @@ sealed interface Utf8StartAccelerator {
             int candidateStart = literalStart - offset;
             if (candidateStart >= searchFrom) {
               int first = scanner.asciiAt(candidateStart);
-              if (first >= 0
-                  && first < charClassPrefixAscii.length
-                  && charClassPrefixAscii[first]
+              if (charClassPrefixAscii.contains(first)
                   && (earliestValid < 0 || candidateStart < earliestValid)) {
                 earliestValid = candidateStart;
               }

--- a/safere/src/test/java/org/safere/AsciiBitmapTest.java
+++ b/safere/src/test/java/org/safere/AsciiBitmapTest.java
@@ -1,0 +1,62 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AsciiBitmapTest {
+
+  @Test
+  void emptyBitmapContainsNothing() {
+    AsciiBitmap bitmap = AsciiBitmap.EMPTY;
+    assertThat(bitmap.isEmpty()).isTrue();
+    assertThat(bitmap.cardinality()).isZero();
+    for (int cp = -1; cp <= 256; cp++) {
+      assertThat(bitmap.contains(cp)).isFalse();
+    }
+  }
+
+  @Test
+  void singleCodePointContainsOnlyThatCodePoint() {
+    for (int target = 0; target < 128; target++) {
+      AsciiBitmap bitmap = AsciiBitmap.of(target);
+      assertThat(bitmap.isEmpty()).isFalse();
+      assertThat(bitmap.cardinality()).isEqualTo(1);
+      assertThat(bitmap.contains(target)).isTrue();
+      assertThat(bitmap.contains(target - 1)).isFalse();
+      assertThat(bitmap.contains(target + 1)).isFalse();
+      assertThat(bitmap.contains(-1)).isFalse();
+      assertThat(bitmap.contains(128)).isFalse();
+    }
+  }
+
+  @Test
+  void builderAddRangeAndContains() {
+    AsciiBitmap digits = new AsciiBitmap.Builder().addRange('0', '9').build();
+    assertThat(digits.cardinality()).isEqualTo(10);
+    for (char c = '0'; c <= '9'; c++) {
+      assertThat(digits.contains(c)).isTrue();
+    }
+    assertThat(digits.contains('a')).isFalse();
+    assertThat(digits.contains('/')).isFalse();
+    assertThat(digits.contains(':')).isFalse();
+  }
+
+  @Test
+  void unionCombinesSets() {
+    AsciiBitmap digits = new AsciiBitmap.Builder().addRange('0', '9').build();
+    AsciiBitmap letters = new AsciiBitmap.Builder().addRange('a', 'z').build();
+    AsciiBitmap alphaNum = digits.union(letters);
+
+    assertThat(alphaNum.cardinality()).isEqualTo(36);
+    assertThat(alphaNum.contains('5')).isTrue();
+    assertThat(alphaNum.contains('x')).isTrue();
+    assertThat(alphaNum.contains('A')).isFalse();
+    assertThat(alphaNum.contains('@')).isFalse();
+  }
+}

--- a/safere/src/test/java/org/safere/AsciiBitmapTest.java
+++ b/safere/src/test/java/org/safere/AsciiBitmapTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class AsciiBitmapTest {
 
   @Test

--- a/safere/src/test/java/org/safere/AsciiBitmapTest.java
+++ b/safere/src/test/java/org/safere/AsciiBitmapTest.java
@@ -59,4 +59,16 @@ class AsciiBitmapTest {
     assertThat(alphaNum.contains('A')).isFalse();
     assertThat(alphaNum.contains('@')).isFalse();
   }
+
+  @Test
+  void toBooleanArrayMatchesContains() {
+    AsciiBitmap bitmap =
+        new AsciiBitmap.Builder().add('a').add('z').addRange('0', '9').add('E').build();
+    boolean[] array = bitmap.toBooleanArray();
+
+    assertThat(array).hasSize(128);
+    for (int cp = 0; cp < 128; cp++) {
+      assertThat(array[cp]).isEqualTo(bitmap.contains(cp));
+    }
+  }
 }

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -348,6 +348,7 @@ class DiagnosticsTest {
 
     assertThat(matcher.find()).isTrue();
     matcher.usePattern(replacement);
+    matcher.reset("remainder");
     assertThat(matcher.find()).isFalse();
 
     assertThat(operationsFor(replacement))

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -57,16 +57,16 @@ class PatternInternalTest {
   void transparentGroupsPreserveCharacterClassAccelerators() {
     Pattern p = Pattern.compile("(?:[A-Z]+)");
 
-    boolean[] prefix = p.charClassPrefixAscii();
+    AsciiBitmap prefix = p.charClassPrefixAscii();
     assertThat(prefix).isNotNull();
-    assertThat(prefix['A']).isTrue();
+    assertThat(prefix.contains('A')).isTrue();
     assertThat(p.matchDescriptor().charClassMatch()).isNotNull();
   }
 
   @Test
   void asciiPrefixScanInfoHandlesMissingAndEmptyClasses() {
     assertThat(Pattern.buildAsciiClassScanInfo(null)).isNull();
-    assertThat(Pattern.buildAsciiClassScanInfo(new boolean[128])).isNull();
+    assertThat(Pattern.buildAsciiClassScanInfo(AsciiBitmap.EMPTY)).isNull();
   }
 
   @Test
@@ -146,48 +146,48 @@ class PatternInternalTest {
   @Test
   void alternatePrefixAcceleration() {
     Pattern p = Pattern.compile("(?:cat|dog|bird)s?");
-    boolean[] prefix = p.charClassPrefixAscii();
+    AsciiBitmap prefix = p.charClassPrefixAscii();
     assertThat(prefix).isNotNull();
-    assertThat(prefix['c']).isTrue();
-    assertThat(prefix['d']).isTrue();
-    assertThat(prefix['b']).isTrue();
-    assertThat(prefix['a']).isFalse();
+    assertThat(prefix.contains('c')).isTrue();
+    assertThat(prefix.contains('d')).isTrue();
+    assertThat(prefix.contains('b')).isTrue();
+    assertThat(prefix.contains('a')).isFalse();
   }
 
   @Test
   void alternatePrefixCaseInsensitiveAcceleration() {
     Pattern p = Pattern.compile("(?i)(?:cat|dog|bird)s?");
-    boolean[] prefix = p.charClassPrefixAscii();
+    AsciiBitmap prefix = p.charClassPrefixAscii();
     assertThat(prefix).isNotNull();
-    assertThat(prefix['c']).isTrue();
-    assertThat(prefix['C']).isTrue();
-    assertThat(prefix['d']).isTrue();
-    assertThat(prefix['D']).isTrue();
-    assertThat(prefix['b']).isTrue();
-    assertThat(prefix['B']).isTrue();
-    assertThat(prefix['a']).isFalse();
+    assertThat(prefix.contains('c')).isTrue();
+    assertThat(prefix.contains('C')).isTrue();
+    assertThat(prefix.contains('d')).isTrue();
+    assertThat(prefix.contains('D')).isTrue();
+    assertThat(prefix.contains('b')).isTrue();
+    assertThat(prefix.contains('B')).isTrue();
+    assertThat(prefix.contains('a')).isFalse();
   }
 
   @Test
   void deeplyNestedRequiredQuantifierPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedRequiredPlusPattern(1_000, "[ab]"));
 
-    boolean[] prefix = p.charClassPrefixAscii();
+    AsciiBitmap prefix = p.charClassPrefixAscii();
     assertThat(prefix).isNotNull();
-    assertThat(prefix['a']).isTrue();
-    assertThat(prefix['b']).isTrue();
-    assertThat(prefix['c']).isFalse();
+    assertThat(prefix.contains('a')).isTrue();
+    assertThat(prefix.contains('b')).isTrue();
+    assertThat(prefix.contains('c')).isFalse();
   }
 
   @Test
   void deeplyNestedAlternationPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedAlternationPattern(1_000));
 
-    boolean[] prefix = p.charClassPrefixAscii();
+    AsciiBitmap prefix = p.charClassPrefixAscii();
     assertThat(prefix).isNotNull();
-    assertThat(prefix['a']).isTrue();
-    assertThat(prefix['b']).isTrue();
-    assertThat(prefix['c']).isFalse();
+    assertThat(prefix.contains('a')).isTrue();
+    assertThat(prefix.contains('b')).isTrue();
+    assertThat(prefix.contains('c')).isFalse();
   }
 
   @Test
@@ -441,19 +441,20 @@ class PatternInternalTest {
 
   private static Pattern.CharClassScanInfo assertAsciiScanInfo(
       int[] members, int[] expectedRanges) {
-    boolean[] asciiClass = new boolean[128];
+    AsciiBitmap.Builder builder = new AsciiBitmap.Builder();
     for (int member : members) {
-      asciiClass[member] = true;
+      builder.add(member);
     }
+    AsciiBitmap asciiClass = builder.build();
 
     Pattern.CharClassScanInfo info = Pattern.buildAsciiClassScanInfo(asciiClass);
 
     assertThat(info).isNotNull();
     assertThat(info.ranges).containsExactly(expectedRanges);
-    for (int codePoint = 0; codePoint < asciiClass.length; codePoint++) {
+    for (int codePoint = 0; codePoint < 128; codePoint++) {
       assertThat(InputScanner.classContains(info.ranges, info.bitmap0, info.bitmap1, codePoint))
           .as("ASCII member %s", codePoint)
-          .isEqualTo(asciiClass[codePoint]);
+          .isEqualTo(asciiClass.containsAscii(codePoint));
     }
     return info;
   }

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -74,9 +74,7 @@ class StartAcceleratorTest {
 
   @Test
   void charClassPrefixAcceleratesStringAndUtf8() {
-    boolean[] ascii = new boolean[128];
-    ascii['a'] = true;
-    ascii['b'] = true;
+    AsciiBitmap ascii = new AsciiBitmap.Builder().add('a').add('b').build();
     StartDescriptor desc = new StartDescriptor(null, false, null, ascii, null);
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);


### PR DESCRIPTION
This splits out the new `AsciiBitmap` approach from #696, and makes a few other small improvements that were mostly left over from other recent changes.

* `AsciiBitmap`: Replace `boolean[128]` arrays for ascii bitmaps with an immutable 128-bit value object (`AsciiBitmap`) backed by two `long` bitmasks (`bitmap0`, `bitmap1`), reducing memory allocations during pattern compilation and matching while improving accelerator efficiency. Update StartDescriptor, StringStartAccelerator, Utf8StartAccelerator, and Pattern (StartAcceleration, KeywordAlternation, extractCharClassPrefixAscii, requiredFirstAscii, buildAsciiClassScanInfo, etc.) to use AsciiBitmap.
* Update `Utf8InputScanner` `indexOfCharClass` to delegate directly to `indexOfCodePointClass`, utilizing existing SIMD/vectorized/SWAR scanning kernels instead of falling back to a scalar byte loop.
* Enable `SingleCharClassPreparedRunner` for all scanner input types in `Matcher`.
* Remove redundant disjoint literal prefilter checks from `Matcher.matchesCore()` and `Matcher.doFindCore()`.