### PR TITLE
Implement MatchResult.hasMatch() on Matcher and SnapshotMatchResult

### DIFF
--- a/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
+++ b/safere-crosscheck/src/main/java/org/safere/crosscheck/Matcher.java
@@ -221,6 +221,15 @@ public final class Matcher implements MatchResult {
     return sr;
   }
 
+  /** Returns whether this matcher has a match. */
+  @Override
+  public boolean hasMatch() {
+    boolean sr = safereMatcher.hasMatch();
+    boolean jr = jdkMatcher.hasMatch();
+    checkBoolean("hasMatch", "", sr, jr);
+    return sr;
+  }
+
   // ---------------------------------------------------------------------------
   // Replacement
   // ---------------------------------------------------------------------------

--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/CrosscheckTest.java
@@ -618,6 +618,19 @@ class CrosscheckTest {
     }
 
     @Test
+    @DisplayName("hasMatch() crosschecks matcher lifecycle state")
+    void hasMatch() {
+      Matcher m = Pattern.compile("abc").matcher("abc");
+      assertThat(m.hasMatch()).isFalse();
+      assertThat(m.find()).isTrue();
+      assertThat(m.hasMatch()).isTrue();
+      m.usePattern(Pattern.compile("xyz"));
+      assertThat(m.hasMatch()).isTrue();
+      m.reset();
+      assertThat(m.hasMatch()).isFalse();
+    }
+
+    @Test
     @DisplayName("namedGroups() returns group mapping")
     void namedGroupsMap() {
       Pattern p = Pattern.compile("(?<year>\\d{4})-(?<month>\\d{2})");

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -92,26 +92,29 @@ final class FindSequenceFuzzer {
     }
 
     FuzzSupport.MatcherPair matcher = pattern.matcher(input);
-    boolean hasMatch = false;
+    boolean canReadGroups = false;
     int steps = data.consumeInt(1, 32);
     for (int i = 0; i < steps; i++) {
-      switch (data.consumeInt(0, 9)) {
-        case 0 -> hasMatch = matcher.matches();
-        case 1 -> hasMatch = matcher.lookingAt();
-        case 2 -> hasMatch = matcher.find();
-        case 3 -> hasMatch = matcher.find(FuzzSupport.consumeIndex(data, input));
+      switch (data.consumeInt(0, 10)) {
+        case 0 -> canReadGroups = matcher.matches();
+        case 1 -> canReadGroups = matcher.lookingAt();
+        case 2 -> canReadGroups = matcher.find();
+        case 3 -> canReadGroups = matcher.find(FuzzSupport.consumeIndex(data, input));
         case 4 -> {
           matcher.reset();
-          hasMatch = false;
+          canReadGroups = false;
         }
         case 5 -> {
           input = data.consumeString(2048);
           matcher.reset(input);
-          hasMatch = false;
+          canReadGroups = false;
         }
         case 6 -> matcher.groupCount();
         case 7 -> {
-          if (hasMatch) {
+          if (canReadGroups) {
+            matcher.group();
+            matcher.start();
+            matcher.end();
             int group = data.consumeInt(0, matcher.groupCount());
             matcher.group(group);
             matcher.start(group);
@@ -121,12 +124,13 @@ final class FindSequenceFuzzer {
         case 8 -> {
           int[] region = FuzzSupport.consumeRegion(data, input);
           matcher.region(region[0], region[1]);
-          hasMatch = false;
+          canReadGroups = false;
         }
         case 9 -> {
           matcher.useAnchoringBounds(data.consumeBoolean());
           matcher.useTransparentBounds(data.consumeBoolean());
         }
+        case 10 -> matcher.hasMatch();
         default -> throw new AssertionError();
       }
     }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -297,10 +297,24 @@ final class FuzzSupport {
       return this;
     }
 
+    boolean hasMatch() {
+      boolean safeRe = safeReMatcher.hasMatch();
+      boolean jdk = runJdkOracle("hasMatch", safeRe, () -> jdkMatcher.hasMatch());
+      assertSame("hasMatch", safeRe, jdk);
+      return safeRe;
+    }
+
     int groupCount() {
       int safeRe = safeReMatcher.groupCount();
       int jdk = runJdkOracle("groupCount", safeRe, () -> jdkMatcher.groupCount());
       assertSame("groupCount", safeRe, jdk);
+      return safeRe;
+    }
+
+    String group() {
+      String safeRe = safeReMatcher.group();
+      String jdk = runJdkOracle("group", safeRe, () -> jdkMatcher.group());
+      assertSame("group", safeRe, jdk);
       return safeRe;
     }
 
@@ -318,6 +332,13 @@ final class FuzzSupport {
       return safeRe;
     }
 
+    int start() {
+      int safeRe = safeReMatcher.start();
+      int jdk = runJdkOracle("start", safeRe, () -> jdkMatcher.start());
+      assertSame("start", safeRe, jdk);
+      return safeRe;
+    }
+
     int start(int group) {
       int safeRe = safeReMatcher.start(group);
       int jdk = runJdkOracle("start(" + group + ")", safeRe, () -> jdkMatcher.start(group));
@@ -329,6 +350,13 @@ final class FuzzSupport {
       int safeRe = safeReMatcher.start(name);
       int jdk = runJdkOracle("start(" + name + ")", safeRe, () -> jdkMatcher.start(name));
       assertSame("start(" + name + ")", safeRe, jdk);
+      return safeRe;
+    }
+
+    int end() {
+      int safeRe = safeReMatcher.end();
+      int jdk = runJdkOracle("end", safeRe, () -> jdkMatcher.end());
+      assertSame("end", safeRe, jdk);
       return safeRe;
     }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2530,6 +2530,17 @@ public final class Matcher implements MatchResult {
   }
 
   /**
+   * Returns {@code true} if this matcher has a match.
+   *
+   * @return {@code true} if this matcher has a match, {@code false} otherwise
+   * @since 20
+   */
+  @Override
+  public boolean hasMatch() {
+    return hasMatch;
+  }
+
+  /**
    * Returns the offset after the last character of the subsequence captured by the given named
    * group.
    *
@@ -3818,6 +3829,11 @@ public final class Matcher implements MatchResult {
       this.groupCount = groupCount;
       this.namedGroups = Collections.unmodifiableMap(namedGroups);
       this.hasMatch = hasMatch;
+    }
+
+    @Override
+    public boolean hasMatch() {
+      return hasMatch;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -3556,15 +3556,24 @@ public final class Matcher implements MatchResult {
       if (!groupZeroResolved) {
         resolveCaptures();
       }
-      searchFrom = groups[1];
-      if (groups[0] == groups[1] && searchFrom < regionEnd) {
+      int prevStart = groups[0];
+      int prevEnd = groups[1];
+      searchFrom = prevEnd;
+      if (prevStart == prevEnd && searchFrom < regionEnd) {
         searchFrom++;
       }
+      this.parentPattern = newPattern;
+      this.groups = new int[2 * newPattern.prog().numCaptures()];
+      Arrays.fill(this.groups, -1);
+      this.groups[0] = prevStart;
+      this.groups[1] = prevEnd;
+      clearDeferredCaptureState();
+    } else {
+      this.parentPattern = newPattern;
+      this.groups = new int[2 * newPattern.prog().numCaptures()];
+      clearCurrentResult();
     }
-    this.parentPattern = newPattern;
-    this.groups = new int[2 * newPattern.prog().numCaptures()];
     invalidatePatternCaches();
-    clearCurrentResult();
     eagerFallbackCaptures = false;
     return this;
   }

--- a/safere/src/main/java/org/safere/MatcherTransitionInventory.java
+++ b/safere/src/main/java/org/safere/MatcherTransitionInventory.java
@@ -219,6 +219,7 @@ final class MatcherTransitionInventory {
           observer(signature("hasTransparentBounds")),
           boundsChange(signature("useAnchoringBounds", boolean.class)),
           observer(signature("hasAnchoringBounds")),
+          observer(signature("hasMatch")),
           transition(
               signature("toMatchResult"),
               ResultEffect.REQUIRES_MATCH,

--- a/safere/src/main/java/org/safere/MatcherTransitionInventory.java
+++ b/safere/src/main/java/org/safere/MatcherTransitionInventory.java
@@ -208,7 +208,7 @@ final class MatcherTransitionInventory {
           observer(signature("toString")),
           transition(
               signature("usePattern", Pattern.class),
-              ResultEffect.RESET_NO_ATTEMPT,
+              ResultEffect.PRESERVE,
               DeferredCaptureEffect.CLEAR,
               CursorEffect.DERIVE_FROM_PREVIOUS_RESULT_THEN_SEARCH,
               ReplacementEffect.PRESERVE,

--- a/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
+++ b/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
@@ -71,7 +71,8 @@ class MatcherDeferredCaptureStateTest {
     matcher.usePattern(Pattern.compile("name"));
 
     assertDeferredCaptureStateClear(matcher);
-    assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+    assertThat(matcher.hasMatch()).isTrue();
+    assertThat(matcher.group()).isEqualTo("id");
   }
 
   @Test

--- a/safere/src/test/java/org/safere/MatcherResultsStreamTest.java
+++ b/safere/src/test/java/org/safere/MatcherResultsStreamTest.java
@@ -44,8 +44,10 @@ class MatcherResultsStreamTest {
     assertThat(results).hasSize(2);
     assertThat(results.get(0).start()).isEqualTo(4);
     assertThat(results.get(0).end()).isEqualTo(7);
+    assertThat(results.get(0).hasMatch()).isTrue();
     assertThat(results.get(1).start()).isEqualTo(12);
     assertThat(results.get(1).end()).isEqualTo(15);
+    assertThat(results.get(1).hasMatch()).isTrue();
   }
 
   @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -2004,7 +2004,9 @@ class MatcherTest {
       Pattern p = Pattern.compile("(\\d+)");
       Matcher m = p.matcher("a1b2");
       m.find();
+      assertThat(m.hasMatch()).isTrue();
       MatchResult r = m.toMatchResult();
+      assertThat(r.hasMatch()).isTrue();
       assertThat(r.group()).isEqualTo("1");
       assertThat(r.group(1)).isEqualTo("1");
       assertThat(r.start()).isEqualTo(1);
@@ -2014,6 +2016,11 @@ class MatcherTest {
       m.find();
       assertThat(m.group()).isEqualTo("2");
       assertThat(r.group()).isEqualTo("1");
+      assertThat(r.hasMatch()).isTrue();
+      // Reset matcher; snapshot remains unaffected.
+      m.reset();
+      assertThat(m.hasMatch()).isFalse();
+      assertThat(r.hasMatch()).isTrue();
     }
 
     @Test
@@ -2022,7 +2029,9 @@ class MatcherTest {
       Pattern p = Pattern.compile("(?<letter>x)(y)?");
       Matcher m = p.matcher("abc");
 
+      assertThat(m.hasMatch()).isFalse();
       MatchResult result = m.toMatchResult();
+      assertThat(result.hasMatch()).isFalse();
 
       assertThat(result.groupCount()).isEqualTo(2);
       assertThat(result.namedGroups()).containsEntry("letter", 1);
@@ -2040,8 +2049,10 @@ class MatcherTest {
       Pattern p = Pattern.compile("x");
       Matcher m = p.matcher("abc");
       assertThat(m.find()).isFalse();
+      assertThat(m.hasMatch()).isFalse();
 
       MatchResult result = m.toMatchResult();
+      assertThat(result.hasMatch()).isFalse();
 
       assertThat(result.groupCount()).isZero();
       assertThatThrownBy(result::start).isInstanceOf(IllegalStateException.class);
@@ -2053,11 +2064,75 @@ class MatcherTest {
       Pattern p = Pattern.compile("(a)|(b)");
       Matcher m = p.matcher("a");
       assertThat(m.matches()).isTrue();
+      assertThat(m.hasMatch()).isTrue();
       MatchResult mr = m.toMatchResult();
+      assertThat(mr.hasMatch()).isTrue();
       assertThat(mr.group(1)).isEqualTo("a");
       assertThat(mr.group(2)).isNull();
       assertThat(mr.start(2)).isEqualTo(-1);
       assertThat(mr.end(2)).isEqualTo(-1);
+    }
+
+    @Nested
+    @DisplayName("hasMatch() lifecycle & contract tests")
+    class HasMatchTests {
+
+      @Test
+      @DisplayName("hasMatch() on fresh matcher returns false")
+      void freshMatcherHasMatchIsFalse() {
+        Pattern p = Pattern.compile("abc");
+        Matcher m = p.matcher("abcdef");
+        assertThat(m.hasMatch()).isFalse();
+      }
+
+      @Test
+      @DisplayName("hasMatch() reflects find() success and failure")
+      void findHasMatch() {
+        Pattern p = Pattern.compile("\\d+");
+        Matcher m = p.matcher("abc123def");
+        assertThat(m.hasMatch()).isFalse();
+
+        assertThat(m.find()).isTrue();
+        assertThat(m.hasMatch()).isTrue();
+
+        assertThat(m.find()).isFalse();
+        assertThat(m.hasMatch()).isFalse();
+      }
+
+      @Test
+      @DisplayName("hasMatch() reflects matches() and lookingAt() success and failure")
+      void matchesAndLookingAtHasMatch() {
+        Pattern p = Pattern.compile("abc");
+        Matcher m = p.matcher("abcdef");
+
+        assertThat(m.matches()).isFalse();
+        assertThat(m.hasMatch()).isFalse();
+
+        assertThat(m.lookingAt()).isTrue();
+        assertThat(m.hasMatch()).isTrue();
+      }
+
+      @Test
+      @DisplayName("hasMatch() resets to false on reset() and usePattern()")
+      void resetAndUsePatternHasMatch() {
+        Pattern p1 = Pattern.compile("abc");
+        Pattern p2 = Pattern.compile("xyz");
+        Matcher m = p1.matcher("abc");
+
+        assertThat(m.find()).isTrue();
+        assertThat(m.hasMatch()).isTrue();
+
+        m.usePattern(p2);
+        assertThat(m.hasMatch()).isFalse();
+
+        m.reset("xyz");
+        assertThat(m.hasMatch()).isFalse();
+        assertThat(m.find()).isTrue();
+        assertThat(m.hasMatch()).isTrue();
+
+        m.reset();
+        assertThat(m.hasMatch()).isFalse();
+      }
     }
 
     @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -2115,7 +2115,7 @@ class MatcherTest {
       }
 
       @Test
-      @DisplayName("hasMatch() resets to false on reset() and usePattern()")
+      @DisplayName("hasMatch() survives usePattern() and resets to false on reset()")
       void resetAndUsePatternHasMatch() {
         Pattern p1 = Pattern.compile("abc");
         Pattern p2 = Pattern.compile("xyz");

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -2123,7 +2123,7 @@ class MatcherTest {
         assertThat(m.hasMatch()).isTrue();
 
         m.usePattern(p2);
-        assertThat(m.hasMatch()).isFalse();
+        assertThat(m.hasMatch()).isTrue();
 
         m.reset("xyz");
         assertThat(m.hasMatch()).isFalse();

--- a/safere/src/test/java/org/safere/MatcherUsePatternTest.java
+++ b/safere/src/test/java/org/safere/MatcherUsePatternTest.java
@@ -69,4 +69,23 @@ class MatcherUsePatternTest {
     m.usePattern(p2);
     assertThat(m.pattern()).isSameAs(p2);
   }
+
+  @Test
+  @DisplayName("usePattern preserves match state and groupCount")
+  void usePatternPreservesMatchState() {
+    Pattern p1 = Pattern.compile("(a)(b)");
+    Pattern p2 = Pattern.compile("(x)(y)(z)");
+    Matcher m = p1.matcher("ab");
+    assertThat(m.find()).isTrue();
+    assertThat(m.hasMatch()).isTrue();
+    assertThat(m.group()).isEqualTo("ab");
+    assertThat(m.start()).isEqualTo(0);
+    assertThat(m.end()).isEqualTo(2);
+    assertThat(m.group(1)).isEqualTo("a");
+    assertThat(m.group(2)).isEqualTo("b");
+
+    m.usePattern(p2);
+    assertThat(m.hasMatch()).isTrue();
+    assertThat(m.groupCount()).isEqualTo(3);
+  }
 }


### PR DESCRIPTION
This adds a missing implementation of https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/regex/Matcher.html#hasMatch()