### PR TITLE
Fix unnecessary fully qualified names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
     <gson.version>2.14.0</gson.version>
     <jmh.version>1.37</jmh.version>
     <error-prone.version>2.50.0</error-prone.version>
-    <error-prone.checks>-Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF -Xep:ExposedPrivateType:OFF -Xep:ImmutableEnumChecker:OFF -Xep:JdkObsolete:OFF -Xep:ThreadPriorityCheck:OFF</error-prone.checks>
+    <error-prone.checks>-XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/generated-sources/.* -Xep:FieldCanBeFinal:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:YodaCondition:ERROR -Xep:UnusedVariable:ERROR -Xep:UnusedMethod:ERROR -Xep:UnusedNestedClass:ERROR -Xep:UnusedTypeParameter:ERROR -Xep:UnnecessaryDefaultInEnumSwitch:ERROR -Xep:StringSplitter:OFF -Xep:ExposedPrivateType:OFF -Xep:ImmutableEnumChecker:OFF -Xep:JdkObsolete:OFF -Xep:ThreadPriorityCheck:OFF</error-prone.checks>
+    <error-prone.extra-checks></error-prone.extra-checks>
     <google-java-format.version>1.35.0</google-java-format.version>
     <pmd.version>7.26.0</pmd.version>
     <spotless.version>3.9.0</spotless.version>
@@ -77,7 +78,7 @@
             <!-- Continue compilation past type-checking errors so Error Prone can analyze
                  code that has downstream errors in later phases. -->
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne ${error-prone.checks}</arg>
+            <arg>-Xplugin:ErrorProne ${error-prone.checks} ${error-prone.extra-checks}</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkCollectionPlan.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /** Discovers generic benchmark runners, trials, and report identities from the declared plan. */
@@ -99,9 +100,7 @@ final class BenchmarkCollectionPlan {
   }
 
   private static List<Runner> filterRunners(
-      List<Runner> runners,
-      java.util.function.Predicate<String> includeTrial,
-      boolean standardOnly) {
+      List<Runner> runners, Predicate<String> includeTrial, boolean standardOnly) {
     return runners.stream()
         .filter(runner -> !standardOnly || runner.profile().equals("standard"))
         .map(

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkFlags.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkFlags.java
@@ -5,6 +5,8 @@
 
 package org.safere.benchmark;
 
+import org.safere.Pattern;
+
 /** Shared parser for benchmark flag-set names. */
 final class BenchmarkFlags {
   private BenchmarkFlags() {}
@@ -12,12 +14,11 @@ final class BenchmarkFlags {
   static int parse(String flagSet) {
     return switch (flagSet) {
       case "0" -> 0;
-      case "CASE_INSENSITIVE" -> org.safere.Pattern.CASE_INSENSITIVE;
-      case "UNICODE_CHARACTER_CLASS" -> org.safere.Pattern.UNICODE_CHARACTER_CLASS;
-      case "CASE_INSENSITIVE_UNICODE_CASE" ->
-          org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CASE;
+      case "CASE_INSENSITIVE" -> Pattern.CASE_INSENSITIVE;
+      case "UNICODE_CHARACTER_CLASS" -> Pattern.UNICODE_CHARACTER_CLASS;
+      case "CASE_INSENSITIVE_UNICODE_CASE" -> Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
       case "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS" ->
-          org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CHARACTER_CLASS;
+          Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS;
       default -> throw new IllegalArgumentException("Unknown flag set: " + flagSet);
     };
   }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Strict, versioned model for the normalized declarative benchmark plan.
@@ -30,8 +31,7 @@ import java.util.regex.Matcher;
 final class DeclarativeBenchmarkPlan {
 
   static final int SCHEMA_VERSION = 1;
-  private static final java.util.regex.Pattern PLACEHOLDER =
-      java.util.regex.Pattern.compile("(?<!\\$)\\{([A-Za-z][A-Za-z0-9_]*)}");
+  private static final Pattern PLACEHOLDER = Pattern.compile("(?<!\\$)\\{([A-Za-z][A-Za-z0-9_]*)}");
 
   private final Map<String, InputDeclaration> inputs;
   private final List<WorkloadDeclaration> workloads;

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/MemoryBenchmark.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.safere.Matcher;
+import org.safere.Pattern;
 
 /**
  * Measures the retained heap size of compiled regex patterns across engines (SafeRE, JDK, RE2/J).
@@ -133,7 +135,7 @@ public final class MemoryBenchmark {
 
     for (int trial = 0; trial < TRIALS; trial++) {
       // Compile the pattern (DFA cache starts empty).
-      org.safere.Pattern p = org.safere.Pattern.compile(pattern);
+      Pattern p = Pattern.compile(pattern);
 
       // Warm up: run a short match so JIT compiles the matching path.
       p.matcher("warmup").find();
@@ -142,7 +144,7 @@ public final class MemoryBenchmark {
       long before = usedMemory();
 
       // Run matching against large text to populate the DFA state cache.
-      org.safere.Matcher m = p.matcher(text);
+      Matcher m = p.matcher(text);
       while (m.find()) {
         // DFA states are lazily created during matching.
       }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/ResolvedBenchmarkPlan.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Materializes the complete engine/workload compatibility join for every benchmark runner.
@@ -90,13 +91,11 @@ final class ResolvedBenchmarkPlan {
     List<DeclarativeBenchmarkPlan.ExpandedWorkload> workloads = plan.expandedWorkloads();
     plan.validateTrialExclusions(
         workloads,
-        engines.stream()
-            .map(Engine::id)
-            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new)));
+        engines.stream().map(Engine::id).collect(Collectors.toCollection(LinkedHashSet::new)));
     patternProfiles.validateReferences(
         workloads.stream()
             .flatMap(workload -> workload.patterns().stream())
-            .collect(java.util.stream.Collectors.toSet()),
+            .collect(Collectors.toSet()),
         "pattern");
     replacementProfiles.validateReferences(
         workloads.stream()
@@ -104,7 +103,7 @@ final class ResolvedBenchmarkPlan {
             .filter(DeclarativeBenchmarkPlan.RecipeString.class::isInstance)
             .map(DeclarativeBenchmarkPlan.RecipeString.class::cast)
             .map(DeclarativeBenchmarkPlan.RecipeString::value)
-            .collect(java.util.stream.Collectors.toSet()),
+            .collect(Collectors.toSet()),
         "replacement");
     JsonArray entries = new JsonArray();
     for (DeclarativeBenchmarkPlan.ExpandedWorkload workload : workloads) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
@@ -5,6 +5,7 @@
 
 package org.safere.benchmark;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,7 +26,7 @@ final class SpecializedBenchmarkPlan {
 
   static SpecializedBenchmarkPlan load() {
     Map<String, Trial> trials = new LinkedHashMap<>();
-    List<MaterializedExecutionPlan.Entry> exclusions = new java.util.ArrayList<>();
+    List<MaterializedExecutionPlan.Entry> exclusions = new ArrayList<>();
     for (MaterializedExecutionPlan.Entry entry :
         MaterializedExecutionPlan.load().entriesForRunner("java")) {
       if (!isSpecialized(entry.operation(), entry.measurement())) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedTrialRunner.java
@@ -8,12 +8,17 @@ package org.safere.benchmark;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.LongAdder;
 import org.openjdk.jmh.infra.Blackhole;
+import org.safere.OperationDiagnostics;
+import org.safere.Pattern;
 import org.safere.PatternSet;
+import org.safere.SafeReMatchDiagnostics;
+import org.safere.Utf8Input;
+import org.safere.Utf8Matcher;
+import org.safere.Utf8Sink;
 
 /** Prepared execution state for one SafeRE-specific declarative trial. */
 final class SpecializedTrialRunner implements AutoCloseable {
-  private static final org.safere.SafeReMatchDiagnostics NO_OP =
-      new org.safere.SafeReMatchDiagnostics() {};
+  private static final SafeReMatchDiagnostics NO_OP = new SafeReMatchDiagnostics() {};
 
   private final Task task;
   private final boolean diagnostics;
@@ -62,14 +67,14 @@ final class SpecializedTrialRunner implements AutoCloseable {
   }
 
   private static Task captureBounds(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
-    org.safere.Utf8Input input = utf8Input(workload);
+    Pattern pattern = Pattern.compile(workload.patterns().getFirst());
+    Utf8Input input = utf8Input(workload);
     int[] groups =
         ((DeclarativeBenchmarkPlan.RecipeIntegerList) workload.arguments().get("groups"))
             .values().stream().mapToInt(Integer::intValue).toArray();
     boolean includeEnd = stringArgument(workload, "bounds", "startEnd").equals("startEnd");
     return blackhole -> {
-      org.safere.Utf8Matcher matcher = pattern.matcher(input);
+      Utf8Matcher matcher = pattern.matcher(input);
       int sum = 0;
       while (matcher.find()) {
         for (int group : groups) {
@@ -84,22 +89,22 @@ final class SpecializedTrialRunner implements AutoCloseable {
   }
 
   private static Task decodeFind(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    Pattern pattern = Pattern.compile(workload.patterns().getFirst());
     byte[] bytes = BenchmarkData.get().getInputBytes(workload.inputIds().getFirst());
     return blackhole ->
         blackhole.consume(pattern.matcher(new String(bytes, StandardCharsets.UTF_8)).find());
   }
 
   private static Task utf8Replacement(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
-    org.safere.Utf8Input input = utf8Input(workload);
-    org.safere.Utf8Input replacement =
-        org.safere.Utf8Input.validated(
+    Pattern pattern = Pattern.compile(workload.patterns().getFirst());
+    Utf8Input input = utf8Input(workload);
+    Utf8Input replacement =
+        Utf8Input.validated(
             stringArgument(workload, "replacement", "").getBytes(StandardCharsets.UTF_8));
     CountingSink sink = new CountingSink();
     return blackhole -> {
       sink.reset();
-      org.safere.Utf8Matcher matcher = pattern.matcher(input);
+      Utf8Matcher matcher = pattern.matcher(input);
       while (matcher.find()) {
         matcher.appendReplacement(sink, replacement);
       }
@@ -115,9 +120,8 @@ final class SpecializedTrialRunner implements AutoCloseable {
             .filter(step -> step.kind() == DeclarativeBenchmarkPlan.LifecycleStepKind.REGION)
             .findFirst()
             .orElseThrow();
-    org.safere.Utf8Input input =
-        org.safere.Utf8Input.trusted(storage, region.start(), region.end() - region.start());
-    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    Utf8Input input = Utf8Input.trusted(storage, region.start(), region.end() - region.start());
+    Pattern pattern = Pattern.compile(workload.patterns().getFirst());
     return blackhole -> blackhole.consume(pattern.find(input));
   }
 
@@ -125,39 +129,36 @@ final class SpecializedTrialRunner implements AutoCloseable {
     byte[] bytes = BenchmarkData.get().getInputBytes(workload.inputIds().getFirst());
     boolean validated = stringArgument(workload, "mode", "trusted").equals("validated");
     return blackhole ->
-        blackhole.consume(
-            validated
-                ? org.safere.Utf8Input.validated(bytes)
-                : org.safere.Utf8Input.trusted(bytes));
+        blackhole.consume(validated ? Utf8Input.validated(bytes) : Utf8Input.trusted(bytes));
   }
 
   private static Task analyze(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
     String regex = workload.patterns().getFirst();
-    return blackhole -> blackhole.consume(org.safere.Pattern.compile(regex));
+    return blackhole -> blackhole.consume(Pattern.compile(regex));
   }
 
   private static Task cachedAnalysis(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    Pattern pattern = Pattern.compile(workload.patterns().getFirst());
     pattern.analysis();
     return blackhole -> blackhole.consume(pattern.analysis());
   }
 
   private static Task compileAndAnalyze(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
     String regex = workload.patterns().getFirst();
-    return blackhole -> blackhole.consume(org.safere.Pattern.compile(regex).analysis());
+    return blackhole -> blackhole.consume(Pattern.compile(regex).analysis());
   }
 
   private static Task diagnostics(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
     String listener = stringArgument(workload, "listener", "disabled");
-    org.safere.Pattern.setDiagnostics(
+    Pattern.setDiagnostics(
         switch (listener) {
-          case "disabled" -> org.safere.SafeReMatchDiagnostics.NONE;
+          case "disabled" -> SafeReMatchDiagnostics.NONE;
           case "noop" -> NO_OP;
           case "longAdder" -> new AggregatingDiagnostics();
           default ->
               throw new IllegalArgumentException("Unknown diagnostics listener: " + listener);
         });
-    org.safere.Pattern pattern = org.safere.Pattern.compile(workload.patterns().getFirst());
+    Pattern pattern = Pattern.compile(workload.patterns().getFirst());
     String input = inputString(workload);
     String action = stringArgument(workload, "action", "find");
     String replacement = stringArgument(workload, "replacement", "");
@@ -174,10 +175,8 @@ final class SpecializedTrialRunner implements AutoCloseable {
     return BenchmarkData.get().getInputString(workload.inputIds().getFirst());
   }
 
-  private static org.safere.Utf8Input utf8Input(
-      DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
-    return org.safere.Utf8Input.trusted(
-        BenchmarkData.get().getInputBytes(workload.inputIds().getFirst()));
+  private static Utf8Input utf8Input(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    return Utf8Input.trusted(BenchmarkData.get().getInputBytes(workload.inputIds().getFirst()));
   }
 
   private static String stringArgument(
@@ -199,7 +198,7 @@ final class SpecializedTrialRunner implements AutoCloseable {
   @Override
   public void close() {
     if (diagnostics) {
-      org.safere.Pattern.setDiagnostics(org.safere.SafeReMatchDiagnostics.NONE);
+      Pattern.setDiagnostics(SafeReMatchDiagnostics.NONE);
     }
   }
 
@@ -207,7 +206,7 @@ final class SpecializedTrialRunner implements AutoCloseable {
     void run(Blackhole blackhole);
   }
 
-  private static final class CountingSink implements org.safere.Utf8Sink {
+  private static final class CountingSink implements Utf8Sink {
     private int length;
 
     @Override
@@ -224,12 +223,12 @@ final class SpecializedTrialRunner implements AutoCloseable {
     }
   }
 
-  private static final class AggregatingDiagnostics extends org.safere.SafeReMatchDiagnostics {
+  private static final class AggregatingDiagnostics extends SafeReMatchDiagnostics {
     private final LongAdder operations = new LongAdder();
     private final LongAdder matches = new LongAdder();
 
     @Override
-    public void onOperationCompleted(org.safere.OperationDiagnostics event) {
+    public void onOperationCompleted(OperationDiagnostics event) {
       operations.increment();
       matches.add(event.matchCount());
     }

--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.stream.Stream;
@@ -482,7 +483,7 @@ public final class Matcher implements MatchResult {
         new Spliterators.AbstractSpliterator<>(
             Long.MAX_VALUE, Spliterator.ORDERED | Spliterator.NONNULL) {
           @Override
-          public boolean tryAdvance(java.util.function.Consumer<? super MatchResult> action) {
+          public boolean tryAdvance(Consumer<? super MatchResult> action) {
             boolean srHasNext = safereIterator.hasNext();
             boolean jrHasNext = jdkIterator.hasNext();
             checkBoolean("results.hasNext", "", srHasNext, jrHasNext);

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.regex.MatchResult;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -609,7 +610,7 @@ class CrosscheckTest {
     void toMatchResult() {
       Matcher m = Pattern.compile("(\\d+)").matcher("abc123def");
       assertThat(m.find()).isTrue();
-      java.util.regex.MatchResult mr = m.toMatchResult();
+      MatchResult mr = m.toMatchResult();
       assertThat(mr.group()).isEqualTo("123");
       assertThat(mr.group(1)).isEqualTo("123");
       assertThat(mr.start()).isEqualTo(3);

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CaseFoldingCharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CaseFoldingCharacterClassDivergenceSweep.java
@@ -5,12 +5,14 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /** Offline differential sweep for case-insensitive character-class closure bugs. */
@@ -19,14 +21,10 @@ public final class CaseFoldingCharacterClassDivergenceSweep {
 
   private static final List<FlagMode> FLAG_MODES =
       List.of(
-          new FlagMode("caseInsensitive", java.util.regex.Pattern.CASE_INSENSITIVE),
+          new FlagMode("caseInsensitive", Pattern.CASE_INSENSITIVE),
+          new FlagMode("unicodeCase", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE),
           new FlagMode(
-              "unicodeCase",
-              java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.UNICODE_CASE),
-          new FlagMode(
-              "unicodeCharacterClass",
-              java.util.regex.Pattern.CASE_INSENSITIVE
-                  | java.util.regex.Pattern.UNICODE_CHARACTER_CLASS));
+              "unicodeCharacterClass", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
 
   private static final List<PatternSpec> PATTERNS =
       List.of(
@@ -333,7 +331,7 @@ public final class CaseFoldingCharacterClassDivergenceSweep {
       return SweepJson.toJson(object);
     }
 
-    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+    private static JsonObject caseJson(CaseSpec spec) {
       var object = SweepJson.object();
       object.addProperty("patternLabel", spec.pattern().label());
       object.addProperty("regex", spec.pattern().regex());

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CharacterClassDivergenceSweep.java
@@ -5,6 +5,8 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -850,12 +852,12 @@ public final class CharacterClassDivergenceSweep {
       return SweepJson.toJson(object);
     }
 
-    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+    private static JsonObject caseJson(CaseSpec spec) {
       var object = SweepJson.object();
       object.addProperty("template", spec.template());
       object.addProperty("comments", spec.comments());
       object.addProperty("negated", spec.negated());
-      var pieces = new com.google.gson.JsonArray();
+      var pieces = new JsonArray();
       for (Piece piece : spec.pieces()) {
         var pieceObject = SweepJson.object();
         pieceObject.addProperty("label", piece.label());

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceExpander.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceExpander.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
@@ -279,7 +280,7 @@ public final class CompactDivergenceExpander {
   }
 
   private static String fileName(String classification) {
-    return classification.toLowerCase(java.util.Locale.ROOT).replace('_', '-');
+    return classification.toLowerCase(Locale.ROOT).replace('_', '-');
   }
 
   private static void deleteExampleFiles(Path expandedDir, CompactDivergenceLogs.Manifest manifest)

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceLogs.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/CompactDivergenceLogs.java
@@ -5,6 +5,7 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonArray;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -117,7 +118,7 @@ final class CompactDivergenceLogs implements AutoCloseable {
         classCounts.addProperty(classifications.get(i), count);
       }
       object.add("classCounts", classCounts);
-      var workerStates = new com.google.gson.JsonArray();
+      var workerStates = new JsonArray();
       for (int i = 0; i < workers.length; i++) {
         var workerObject = SweepJson.object();
         workerObject.addProperty("worker", i);
@@ -145,12 +146,12 @@ final class CompactDivergenceLogs implements AutoCloseable {
     object.addProperty("rangeEnd", rangeEndExclusive);
     object.addProperty("totalCases", totalCases);
     object.addProperty("threads", workers.length);
-    var classes = new com.google.gson.JsonArray();
+    var classes = new JsonArray();
     for (String classification : classifications) {
       classes.add(classification);
     }
     object.add("classifications", classes);
-    var statuses = new com.google.gson.JsonArray();
+    var statuses = new JsonArray();
     for (DivergenceStatus status : classificationStatuses) {
       statuses.add(status.name());
     }

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ControlEscapeDivergenceSweep.java
@@ -5,6 +5,7 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -366,7 +367,7 @@ public final class ControlEscapeDivergenceSweep {
       return SweepJson.toJson(object);
     }
 
-    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+    private static JsonObject caseJson(CaseSpec spec) {
       var object = SweepJson.object();
       object.addProperty("target", spec.target());
       object.addProperty("contextLabel", spec.context().label());

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/DfaSandwichLeftmostStartDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/DfaSandwichLeftmostStartDivergenceSweep.java
@@ -12,7 +12,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /** Offline differential sweep for reverse-DFA sandwich leftmost-start semantics. */
 public final class DfaSandwichLeftmostStartDivergenceSweep {
@@ -68,9 +70,9 @@ public final class DfaSandwichLeftmostStartDivergenceSweep {
   private static final List<FlagMode> FLAG_MODES =
       List.of(
           flags("none", 0),
-          flags("dotall", java.util.regex.Pattern.DOTALL),
-          flags("multiline", java.util.regex.Pattern.MULTILINE),
-          flags("unicodeCharacterClass", java.util.regex.Pattern.UNICODE_CHARACTER_CLASS));
+          flags("dotall", Pattern.DOTALL),
+          flags("multiline", Pattern.MULTILINE),
+          flags("unicodeCharacterClass", Pattern.UNICODE_CHARACTER_CLASS));
 
   private static final List<String> INPUTS =
       List.of(
@@ -313,13 +315,11 @@ public final class DfaSandwichLeftmostStartDivergenceSweep {
   }
 
   private static List<String> divergenceClassificationNames() {
-    return java.util.Arrays.stream(DivergenceClass.values()).map(Enum::name).toList();
+    return Arrays.stream(DivergenceClass.values()).map(Enum::name).toList();
   }
 
   private static List<DivergenceStatus> divergenceClassificationStatuses() {
-    return java.util.Arrays.stream(DivergenceClass.values())
-        .map(DivergenceClassification::status)
-        .toList();
+    return Arrays.stream(DivergenceClass.values()).map(DivergenceClassification::status).toList();
   }
 
   private static CaseSpec caseFromIndex(long index) {

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/GraphemeClusterDivergenceSweep.java
@@ -5,6 +5,7 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -1248,7 +1249,7 @@ public final class GraphemeClusterDivergenceSweep {
       return SweepJson.toJson(object);
     }
 
-    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+    private static JsonObject caseJson(CaseSpec spec) {
       var object = SweepJson.object();
       object.addProperty("regexLabel", spec.regexTemplate().label());
       object.addProperty("regex", spec.regex());

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/UnicodeCharacterClassDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/UnicodeCharacterClassDivergenceSweep.java
@@ -5,6 +5,7 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -206,7 +207,7 @@ public final class UnicodeCharacterClassDivergenceSweep {
       return SweepJson.toJson(object);
     }
 
-    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+    private static JsonObject caseJson(CaseSpec spec) {
       var object = SweepJson.object();
       object.addProperty("label", spec.regexCase().label());
       object.addProperty("regex", spec.regexCase().regex());

--- a/safere-exhaustive/src/main/java/org/safere/exhaustive/ZeroWidthQuantifierDivergenceSweep.java
+++ b/safere-exhaustive/src/main/java/org/safere/exhaustive/ZeroWidthQuantifierDivergenceSweep.java
@@ -5,6 +5,7 @@
 
 package org.safere.exhaustive;
 
+import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -18,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Offline differential sweep for repeated quantifiers over zero-width operands. */
 public final class ZeroWidthQuantifierDivergenceSweep {
@@ -26,14 +29,14 @@ public final class ZeroWidthQuantifierDivergenceSweep {
   private static final int ACTIONABLE_SAMPLE_LIMIT = 100;
   private static final int MAX_QUANTIFIER_CHAIN_LENGTH = 4;
   private static final long DEFAULT_PROGRESS_INTERVAL = 10_000_000;
-  private static final java.util.regex.Pattern CAPTURE_FIELD =
-      java.util.regex.Pattern.compile("g(\\d+)=(?:null|-?\\d+-\\d+:[^;}]*+)");
-  private static final java.util.regex.Pattern FIND_TRACE_FIELD =
-      java.util.regex.Pattern.compile("(?:^|,)[^,:]*+:find\\d+=(?:true@\\d+-\\d+|false)");
-  private static final java.util.regex.Pattern NON_REPLACEMENT_TRACE_FIELD =
-      java.util.regex.Pattern.compile("(?:^|,)([^,:]*+:(?:matches|lookingAt|find\\d++))=([^,]*+)");
-  private static final java.util.regex.Pattern DECOMPOSED_E_ACUTE_TRACE_FIELD =
-      java.util.regex.Pattern.compile("(?:^|,)e\u0301:[^,]*");
+  private static final Pattern CAPTURE_FIELD =
+      Pattern.compile("g(\\d+)=(?:null|-?\\d+-\\d+:[^;}]*+)");
+  private static final Pattern FIND_TRACE_FIELD =
+      Pattern.compile("(?:^|,)[^,:]*+:find\\d+=(?:true@\\d+-\\d+|false)");
+  private static final Pattern NON_REPLACEMENT_TRACE_FIELD =
+      Pattern.compile("(?:^|,)([^,:]*+:(?:matches|lookingAt|find\\d++))=([^,]*+)");
+  private static final Pattern DECOMPOSED_E_ACUTE_TRACE_FIELD =
+      Pattern.compile("(?:^|,)e\u0301:[^,]*");
 
   private static final List<Atom> ZERO_WIDTH_ATOMS =
       List.of(
@@ -77,9 +80,9 @@ public final class ZeroWidthQuantifierDivergenceSweep {
   private static final List<FlagMode> FLAG_MODES =
       List.of(
           new FlagMode("none", "", 0, ""),
-          new FlagMode("commentsFlag", "", java.util.regex.Pattern.COMMENTS, " "),
-          new FlagMode("commentsFlagTab", "", java.util.regex.Pattern.COMMENTS, "\t"),
-          new FlagMode("commentsFlagComment", "", java.util.regex.Pattern.COMMENTS, "#q\n"),
+          new FlagMode("commentsFlag", "", Pattern.COMMENTS, " "),
+          new FlagMode("commentsFlagTab", "", Pattern.COMMENTS, "\t"),
+          new FlagMode("commentsFlagComment", "", Pattern.COMMENTS, "#q\n"),
           new FlagMode("commentsEmbedded", "(?x)", 0, " "),
           new FlagMode("commentsEmbeddedComment", "(?x)", 0, "#q\n"));
 
@@ -220,7 +223,7 @@ public final class ZeroWidthQuantifierDivergenceSweep {
             SweepJson.string(caseObject, "trivia")));
   }
 
-  private static QuantifierChain replayQuantifierChain(com.google.gson.JsonObject caseObject) {
+  private static QuantifierChain replayQuantifierChain(JsonObject caseObject) {
     if (caseObject.has("quantifierChainLabel")) {
       return new QuantifierChain(
           SweepJson.string(caseObject, "quantifierChainLabel"),
@@ -759,7 +762,7 @@ public final class ZeroWidthQuantifierDivergenceSweep {
       return SweepJson.toJson(object);
     }
 
-    private static com.google.gson.JsonObject caseJson(CaseSpec spec) {
+    private static JsonObject caseJson(CaseSpec spec) {
       var object = SweepJson.object();
       object.addProperty("operandLabel", spec.operand().label());
       object.addProperty("operandRegex", spec.operand().regex());
@@ -1231,7 +1234,7 @@ public final class ZeroWidthQuantifierDivergenceSweep {
 
   private static Map<String, String> nonReplacementTraceFields(String trace) {
     Map<String, String> fields = new LinkedHashMap<>();
-    java.util.regex.Matcher matcher = NON_REPLACEMENT_TRACE_FIELD.matcher(trace);
+    Matcher matcher = NON_REPLACEMENT_TRACE_FIELD.matcher(trace);
     while (matcher.find()) {
       fields.put(matcher.group(1), matcher.group(2));
     }

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/CompactDivergenceLogsTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/CompactDivergenceLogsTest.java
@@ -6,6 +6,7 @@
 package org.safere.exhaustive;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.BufferedWriter;
 import java.io.StringWriter;
@@ -123,7 +124,7 @@ class CompactDivergenceLogsTest {
     }
 
     assertThat(
-            org.assertj.core.api.Assertions.catchThrowable(
+            catchThrowable(
                 () ->
                     new CompactDivergenceLogs(
                         tempDir,
@@ -181,7 +182,7 @@ class CompactDivergenceLogsTest {
     }
 
     assertThat(
-            org.assertj.core.api.Assertions.catchThrowable(
+            catchThrowable(
                 () ->
                     CompactDivergenceExpander.main(
                         new String[] {"--input-dir=" + tempDir, "--sample-limit=2"})))

--- a/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
+++ b/safere-exhaustive/src/test/java/org/safere/exhaustive/SweepCliSmokeTest.java
@@ -6,12 +6,15 @@
 package org.safere.exhaustive;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -155,7 +158,7 @@ class SweepCliSmokeTest {
   void regionScalarSweepClassifiesQuantifiedSplitSurrogateCompositionAsIntentional() {
     assertThat(
             RegionScalarDivergenceSweep.classifyDivergenceShapeForTesting(
-                ".", "%s+", java.util.regex.Pattern.DOTALL, "\uD83D\uDE00", 0, 1))
+                ".", "%s+", Pattern.DOTALL, "\uD83D\uDE00", 0, 1))
         .isEqualTo("QUANTIFIED_SPLIT_SURROGATE_SCALAR_COMPOSITION");
     assertThat(
             RegionScalarDivergenceSweep.classifyDivergenceShapeForTesting(
@@ -167,7 +170,7 @@ class SweepCliSmokeTest {
   void regionScalarSweepIncludesSplitSurrogateOrdinaryAtomCases() {
     assertThat(
             RegionScalarDivergenceSweep.containsGeneratedCaseForTesting(
-                ".", "%s", java.util.regex.Pattern.DOTALL, "\uD83D\uDE00", 0, 1))
+                ".", "%s", Pattern.DOTALL, "\uD83D\uDE00", 0, 1))
         .isTrue();
     assertThat(
             RegionScalarDivergenceSweep.containsGeneratedCaseForTesting(
@@ -187,7 +190,7 @@ class SweepCliSmokeTest {
         .isTrue();
     assertThat(
             RegionZeroWidthDivergenceSweep.containsGeneratedCaseForTesting(
-                "\\B", java.util.regex.Pattern.UNICODE_CHARACTER_CLASS, "a\uD83D\uDE00", 1, 2))
+                "\\B", Pattern.UNICODE_CHARACTER_CLASS, "a\uD83D\uDE00", 1, 2))
         .isTrue();
     assertThat(
             RegionZeroWidthDivergenceSweep.containsGeneratedCaseForTesting(
@@ -199,7 +202,7 @@ class SweepCliSmokeTest {
         .isTrue();
     assertThat(
             RegionZeroWidthDivergenceSweep.containsGeneratedCaseForTesting(
-                "\\B.", java.util.regex.Pattern.DOTALL, "\uD83D\uDE00", 0, 1))
+                "\\B.", Pattern.DOTALL, "\uD83D\uDE00", 0, 1))
         .isTrue();
     assertThat(
             RegionZeroWidthDivergenceSweep.containsGeneratedCaseForTesting(
@@ -223,7 +226,7 @@ class SweepCliSmokeTest {
         .isEqualTo("NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION");
     assertThat(
             RegionZeroWidthDivergenceSweep.classifyDivergenceShapeForTesting(
-                "y|\\B.", java.util.regex.Pattern.DOTALL, "x\uD83D\uDE00y", 1, 4, true, false))
+                "y|\\B.", Pattern.DOTALL, "x\uD83D\uDE00y", 1, 4, true, false))
         .isEqualTo("NON_WORD_BOUNDARY_SPLIT_SURROGATE_INTERIOR_POSITION");
   }
 
@@ -276,7 +279,7 @@ class SweepCliSmokeTest {
 
   @Test
   void regexSweepTraceIncludesCapturesForZeroWidthPossessiveStar() {
-    RegexSweep.Outcome outcome = RegexSweep.jdkTraceOutcome("()*+", 0, java.util.List.of(""), 1);
+    RegexSweep.Outcome outcome = RegexSweep.jdkTraceOutcome("()*+", 0, List.of(""), 1);
 
     assertThat(outcome.accepted()).isTrue();
     assertThat(outcome.trace()).contains(":matches=true@0-0{groups=1;g1=0-0:");
@@ -301,14 +304,11 @@ class SweepCliSmokeTest {
                 "((\\b{g})*+)a?", "a"))
         .isTrue();
 
-    RegexSweep.Outcome outcome =
-        RegexSweep.jdkTraceOutcome("(?:()*+|a).", 0, java.util.List.of("ab"), 1);
-    RegexSweep.Outcome capturedAnchor =
-        RegexSweep.jdkTraceOutcome("(^)*+a", 0, java.util.List.of("ba"), 1);
-    RegexSweep.Outcome zeroCount =
-        RegexSweep.jdkTraceOutcome("(){0}+a", 0, java.util.List.of("ba"), 1);
+    RegexSweep.Outcome outcome = RegexSweep.jdkTraceOutcome("(?:()*+|a).", 0, List.of("ab"), 1);
+    RegexSweep.Outcome capturedAnchor = RegexSweep.jdkTraceOutcome("(^)*+a", 0, List.of("ba"), 1);
+    RegexSweep.Outcome zeroCount = RegexSweep.jdkTraceOutcome("(){0}+a", 0, List.of("ba"), 1);
     RegexSweep.Outcome repeatedFindZeroLength =
-        RegexSweep.jdkTraceOutcome("((\\b{g})*+)a?", 0, java.util.List.of("a"), 2);
+        RegexSweep.jdkTraceOutcome("((\\b{g})*+)a?", 0, List.of("a"), 2);
 
     assertThat(outcome.accepted()).isTrue();
     assertThat(outcome.trace()).contains("ab:matches=true@0-2{groups=1;g1=0-0:");
@@ -700,7 +700,7 @@ class SweepCliSmokeTest {
         """);
 
     assertThat(
-            org.assertj.core.api.Assertions.catchThrowable(
+            catchThrowable(
                 () -> ZeroWidthQuantifierDivergenceSweep.main(replayArgs(outputDir, replayFile))))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("unknown behavioral divergences");
@@ -764,7 +764,7 @@ class SweepCliSmokeTest {
         """);
 
     assertThat(
-            org.assertj.core.api.Assertions.catchThrowable(
+            catchThrowable(
                 () ->
                     GraphemeClusterDivergenceSweep.main(
                         replayArgs(outputDir, replayFile, "--unknown-stratified-samples=2"))))

--- a/safere-ffm-re2/src/main/java/org/safere/re2ffm/Re2Shim.java
+++ b/safere-ffm-re2/src/main/java/org/safere/re2ffm/Re2Shim.java
@@ -12,6 +12,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -351,8 +352,7 @@ final class Re2Shim {
       int actualLen = outLenSeg.get(ValueLayout.JAVA_INT, 0);
       byte[] resBytes = new byte[actualLen];
       MemorySegment.copy(outBuf, ValueLayout.JAVA_BYTE, 0, resBytes, 0, actualLen);
-      return new ReplaceResult(
-          new String(resBytes, java.nio.charset.StandardCharsets.UTF_8), count);
+      return new ReplaceResult(new String(resBytes, StandardCharsets.UTF_8), count);
     }
   }
 }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
@@ -9,6 +9,8 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 import java.util.Objects;
+import org.safere.Matcher;
+import org.safere.Pattern;
 
 final class DialectSyntaxFuzzer {
 
@@ -82,8 +84,8 @@ final class DialectSyntaxFuzzer {
   }
 
   private static void assertSafeRePythonNamedGroupExtension(String regex) {
-    org.safere.Pattern pattern = org.safere.Pattern.compile(regex);
-    org.safere.Matcher matcher = pattern.matcher("a");
+    Pattern pattern = Pattern.compile(regex);
+    Matcher matcher = pattern.matcher("a");
     if (!matcher.matches()) {
       throw new AssertionError("SafeRE Python-style named group did not match: " + regex);
     }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -8,13 +8,12 @@ package org.safere.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
+import org.safere.Pattern;
 
 final class MatchFuzzer {
-  private static final int CI = org.safere.Pattern.CASE_INSENSITIVE;
-  private static final int CI_U =
-      org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CASE;
-  private static final int CI_UCC =
-      org.safere.Pattern.CASE_INSENSITIVE | org.safere.Pattern.UNICODE_CHARACTER_CLASS;
+  private static final int CI = Pattern.CASE_INSENSITIVE;
+  private static final int CI_U = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+  private static final int CI_UCC = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS;
 
   private static final List<RegressionCase> CASE_FOLDING_REGRESSIONS =
       List.of(
@@ -94,7 +93,7 @@ final class MatchFuzzer {
 
   private static void assertUnicodeBoundaryStartCacheMatchesJdk() {
     String regex = "\\b.";
-    int flags = org.safere.Pattern.UNICODE_CHARACTER_CLASS;
+    int flags = Pattern.UNICODE_CHARACTER_CLASS;
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, flags);
     if (pattern == null) {
       return;
@@ -180,7 +179,7 @@ final class MatchFuzzer {
 
   private static void assertZeroWidthPossessiveCaptureRetentionJdk() {
     FuzzSupport.CompiledPattern pattern =
-        FuzzSupport.compileCompatibleOrSkip("(?m:^(\\B)*+$)", org.safere.Pattern.MULTILINE);
+        FuzzSupport.compileCompatibleOrSkip("(?m:^(\\B)*+$)", Pattern.MULTILINE);
     if (pattern == null) {
       return;
     }
@@ -207,7 +206,7 @@ final class MatchFuzzer {
   }
 
   private static void assertFullMatchesSafeRe(String regex, int flags, List<String> inputs) {
-    org.safere.Pattern pattern = org.safere.Pattern.compile(regex, flags);
+    Pattern pattern = Pattern.compile(regex, flags);
     for (String input : inputs) {
       if (!pattern.matcher(input).matches()) {
         throw new AssertionError(

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -8,6 +8,7 @@ package org.safere.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
+import org.safere.Pattern;
 
 final class ParserCompatibilityFuzzer {
 
@@ -146,7 +147,7 @@ final class ParserCompatibilityFuzzer {
     int flags = FuzzSupport.consumeParserFlags(data);
     String regex;
     if (data.consumeBoolean()) {
-      flags |= org.safere.Pattern.COMMENTS;
+      flags |= Pattern.COMMENTS;
       regex =
           data.pickValue(COMMENT_TERMINATED_PREFIXES) + data.pickValue(MALFORMED_GROUP_SUFFIXES);
     } else if (data.consumeBoolean()) {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
@@ -9,6 +9,8 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.ArrayList;
 import java.util.List;
+import org.safere.Matcher;
+import org.safere.Pattern;
 
 final class RegionBoundsFuzzer {
   private record GraphemeRegion(String input, int start, int end) {}
@@ -130,8 +132,8 @@ final class RegionBoundsFuzzer {
 
   private static void compareSafeReGraphemeModelCases() {
     for (SafeReModelCase testCase : SAFE_RE_GRAPHEME_MODEL_CASES) {
-      org.safere.Matcher matcher =
-          org.safere.Pattern.compile(testCase.regex())
+      Matcher matcher =
+          Pattern.compile(testCase.regex())
               .matcher(testCase.input())
               .region(testCase.start(), testCase.end());
       List<String> actual = new ArrayList<>();

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -8,6 +8,7 @@ package org.safere.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -255,7 +256,7 @@ final class Utf8InputFuzzer {
           .onUnmappableCharacter(CodingErrorAction.REPORT)
           .decode(ByteBuffer.wrap(bytes, offset, length));
       return true;
-    } catch (java.nio.charset.CharacterCodingException e) {
+    } catch (CharacterCodingException e) {
       return false;
     }
   }

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -22,6 +22,7 @@
     <workCounter.enabled>false</workCounter.enabled>
     <test.groups></test.groups>
     <test.excludedGroups>work-counter</test.excludedGroups>
+    <error-prone.extra-checks>-Xep:UnnecessarilyFullyQualified:ERROR</error-prone.extra-checks>
   </properties>
 
   <dependencyManagement>
@@ -134,7 +135,7 @@ final class WorkCounterConfig {
                 <!-- Continue compilation past type-checking errors so Error Prone can analyze
                      code that has downstream errors in later phases. -->
                 <arg>--should-stop=ifError=FLOW</arg>
-                <arg>-Xplugin:ErrorProne -XepCompilingTestOnlyCode ${error-prone.checks}</arg>
+                <arg>-Xplugin:ErrorProne -XepCompilingTestOnlyCode ${error-prone.checks} ${error-prone.extra-checks}</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -12,6 +12,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MutableCallSite;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
@@ -307,18 +309,16 @@ public final class Pattern implements Serializable {
     this.prefixUtf8 =
         startDescriptor.prefix() == null || startDescriptor.prefix().isEmpty()
             ? null
-            : startDescriptor.prefix().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            : startDescriptor.prefix().getBytes(StandardCharsets.UTF_8);
     this.anchoredPrefix = startDescriptor.anchoredPrefix();
     this.anchoredPrefixUtf8 =
         anchoredPrefix == null || anchoredPrefix.isEmpty()
             ? null
-            : anchoredPrefix.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            : anchoredPrefix.getBytes(StandardCharsets.UTF_8);
     this.matchDescriptor = matchDescriptor != null ? matchDescriptor : MatchDescriptor.NONE;
     String literalMatch = this.matchDescriptor.literalMatch();
     this.literalMatchUtf8 =
-        literalMatch == null
-            ? null
-            : literalMatch.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        literalMatch == null ? null : literalMatch.getBytes(StandardCharsets.UTF_8);
     this.literalMatchFailure = literalMatchUtf8 == null ? null : literalFailure(literalMatchUtf8);
     this.literalMatchShifts = literalMatchUtf8 == null ? null : literalShifts(literalMatchUtf8);
     this.hasLazy = hasLazy;
@@ -784,7 +784,7 @@ public final class Pattern implements Serializable {
       return null;
     }
     int[] shifts = new int[256];
-    java.util.Arrays.fill(shifts, literal.length);
+    Arrays.fill(shifts, literal.length);
     for (int index = 0; index < literal.length - 1; index++) {
       shifts[literal[index] & 0xFF] = literal.length - index - 1;
     }
@@ -2018,7 +2018,7 @@ public final class Pattern implements Serializable {
       this.minOffset = minOffset;
       this.maxOffset = maxOffset;
       this.discreteOffsets = discreteOffsets;
-      this.utf8 = literal.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      this.utf8 = literal.getBytes(StandardCharsets.UTF_8);
       this.failure = literalFailure(utf8);
       this.shifts = literalShifts(utf8);
     }
@@ -2351,7 +2351,7 @@ public final class Pattern implements Serializable {
       if (child.discreteWidths == null) {
         return new AsciiWidthRange(0, child.maxWidth, null);
       }
-      java.util.TreeSet<Integer> discrete = new java.util.TreeSet<>();
+      TreeSet<Integer> discrete = new TreeSet<>();
       discrete.add(0);
       for (int width : child.discreteWidths) {
         discrete.add(width);
@@ -2368,7 +2368,7 @@ public final class Pattern implements Serializable {
       }
       int minWidth = Integer.MAX_VALUE;
       int maxWidth = Integer.MIN_VALUE;
-      java.util.TreeSet<Integer> discrete = new java.util.TreeSet<>();
+      TreeSet<Integer> discrete = new TreeSet<>();
       boolean allDiscrete = true;
       for (AsciiWidthRange child : childArgs) {
         if (!child.isValid()) {
@@ -2417,7 +2417,7 @@ public final class Pattern implements Serializable {
     if (left.discreteWidths != null
         && right.discreteWidths != null
         && left.discreteWidths.length * right.discreteWidths.length <= 16) {
-      java.util.TreeSet<Integer> combined = new java.util.TreeSet<>();
+      TreeSet<Integer> combined = new TreeSet<>();
       for (int leftWidth : left.discreteWidths) {
         for (int rightWidth : right.discreteWidths) {
           int width = addWidth(leftWidth, rightWidth);

--- a/safere/src/test/java/org/safere/CrossEngineExhaustiveTest.java
+++ b/safere/src/test/java/org/safere/CrossEngineExhaustiveTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.DisplayName;
@@ -832,7 +833,7 @@ class CrossEngineExhaustiveTest {
           boolean jdkFound = jdkM.find();
 
           assertThat(safereFound)
-              .as("find() pat=%s bytes=%s", pat, java.util.Arrays.toString(bytes))
+              .as("find() pat=%s bytes=%s", pat, Arrays.toString(bytes))
               .isEqualTo(jdkFound);
 
           if (safereFound && jdkFound) {

--- a/safere/src/test/java/org/safere/ExhaustiveUtils.java
+++ b/safere/src/test/java/org/safere/ExhaustiveUtils.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayDeque;
@@ -150,7 +151,7 @@ final class ExhaustiveUtils {
     }
 
     Utf8Coordinates utf8Coordinates = Utf8Coordinates.forText(text);
-    byte[] utf8 = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] utf8 = text.getBytes(UTF_8);
 
     // Compare matches()
     tests++;
@@ -352,7 +353,7 @@ final class ExhaustiveUtils {
     }
 
     static Utf8Coordinates forText(String text) {
-      byte[] utf8 = text.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      byte[] utf8 = text.getBytes(UTF_8);
       int[] utf16ByUtf8Offset = new int[utf8.length + 1];
       Arrays.fill(utf16ByUtf8Offset, -1);
       int utf8Offset = 0;

--- a/safere/src/test/java/org/safere/MatcherFunctionalReplaceTest.java
+++ b/safere/src/test/java/org/safere/MatcherFunctionalReplaceTest.java
@@ -10,6 +10,8 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ConcurrentModificationException;
+import java.util.function.Function;
 import java.util.regex.MatchResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -100,7 +102,7 @@ class MatcherFunctionalReplaceTest {
   void replaceAllFunctionNullThrows() {
     Pattern p = Pattern.compile("x");
     Matcher m = p.matcher("x");
-    assertThatThrownBy(() -> m.replaceAll((java.util.function.Function<MatchResult, String>) null))
+    assertThatThrownBy(() -> m.replaceAll((Function<MatchResult, String>) null))
         .isInstanceOf(NullPointerException.class);
   }
 
@@ -109,8 +111,7 @@ class MatcherFunctionalReplaceTest {
   void replaceFirstFunctionNullThrows() {
     Pattern p = Pattern.compile("x");
     Matcher m = p.matcher("x");
-    assertThatThrownBy(
-            () -> m.replaceFirst((java.util.function.Function<MatchResult, String>) null))
+    assertThatThrownBy(() -> m.replaceFirst((Function<MatchResult, String>) null))
         .isInstanceOf(NullPointerException.class);
   }
 
@@ -130,7 +131,7 @@ class MatcherFunctionalReplaceTest {
                       m.find();
                       return "x";
                     }))
-        .isInstanceOf(java.util.ConcurrentModificationException.class);
+        .isInstanceOf(ConcurrentModificationException.class);
   }
 
   @Test
@@ -149,6 +150,6 @@ class MatcherFunctionalReplaceTest {
                       m.find();
                       return "x";
                     }))
-        .isInstanceOf(java.util.ConcurrentModificationException.class);
+        .isInstanceOf(ConcurrentModificationException.class);
   }
 }

--- a/safere/src/test/java/org/safere/MatcherResultsStreamTest.java
+++ b/safere/src/test/java/org/safere/MatcherResultsStreamTest.java
@@ -10,7 +10,10 @@ package org.safere;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ConcurrentModificationException;
+import java.util.List;
 import java.util.regex.MatchResult;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,8 +25,7 @@ class MatcherResultsStreamTest {
   void resultsStream() {
     Pattern p = Pattern.compile("\\d+");
     Matcher m = p.matcher("abc 123 def 456 ghi");
-    java.util.List<String> matches =
-        m.results().map(MatchResult::group).collect(java.util.stream.Collectors.toList());
+    List<String> matches = m.results().map(MatchResult::group).collect(Collectors.toList());
     assertThat(matches).containsExactly("123", "456");
   }
 
@@ -40,7 +42,7 @@ class MatcherResultsStreamTest {
   void resultsPositions() {
     Pattern p = Pattern.compile("[a-z]+");
     Matcher m = p.matcher("123 abc 456 def");
-    java.util.List<MatchResult> results = m.results().collect(java.util.stream.Collectors.toList());
+    List<MatchResult> results = m.results().collect(Collectors.toList());
     assertThat(results).hasSize(2);
     assertThat(results.get(0).start()).isEqualTo(4);
     assertThat(results.get(0).end()).isEqualTo(7);
@@ -65,7 +67,7 @@ class MatcherResultsStreamTest {
                           m.find();
                           return result.group();
                         })
-                    .collect(java.util.stream.Collectors.toList()))
-        .isInstanceOf(java.util.ConcurrentModificationException.class);
+                    .collect(Collectors.toList()))
+        .isInstanceOf(ConcurrentModificationException.class);
   }
 }

--- a/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
+++ b/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.MatchResult;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -235,7 +236,7 @@ class MatcherStateMachineTraceTest {
 
     void appendTail(StringBuilder builder);
 
-    java.util.stream.Stream<String> resultsWithMutation(Mutation mutation);
+    Stream<String> resultsWithMutation(Mutation mutation);
 
     String replaceAllWithMutation(Mutation mutation);
 
@@ -350,7 +351,7 @@ class MatcherStateMachineTraceTest {
     }
 
     @Override
-    public java.util.stream.Stream<String> resultsWithMutation(Mutation mutation) {
+    public Stream<String> resultsWithMutation(Mutation mutation) {
       return matcher
           .results()
           .map(
@@ -487,7 +488,7 @@ class MatcherStateMachineTraceTest {
     }
 
     @Override
-    public java.util.stream.Stream<String> resultsWithMutation(Mutation mutation) {
+    public Stream<String> resultsWithMutation(Mutation mutation) {
       return matcher
           .results()
           .map(

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -7,11 +7,13 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.regex.MatchResult;
@@ -1946,7 +1948,7 @@ class MatcherTest {
     void customCharSequenceWithoutToString() {
       // A CharSequence backed by a byte array that does NOT override toString().
       // This mimics Ghidra's ByteCharSequence pattern.
-      byte[] data = "hello world".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+      byte[] data = "hello world".getBytes(US_ASCII);
       CharSequence byteSeq =
           new CharSequence() {
             @Override
@@ -3131,7 +3133,7 @@ class MatcherTest {
     for (int i = 0; i < samples.length; i++) {
       samples[i] = runtimeNanos(task);
     }
-    java.util.Arrays.sort(samples);
+    Arrays.sort(samples);
     return samples[samples.length / 2];
   }
 

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -7,6 +7,7 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -388,14 +389,8 @@ class PatternInternalTest {
   @Test
   void endAnchoredSuffixRejectsUtf8Input() {
     Pattern p = Pattern.compile(".*\\.json$");
-    assertThat(
-            p.find(
-                Utf8Input.trusted("config.json".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-        .isTrue();
-    assertThat(
-            p.find(
-                Utf8Input.trusted("config.yaml".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-        .isFalse();
+    assertThat(p.find(Utf8Input.trusted("config.json".getBytes(UTF_8)))).isTrue();
+    assertThat(p.find(Utf8Input.trusted("config.yaml".getBytes(UTF_8)))).isFalse();
   }
 
   @Test

--- a/safere/src/test/java/org/safere/PatternSplitAsStreamTest.java
+++ b/safere/src/test/java/org/safere/PatternSplitAsStreamTest.java
@@ -9,6 +9,8 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -75,8 +77,7 @@ class PatternSplitAsStreamTest {
   @DisplayName("splitAsStream splits input around matches")
   void splitAsStreamBasic() {
     Pattern p = Pattern.compile(",");
-    java.util.List<String> parts =
-        p.splitAsStream("a,b,c").collect(java.util.stream.Collectors.toList());
+    List<String> parts = p.splitAsStream("a,b,c").collect(Collectors.toList());
     assertThat(parts).containsExactly("a", "b", "c");
   }
 
@@ -84,8 +85,7 @@ class PatternSplitAsStreamTest {
   @DisplayName("splitAsStream with no match returns entire input")
   void splitAsStreamNoMatch() {
     Pattern p = Pattern.compile(",");
-    java.util.List<String> parts =
-        p.splitAsStream("abc").collect(java.util.stream.Collectors.toList());
+    List<String> parts = p.splitAsStream("abc").collect(Collectors.toList());
     assertThat(parts).containsExactly("abc");
   }
 
@@ -93,8 +93,7 @@ class PatternSplitAsStreamTest {
   @DisplayName("splitAsStream with regex pattern")
   void splitAsStreamRegex() {
     Pattern p = Pattern.compile("\\s+");
-    java.util.List<String> parts =
-        p.splitAsStream("hello  world\tfoo").collect(java.util.stream.Collectors.toList());
+    List<String> parts = p.splitAsStream("hello  world\tfoo").collect(Collectors.toList());
     assertThat(parts).containsExactly("hello", "world", "foo");
   }
 
@@ -110,8 +109,7 @@ class PatternSplitAsStreamTest {
   @DisplayName("splitAsStream discards trailing empty strings")
   void splitAsStreamTrailingEmpty() {
     Pattern p = Pattern.compile(",");
-    java.util.List<String> parts =
-        p.splitAsStream("a,b,").collect(java.util.stream.Collectors.toList());
+    List<String> parts = p.splitAsStream("a,b,").collect(Collectors.toList());
     assertThat(parts).containsExactly("a", "b");
   }
 
@@ -119,9 +117,8 @@ class PatternSplitAsStreamTest {
   @DisplayName("splitAsStream reads custom CharSequence content via charAt()")
   void splitAsStreamCustomCharSequence() {
     Pattern p = Pattern.compile(",");
-    java.util.List<String> parts =
-        p.splitAsStream(new LiteralCharSequence("a,b,c"))
-            .collect(java.util.stream.Collectors.toList());
+    List<String> parts =
+        p.splitAsStream(new LiteralCharSequence("a,b,c")).collect(Collectors.toList());
     assertThat(parts).containsExactly("a", "b", "c");
   }
 
@@ -134,6 +131,6 @@ class PatternSplitAsStreamTest {
 
     input.set("x,y,z");
 
-    assertThat(stream.collect(java.util.stream.Collectors.toList())).containsExactly("x", "y", "z");
+    assertThat(stream.collect(Collectors.toList())).containsExactly("x", "y", "z");
   }
 }

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -7,6 +7,7 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1074,10 +1075,7 @@ class PatternTest {
       Matcher m = p.matcher("grapefruit orange peach plum lemon");
       assertThat(m.find()).isFalse();
 
-      Utf8Input input =
-          Utf8Input.trusted(
-              "grapefruit orange peach plum lemon"
-                  .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      Utf8Input input = Utf8Input.trusted("grapefruit orange peach plum lemon".getBytes(UTF_8));
       assertThat(p.find(input)).isFalse();
     }
 
@@ -1090,9 +1088,7 @@ class PatternTest {
       assertThat(m.group()).isEqualTo("grapefruit banana peach pineapple lemon");
 
       Utf8Input input =
-          Utf8Input.trusted(
-              "grapefruit banana peach pineapple lemon"
-                  .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+          Utf8Input.trusted("grapefruit banana peach pineapple lemon".getBytes(UTF_8));
       assertThat(p.find(input)).isTrue();
     }
 
@@ -1124,8 +1120,7 @@ class PatternTest {
     @DisplayName("supplementary literals are not subsumed by UTF-16 surrogate fragments")
     void supplementaryLiteralIsNotPrunedBySurrogateFragment() {
       Pattern p = Pattern.compile("(?:a\uD83D|za\uD83D\uDE00|banana)");
-      Utf8Input input =
-          Utf8Input.trusted("za\uD83D\uDE00".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      Utf8Input input = Utf8Input.trusted("za\uD83D\uDE00".getBytes(UTF_8));
 
       assertThat(p.find(input)).isTrue();
     }
@@ -1150,16 +1145,8 @@ class PatternTest {
       assertThat(p.matcher(".jso").matches()).isFalse();
 
       // Utf8Input
-      assertThat(
-              p.find(
-                  Utf8Input.trusted(
-                      "config.json".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-          .isTrue();
-      assertThat(
-              p.find(
-                  Utf8Input.trusted(
-                      "config.yaml".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-          .isFalse();
+      assertThat(p.find(Utf8Input.trusted("config.json".getBytes(UTF_8)))).isTrue();
+      assertThat(p.find(Utf8Input.trusted("config.yaml".getBytes(UTF_8)))).isFalse();
     }
 
     @Test
@@ -1176,16 +1163,8 @@ class PatternTest {
         assertThat(p.matcher("config.YAML").find()).isFalse();
 
         // Utf8Input
-        assertThat(
-                p.find(
-                    Utf8Input.trusted(
-                        "config.JSON".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isTrue();
-        assertThat(
-                p.find(
-                    Utf8Input.trusted(
-                        "config.YAML".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isFalse();
+        assertThat(p.find(Utf8Input.trusted("config.JSON".getBytes(UTF_8)))).isTrue();
+        assertThat(p.find(Utf8Input.trusted("config.YAML".getBytes(UTF_8)))).isFalse();
       }
     }
 
@@ -1199,17 +1178,10 @@ class PatternTest {
           String input = "config.json" + term;
           assertThat(p.matcher(input).find()).isTrue();
           assertThat(p.matcher(input).matches()).isFalse();
-          assertThat(
-                  p.find(
-                      Utf8Input.trusted(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-              .isTrue();
+          assertThat(p.find(Utf8Input.trusted(input.getBytes(UTF_8)))).isTrue();
         }
         assertThat(p.matcher("config.yaml\u0085").find()).isFalse();
-        assertThat(
-                p.find(
-                    Utf8Input.trusted(
-                        "config.yaml\u0085".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isFalse();
+        assertThat(p.find(Utf8Input.trusted("config.yaml\u0085".getBytes(UTF_8)))).isFalse();
       }
     }
 
@@ -1220,20 +1192,14 @@ class PatternTest {
 
       assertThat(p.matcher("config.json").find()).isTrue();
       assertThat(p.matcher("config.json").matches()).isTrue();
-      assertThat(
-              p.find(
-                  Utf8Input.trusted(
-                      "config.json".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-          .isTrue();
+      assertThat(p.find(Utf8Input.trusted("config.json".getBytes(UTF_8)))).isTrue();
 
       String[] terminators = {"\n", "\r\n", "\r", "\u0085", "\u2028", "\u2029"};
       for (String term : terminators) {
         String input = "config.json" + term;
         assertThat(p.matcher(input).find()).isFalse();
         assertThat(p.matcher(input).matches()).isFalse();
-        assertThat(
-                p.find(Utf8Input.trusted(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isFalse();
+        assertThat(p.find(Utf8Input.trusted(input.getBytes(UTF_8)))).isFalse();
       }
     }
 
@@ -1244,20 +1210,14 @@ class PatternTest {
 
       assertThat(p.matcher("config.json\n").find()).isTrue();
       assertThat(p.matcher("config.json\n").matches()).isFalse();
-      assertThat(
-              p.find(
-                  Utf8Input.trusted(
-                      "config.json\n".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-          .isTrue();
+      assertThat(p.find(Utf8Input.trusted("config.json\n".getBytes(UTF_8)))).isTrue();
 
       String[] nonUnixTerminators = {"\r", "\r\n", "\u0085", "\u2028", "\u2029"};
       for (String term : nonUnixTerminators) {
         String input = "config.json" + term;
         assertThat(p.matcher(input).find()).isFalse();
         assertThat(p.matcher(input).matches()).isFalse();
-        assertThat(
-                p.find(Utf8Input.trusted(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isFalse();
+        assertThat(p.find(Utf8Input.trusted(input.getBytes(UTF_8)))).isFalse();
       }
     }
 
@@ -1266,7 +1226,7 @@ class PatternTest {
     @DisplayName("end anchors recognize every final line terminator")
     void endAnchorsRecognizeEveryFinalLineTerminator(String terminator) {
       String input = "config.json" + terminator;
-      Utf8Input utf8 = Utf8Input.trusted(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      Utf8Input utf8 = Utf8Input.trusted(input.getBytes(UTF_8));
 
       for (String anchor : List.of("$", "\\Z")) {
         Pattern suffix = Pattern.compile(".*\\.json" + anchor);
@@ -1275,10 +1235,7 @@ class PatternTest {
         assertThat(suffix.matcher(input).find()).isTrue();
         assertThat(suffix.find(utf8)).isTrue();
         assertThat(characterClass.matcher("item3" + terminator).find()).isTrue();
-        assertThat(
-                characterClass.find(
-                    Utf8Input.trusted(
-                        ("item3" + terminator).getBytes(java.nio.charset.StandardCharsets.UTF_8))))
+        assertThat(characterClass.find(Utf8Input.trusted(("item3" + terminator).getBytes(UTF_8))))
             .isTrue();
       }
     }
@@ -1288,7 +1245,7 @@ class PatternTest {
     @DisplayName("UNIX_LINES restricts final line terminators to newline")
     void unixLinesRestrictsFinalLineTerminatorsToNewline(String terminator) {
       String input = "config.json" + terminator;
-      Utf8Input utf8 = Utf8Input.trusted(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      Utf8Input utf8 = Utf8Input.trusted(input.getBytes(UTF_8));
 
       for (String anchor : List.of("$", "\\Z")) {
         Pattern suffix = Pattern.compile(".*\\.json" + anchor, Pattern.UNIX_LINES);
@@ -1312,10 +1269,7 @@ class PatternTest {
           String input = "item123" + term;
           assertThat(p.matcher(input).find()).isTrue();
           assertThat(p.matcher(input).matches()).isFalse();
-          assertThat(
-                  p.find(
-                      Utf8Input.trusted(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-              .isTrue();
+          assertThat(p.find(Utf8Input.trusted(input.getBytes(UTF_8)))).isTrue();
         }
 
         assertThat(p.matcher("item123abc").find()).isFalse();
@@ -1328,15 +1282,8 @@ class PatternTest {
         assertThat(p.matcher("\u0085").find()).isFalse();
 
         // Utf8Input
-        assertThat(
-                p.find(
-                    Utf8Input.trusted("item123".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isTrue();
-        assertThat(
-                p.find(
-                    Utf8Input.trusted(
-                        "item123abc".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
-            .isFalse();
+        assertThat(p.find(Utf8Input.trusted("item123".getBytes(UTF_8)))).isTrue();
+        assertThat(p.find(Utf8Input.trusted("item123abc".getBytes(UTF_8)))).isFalse();
       }
     }
 
@@ -1388,10 +1335,9 @@ class PatternTest {
       assertThat(p.matcher("prefix https://example.com").find()).isFalse();
 
       // Utf8Input
-      byte[] matchUtf8 = "https://example.com".getBytes(java.nio.charset.StandardCharsets.UTF_8);
-      byte[] noMatchUtf8 = "http://example.com".getBytes(java.nio.charset.StandardCharsets.UTF_8);
-      byte[] lateMatchUtf8 =
-          "prefix https://example.com".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      byte[] matchUtf8 = "https://example.com".getBytes(UTF_8);
+      byte[] noMatchUtf8 = "http://example.com".getBytes(UTF_8);
+      byte[] lateMatchUtf8 = "prefix https://example.com".getBytes(UTF_8);
 
       assertThat(p.find(Utf8Input.trusted(matchUtf8))).isTrue();
       assertThat(p.find(Utf8Input.trusted(noMatchUtf8))).isFalse();
@@ -1416,8 +1362,8 @@ class PatternTest {
       assertThat(p.matcher("").lookingAt()).isFalse();
 
       // Utf8Input
-      byte[] matchUtf8 = "123abc".getBytes(java.nio.charset.StandardCharsets.UTF_8);
-      byte[] noMatchUtf8 = "abc123".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      byte[] matchUtf8 = "123abc".getBytes(UTF_8);
+      byte[] noMatchUtf8 = "abc123".getBytes(UTF_8);
 
       assertThat(p.find(Utf8Input.trusted(matchUtf8))).isTrue();
       assertThat(p.find(Utf8Input.trusted(noMatchUtf8))).isFalse();

--- a/safere/src/test/java/org/safere/QuantifiedCaptureSemanticsTest.java
+++ b/safere/src/test/java/org/safere/QuantifiedCaptureSemanticsTest.java
@@ -366,7 +366,7 @@ class QuantifiedCaptureSemanticsTest {
   }
 
   private static void assertMatchResultMatchesJdk(
-      GeneratedCase testCase, java.util.regex.MatchResult jdk, MatchResult safere) {
+      GeneratedCase testCase, MatchResult jdk, MatchResult safere) {
     assertThat(safere.groupCount()).isEqualTo(jdk.groupCount());
     for (int group = 0; group <= jdk.groupCount(); group++) {
       assertThat(safere.group(group))

--- a/safere/src/test/java/org/safere/RE2ByteSearchTest.java
+++ b/safere/src/test/java/org/safere/RE2ByteSearchTest.java
@@ -13,10 +13,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -266,7 +268,7 @@ class RE2ByteSearchTest {
     if (found && tc.expectedFindGroup() != null) {
       // Test caller-owned zero-copy group slicing from byte bounds.
       byte[] expectedBytes = tc.expectedFindGroup().getBytes(StandardCharsets.UTF_8);
-      assertThat(java.util.Arrays.copyOfRange(bytes, m.start(), m.end()))
+      assertThat(Arrays.copyOfRange(bytes, m.start(), m.end()))
           .as(
               "find() bounds for pattern \"%s\" on byte representation of \"%s\"",
               tc.pattern(), tc.text())
@@ -274,7 +276,7 @@ class RE2ByteSearchTest {
     }
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testWordBoundaryDiscrepancy() {
     Pattern p = Pattern.compile("(?:(?:(?:\\b).)*)");
     byte[] bytes = "aa ".getBytes(StandardCharsets.UTF_8);
@@ -286,7 +288,7 @@ class RE2ByteSearchTest {
     assertThat(matches).containsExactly("[0,1)", "[1,1)", "[2,3)", "[3,3)");
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testWordBoundaryDiscrepancyString() {
     Pattern p = Pattern.compile("(?:(?:(?:\\b).)*)");
     Matcher m = p.matcher("aa ");
@@ -297,7 +299,7 @@ class RE2ByteSearchTest {
     assertThat(matches).containsExactly("[0,1)", "[1,1)", "[2,3)", "[3,3)");
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testDollarNewlineDiscrepancy() {
     Pattern p = Pattern.compile("(?:(?:(?:$)\n))$");
     byte[] bytes =
@@ -309,7 +311,7 @@ class RE2ByteSearchTest {
     assertThat(m.end()).isEqualTo(263);
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testDollarNewlineDiscrepancyString() {
     Pattern p = Pattern.compile("(?:(?:(?:$)\n))$");
     String text =
@@ -320,7 +322,7 @@ class RE2ByteSearchTest {
     assertThat(m.end()).isEqualTo(263);
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testUnixLinesDollarTrailingCr() {
     Pattern p = Pattern.compile("a$", Pattern.UNIX_LINES);
     byte[] bytes = "a\r".getBytes(StandardCharsets.UTF_8);
@@ -328,23 +330,23 @@ class RE2ByteSearchTest {
     assertThat(m.find()).isFalse();
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testGraphemePatternByteMode() {
     Pattern p = Pattern.compile("a\\X");
     byte[] bytes = "ab".getBytes(StandardCharsets.UTF_8);
     Utf8Matcher m = p.matcher(Utf8Input.validated(bytes));
-    org.junit.jupiter.api.Assertions.assertTrue(m.find());
-    org.junit.jupiter.api.Assertions.assertEquals(0, m.start());
-    org.junit.jupiter.api.Assertions.assertEquals(2, m.end());
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(0);
+    assertThat(m.end()).isEqualTo(2);
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void testUnicodeWordBoundaryByteMode() {
     Pattern p = Pattern.compile("\\ba", Pattern.UNICODE_CHARACTER_CLASS);
     byte[] bytes = "ab".getBytes(StandardCharsets.UTF_8);
     Utf8Matcher m = p.matcher(Utf8Input.validated(bytes));
-    org.junit.jupiter.api.Assertions.assertTrue(m.find());
-    org.junit.jupiter.api.Assertions.assertEquals(0, m.start());
-    org.junit.jupiter.api.Assertions.assertEquals(1, m.end());
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(0);
+    assertThat(m.end()).isEqualTo(1);
   }
 }

--- a/safere/src/test/java/org/safere/RandomTest.java
+++ b/safere/src/test/java/org/safere/RandomTest.java
@@ -111,7 +111,7 @@ class RandomTest {
       }
       try {
         jdkPattern = java.util.regex.Pattern.compile(pattern);
-      } catch (java.util.regex.PatternSyntaxException e) {
+      } catch (PatternSyntaxException e) {
         skipped++;
         continue;
       }

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -617,7 +618,7 @@ class Utf8InputScannerTest {
   }
 
   private static List<Integer> traceForward(Utf8InputScanner scanner) {
-    java.util.ArrayList<Integer> result = new java.util.ArrayList<>();
+    ArrayList<Integer> result = new ArrayList<>();
     int position = 0;
     while (position < scanner.length()) {
       long decoded = scanner.decodeForward(position);
@@ -628,7 +629,7 @@ class Utf8InputScannerTest {
   }
 
   private static List<Integer> traceBackward(Utf8InputScanner scanner) {
-    java.util.ArrayList<Integer> result = new java.util.ArrayList<>();
+    ArrayList<Integer> result = new ArrayList<>();
     int position = scanner.length();
     while (position > 0) {
       long decoded = scanner.decodeBackward(position);

--- a/safere/src/test/java/org/safere/Utf8LinearTimeTest.java
+++ b/safere/src/test/java/org/safere/Utf8LinearTimeTest.java
@@ -8,6 +8,7 @@ package org.safere;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -96,12 +97,12 @@ class Utf8LinearTimeTest {
   }
 
   private static byte[] validInput(int scalars) {
-    return "aé😀".repeat(scalars / 3).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    return "aé😀".repeat(scalars / 3).getBytes(UTF_8);
   }
 
   private static byte[] malformedInput(int bytes) {
     byte[] input = new byte[bytes];
-    java.util.Arrays.fill(input, (byte) 0x80);
+    Arrays.fill(input, (byte) 0x80);
     return input;
   }
 }


### PR DESCRIPTION
And enable https://errorprone.info/bugpattern/UnnecessarilyFullyQualified for the safere module

I left is disabled for other submodules, since the readability of the main module is more important, and some of the other code is doing things like comparing different regex engines where there are multiple versions of `Matcher` and `Pattern` and using fully qualified names is more deliberate.