### PR TITLE
Add CharClassEscape to accelerate DFA self-loops on character classes

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -3178,6 +3178,44 @@
       "requirements": []
     },
     {
+      "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeywordFind.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        {
+          "java": "(?i)keyword_to_find",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
+      ],
+      "inputs": [
+        "realWorldRegex.caseInsensitiveKeyword.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "requirements": []
+    },
+    {
       "id": "RealWorldRegexBenchmark.runBenchmark.boundedNameMatch.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [

--- a/safere-vector-benchmarks/src/main/java/org/safere/Utf8ScannerBenchmarkAccess.java
+++ b/safere-vector-benchmarks/src/main/java/org/safere/Utf8ScannerBenchmarkAccess.java
@@ -22,7 +22,7 @@ public final class Utf8ScannerBenchmarkAccess {
 
   /** Returns the first byte position in the configured code-point ranges. */
   public int indexOfCodePointClass(int start) {
-    return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, start);
+    return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, start, scanner.length());
   }
 
   private static long asciiBitmap(int[] ranges, int first, int last) {

--- a/safere/src/main/java/org/safere/AsciiBitmap.java
+++ b/safere/src/main/java/org/safere/AsciiBitmap.java
@@ -5,6 +5,8 @@
 
 package org.safere;
 
+import java.util.Arrays;
+
 /**
  * Immutable 128-bit bitmap representing a set of ASCII code points (0–127).
  *
@@ -66,6 +68,29 @@ record AsciiBitmap(long bitmap0, long bitmap1) {
       }
     }
     return array;
+  }
+
+  /** Returns inclusive [low0, high0, low1, high1, ...] range pairs representing this ASCII set. */
+  int[] toRanges() {
+    int[] temp = new int[256];
+    int count = 0;
+    int start = -1;
+    for (int i = 0; i < 128; i++) {
+      if (containsAscii(i)) {
+        if (start == -1) {
+          start = i;
+        }
+      } else if (start != -1) {
+        temp[count++] = start;
+        temp[count++] = i - 1;
+        start = -1;
+      }
+    }
+    if (start != -1) {
+      temp[count++] = start;
+      temp[count++] = 127;
+    }
+    return Arrays.copyOf(temp, count);
   }
 
   static final class Builder {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -808,9 +808,9 @@ final class Dfa {
 
   private AcceleratorPolicy startAccelerationPolicy(InputScanner text) {
     return switch (text) {
-      case Utf8InputScanner utf8 ->
+      case Utf8InputScanner unusedUtf8 ->
           utf8StartAccelerator != null ? utf8StartAccelerator.policy() : null;
-      case StringInputScanner string ->
+      case StringInputScanner unusedString ->
           stringStartAccelerator != null ? stringStartAccelerator.policy() : null;
     };
   }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -807,37 +807,12 @@ final class Dfa {
   }
 
   private AcceleratorPolicy startAccelerationPolicy(InputScanner text) {
-    if (text instanceof Utf8InputScanner) {
-      return utf8StartAccelerator != null ? utf8StartAccelerator.policy() : null;
-    }
-    if (text instanceof StringInputScanner) {
-      return stringStartAccelerator != null ? stringStartAccelerator.policy() : null;
-    }
-    return null;
-  }
-
-  /**
-   * Fast-forwards to the next escape character in a self-loop state.
-   *
-   * <p>Direct sealed-type pattern matching avoids {@code invokeinterface} dispatch overhead on hot
-   * matching loops (see PR #693 and PR #695 review). HotSpot C2 does not automatically devirtualize
-   * megamorphic interface calls with &ge; 3 implementations across the JVM lifecycle; unwrapping
-   * the sealed record subtypes at this call site allows C2 to inline the underlying {@link
-   * InputScanner} search primitives directly into the caller.
-   */
-  private static int findSelfLoopEscape(
-      StateAccelerator accelerator, InputScanner text, int fromIndex, int limit) {
-    if (accelerator instanceof StateAccelerator.SingleAsciiEscape single) {
-      return text.indexOfAscii(single.escape(), fromIndex, limit);
-    } else if (accelerator instanceof StateAccelerator.AsciiPairEscape pair) {
-      return text.indexOfAsciiPair(pair.c1(), pair.c2(), fromIndex, limit);
-    } else if (accelerator instanceof StateAccelerator.AsciiTripleEscape triple) {
-      return text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
-    } else if (accelerator instanceof StateAccelerator.CharClassEscape cc) {
-      int found = text.indexOfCodePointClass(cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex);
-      return (found >= 0 && found < limit) ? found : -1;
-    }
-    return accelerator.findEscape(text, fromIndex, limit);
+    return switch (text) {
+      case Utf8InputScanner utf8 ->
+          utf8StartAccelerator != null ? utf8StartAccelerator.policy() : null;
+      case StringInputScanner string ->
+          stringStartAccelerator != null ? stringStartAccelerator.policy() : null;
+    };
   }
 
   private static boolean instMatches(Inst ip, int ch) {
@@ -1344,20 +1319,25 @@ final class Dfa {
    * state.
    */
   private int fastForward(InputScanner text, int pos, int posDepThreshold) {
-    if (text instanceof Utf8InputScanner utf8Scanner) {
-      if (utf8StartAccelerator != null) {
-        int idx = utf8StartAccelerator.findCandidate(utf8Scanner, pos);
-        if (idx >= 0) {
-          return Math.min(idx, posDepThreshold - 1);
+    return switch (text) {
+      case Utf8InputScanner utf8Scanner -> {
+        if (utf8StartAccelerator != null) {
+          int idx = Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, utf8Scanner, pos);
+          if (idx >= 0) {
+            yield Math.min(idx, posDepThreshold - 1);
+          }
+          yield -1;
         }
-        return -1;
+        yield pos;
       }
-    } else if (text instanceof StringInputScanner stringScanner) {
-      if (stringStartAccelerator != null) {
-        return stringStartAccelerator.findCandidate(stringScanner.text(), pos, prog.unixLines());
+      case StringInputScanner stringScanner -> {
+        if (stringStartAccelerator != null) {
+          yield StringStartAccelerator.findNextCandidate(
+              stringStartAccelerator, stringScanner.text(), pos, prog.unixLines());
+        }
+        yield pos;
       }
-    }
-    return pos;
+    };
   }
 
   /**
@@ -1474,7 +1454,7 @@ final class Dfa {
       int sId = s.id * numClasses;
       while (pos < limit) {
         if (s.accelerator != null && !s.isStartState && (limit - pos >= 16)) {
-          int nextPos = findSelfLoopEscape(s.accelerator, text, pos, limit);
+          int nextPos = StateAccelerator.findNextEscape(s.accelerator, text, pos, limit);
           if (nextPos == -1) {
             pos = limit;
             break;
@@ -1593,7 +1573,7 @@ final class Dfa {
         }
       }
       if (s.accelerator != null && !s.isStartState && (textLen - pos >= 16)) {
-        int nextPos = findSelfLoopEscape(s.accelerator, text, pos, textLen);
+        int nextPos = StateAccelerator.findNextEscape(s.accelerator, text, pos, textLen);
         if (nextPos == -1) {
           pos = textLen;
         } else if (nextPos > pos) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -730,6 +730,7 @@ final class Dfa {
 
     int escapeCount = 0;
     int[] escapes = new int[4];
+    AsciiBitmap.Builder escapeBitmap = null;
     int[] seeds = new int[insts.length];
 
     for (int ch = 0; ch < 128; ch++) {
@@ -740,25 +741,19 @@ final class Dfa {
           seeds[seedCount++] = ip.out;
         }
       }
-      if (seedCount == 0) {
+      if (seedCount == 0 || !Arrays.equals(expand(seeds, seedCount, 0), insts)) {
         if (escapeCount < 4) {
           escapes[escapeCount] = ch;
+        } else if (escapeBitmap == null) {
+          escapeBitmap = new AsciiBitmap.Builder();
+          for (int i = 0; i < 4; i++) {
+            escapeBitmap.add(escapes[i]);
+          }
+        }
+        if (escapeBitmap != null) {
+          escapeBitmap.add(ch);
         }
         escapeCount++;
-        if (escapeCount == 4) {
-          return null;
-        }
-        continue;
-      }
-      int[] frontier = expand(seeds, seedCount, 0);
-      if (!Arrays.equals(frontier, insts)) {
-        if (escapeCount < 4) {
-          escapes[escapeCount] = ch;
-        }
-        escapeCount++;
-        if (escapeCount == 4) {
-          return null;
-        }
       }
     }
 
@@ -789,6 +784,13 @@ final class Dfa {
         return new StateAccelerator.AsciiPairEscape(escapes[0], escapes[1]);
       } else {
         return new StateAccelerator.AsciiTripleEscape(escapes[0], escapes[1], escapes[2]);
+      }
+    }
+    if (escapeBitmap != null && escapeCount < 128) {
+      AsciiBitmap bitmap = escapeBitmap.build();
+      int[] ranges = bitmap.toRanges();
+      if (ranges.length <= 8) {
+        return new StateAccelerator.CharClassEscape(ranges, bitmap.bitmap0(), bitmap.bitmap1());
       }
     }
     return null;
@@ -831,6 +833,9 @@ final class Dfa {
       return text.indexOfAsciiPair(pair.c1(), pair.c2(), fromIndex, limit);
     } else if (accelerator instanceof StateAccelerator.AsciiTripleEscape triple) {
       return text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
+    } else if (accelerator instanceof StateAccelerator.CharClassEscape cc) {
+      int found = text.indexOfCodePointClass(cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex);
+      return (found >= 0 && found < limit) ? found : -1;
     }
     return accelerator.findEscape(text, fromIndex, limit);
   }

--- a/safere/src/main/java/org/safere/GraphemeSupport.java
+++ b/safere/src/main/java/org/safere/GraphemeSupport.java
@@ -305,25 +305,31 @@ final class GraphemeSupport {
   }
 
   static int inputCodePointAt(InputScanner text, int pos, int endPos, boolean graphemeSensitive) {
-    if (text instanceof StringInputScanner stringInput) {
-      return inputCodePointAt(stringInput.text(), pos, endPos, graphemeSensitive);
-    }
-    if (pos < 0 || pos >= endPos || pos >= text.length()) {
-      return -1;
-    }
-    long decoded = text.decodeForward(pos);
-    return InputScanner.position(decoded) <= endPos ? InputScanner.codePoint(decoded) : -1;
+    return switch (text) {
+      case StringInputScanner stringInput ->
+          inputCodePointAt(stringInput.text(), pos, endPos, graphemeSensitive);
+      case Utf8InputScanner utf8Input -> {
+        if (pos < 0 || pos >= endPos || pos >= utf8Input.length()) {
+          yield -1;
+        }
+        long decoded = utf8Input.decodeForward(pos);
+        yield InputScanner.position(decoded) <= endPos ? InputScanner.codePoint(decoded) : -1;
+      }
+    };
   }
 
   static int inputNextPos(InputScanner text, int pos, int endPos, boolean graphemeSensitive) {
-    if (text instanceof StringInputScanner stringInput) {
-      return inputNextPos(stringInput.text(), pos, endPos, graphemeSensitive);
-    }
-    if (pos < 0 || pos >= endPos || pos >= text.length()) {
-      return endPos + 1;
-    }
-    int next = InputScanner.position(text.decodeForward(pos));
-    return next <= endPos ? next : endPos + 1;
+    return switch (text) {
+      case StringInputScanner stringInput ->
+          inputNextPos(stringInput.text(), pos, endPos, graphemeSensitive);
+      case Utf8InputScanner utf8Input -> {
+        if (pos < 0 || pos >= endPos || pos >= utf8Input.length()) {
+          yield endPos + 1;
+        }
+        int next = InputScanner.position(utf8Input.decodeForward(pos));
+        yield next <= endPos ? next : endPos + 1;
+      }
+    };
   }
 
   static int graphemeNextPos(InputScanner text, int pos, int endPos) {

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -32,11 +32,6 @@ sealed interface InputScanner permits StringInputScanner, Utf8InputScanner {
    */
   int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit);
 
-  /** Returns the first position in {@code [start, length())} belonging to the code-point class. */
-  default int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
-    return indexOfCodePointClass(ranges, bitmap0, bitmap1, start, length());
-  }
-
   /**
    * Returns the first index in {@code [fromIndex, limit)} containing {@code ascii}, or {@code -1}
    * if none exists.

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -5,7 +5,7 @@
 
 package org.safere;
 
-interface InputScanner {
+sealed interface InputScanner permits StringInputScanner, Utf8InputScanner {
   int END_OF_INPUT = -1;
 
   /** Returns the length of the input in index units (chars for String, bytes for byte[]). */
@@ -26,8 +26,11 @@ interface InputScanner {
    */
   int singleUnitCodePointBefore(int pos);
 
-  /** Returns the first position at or after {@code start} in the supplied code-point class. */
-  int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start);
+  /**
+   * Returns the first position in {@code [start, limit)} belonging to the supplied code-point
+   * class.
+   */
+  int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit);
 
   /**
    * Returns the first index in {@code [fromIndex, limit)} containing {@code ascii}, or {@code -1}

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -32,6 +32,11 @@ sealed interface InputScanner permits StringInputScanner, Utf8InputScanner {
    */
   int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit);
 
+  /** Returns the first position in {@code [start, length())} belonging to the code-point class. */
+  default int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
+    return indexOfCodePointClass(ranges, bitmap0, bitmap1, start, length());
+  }
+
   /**
    * Returns the first index in {@code [fromIndex, limit)} containing {@code ascii}, or {@code -1}
    * if none exists.

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -581,7 +581,12 @@ public final class Matcher implements MatchResult {
     }
     int idx =
         activeScanner()
-            .indexOfCodePointClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex);
+            .indexOfCodePointClass(
+                scanInfo.ranges,
+                scanInfo.bitmap0,
+                scanInfo.bitmap1,
+                fromIndex,
+                activeScanner().length());
     if (idx >= 0) {
       int end =
           text != null
@@ -4052,7 +4057,11 @@ public final class Matcher implements MatchResult {
       }
       int idx =
           scanner.indexOfCodePointClass(
-              singleCharClass.ranges, singleCharClass.bitmap0, singleCharClass.bitmap1, fromIndex);
+              singleCharClass.ranges,
+              singleCharClass.bitmap0,
+              singleCharClass.bitmap1,
+              fromIndex,
+              scanner.length());
       if (idx < 0) {
         return -1L;
       }

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -168,7 +168,8 @@ sealed interface RejectPrefilter
       if (!options.charClassMatchFastPaths()) {
         return false;
       }
-      return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, searchFrom) < 0;
+      return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, searchFrom, scanner.length())
+          < 0;
     }
 
     @Override
@@ -176,7 +177,8 @@ sealed interface RejectPrefilter
       if (!options.charClassMatchFastPaths()) {
         return false;
       }
-      return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, searchFrom) < 0;
+      return scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, searchFrom, scanner.length())
+          < 0;
     }
 
     @Override

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -45,7 +45,7 @@ sealed interface StateAccelerator {
             case Utf8InputScanner utf8 ->
                 utf8.indexOfCodePointClass(
                     cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
-            case StringInputScanner str -> -1;
+            case StringInputScanner unusedString -> -1;
               // TODO: Enable character-class self-loop acceleration for StringInputScanner once
               // vectorized string scanning is available (see PR #656). On scalar
               // StringInputScanner, the scalar charAt/bitmap loop is slower than the DFA table.

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -23,6 +23,36 @@ sealed interface StateAccelerator {
    */
   int findEscape(InputScanner text, int fromIndex, int limit);
 
+  /**
+   * Fast-forwards to the next escape character in a self-loop state using pattern-matched
+   * devirtualization.
+   *
+   * <p>Direct sealed-type pattern matching avoids {@code invokeinterface} dispatch overhead on hot
+   * matching loops. HotSpot C2 does not automatically devirtualize megamorphic interface calls with
+   * &ge; 3 implementations across the JVM lifecycle; switching over the sealed record subtypes here
+   * allows C2 to inline the underlying {@link InputScanner} search primitives directly into caller
+   * loops.
+   */
+  static int findNextEscape(
+      StateAccelerator accelerator, InputScanner text, int fromIndex, int limit) {
+    return switch (accelerator) {
+      case SingleAsciiEscape single -> text.indexOfAscii(single.escape(), fromIndex, limit);
+      case AsciiPairEscape pair -> text.indexOfAsciiPair(pair.c1(), pair.c2(), fromIndex, limit);
+      case AsciiTripleEscape triple ->
+          text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
+      case CharClassEscape cc -> {
+        // TODO: Enable character-class self-loop acceleration for StringInputScanner once
+        // vectorized string scanning is available (see PR #656). On scalar StringInputScanner,
+        // the scalar charAt/bitmap loop is slower than the DFA's native transition table.
+        if (text instanceof Utf8InputScanner) {
+          yield text.indexOfCodePointClass(
+              cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
+        }
+        yield -1;
+      }
+    };
+  }
+
   /** Accelerator for a single escape character (e.g. quote {@code '"'} or newline {@code '\n'}). */
   record SingleAsciiEscape(int escape) implements StateAccelerator {
     @Override
@@ -52,8 +82,7 @@ sealed interface StateAccelerator {
   record CharClassEscape(int[] ranges, long bitmap0, long bitmap1) implements StateAccelerator {
     @Override
     public int findEscape(InputScanner text, int fromIndex, int limit) {
-      int found = text.indexOfCodePointClass(ranges, bitmap0, bitmap1, fromIndex);
-      return (found >= 0 && found < limit) ? found : -1;
+      return text.indexOfCodePointClass(ranges, bitmap0, bitmap1, fromIndex, limit);
     }
   }
 }

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -46,4 +46,14 @@ sealed interface StateAccelerator {
       return text.indexOfAsciiTriple(c1, c2, c3, fromIndex, limit);
     }
   }
+
+  /** Accelerator for a character-class escape (e.g. delimiters or character ranges). */
+  @SuppressWarnings("ArrayRecordComponent")
+  record CharClassEscape(int[] ranges, long bitmap0, long bitmap1) implements StateAccelerator {
+    @Override
+    public int findEscape(InputScanner text, int fromIndex, int limit) {
+      int found = text.indexOfCodePointClass(ranges, bitmap0, bitmap1, fromIndex);
+      return (found >= 0 && found < limit) ? found : -1;
+    }
+  }
 }

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -41,15 +41,7 @@ sealed interface StateAccelerator {
       case AsciiTripleEscape triple ->
           text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
       case CharClassEscape cc ->
-          switch (text) {
-            case Utf8InputScanner utf8 ->
-                utf8.indexOfCodePointClass(
-                    cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
-            case StringInputScanner unusedString -> -1;
-              // TODO: Enable character-class self-loop acceleration for StringInputScanner once
-              // vectorized string scanning is available (see PR #656). On scalar
-              // StringInputScanner, the scalar charAt/bitmap loop is slower than the DFA table.
-          };
+          text.indexOfCodePointClass(cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
     };
   }
 

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -40,16 +40,16 @@ sealed interface StateAccelerator {
       case AsciiPairEscape pair -> text.indexOfAsciiPair(pair.c1(), pair.c2(), fromIndex, limit);
       case AsciiTripleEscape triple ->
           text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
-      case CharClassEscape cc -> {
-        // TODO: Enable character-class self-loop acceleration for StringInputScanner once
-        // vectorized string scanning is available (see PR #656). On scalar StringInputScanner,
-        // the scalar charAt/bitmap loop is slower than the DFA's native transition table.
-        if (text instanceof Utf8InputScanner) {
-          yield text.indexOfCodePointClass(
-              cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
-        }
-        yield -1;
-      }
+      case CharClassEscape cc ->
+          switch (text) {
+            case Utf8InputScanner utf8 ->
+                utf8.indexOfCodePointClass(
+                    cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
+            case StringInputScanner str -> -1;
+              // TODO: Enable character-class self-loop acceleration for StringInputScanner once
+              // vectorized string scanning is available (see PR #656). On scalar
+              // StringInputScanner, the scalar charAt/bitmap loop is slower than the DFA table.
+          };
     };
   }
 

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -97,9 +97,10 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
-  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
+  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit) {
     int position = Math.max(0, start);
-    while (position < text.length()) {
+    int bound = Math.min(limit, text.length());
+    while (position < bound) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
       }

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -43,6 +43,25 @@ sealed interface StringStartAccelerator {
    */
   int findCandidate(String text, int fromIndex, boolean unixLines);
 
+  /**
+   * Finds the next candidate match start position at or after {@code fromIndex} using
+   * pattern-matched devirtualization.
+   *
+   * <p>Direct sealed-type pattern matching avoids {@code invokeinterface} dispatch overhead on hot
+   * matching loops. HotSpot C2 does not automatically devirtualize megamorphic interface calls with
+   * &ge; 3 implementations across the JVM lifecycle; switching over the sealed subtypes here allows
+   * C2 to inline candidate searches directly into caller loops.
+   */
+  static int findNextCandidate(
+      StringStartAccelerator accelerator, String text, int fromIndex, boolean unixLines) {
+    return switch (accelerator) {
+      case Literal lit -> lit.findCandidate(text, fromIndex, unixLines);
+      case FixedOffset fo -> fo.findCandidate(text, fromIndex, unixLines);
+      case CharClass cc -> cc.findCandidate(text, fromIndex, unixLines);
+      case LineAnchor la -> la.findCandidate(text, fromIndex, unixLines);
+    };
+  }
+
   /** Returns the tuning and diagnostic policy for this accelerator. */
   default AcceleratorPolicy policy() {
     return AcceleratorPolicy.DEFAULT;

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -169,17 +169,21 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   }
 
   @Override
-  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
+  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit) {
     int position = Math.max(0, start);
+    int scanLen = Math.min(length, limit);
+    if (position >= scanLen) {
+      return -1;
+    }
     if (!WorkCounterConfig.ENABLED) {
       if (scanProvider == null
           && ranges.length >= 4
           && ranges.length <= 8
           && ranges[0] >= 0
           && ranges[ranges.length - 1] < 0x80
-          && length - position >= MULTI_RANGE_SWAR_MINIMUM_LENGTH
+          && scanLen - position >= MULTI_RANGE_SWAR_MINIMUM_LENGTH
           && (ranges.length != 4 || ranges[0] != ranges[1] || ranges[2] != ranges[3])) {
-        int scalarLimit = position + MULTI_RANGE_SWAR_SCALAR_PROLOGUE_LENGTH;
+        int scalarLimit = Math.min(scanLen, position + MULTI_RANGE_SWAR_SCALAR_PROLOGUE_LENGTH);
         for (; position < scalarLimit; position++) {
           int value = unsignedByteAt(position);
           if ((value < Long.SIZE && (bitmap0 & (1L << value)) != 0)
@@ -189,17 +193,21 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
             return position;
           }
         }
-        return indexOfMultipleByteRanges(ranges, bitmap0, bitmap1, position);
+        if (position >= scanLen) {
+          return -1;
+        }
+        return ByteSwarScan.indexOfMultipleByteRanges(
+            bytes, offset, scanLen, ranges, bitmap0, bitmap1, position);
       }
-      int asciiResult = indexOfAsciiRanges(ranges, bitmap0, bitmap1, position);
+      int asciiResult = indexOfAsciiRanges(ranges, bitmap0, bitmap1, position, scanLen);
       if (asciiResult >= -1) {
         return asciiResult;
       }
       if (bitmap0 == 0 && bitmap1 == 0) {
-        return indexOfNonAsciiCodePointClass(ranges, position);
+        return indexOfNonAsciiCodePointClass(ranges, position, scanLen);
       }
     }
-    while (position < length) {
+    while (position < scanLen) {
       int codePointPosition = position;
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
@@ -213,7 +221,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
         position = InputScanner.position(decoded);
       }
       if (InputScanner.classContains(ranges, bitmap0, bitmap1, codePoint)) {
-        return codePointPosition;
+        return codePointPosition < scanLen ? codePointPosition : -1;
       }
     }
     return -1;
@@ -225,17 +233,17 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
    * @return the match position, {@code -1} when the class is absent, or {@code -2} when the class
    *     requires the general code-point scan
    */
-  private int indexOfAsciiRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
+  private int indexOfAsciiRanges(int[] ranges, long bitmap0, long bitmap1, int start, int scanLen) {
     if (ranges.length >= 2 && ranges[0] >= 0 && ranges[ranges.length - 1] < 0x80) {
-      if (scanProvider != null && length - start >= scanProvider.minimumInputLength()) {
+      if (scanProvider != null && scanLen - start >= scanProvider.minimumInputLength()) {
         int position = start;
-        int scalarLimit = Math.min(length, position + VECTOR_SCALAR_PROLOGUE_LENGTH);
+        int scalarLimit = Math.min(scanLen, position + VECTOR_SCALAR_PROLOGUE_LENGTH);
         for (; position < scalarLimit; position++) {
           if (InputScanner.classContains(ranges, bitmap0, bitmap1, unsignedByteAt(position))) {
             return position;
           }
         }
-        int result = scanProvider.indexOfAsciiClass(bytes, offset, length, ranges, position);
+        int result = scanProvider.indexOfAsciiClass(bytes, offset, scanLen, ranges, position);
         if (result != VectorScanProvider.UNSUPPORTED) {
           return result;
         }
@@ -245,12 +253,13 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       int low = ranges[0];
       int high = ranges[1];
       if (low == high) {
-        return indexOfByte((byte) low, start);
+        int res = indexOfByte((byte) low, start);
+        return (res >= 0 && res < scanLen) ? res : -1;
       }
       if (high == low + 1) {
-        return ByteSwarScan.indexOfBytePair(bytes, offset, length, (byte) low, (byte) high, start);
+        return ByteSwarScan.indexOfBytePair(bytes, offset, scanLen, (byte) low, (byte) high, start);
       }
-      return ByteSwarScan.indexOfByteRange(bytes, offset, length, low, high, start);
+      return ByteSwarScan.indexOfByteRange(bytes, offset, scanLen, low, high, start);
     }
     if (ranges.length == 4
         && ranges[0] == ranges[1]
@@ -258,20 +267,15 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
         && ranges[0] >= 0
         && ranges[3] < 0x80) {
       return ByteSwarScan.indexOfBytePair(
-          bytes, offset, length, (byte) ranges[0], (byte) ranges[2], start);
+          bytes, offset, scanLen, (byte) ranges[0], (byte) ranges[2], start);
     }
     return -2;
   }
 
-  private int indexOfMultipleByteRanges(int[] ranges, long bitmap0, long bitmap1, int start) {
-    return ByteSwarScan.indexOfMultipleByteRanges(
-        bytes, offset, length, ranges, bitmap0, bitmap1, start);
-  }
-
-  private int indexOfNonAsciiCodePointClass(int[] ranges, int start) {
+  private int indexOfNonAsciiCodePointClass(int[] ranges, int start, int scanLen) {
     int position = start;
-    int wordEnd = length - Long.BYTES;
-    while (position < length) {
+    int wordEnd = scanLen - Long.BYTES;
+    while (position < scanLen) {
       if (position <= wordEnd) {
         long word = (long) LONG_VIEW.get(bytes, offset + position);
         if ((word & BYTE_HIGH_BITS) == 0) {
@@ -289,7 +293,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       int codePoint = InputScanner.codePoint(decoded);
       position = InputScanner.position(decoded);
       if (InputScanner.classContains(ranges, 0, 0, codePoint)) {
-        return codePointPosition;
+        return codePointPosition < scanLen ? codePointPosition : -1;
       }
     }
     return -1;
@@ -677,6 +681,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
 
   @Override
   public int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
-    return indexOfCodePointClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, start);
+    return indexOfCodePointClass(
+        scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, start, length);
   }
 }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -169,6 +169,11 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   }
 
   @Override
+  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
+    return indexOfCodePointClass(ranges, bitmap0, bitmap1, start, length);
+  }
+
+  @Override
   public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit) {
     int position = Math.max(0, start);
     int scanLen = Math.min(length, limit);

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -169,11 +169,6 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   }
 
   @Override
-  public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start) {
-    return indexOfCodePointClass(ranges, bitmap0, bitmap1, start, length);
-  }
-
-  @Override
   public int indexOfCodePointClass(int[] ranges, long bitmap0, long bitmap1, int start, int limit) {
     int position = Math.max(0, start);
     int scanLen = Math.min(length, limit);

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -48,6 +48,25 @@ sealed interface Utf8StartAccelerator {
    */
   int findCandidate(Utf8InputScanner scanner, int fromIndex);
 
+  /**
+   * Finds the next candidate match start position at or after {@code pos} using pattern-matched
+   * devirtualization.
+   *
+   * <p>Direct sealed-type pattern matching avoids {@code invokeinterface} dispatch overhead on hot
+   * matching loops. HotSpot C2 does not automatically devirtualize megamorphic interface calls with
+   * &ge; 3 implementations across the JVM lifecycle; switching over the sealed record subtypes here
+   * allows C2 to inline candidate searches directly into caller loops.
+   */
+  static int findNextCandidate(
+      Utf8StartAccelerator accelerator, Utf8InputScanner scanner, int pos) {
+    return switch (accelerator) {
+      case Literal lit -> lit.findCandidate(scanner, pos);
+      case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
+      case FixedOffset fo -> fo.findCandidate(scanner, pos);
+      case CharClass cc -> cc.findCandidate(scanner, pos);
+    };
+  }
+
   /** Returns the tuning and diagnostic policy for this accelerator. */
   default AcceleratorPolicy policy() {
     return AcceleratorPolicy.DEFAULT;
@@ -167,7 +186,7 @@ sealed interface Utf8StartAccelerator {
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       if (scanInfo != null) {
         return scanner.indexOfCodePointClass(
-            scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex);
+            scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex, scanner.length());
       }
       return fromIndex;
     }

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -682,4 +682,13 @@ class DfaTest {
     assertThat(accelerated.matcher(input).find()).isTrue();
     assertThat(accelerated.find(Utf8Input.validated(input.getBytes(UTF_8)))).isTrue();
   }
+
+  @Test
+  void wordBoundaryLongText() {
+    String regex = "(?:\\w(?:\\b))";
+    String input = "#".repeat(260) + "a";
+    Pattern pattern = Pattern.compile(regex);
+    assertThat(pattern.matcher(input).find()).isTrue();
+    assertThat(pattern.find(Utf8Input.validated(input.getBytes(UTF_8)))).isTrue();
+  }
 }

--- a/safere/src/test/java/org/safere/InputScannerTest.java
+++ b/safere/src/test/java/org/safere/InputScannerTest.java
@@ -44,15 +44,21 @@ class InputScannerTest {
     StringInputScanner stringScanner = new StringInputScanner(text);
     Utf8InputScanner utf8Scanner = new Utf8InputScanner(text.getBytes(UTF_8));
 
-    assertThat(stringScanner.indexOfCodePointClass(cjk, 0, 0, 0)).isEqualTo(4);
-    assertThat(stringScanner.indexOfCodePointClass(supplementary, 0, 0, 0)).isEqualTo(2);
-    assertThat(stringScanner.indexOfCodePointClass(cjk, 0, 0, 5)).isEqualTo(-1);
-    assertThat(utf8Scanner.indexOfCodePointClass(cjk, 0, 0, 0)).isEqualTo(7);
-    assertThat(utf8Scanner.indexOfCodePointClass(supplementary, 0, 0, 0)).isEqualTo(3);
-    assertThat(utf8Scanner.indexOfCodePointClass(cjk, 0, 0, 10)).isEqualTo(-1);
+    assertThat(stringScanner.indexOfCodePointClass(cjk, 0, 0, 0, stringScanner.length()))
+        .isEqualTo(4);
+    assertThat(stringScanner.indexOfCodePointClass(supplementary, 0, 0, 0, stringScanner.length()))
+        .isEqualTo(2);
+    assertThat(stringScanner.indexOfCodePointClass(cjk, 0, 0, 5, stringScanner.length()))
+        .isEqualTo(-1);
+    assertThat(utf8Scanner.indexOfCodePointClass(cjk, 0, 0, 0, utf8Scanner.length())).isEqualTo(7);
+    assertThat(utf8Scanner.indexOfCodePointClass(supplementary, 0, 0, 0, utf8Scanner.length()))
+        .isEqualTo(3);
+    assertThat(utf8Scanner.indexOfCodePointClass(cjk, 0, 0, 10, utf8Scanner.length()))
+        .isEqualTo(-1);
 
     Utf8InputScanner paddedUtf8Scanner =
         new Utf8InputScanner(("a".repeat(24) + "中").getBytes(UTF_8));
-    assertThat(paddedUtf8Scanner.indexOfCodePointClass(cjk, 0, 0, 0)).isEqualTo(24);
+    assertThat(paddedUtf8Scanner.indexOfCodePointClass(cjk, 0, 0, 0, paddedUtf8Scanner.length()))
+        .isEqualTo(24);
   }
 }

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -137,7 +137,7 @@ class Utf8InputScannerTest {
           storage[offset + expected] = (byte) matchingByte;
           Utf8InputScanner scanner = new Utf8InputScanner(storage, offset, 40);
 
-          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, 0))
+          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, 0, scanner.length()))
               .as("ranges %s, offset %s, position %s", Arrays.toString(ranges), offset, expected)
               .isEqualTo(expected);
         }
@@ -166,10 +166,12 @@ class Utf8InputScannerTest {
           storage[offset + expected] = (byte) ranges[ranges.length - 1];
           Utf8InputScanner scanner = new Utf8InputScanner(storage, offset, length);
 
-          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, 0))
+          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, 0, scanner.length()))
               .as("ranges %s, offset %s, position %s", Arrays.toString(ranges), offset, expected)
               .isEqualTo(expected);
-          assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, expected + 1))
+          assertThat(
+                  scanner.indexOfCodePointClass(
+                      ranges, bitmap0, bitmap1, expected + 1, scanner.length()))
               .as("absent tail for ranges %s, offset %s", Arrays.toString(ranges), offset)
               .isEqualTo(-1);
         }
@@ -228,9 +230,12 @@ class Utf8InputScannerTest {
 
     Utf8InputScanner scanner = new Utf8InputScanner(bytes);
 
-    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, -4)).isEqualTo(0);
-    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, 1)).isEqualTo(bytes.length - 1);
-    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, bytes.length)).isEqualTo(-1);
+    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, -4, scanner.length()))
+        .isEqualTo(0);
+    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, 1, scanner.length()))
+        .isEqualTo(bytes.length - 1);
+    assertThat(scanner.indexOfCodePointClass(digits, bitmap0, 0, bytes.length, scanner.length()))
+        .isEqualTo(-1);
   }
 
   @Test
@@ -252,7 +257,9 @@ class Utf8InputScannerTest {
             int clampedStart = Math.max(0, start);
             int expected = clampedStart <= high ? Math.max(clampedStart, low) : -1;
 
-            assertThat(scanner.indexOfCodePointClass(ranges, bitmap0, bitmap1, start))
+            assertThat(
+                    scanner.indexOfCodePointClass(
+                        ranges, bitmap0, bitmap1, start, scanner.length()))
                 .as("offset %s, range [%s, %s], start %s", offset, low, high, start)
                 .isEqualTo(expected);
           }


### PR DESCRIPTION
I found this opportunity looking at vectorized String scans (https://github.com/eaftan/safere/pull/656), this adds the optimization to the existing DFA loop acceleration, which is beneficial for the existing accelerators.

- Add `StateAccelerator.CharClassEscape` record
- Collect escape sets with `AsciiBitmap` in `Dfa.analyzeStateAcceleration`
- Fast-forward DFA self-loop states with character class escapes via `InputScanner.indexOfCodePointClass

This also refactors `instanceof` checks on accelerators that are being used to avoid megamorphic virtual calls to use `instanceof` patterns patterns in switches. They should get optimized the same and have exhaustiveness checking, which is helpful to ensure that all of the fast paths are being used everywhere they should.

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline main \
  --current dfa-char-class-acceleration \
  '(schemeReplace|markupEntityStrip|customProtocolLinkReplace|findDigitAbsent).*@safere-(string|utf8)'
```

| Benchmark                                |  baseline (ns/op) |   current (ns/op) | Speedup |
| ---------------------------------------- | ----------------- | ----------------- | ------- |
| customProtocolLinkReplace.match.1000     |       19200 ± 938 |       18893 ± 710 |   1.02x |
| customProtocolLinkReplace.match.10000    |     784385 ± 7214 |     792441 ± 6116 |   0.99x |
| customProtocolLinkReplace.match.100000   | 14929314 ± 647164 | 14792199 ± 236883 |   1.01x |
| customProtocolLinkReplace.noMatch.1000   |         2025 ± 30 |         2027 ± 28 |   1.00x |
| customProtocolLinkReplace.noMatch.10000  |       19121 ± 227 |       19013 ± 152 |   1.01x |
| customProtocolLinkReplace.noMatch.100000 |    364816 ± 13613 |     193113 ± 6295 |   1.89x |
| markupEntityStrip.match.1000             |        7136 ± 212 |        6759 ± 103 |   1.06x |
| markupEntityStrip.match.10000            |      68263 ± 1634 |      70546 ± 5250 |   0.97x |
| markupEntityStrip.match.100000           |     676285 ± 8013 |    678516 ± 10835 |   1.00x |
| markupEntityStrip.noMatch.1000           |         157 ± 6.8 |         159 ± 7.8 |   0.98x |
| markupEntityStrip.noMatch.10000          |         1112 ± 11 |         1116 ± 17 |   1.00x |
| markupEntityStrip.noMatch.100000         |       10689 ± 115 |       10856 ± 416 |   0.98x |
| findDigitAbsent.1024                     |         644 ± 4.6 |          653 ± 17 |   0.99x |
| findDigitAbsent.32768                    |      20684 ± 5171 |      20477 ± 5500 |   1.01x |
| findDigitAbsent.1048576                  |    606095 ± 14699 |    612179 ± 14332 |   0.99x |