### PR TITLE
Optimize pattern compilation and memory allocation

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -115,6 +115,7 @@
                         <exclude name="GraphemeLinearTimeTest.java"/>
                         <exclude name="InstOpTest.java"/>
                         <exclude name="InstTest.java"/>
+                        <exclude name="IntArrayListTest.java"/>
                         <exclude name="InputScannerTest.java"/>
                         <exclude name="MatcherDeferredCaptureStateTest.java"/>
                         <exclude name="MatcherTransitionInventoryTest.java"/>

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -657,19 +657,27 @@ final class Compiler extends Walker<Compiler.Frag> {
    * ("patched") to point to the next instruction. The list is threaded through the unused out/out1
    * fields of the instructions themselves.
    *
-   * <p>Encoding: {@code (instIndex << 1)} means patch {@code inst.out}; {@code (instIndex << 1) |
-   * 1} means patch {@code inst.out1}.
+   * <p>A patch list is packed into a primitive {@code long}: upper 32 bits are {@code head}, lower
+   * 32 bits are {@code tail}.
    */
-  record PatchList(int head, int tail) {
+  private static final class PatchList {
 
-    static final PatchList EMPTY = new PatchList(0, 0);
+    static final long EMPTY = 0L;
 
-    static PatchList mk(int encoded) {
-      return new PatchList(encoded, encoded);
+    static long mk(int encoded) {
+      return ((long) encoded << 32) | (encoded & 0xFFFFFFFFL);
     }
 
-    static void patch(Prog prog, PatchList l, int target) {
-      int current = l.head;
+    static int head(long l) {
+      return (int) (l >>> 32);
+    }
+
+    static int tail(long l) {
+      return (int) l;
+    }
+
+    static void patch(Prog prog, long l, int target) {
+      int current = head(l);
       while (current != 0) {
         Inst ip = prog.mutableInst(current >> 1);
         if ((current & 1) != 0) {
@@ -682,20 +690,24 @@ final class Compiler extends Walker<Compiler.Frag> {
       }
     }
 
-    static PatchList append(Prog prog, PatchList l1, PatchList l2) {
-      if (l1.head == 0) {
+    static long append(Prog prog, long l1, long l2) {
+      int h1 = head(l1);
+      if (h1 == 0) {
         return l2;
       }
-      if (l2.head == 0) {
+      int h2 = head(l2);
+      if (h2 == 0) {
         return l1;
       }
-      Inst ip = prog.mutableInst(l1.tail >> 1);
-      if ((l1.tail & 1) != 0) {
-        ip.out1 = l2.head;
+      int t1 = tail(l1);
+      Inst ip = prog.mutableInst(t1 >> 1);
+      if ((t1 & 1) != 0) {
+        ip.out1 = h2;
       } else {
-        ip.out = l2.head;
+        ip.out = h2;
       }
-      return new PatchList(l1.head, l2.tail);
+      int t2 = tail(l2);
+      return ((long) h1 << 32) | (t2 & 0xFFFFFFFFL);
     }
   }
 
@@ -707,7 +719,7 @@ final class Compiler extends Walker<Compiler.Frag> {
    * A compiled program fragment with a beginning instruction, a patch list of unfilled outputs, and
    * a nullable flag.
    */
-  record Frag(int begin, PatchList end, boolean nullable) {
+  record Frag(int begin, long end, boolean nullable) {
     static final Frag NO_MATCH = new Frag(0, PatchList.EMPTY, false);
   }
 
@@ -734,7 +746,7 @@ final class Compiler extends Walker<Compiler.Frag> {
 
     // Elide no-op.
     Inst begin = prog.mutableInst(a.begin);
-    if (begin.op == InstOp.NOP && a.end.head == (a.begin << 1) && begin.out == 0) {
+    if (begin.op == InstOp.NOP && PatchList.head(a.end) == (a.begin << 1) && begin.out == 0) {
       PatchList.patch(prog, a.end, b.begin);
       return b;
     }
@@ -779,7 +791,7 @@ final class Compiler extends Walker<Compiler.Frag> {
       }
       int loopReg = nextLoopReg++;
       prog.mutableInst(pcId).initProgressCheck(loopReg, a.begin, 0, nongreedy);
-      PatchList pl = PatchList.mk((pcId << 1) | 1); // patch out1 (exit)
+      long pl = PatchList.mk((pcId << 1) | 1); // patch out1 (exit)
 
       // Patch the body end to loop back to pcId.
       PatchList.patch(prog, a.end, pcId);
@@ -790,7 +802,7 @@ final class Compiler extends Walker<Compiler.Frag> {
     if (id < 0) {
       return Frag.NO_MATCH;
     }
-    PatchList pl;
+    long pl;
     if (nongreedy) {
       prog.mutableInst(id).initAlt(0, a.begin);
       pl = PatchList.mk(id << 1);
@@ -811,7 +823,7 @@ final class Compiler extends Walker<Compiler.Frag> {
     if (id < 0) {
       return Frag.NO_MATCH;
     }
-    PatchList pl;
+    long pl;
     if (nongreedy) {
       prog.mutableInst(id).initAlt(0, a.begin);
       pl = PatchList.mk(id << 1);
@@ -831,7 +843,7 @@ final class Compiler extends Walker<Compiler.Frag> {
     if (id < 0) {
       return Frag.NO_MATCH;
     }
-    PatchList pl;
+    long pl;
     if (nongreedy) {
       prog.mutableInst(id).initAlt(0, a.begin);
       pl = PatchList.mk(id << 1);
@@ -907,11 +919,13 @@ final class Compiler extends Walker<Compiler.Frag> {
   }
 
   private void suppressCapture(Frag a, int cap) {
-    if (isNoMatch(a) || a.end.head != a.end.tail || (a.end.head & 1) != 0) {
+    if (isNoMatch(a)
+        || PatchList.head(a.end) != PatchList.tail(a.end)
+        || (PatchList.head(a.end) & 1) != 0) {
       return;
     }
     Inst start = prog.mutableInst(a.begin);
-    int endId = a.end.head >> 1;
+    int endId = PatchList.head(a.end) >> 1;
     Inst end = prog.mutableInst(endId);
     if (start.op == InstOp.CAPTURE
         && start.arg == 2 * cap
@@ -979,6 +993,28 @@ final class Compiler extends Walker<Compiler.Frag> {
     }
     prog.mutableInst(id).initCharClass(0, new int[] {upper, upper, lower, lower});
     return new Frag(id, PatchList.mk(id << 1), false);
+  }
+
+  private Frag literalString(int[] runes, int flags) {
+    if (runes == null || runes.length == 0) {
+      return nop();
+    }
+    if (runes.length == 1) {
+      return literal(runes[0], flags);
+    }
+    Frag first = literal(runes[0], flags);
+    if (isNoMatch(first)) {
+      return Frag.NO_MATCH;
+    }
+    Frag current = first;
+    for (int i = 1; i < runes.length; i++) {
+      Frag next = literal(runes[i], flags);
+      if (isNoMatch(next)) {
+        return Frag.NO_MATCH;
+      }
+      current = cat(current, next);
+    }
+    return current;
   }
 
   private static boolean isAsciiLetter(int rune) {
@@ -1061,16 +1097,7 @@ final class Compiler extends Walker<Compiler.Frag> {
 
       case LITERAL -> literal(re.rune, re.flags);
 
-      case LITERAL_STRING -> {
-        if (re.runes == null || re.runes.length == 0) {
-          yield nop();
-        }
-        Frag f = literal(re.runes[0], re.flags);
-        for (int i = 1; i < re.runes.length; i++) {
-          f = cat(f, literal(re.runes[i], re.flags));
-        }
-        yield f;
-      }
+      case LITERAL_STRING -> literalString(re.runes, re.flags);
 
       case ANY_CHAR -> anyCodePoint();
 

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -9,8 +9,6 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.NavigableSet;
-import java.util.TreeSet;
 
 /**
  * Lazy DFA execution engine. Builds DFA states on demand from the compiled NFA program using the
@@ -331,7 +329,7 @@ final class Dfa {
    * current character is a word character.
    */
   private static int[] buildBoundaries(Prog prog) {
-    TreeSet<Integer> bounds = new TreeSet<>();
+    IntArrayList bounds = new IntArrayList();
     bounds.add(0);
     bounds.add(Utils.MAX_RUNE + 1);
     boolean hasWordBoundary = false;
@@ -387,11 +385,11 @@ final class Dfa {
       bounds.add(0x61); // 'a'
       bounds.add(0x7B); // 'z' + 1
     }
-    return bounds.stream().mapToInt(Integer::intValue).toArray();
+    return bounds.toSortedUniqueArray();
   }
 
   /** Adds boundaries for a [lo, hi] code point range. */
-  private static void addRangeBoundaries(NavigableSet<Integer> bounds, int lo, int hi) {
+  private static void addRangeBoundaries(IntArrayList bounds, int lo, int hi) {
     bounds.add(lo);
     if (hi < Utils.MAX_RUNE) {
       bounds.add(hi + 1);
@@ -404,7 +402,7 @@ final class Dfa {
    * have their own equivalence classes so the DFA doesn't conflate them with non-matching
    * characters in the same class.
    */
-  private static void addCaseFoldBoundaries(NavigableSet<Integer> bounds, int lo, int hi) {
+  private static void addCaseFoldBoundaries(IntArrayList bounds, int lo, int hi) {
     for (int cp = lo; cp <= hi; cp++) {
       int folded = Inst.simpleFold(cp);
       while (folded != cp) {

--- a/safere/src/main/java/org/safere/IntArrayList.java
+++ b/safere/src/main/java/org/safere/IntArrayList.java
@@ -1,0 +1,73 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Portions derived from RE2/J (https://github.com/google/re2j),
+// Copyright (c) 2009 The Go Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Arrays;
+
+/**
+ * A resizable array of primitive {@code int} values to avoid boxing and object allocation
+ * overhead.
+ */
+final class IntArrayList {
+
+  private int[] data;
+  private int size;
+
+  IntArrayList() {
+    this(16);
+  }
+
+  IntArrayList(int capacity) {
+    data = new int[Math.max(4, capacity)];
+  }
+
+  void add(int value) {
+    if (size == data.length) {
+      data = Arrays.copyOf(data, data.length * 2);
+    }
+    data[size++] = value;
+  }
+
+  int size() {
+    return size;
+  }
+
+  int get(int index) {
+    return data[index];
+  }
+
+  void clear() {
+    size = 0;
+  }
+
+  boolean isEmpty() {
+    return size == 0;
+  }
+
+  int removeLast() {
+    return data[--size];
+  }
+
+  int[] toArray() {
+    return Arrays.copyOf(data, size);
+  }
+
+  int[] toSortedUniqueArray() {
+    if (size == 0) {
+      return new int[0];
+    }
+    Arrays.sort(data, 0, size);
+    int unique = 1;
+    for (int i = 1; i < size; i++) {
+      if (data[i] != data[unique - 1]) {
+        data[unique++] = data[i];
+      }
+    }
+    return Arrays.copyOf(data, unique);
+  }
+}

--- a/safere/src/main/java/org/safere/IntArrayList.java
+++ b/safere/src/main/java/org/safere/IntArrayList.java
@@ -10,8 +10,7 @@ package org.safere;
 import java.util.Arrays;
 
 /**
- * A resizable array of primitive {@code int} values to avoid boxing and object allocation
- * overhead.
+ * A resizable array of primitive {@code int} values to avoid boxing and object allocation overhead.
  */
 final class IntArrayList {
 

--- a/safere/src/main/java/org/safere/MatchDescriptor.java
+++ b/safere/src/main/java/org/safere/MatchDescriptor.java
@@ -40,8 +40,6 @@ record MatchDescriptor(
   }
 
   boolean hasFindFastPath() {
-    return literalMatch != null
-        || singleCharClass != null
-        || keywordAlternation != null;
+    return literalMatch != null || singleCharClass != null || keywordAlternation != null;
   }
 }

--- a/safere/src/main/java/org/safere/MatchDescriptor.java
+++ b/safere/src/main/java/org/safere/MatchDescriptor.java
@@ -38,4 +38,10 @@ record MatchDescriptor(
         || keywordAlternation != null
         || charClassMatch != null;
   }
+
+  boolean hasFindFastPath() {
+    return literalMatch != null
+        || singleCharClass != null
+        || keywordAlternation != null;
+  }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1282,8 +1282,8 @@ public final class Matcher implements MatchResult {
   private boolean canUseReverseDfa() {
     return enginePathOptions().dfa()
         && enginePathOptions().reverseDfa()
-        && dfaSupportsProgram(parentPattern.flatReverseDfaProg())
-        && !parentPattern.prog().anchorStart();
+        && parentPattern.canUseReverseDfa()
+        && dfaSupportsProgram(parentPattern.flatReverseDfaProg());
   }
 
   /**

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -490,43 +490,26 @@ final class OnePass {
 
   /** Builds sorted code point boundaries from all CHAR_RANGE and CHAR_CLASS instructions. */
   private static int[] buildBoundaries(Prog prog) {
-    int maxBounds = 2;
+    IntArrayList bounds = new IntArrayList();
+    bounds.add(0);
+    bounds.add(Utils.MAX_RUNE + 1);
     for (int i = 0; i < prog.size(); i++) {
       Inst inst = prog.inst(i);
       if (inst.op == InstOp.CHAR_RANGE) {
-        maxBounds += 2;
-      } else if (inst.op == InstOp.CHAR_CLASS) {
-        maxBounds += inst.ranges.length;
-      }
-    }
-    int[] raw = new int[maxBounds];
-    int count = 0;
-    raw[count++] = 0;
-    raw[count++] = Utils.MAX_RUNE + 1;
-    for (int i = 0; i < prog.size(); i++) {
-      Inst inst = prog.inst(i);
-      if (inst.op == InstOp.CHAR_RANGE) {
-        raw[count++] = inst.lo;
+        bounds.add(inst.lo);
         if (inst.hi < Utils.MAX_RUNE) {
-          raw[count++] = inst.hi + 1;
+          bounds.add(inst.hi + 1);
         }
       } else if (inst.op == InstOp.CHAR_CLASS) {
         for (int j = 0; j < inst.ranges.length; j += 2) {
-          raw[count++] = inst.ranges[j];
+          bounds.add(inst.ranges[j]);
           if (inst.ranges[j + 1] < Utils.MAX_RUNE) {
-            raw[count++] = inst.ranges[j + 1] + 1;
+            bounds.add(inst.ranges[j + 1] + 1);
           }
         }
       }
     }
-    Arrays.sort(raw, 0, count);
-    int unique = 0;
-    for (int i = 0; i < count; i++) {
-      if (unique == 0 || raw[i] != raw[unique - 1]) {
-        raw[unique++] = raw[i];
-      }
-    }
-    return Arrays.copyOf(raw, unique);
+    return bounds.toSortedUniqueArray();
   }
 
   // -------------------------------------------------------------------------

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -339,9 +339,11 @@ public final class Pattern implements Serializable {
     this.rejectPrefilter = RejectPrefilter.create(this.rejectDescriptor);
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
-    onePassAnalysis();
+    if (canUseOnePass()) {
+      onePassAnalysis();
+    }
     forwardDfaSetup();
-    if (!prog.anchorStart()) {
+    if (canUseReverseDfa()) {
       flatReverseDfaProg();
     }
 
@@ -1091,6 +1093,11 @@ public final class Pattern implements Serializable {
   private OnePassAnalysis onePassAnalysis() {
     OnePassAnalysis analysis = onePassAnalysis;
     if (analysis == null) {
+      if (!canUseOnePass()) {
+        analysis = OnePassAnalysis.DISABLED;
+        onePassAnalysis = analysis;
+        return analysis;
+      }
       // Lazy quantifiers are excluded because OnePass returns leftmost-longest capture group
       // boundaries, which differs from leftmost-first semantics for lazy groups. When hasLazy is
       // true, neither canPrimary nor canSubmatch can use OnePass, so we can skip building OnePass.
@@ -1203,6 +1210,21 @@ public final class Pattern implements Serializable {
   /** Returns whether this pattern contains any lazy quantifiers. */
   boolean hasLazyQuantifiers() {
     return hasLazy;
+  }
+
+  /**
+   * Returns true if this pattern can participate in reverse DFA matching (e.g. unanchored find
+   * or end-anchored reverse-first rejection).
+   */
+  boolean canUseReverseDfa() {
+    return !prog.anchorStart() && !matchDescriptor.hasFindFastPath();
+  }
+
+  /**
+   * Returns true if this pattern can participate in OnePass matching or capture extraction.
+   */
+  boolean canUseOnePass() {
+    return !hasLazy && !matchDescriptor.hasFindFastPath();
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1213,16 +1213,14 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Returns true if this pattern can participate in reverse DFA matching (e.g. unanchored find
-   * or end-anchored reverse-first rejection).
+   * Returns true if this pattern can participate in reverse DFA matching (e.g. unanchored find or
+   * end-anchored reverse-first rejection).
    */
   boolean canUseReverseDfa() {
     return !prog.anchorStart() && !matchDescriptor.hasFindFastPath();
   }
 
-  /**
-   * Returns true if this pattern can participate in OnePass matching or capture extraction.
-   */
+  /** Returns true if this pattern can participate in OnePass matching or capture extraction. */
   boolean canUseOnePass() {
     return !hasLazy && !matchDescriptor.hasFindFastPath();
   }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -339,7 +339,7 @@ public final class Pattern implements Serializable {
     this.rejectPrefilter = RejectPrefilter.create(this.rejectDescriptor);
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
-    if (canUseOnePass()) {
+    if (shouldEagerlyBuildOnePass()) {
       onePassAnalysis();
     }
     forwardDfaSetup();
@@ -1107,11 +1107,6 @@ public final class Pattern implements Serializable {
   private OnePassAnalysis onePassAnalysis() {
     OnePassAnalysis analysis = onePassAnalysis;
     if (analysis == null) {
-      if (!canUseOnePass()) {
-        analysis = OnePassAnalysis.DISABLED;
-        onePassAnalysis = analysis;
-        return analysis;
-      }
       // Lazy quantifiers are excluded because OnePass returns leftmost-longest capture group
       // boundaries, which differs from leftmost-first semantics for lazy groups. When hasLazy is
       // true, neither canPrimary nor canSubmatch can use OnePass, so we can skip building OnePass.
@@ -1234,8 +1229,7 @@ public final class Pattern implements Serializable {
     return !prog.anchorStart() && !matchDescriptor.hasFindFastPath();
   }
 
-  /** Returns true if this pattern can participate in OnePass matching or capture extraction. */
-  boolean canUseOnePass() {
+  private boolean shouldEagerlyBuildOnePass() {
     return !hasLazy && !matchDescriptor.hasFindFastPath();
   }
 

--- a/safere/src/main/java/org/safere/Prog.java
+++ b/safere/src/main/java/org/safere/Prog.java
@@ -10,7 +10,6 @@ package org.safere;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -471,6 +470,35 @@ final class Prog {
     }
   }
 
+  private static final class PredecessorGraph {
+    final int[] head;
+    int[] nextEdge;
+    int[] predInst;
+    int edgeCount;
+
+    PredecessorGraph(int ninst) {
+      head = new int[ninst];
+      Arrays.fill(head, -1);
+      nextEdge = new int[Math.max(16, ninst * 2)];
+      predInst = new int[Math.max(16, ninst * 2)];
+    }
+
+    void addPredecessor(int to, int from) {
+      if (to < 0 || to >= head.length) {
+        return;
+      }
+      if (edgeCount == nextEdge.length) {
+        int newCap = nextEdge.length * 2;
+        nextEdge = Arrays.copyOf(nextEdge, newCap);
+        predInst = Arrays.copyOf(predInst, newCap);
+      }
+      int edge = edgeCount++;
+      predInst[edge] = from;
+      nextEdge[edge] = head[to];
+      head[to] = edge;
+    }
+  }
+
   public void flatten() {
     if (didFlatten) {
       return;
@@ -479,25 +507,21 @@ final class Prog {
     int ninst = instructions.size();
     int[] rootmap = new int[ninst];
     Arrays.fill(rootmap, -1);
-    List<Integer> roots = new ArrayList<>();
-
-    List<List<Integer>> predecessors = new ArrayList<>(ninst);
-    for (int i = 0; i < ninst; i++) {
-      predecessors.add(new ArrayList<>());
-    }
+    IntArrayList roots = new IntArrayList(ninst);
+    PredecessorGraph predecessors = new PredecessorGraph(ninst);
 
     boolean[] reachable = new boolean[ninst];
-    List<Integer> reachableList = new ArrayList<>();
-    List<Integer> stack = new ArrayList<>();
+    IntArrayList reachableList = new IntArrayList(ninst);
+    IntArrayList stack = new IntArrayList(ninst);
 
     // Pass 1: Mark successor roots and predecessors.
     markSuccessors(rootmap, roots, predecessors, reachable, reachableList, stack);
 
     // Pass 2: Mark dominator roots by working backwards.
-    List<Integer> sortedRoots = new ArrayList<>(roots);
-    Collections.sort(sortedRoots);
-    for (int i = sortedRoots.size() - 1; i >= 0; i--) {
-      int root = sortedRoots.get(i);
+    int[] sortedRoots = roots.toArray();
+    Arrays.sort(sortedRoots);
+    for (int i = sortedRoots.length - 1; i >= 0; i--) {
+      int root = sortedRoots[i];
       markDominator(root, rootmap, roots, predecessors, reachable, reachableList, stack);
     }
 
@@ -508,7 +532,7 @@ final class Prog {
     for (int r = 0; r < roots.size(); r++) {
       int root = roots.get(r);
       flatmap[r] = flat.size();
-      emitList(root, rootmap, flat, reachable, stack);
+      emitList(root, rootmap, flat, reachable, reachableList, stack);
       flat.get(flat.size() - 1).last = true;
     }
 
@@ -541,11 +565,11 @@ final class Prog {
 
   private void markSuccessors(
       int[] rootmap,
-      List<Integer> roots,
-      List<List<Integer>> predecessors,
+      IntArrayList roots,
+      PredecessorGraph predecessors,
       boolean[] reachable,
-      List<Integer> reachableList,
-      List<Integer> stack) {
+      IntArrayList reachableList,
+      IntArrayList stack) {
 
     // Mark the kInstFail instruction.
     rootmap[0] = roots.size();
@@ -561,7 +585,6 @@ final class Prog {
       roots.add(start);
     }
 
-    Arrays.fill(reachable, false);
     reachableList.clear();
     stack.clear();
     stack.add(startUnanchored);
@@ -586,9 +609,8 @@ final class Prog {
         case ALT, ALT_MATCH -> {
           int out = inst.out;
           int out1 = inst.out1;
-          for (int o : new int[] {out, out1}) {
-            predecessors.get(o).add(id);
-          }
+          predecessors.addPredecessor(out, id);
+          predecessors.addPredecessor(out1, id);
           stack.add(out1);
           nextId = out;
         }
@@ -622,18 +644,21 @@ final class Prog {
         }
       }
     }
+
+    for (int i = 0; i < reachableList.size(); i++) {
+      reachable[reachableList.get(i)] = false;
+    }
   }
 
   private void markDominator(
       int root,
       int[] rootmap,
-      List<Integer> roots,
-      List<List<Integer>> predecessors,
+      IntArrayList roots,
+      PredecessorGraph predecessors,
       boolean[] reachable,
-      List<Integer> reachableList,
-      List<Integer> stack) {
+      IntArrayList reachableList,
+      IntArrayList stack) {
 
-    Arrays.fill(reachable, false);
     reachableList.clear();
     stack.clear();
     stack.add(root);
@@ -679,9 +704,10 @@ final class Prog {
       }
     }
 
-    for (int i : reachableList) {
-      List<Integer> preds = predecessors.get(i);
-      for (int pred : preds) {
+    for (int idx = 0; idx < reachableList.size(); idx++) {
+      int i = reachableList.get(idx);
+      for (int edge = predecessors.head[i]; edge != -1; edge = predecessors.nextEdge[edge]) {
+        int pred = predecessors.predInst[edge];
         if (!reachable[pred]) {
           if (rootmap[i] == -1) {
             rootmap[i] = roots.size();
@@ -690,12 +716,21 @@ final class Prog {
         }
       }
     }
+
+    for (int idx = 0; idx < reachableList.size(); idx++) {
+      reachable[reachableList.get(idx)] = false;
+    }
   }
 
   private void emitList(
-      int root, int[] rootmap, List<Inst> flat, boolean[] reachable, List<Integer> stack) {
+      int root,
+      int[] rootmap,
+      List<Inst> flat,
+      boolean[] reachable,
+      IntArrayList reachableList,
+      IntArrayList stack) {
 
-    Arrays.fill(reachable, false);
+    reachableList.clear();
     stack.clear();
     stack.add(root);
 
@@ -712,6 +747,7 @@ final class Prog {
         continue;
       }
       reachable[id] = true;
+      reachableList.add(id);
 
       if (id != root && rootmap[id] != -1) {
         Inst nop = new Inst();
@@ -756,6 +792,10 @@ final class Prog {
           flat.add(newInst);
         }
       }
+    }
+
+    for (int idx = 0; idx < reachableList.size(); idx++) {
+      reachable[reachableList.get(idx)] = false;
     }
   }
 }

--- a/safere/src/main/java/org/safere/Walker.java
+++ b/safere/src/main/java/org/safere/Walker.java
@@ -24,6 +24,7 @@ import java.util.List;
 abstract class Walker<T> {
 
   private final ArrayList<WalkState<T>> stack = new ArrayList<>();
+  private final boolean[] stop = new boolean[1];
   private boolean stoppedEarly;
   private int maxVisits;
 
@@ -126,7 +127,7 @@ abstract class Walker<T> {
           parent.n++;
           continue;
         }
-        boolean[] stop = {false};
+        stop[0] = false;
         s.preArg = preVisit(re, s.parentArg, stop);
         if (stop[0]) {
           T t = s.preArg;

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -103,6 +104,22 @@ class DiagnosticsTest {
               assertThat(event.captureStrategy()).isEqualTo(MatchStrategy.ONE_PASS);
               assertThat(event.captureMode()).isEqualTo(CaptureMode.EAGER);
             });
+  }
+
+  @Test
+  void capturedLiteralRetainsEnginesNeededWhenLiteralRunnerIsIneligible() {
+    Pattern.setDiagnostics(diagnostics);
+
+    Pattern lookingAtPattern = Pattern.compile("(foo)");
+    assertThat(lookingAtPattern.matcher("foobar").lookingAt()).isTrue();
+    assertThat(operationsFor(lookingAtPattern).getLast().boundaryStrategy())
+        .isEqualTo(MatchStrategy.ONE_PASS);
+
+    Pattern foldedUtf8Pattern = Pattern.compile("(?i)foo");
+    assertThat(foldedUtf8Pattern.matcher(Utf8Input.validated("FOObar".getBytes(UTF_8))).lookingAt())
+        .isTrue();
+    assertThat(operationsFor(foldedUtf8Pattern).getLast().boundaryStrategy())
+        .isEqualTo(MatchStrategy.ONE_PASS);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/IntArrayListTest.java
+++ b/safere/src/test/java/org/safere/IntArrayListTest.java
@@ -1,0 +1,74 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
+class IntArrayListTest {
+
+  @Test
+  void basicOperations() {
+    IntArrayList list = new IntArrayList(4);
+    assertThat(list.isEmpty()).isTrue();
+    assertThat(list.size()).isEqualTo(0);
+
+    list.add(10);
+    list.add(20);
+    list.add(30);
+
+    assertThat(list.isEmpty()).isFalse();
+    assertThat(list.size()).isEqualTo(3);
+    assertThat(list.get(0)).isEqualTo(10);
+    assertThat(list.get(1)).isEqualTo(20);
+    assertThat(list.get(2)).isEqualTo(30);
+
+    assertThat(list.removeLast()).isEqualTo(30);
+    assertThat(list.size()).isEqualTo(2);
+
+    assertThat(list.toArray()).containsExactly(10, 20);
+
+    list.clear();
+    assertThat(list.isEmpty()).isTrue();
+    assertThat(list.size()).isEqualTo(0);
+    assertThat(list.toArray()).isEmpty();
+  }
+
+  @Test
+  void growthBeyondCapacity() {
+    IntArrayList list = new IntArrayList(2);
+    for (int i = 0; i < 100; i++) {
+      list.add(i);
+    }
+    assertThat(list.size()).isEqualTo(100);
+    for (int i = 0; i < 100; i++) {
+      assertThat(list.get(i)).isEqualTo(i);
+    }
+  }
+
+  @Test
+  void toSortedUniqueArray() {
+    IntArrayList list = new IntArrayList();
+    assertThat(list.toSortedUniqueArray()).isEmpty();
+
+    list.add(42);
+    assertThat(list.toSortedUniqueArray()).containsExactly(42);
+
+    list.clear();
+    list.add(5);
+    list.add(1);
+    list.add(3);
+    list.add(1);
+    list.add(5);
+    list.add(2);
+    list.add(3);
+    list.add(5);
+
+    assertThat(list.toSortedUniqueArray()).containsExactly(1, 2, 3, 5);
+  }
+}


### PR DESCRIPTION
This optimizes parts of `Pattern.compile` that showed up in profiles.

- Use primitive `IntArrayList` and in-place sorting for DFA and OnePass boundary extraction.
- Flatten predecessor graph and use $O(\text{visited})$ reachability resets during AST dominator analysis in `Prog`.
- Pack `PatchList` into primitive `long`s and reuse `stop` arrays in `Walker`.
- Skip `flatReverseDfaProg` and `OnePass` for patterns that don't need them (e.g. fast-path literal/keyword matches), similar to what #703 did for `OnePass`.

```
COMPILE_TRIALS="CompileBenchmark.compileSimple@safere-string,\
CompileBenchmark.compileMedium@safere-string,\
CompileBenchmark.compileComplex@safere-string,\
CompileBenchmark.compileAlternation@safere-string"
```

```
./run-java-benchmarks.sh CrossEngineScalingBenchmark.run --fastbuild -- -p crossEngineScalingTrial="$COMPILE_TRIALS"
```

| Benchmark          | baseline (us/op) | current (us/op) | Speedup |
| ------------------ | ---------------- | --------------- | ------- |
| compileSimple      |       7.9 ± 0.33 |      2.7 ± 0.39 |   2.99x |
| compileMedium      |         35 ± 2.7 |        31 ± 2.3 |   1.13x |
| compileComplex     |         20 ± 2.4 |        17 ± 1.7 |   1.16x |
| compileAlternation |         36 ± 2.0 |       28 ± 0.63 |   1.27x |