### PR TITLE
Fix UTF-8 code-point boundary stepping in unanchored grapheme NFA search

### DIFF
--- a/safere-crosscheck/src/test/java/org/safere/crosscheck/Utf8CrosscheckTest.java
+++ b/safere-crosscheck/src/test/java/org/safere/crosscheck/Utf8CrosscheckTest.java
@@ -127,6 +127,12 @@ class Utf8CrosscheckTest {
     Pattern.compile("a").find(malformed);
   }
 
+  @Test
+  void graphemeClusterPatternDoesNotSplitUtf8MultibyteCodePointInUnanchoredFind() {
+    Utf8Matcher matcher = Pattern.compile(".\\X| /0? ?5-").matcher(input("\u1e99| 5  \u8ed6"));
+    while (matcher.find()) {}
+  }
+
   private static Utf8Input input(String text) {
     return Utf8Input.validated(text.getBytes(UTF_8));
   }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -32,6 +32,7 @@ final class Utf8InputFuzzer {
     assertMultiOffsetLiteralOccurrencesMatchString(data);
     assertFinalLineTerminatorEndAnchorsMatchJdk(data);
     assertPositionDependentStartAccelerationMatchesJdk(data);
+    assertGraphemeSearchMatchesString(data);
     String repeatedLiteral =
         String.valueOf((char) data.consumeInt('A', 'Z')).repeat(data.consumeInt(2, 32));
     String suffix = new String(data.consumeBytes(data.consumeInt(0, 64)), StandardCharsets.UTF_8);
@@ -154,6 +155,33 @@ final class Utf8InputFuzzer {
       Utf8Input utf8 = Utf8Input.validated(input.getBytes(StandardCharsets.UTF_8));
       if (pattern.matcher(input).find() != expected || pattern.find(utf8) != expected) {
         throw new AssertionError("DFA-loop start acceleration differs from JDK anchor semantics");
+      }
+    }
+  }
+
+  private static void assertGraphemeSearchMatchesString(FuzzedDataProvider data) {
+    String regex = data.pickValue(List.of(".\\X|z", "(?:.\\X)|z", ".\\X| /0? ?5-", "(?:a|.)\\X|z"));
+    String input =
+        data.pickValue(List.of("é", "軖", "😀", "a\u0301", "👩‍💻", "🇺🇸"))
+            + data.pickValue(List.of("", "| 5  軖", "z", " β"));
+    Pattern pattern = Pattern.compile(regex);
+    org.safere.Matcher stringMatcher = pattern.matcher(input);
+    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+    Utf8Matcher utf8Matcher = pattern.matcher(Utf8Input.validated(bytes));
+
+    while (true) {
+      boolean stringFound = stringMatcher.find();
+      boolean utf8Found = utf8Matcher.find();
+      if (utf8Found != stringFound) {
+        throw new AssertionError("UTF-8 grapheme search result differs from String search");
+      }
+      if (!stringFound) {
+        return;
+      }
+      if (utf8Matcher.start() != utf8Offset(input, stringMatcher.start())
+          || utf8Matcher.end() != utf8Offset(input, stringMatcher.end())
+          || !Objects.equals(stringMatcher.group(), decodeGroup(bytes, utf8Matcher))) {
+        throw new AssertionError("UTF-8 grapheme search bounds differ from String search");
       }
     }
   }

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -679,7 +679,9 @@ final class Nfa {
     int[] initialCap = new int[threadArraySize];
 
     int engineEndPos = context.engineEndPos();
-    for (int pos = start; pos < engineEndPos + 2; pos++) {
+    boolean isUtf8 = text instanceof Utf8InputScanner;
+    int pos = start;
+    while (pos < engineEndPos + 2) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
       }
@@ -694,13 +696,21 @@ final class Nfa {
         addToThreadq(runq, prog.start(), text, pos, initialCap, false);
       }
 
+      int nextBoundaryPos;
       if (!runq.isEmpty()) {
         long stepResult = inputStep(text, pos);
         int cp = (int) (stepResult >>> 32);
         int nextPos = (int) stepResult;
         step(runq, delayedBuffer, delayedGrapheme, cp, text, pos, nextPos);
+        nextBoundaryPos = nextPos;
       } else {
         freeQueue(runq);
+        if (isUtf8 && pos < engineEndPos) {
+          long decoded = text.decodeForward(pos);
+          nextBoundaryPos = Math.max(pos + 1, InputScanner.position(decoded));
+        } else {
+          nextBoundaryPos = pos + 1;
+        }
       }
       if (matched
           && runq.isEmpty()
@@ -708,6 +718,11 @@ final class Nfa {
               ? delayedGrapheme.isEmpty()
               : isDelayedBufferEmpty(delayedBuffer))) {
         break;
+      }
+      if (isUtf8 && pos < engineEndPos) {
+        pos = nextBoundaryPos;
+      } else {
+        pos++;
       }
     }
 

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -366,6 +366,27 @@ class Utf8MatcherStateMachineTest {
   }
 
   @Test
+  void graphemePatternDoesNotSplitMultibyteCodePointInUnanchoredFind() {
+    String input = "\u1e99| 5  \u8ed6";
+    Utf8Matcher utf8Matcher =
+        Pattern.compile(".\\X| /0? ?5-").matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+    List<List<Integer>> actualMatches = new ArrayList<>();
+    while (utf8Matcher.find()) {
+      actualMatches.add(List.of(utf8Matcher.start(), utf8Matcher.end()));
+    }
+
+    Matcher stringMatcher = Pattern.compile(".\\X| /0? ?5-").matcher(input);
+    List<List<Integer>> expectedMatches = new ArrayList<>();
+    while (stringMatcher.find()) {
+      expectedMatches.add(
+          List.of(
+              utf8Offset(input, stringMatcher.start()), utf8Offset(input, stringMatcher.end())));
+    }
+
+    assertThat(actualMatches).isEqualTo(expectedMatches);
+  }
+
+  @Test
   void graphemePatternsWorkAcrossUtf8Scalars() {
     for (String input : List.of("a\r\nb", "a\u0301b", "👩‍💻x", "🇺🇸x")) {
       assertGraphemePatternsWorkAcrossUtf8Scalars(input);


### PR DESCRIPTION
This fixes a crosscheck divergence caught by fuzzing.

For patterns with grapheme semantics, `doSearchEveryCharPosition` previously stepped byte-by-byte. On multi-byte UTF-8 sequences, this caused candidate match attempts to start inside code points.

This fix ensures stepping advances across code-point boundaries.