### PR TITLE
Vectorize multi-character case-insensitive ASCII prefix search on UTF-8

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -3178,6 +3178,44 @@
       "requirements": []
     },
     {
+      "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeywordFind.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        {
+          "java": "(?i)keyword_to_find",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
+      ],
+      "inputs": [
+        "realWorldRegex.caseInsensitiveKeyword.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "requirements": []
+    },
+    {
       "id": "RealWorldRegexBenchmark.runBenchmark.boundedNameMatch.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [

--- a/safere/src/main/java/org/safere/Ascii.java
+++ b/safere/src/main/java/org/safere/Ascii.java
@@ -128,4 +128,104 @@ final class Ascii {
     }
     return true;
   }
+
+  /**
+   * Approximate byte frequency ranks (0 = most common in text/code, 127 = rarest) for ASCII
+   * characters, mapping uppercase and lowercase to the same rank.
+   */
+  private static final byte[] ASCII_FREQUENCY_RANK = new byte[128];
+
+  static {
+    // Default all unlisted ASCII to high rarity
+    for (int i = 0; i < 128; i++) {
+      ASCII_FREQUENCY_RANK[i] = 100;
+    }
+    // Control characters (rare in text)
+    for (int i = 0; i < 32; i++) {
+      ASCII_FREQUENCY_RANK[i] = 120;
+    }
+    // High-frequency whitespace
+    ASCII_FREQUENCY_RANK[' '] = 0;
+    ASCII_FREQUENCY_RANK['\n'] = 15;
+    ASCII_FREQUENCY_RANK['\t'] = 45;
+    ASCII_FREQUENCY_RANK['\r'] = 55;
+
+    // Common letters (case-folded: 'a'/'A' share rank)
+    setLetterRank('e', 1);
+    setLetterRank('t', 2);
+    setLetterRank('a', 3);
+    setLetterRank('o', 4);
+    setLetterRank('i', 5);
+    setLetterRank('n', 6);
+    setLetterRank('s', 7);
+    setLetterRank('r', 8);
+    setLetterRank('h', 9);
+    setLetterRank('l', 10);
+    setLetterRank('d', 11);
+    setLetterRank('c', 12);
+    setLetterRank('u', 13);
+    setLetterRank('m', 14);
+    setLetterRank('f', 16);
+    setLetterRank('p', 17);
+    setLetterRank('g', 18);
+    setLetterRank('w', 19);
+    setLetterRank('y', 20);
+    setLetterRank('b', 21);
+    setLetterRank('v', 22);
+    setLetterRank('k', 23);
+    setLetterRank('x', 24);
+    setLetterRank('j', 25);
+    setLetterRank('q', 26);
+    setLetterRank('z', 27);
+
+    // Common code/JSON/protocol punctuation
+    ASCII_FREQUENCY_RANK['"'] = 15;
+    ASCII_FREQUENCY_RANK[':'] = 16;
+    ASCII_FREQUENCY_RANK[','] = 17;
+    ASCII_FREQUENCY_RANK['.'] = 18;
+    ASCII_FREQUENCY_RANK['/'] = 19;
+    ASCII_FREQUENCY_RANK['-'] = 20;
+    ASCII_FREQUENCY_RANK['_'] = 21;
+    ASCII_FREQUENCY_RANK['='] = 22;
+    ASCII_FREQUENCY_RANK[';'] = 23;
+    ASCII_FREQUENCY_RANK['('] = 25;
+    ASCII_FREQUENCY_RANK[')'] = 25;
+    ASCII_FREQUENCY_RANK['{'] = 26;
+    ASCII_FREQUENCY_RANK['}'] = 26;
+    ASCII_FREQUENCY_RANK['['] = 27;
+    ASCII_FREQUENCY_RANK[']'] = 27;
+
+    // Digits
+    for (char d = '0'; d <= '9'; d++) {
+      ASCII_FREQUENCY_RANK[d] = (byte) (30 + (d - '0'));
+    }
+  }
+
+  private static void setLetterRank(char c, int rank) {
+    ASCII_FREQUENCY_RANK[c] = (byte) rank;
+    ASCII_FREQUENCY_RANK[Character.toUpperCase(c)] = (byte) rank;
+  }
+
+  /** Returns the byte frequency rank for an ASCII character (higher = rarer). */
+  static int frequencyRank(char c) {
+    return c < 128 ? (ASCII_FREQUENCY_RANK[c] & 0xFF) : 127;
+  }
+
+  /**
+   * Returns the offset of the rarest ASCII character in the prefix (up to prefixLen). If all
+   * characters have identical rank, returns 0.
+   */
+  static int rarestAsciiOffset(String prefix, int prefixLen) {
+    int bestOffset = 0;
+    int maxRank = -1;
+    for (int i = 0; i < prefixLen; i++) {
+      char c = prefix.charAt(i);
+      int rank = frequencyRank(c);
+      if (rank > maxRank) {
+        maxRank = rank;
+        bestOffset = i;
+      }
+    }
+    return bestOffset;
+  }
 }

--- a/safere/src/main/java/org/safere/Ascii.java
+++ b/safere/src/main/java/org/safere/Ascii.java
@@ -104,4 +104,28 @@ final class Ascii {
     }
     return failure;
   }
+
+  /** Returns whether a string matches a pattern prefix ignoring ASCII case. */
+  static boolean regionMatchesIgnoreCase(String text, int offset, String prefix, int prefixLen) {
+    for (int i = 0; i < prefixLen; i++) {
+      char c = text.charAt(offset + i);
+      char p = prefix.charAt(i);
+      if (c != p && toLowerCase(c) != toLowerCase(p)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Returns whether a byte array matches a pattern prefix ignoring ASCII case. */
+  static boolean regionMatchesIgnoreCase(byte[] bytes, int offset, String prefix, int prefixLen) {
+    for (int i = 0; i < prefixLen; i++) {
+      int c = bytes[offset + i] & 0xFF;
+      char p = prefix.charAt(i);
+      if (c != p && toLowerCase(c) != toLowerCase(p)) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -89,6 +89,8 @@ final class ByteVectorScan {
       return Math.min(Math.max(0, start), length);
     }
     int pos = Math.max(0, start);
+    long verificationWork = 0;
+    long workLimit = Utf8InputScanner.workLimit(length - pos);
 
     // Fast scalar prologue to catch immediate matches without SIMD setup
     int scalarPrologueLimit = Math.min(length - prefixLen + 1, pos + Integer.BYTES);
@@ -98,6 +100,12 @@ final class ByteVectorScan {
           && Ascii.regionMatchesIgnoreCase(bytes, offset + pos, prefix, prefixLen)) {
         return pos;
       }
+      if (b == (low & 0xFF) || b == (high & 0xFF)) {
+        verificationWork += prefixLen;
+        if (verificationWork >= workLimit) {
+          return VectorScanProvider.UNSUPPORTED;
+        }
+      }
     }
 
     int vectorLen = SPECIES.length();
@@ -105,8 +113,16 @@ final class ByteVectorScan {
     if (pos > limit) {
       int limitScalar = length - prefixLen;
       for (int p = Math.max(start, pos - anchorOffset); p <= limitScalar; p++) {
+        int b = bytes[offset + p + anchorOffset] & 0xFF;
+        if (b != (low & 0xFF) && b != (high & 0xFF)) {
+          continue;
+        }
         if (Ascii.regionMatchesIgnoreCase(bytes, offset + p, prefix, prefixLen)) {
           return p;
+        }
+        verificationWork += prefixLen;
+        if (verificationWork >= workLimit) {
+          return VectorScanProvider.UNSUPPORTED;
         }
       }
       return -1;
@@ -124,10 +140,15 @@ final class ByteVectorScan {
         while (activeLanes != 0) {
           int bit = Long.numberOfTrailingZeros(activeLanes);
           int candidatePos = pos + bit - anchorOffset;
-          if (candidatePos >= start
-              && candidatePos + prefixLen <= length
+          if (candidateInBounds(candidatePos, start, length, prefixLen)
               && Ascii.regionMatchesIgnoreCase(bytes, offset + candidatePos, prefix, prefixLen)) {
             return candidatePos;
+          }
+          if (candidateInBounds(candidatePos, start, length, prefixLen)) {
+            verificationWork += prefixLen;
+            if (verificationWork >= workLimit) {
+              return VectorScanProvider.UNSUPPORTED;
+            }
           }
           activeLanes &= activeLanes - 1;
         }
@@ -136,11 +157,23 @@ final class ByteVectorScan {
 
     int limitScalar = length - prefixLen;
     for (int p = Math.max(start, pos - anchorOffset); p <= limitScalar; p++) {
+      int b = bytes[offset + p + anchorOffset] & 0xFF;
+      if (b != (low & 0xFF) && b != (high & 0xFF)) {
+        continue;
+      }
       if (Ascii.regionMatchesIgnoreCase(bytes, offset + p, prefix, prefixLen)) {
         return p;
       }
+      verificationWork += prefixLen;
+      if (verificationWork >= workLimit) {
+        return VectorScanProvider.UNSUPPORTED;
+      }
     }
     return -1;
+  }
+
+  static boolean candidateInBounds(int candidate, int start, int length, int prefixLength) {
+    return candidate >= start && candidate <= length - prefixLength;
   }
 
   private ByteVectorScan() {}

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -140,11 +140,11 @@ final class ByteVectorScan {
         while (activeLanes != 0) {
           int bit = Long.numberOfTrailingZeros(activeLanes);
           int candidatePos = pos + bit - anchorOffset;
-          if (candidateInBounds(candidatePos, start, length, prefixLen)
+          if (Utf8InputScanner.candidatePrefixInBounds(candidatePos, start, length, prefixLen)
               && Ascii.regionMatchesIgnoreCase(bytes, offset + candidatePos, prefix, prefixLen)) {
             return candidatePos;
           }
-          if (candidateInBounds(candidatePos, start, length, prefixLen)) {
+          if (Utf8InputScanner.candidatePrefixInBounds(candidatePos, start, length, prefixLen)) {
             verificationWork += prefixLen;
             if (verificationWork >= workLimit) {
               return VectorScanProvider.UNSUPPORTED;
@@ -170,10 +170,6 @@ final class ByteVectorScan {
       }
     }
     return -1;
-  }
-
-  static boolean candidateInBounds(int candidate, int start, int length, int prefixLength) {
-    return candidate >= start && candidate <= length - prefixLength;
   }
 
   private ByteVectorScan() {}

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -143,24 +143,5 @@ final class ByteVectorScan {
     return -1;
   }
 
-  public static int indexOfIgnoreCase(
-      byte[] bytes, int offset, int length, String prefix, int start) {
-    int prefixLen = prefix.length();
-    if (prefixLen == 0) {
-      return Math.min(Math.max(0, start), length);
-    }
-    for (int i = 0; i < prefixLen; i++) {
-      if (prefix.charAt(i) > 127) {
-        return VectorScanProvider.UNSUPPORTED;
-      }
-    }
-    int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefixLen);
-    char anchor = prefix.charAt(anchorOffset);
-    byte low = (byte) Ascii.toLowerCase(anchor);
-    byte high = (byte) Ascii.toUpperCase(anchor);
-    return indexOfIgnoreCase(
-        bytes, offset, length, prefix, prefixLen, anchorOffset, low, high, start);
-  }
-
   private ByteVectorScan() {}
 }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -76,25 +76,42 @@ final class ByteVectorScan {
   }
 
   public static int indexOfIgnoreCase(
-      byte[] bytes, int offset, int length, String prefix, int start) {
-    int prefixLen = prefix.length();
+      byte[] bytes,
+      int offset,
+      int length,
+      String prefix,
+      int prefixLen,
+      int anchorOffset,
+      byte low,
+      byte high,
+      int start) {
     if (prefixLen == 0) {
       return Math.min(Math.max(0, start), length);
     }
-    for (int i = 0; i < prefixLen; i++) {
-      if (prefix.charAt(i) > 127) {
-        return VectorScanProvider.UNSUPPORTED;
+    int pos = Math.max(0, start);
+
+    // Fast scalar prologue to catch immediate matches without SIMD setup
+    int scalarPrologueLimit = Math.min(length - prefixLen + 1, pos + Integer.BYTES);
+    for (; pos < scalarPrologueLimit; pos++) {
+      int b = bytes[offset + pos + anchorOffset] & 0xFF;
+      if ((b == (low & 0xFF) || b == (high & 0xFF))
+          && Ascii.regionMatchesIgnoreCase(bytes, offset + pos, prefix, prefixLen)) {
+        return pos;
       }
     }
 
-    int pos = Math.max(0, start);
     int vectorLen = SPECIES.length();
     int limit = length - vectorLen;
+    if (pos > limit) {
+      int limitScalar = length - prefixLen;
+      for (int p = Math.max(start, pos - anchorOffset); p <= limitScalar; p++) {
+        if (Ascii.regionMatchesIgnoreCase(bytes, offset + p, prefix, prefixLen)) {
+          return p;
+        }
+      }
+      return -1;
+    }
 
-    int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefixLen);
-    char anchor = prefix.charAt(anchorOffset);
-    byte low = (byte) Ascii.toLowerCase(anchor);
-    byte high = (byte) Ascii.toUpperCase(anchor);
     ByteVector lowVec = ByteVector.broadcast(SPECIES, low);
     ByteVector highVec = ByteVector.broadcast(SPECIES, high);
 
@@ -124,6 +141,25 @@ final class ByteVectorScan {
       }
     }
     return -1;
+  }
+
+  public static int indexOfIgnoreCase(
+      byte[] bytes, int offset, int length, String prefix, int start) {
+    int prefixLen = prefix.length();
+    if (prefixLen == 0) {
+      return Math.min(Math.max(0, start), length);
+    }
+    for (int i = 0; i < prefixLen; i++) {
+      if (prefix.charAt(i) > 127) {
+        return VectorScanProvider.UNSUPPORTED;
+      }
+    }
+    int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefixLen);
+    char anchor = prefix.charAt(anchorOffset);
+    byte low = (byte) Ascii.toLowerCase(anchor);
+    byte high = (byte) Ascii.toUpperCase(anchor);
+    return indexOfIgnoreCase(
+        bytes, offset, length, prefix, prefixLen, anchorOffset, low, high, start);
   }
 
   private ByteVectorScan() {}

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -91,9 +91,10 @@ final class ByteVectorScan {
     int vectorLen = SPECIES.length();
     int limit = length - vectorLen;
 
-    char first = prefix.charAt(0);
-    byte low = (byte) Ascii.toLowerCase(first);
-    byte high = (byte) Ascii.toUpperCase(first);
+    int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefixLen);
+    char anchor = prefix.charAt(anchorOffset);
+    byte low = (byte) Ascii.toLowerCase(anchor);
+    byte high = (byte) Ascii.toUpperCase(anchor);
     ByteVector lowVec = ByteVector.broadcast(SPECIES, low);
     ByteVector highVec = ByteVector.broadcast(SPECIES, high);
 
@@ -105,8 +106,9 @@ final class ByteVectorScan {
         long activeLanes = matchMask.toLong();
         while (activeLanes != 0) {
           int bit = Long.numberOfTrailingZeros(activeLanes);
-          int candidatePos = pos + bit;
-          if (candidatePos + prefixLen <= length
+          int candidatePos = pos + bit - anchorOffset;
+          if (candidatePos >= start
+              && candidatePos + prefixLen <= length
               && Ascii.regionMatchesIgnoreCase(bytes, offset + candidatePos, prefix, prefixLen)) {
             return candidatePos;
           }
@@ -116,9 +118,9 @@ final class ByteVectorScan {
     }
 
     int limitScalar = length - prefixLen;
-    for (; pos <= limitScalar; pos++) {
-      if (Ascii.regionMatchesIgnoreCase(bytes, offset + pos, prefix, prefixLen)) {
-        return pos;
+    for (int p = Math.max(start, pos - anchorOffset); p <= limitScalar; p++) {
+      if (Ascii.regionMatchesIgnoreCase(bytes, offset + p, prefix, prefixLen)) {
+        return p;
       }
     }
     return -1;

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import static jdk.incubator.vector.VectorOperators.EQ;
 import static jdk.incubator.vector.VectorOperators.GE;
 import static jdk.incubator.vector.VectorOperators.LE;
 
@@ -85,18 +86,42 @@ final class ByteVectorScan {
         return VectorScanProvider.UNSUPPORTED;
       }
     }
-    if (prefixLen > 1) {
-      return VectorScanProvider.UNSUPPORTED;
-    }
+
+    int pos = Math.max(0, start);
+    int vectorLen = SPECIES.length();
+    int limit = length - vectorLen;
+
     char first = prefix.charAt(0);
     byte low = (byte) Ascii.toLowerCase(first);
     byte high = (byte) Ascii.toUpperCase(first);
-    if (low == high) {
-      int[] range = new int[] {low, low};
-      return indexOfAsciiClass(bytes, offset, length, range, start);
+    ByteVector lowVec = ByteVector.broadcast(SPECIES, low);
+    ByteVector highVec = ByteVector.broadcast(SPECIES, high);
+
+    for (; pos <= limit; pos += vectorLen) {
+      ByteVector inputVec = ByteVector.fromArray(SPECIES, bytes, offset + pos);
+      VectorMask<Byte> matchMask = inputVec.compare(EQ, lowVec).or(inputVec.compare(EQ, highVec));
+
+      if (matchMask.anyTrue()) {
+        long activeLanes = matchMask.toLong();
+        while (activeLanes != 0) {
+          int bit = Long.numberOfTrailingZeros(activeLanes);
+          int candidatePos = pos + bit;
+          if (candidatePos + prefixLen <= length
+              && Ascii.regionMatchesIgnoreCase(bytes, offset + candidatePos, prefix, prefixLen)) {
+            return candidatePos;
+          }
+          activeLanes &= activeLanes - 1;
+        }
+      }
     }
-    int[] ranges = new int[] {high, high, low, low};
-    return indexOfAsciiClass(bytes, offset, length, ranges, start);
+
+    int limitScalar = length - prefixLen;
+    for (; pos <= limitScalar; pos++) {
+      if (Ascii.regionMatchesIgnoreCase(bytes, offset + pos, prefix, prefixLen)) {
+        return pos;
+      }
+    }
+    return -1;
   }
 
   private ByteVectorScan() {}

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -399,18 +399,6 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
     return indexOfLinearIgnoreCase(bytes, offset, length, prefix, failure, start);
   }
 
-  int indexOfIgnoreCase(String prefix, int[] failure, int start) {
-    int prefixLen = prefix.length();
-    if (prefixLen == 0) {
-      return start;
-    }
-    int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefixLen);
-    char anchor = prefix.charAt(anchorOffset);
-    byte low = (byte) Ascii.toLowerCase(anchor);
-    byte high = (byte) Ascii.toUpperCase(anchor);
-    return indexOfIgnoreCase(prefix, failure, anchorOffset, low, high, start);
-  }
-
   static int indexOfLinearIgnoreCase(
       byte[] bytes, int offset, int length, String prefix, int[] failure, int start) {
     int prefixLen = prefix.length();

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -366,32 +366,49 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
     return -1;
   }
 
-  int indexOfIgnoreCase(String prefix, int[] failure, int start) {
+  int indexOfIgnoreCase(
+      String prefix, int[] failure, int anchorOffset, byte anchorLow, byte anchorHigh, int start) {
     int prefixLen = prefix.length();
     if (prefixLen == 0) {
       return start;
     }
     if (!WorkCounterConfig.ENABLED) {
       if (scanProvider != null && length - start >= scanProvider.minimumInputLength()) {
-        int result = ByteVectorScan.indexOfIgnoreCase(bytes, offset, length, prefix, start);
+        int result =
+            ByteVectorScan.indexOfIgnoreCase(
+                bytes,
+                offset,
+                length,
+                prefix,
+                prefixLen,
+                anchorOffset,
+                anchorLow,
+                anchorHigh,
+                start);
         if (result != VectorScanProvider.UNSUPPORTED) {
           return result;
         }
       }
       if (prefixLen == 1) {
-        char first = prefix.charAt(0);
-        if (first <= 127) {
-          int low = Ascii.toLowerCase(first);
-          int high = Ascii.toUpperCase(first);
-          if (low == high) {
-            return indexOfByte((byte) low, start);
-          }
-          return ByteSwarScan.indexOfBytePair(
-              bytes, offset, length, (byte) low, (byte) high, start);
+        if (anchorLow == anchorHigh) {
+          return indexOfByte(anchorLow, start);
         }
+        return ByteSwarScan.indexOfBytePair(bytes, offset, length, anchorLow, anchorHigh, start);
       }
     }
     return indexOfLinearIgnoreCase(bytes, offset, length, prefix, failure, start);
+  }
+
+  int indexOfIgnoreCase(String prefix, int[] failure, int start) {
+    int prefixLen = prefix.length();
+    if (prefixLen == 0) {
+      return start;
+    }
+    int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefixLen);
+    char anchor = prefix.charAt(anchorOffset);
+    byte low = (byte) Ascii.toLowerCase(anchor);
+    byte high = (byte) Ascii.toUpperCase(anchor);
+    return indexOfIgnoreCase(prefix, failure, anchorOffset, low, high, start);
   }
 
   static int indexOfLinearIgnoreCase(

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -340,6 +340,10 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
     return Math.max(1L, (long) remaining * 2);
   }
 
+  static boolean candidatePrefixInBounds(int candidate, int start, int length, int prefixLength) {
+    return candidate >= start && candidate <= length - prefixLength;
+  }
+
   static long addCandidateWork(long work, int candidateCount, int literalLength) {
     return work + (long) candidateCount * literalLength + Long.BYTES;
   }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -372,6 +372,12 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       return start;
     }
     if (!WorkCounterConfig.ENABLED) {
+      if (scanProvider != null && length - start >= scanProvider.minimumInputLength()) {
+        int result = ByteVectorScan.indexOfIgnoreCase(bytes, offset, length, prefix, start);
+        if (result != VectorScanProvider.UNSUPPORTED) {
+          return result;
+        }
+      }
       if (prefixLen == 1) {
         char first = prefix.charAt(0);
         if (first <= 127) {
@@ -379,21 +385,6 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
           int high = Ascii.toUpperCase(first);
           if (low == high) {
             return indexOfByte((byte) low, start);
-          }
-          if (scanProvider != null && length - start >= scanProvider.minimumInputLength()) {
-            int position = start;
-            int scalarLimit = Math.min(length, position + VECTOR_SCALAR_PROLOGUE_LENGTH);
-            for (; position < scalarLimit; position++) {
-              int b = bytes[offset + position] & 0xFF;
-              if (b == low || b == high) {
-                return position;
-              }
-            }
-            int[] ranges = new int[] {high, high, low, low};
-            int result = scanProvider.indexOfAsciiClass(bytes, offset, length, ranges, position);
-            if (result != VectorScanProvider.UNSUPPORTED) {
-              return result;
-            }
           }
           return ByteSwarScan.indexOfBytePair(
               bytes, offset, length, (byte) low, (byte) high, start);

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -77,7 +77,9 @@ sealed interface Utf8StartAccelerator {
   }
 
   @SuppressWarnings("ArrayRecordComponent")
-  record CaseInsensitiveLiteral(String prefix, int[] failure) implements Utf8StartAccelerator {
+  record CaseInsensitiveLiteral(
+      String prefix, int[] failure, int anchorOffset, byte anchorLow, byte anchorHigh)
+      implements Utf8StartAccelerator {
 
     static Utf8StartAccelerator create(String prefix) {
       for (int i = 0; i < prefix.length(); i++) {
@@ -85,7 +87,12 @@ sealed interface Utf8StartAccelerator {
           return null;
         }
       }
-      return new CaseInsensitiveLiteral(prefix, Ascii.ignoreCaseFailure(prefix));
+      int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefix.length());
+      char anchor = prefix.charAt(anchorOffset);
+      byte low = (byte) Ascii.toLowerCase(anchor);
+      byte high = (byte) Ascii.toUpperCase(anchor);
+      return new CaseInsensitiveLiteral(
+          prefix, Ascii.ignoreCaseFailure(prefix), anchorOffset, low, high);
     }
 
     @Override
@@ -95,7 +102,8 @@ sealed interface Utf8StartAccelerator {
 
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      return scanner.indexOfIgnoreCase(prefix, failure, fromIndex);
+      return scanner.indexOfIgnoreCase(
+          prefix, failure, anchorOffset, anchorLow, anchorHigh, fromIndex);
     }
   }
 

--- a/safere/src/test/java/org/safere/ShortScanEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/ShortScanEquivalenceTest.java
@@ -6,6 +6,7 @@
 package org.safere;
 
 import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
@@ -46,6 +47,28 @@ class ShortScanEquivalenceTest {
     } catch (Throwable t) {
       return false;
     }
+  }
+
+  @Test
+  void denseIgnoreCaseCandidatesFallBackBeforeReplayingLongPrefixes() {
+    if (!isVectorApiAvailable()) {
+      return;
+    }
+    String prefix = "z".repeat(64) + "y";
+    byte[] input = "z".repeat(4_096).getBytes(UTF_8);
+
+    assertThat(
+            ByteVectorScan.indexOfIgnoreCase(
+                input, 0, input.length, prefix, prefix.length(), 0, (byte) 'z', (byte) 'Z', 0))
+        .isEqualTo(VectorScanProvider.UNSUPPORTED);
+  }
+
+  @Test
+  void vectorCandidateBoundsDoNotOverflow() {
+    assertThat(ByteVectorScan.candidateInBounds(Integer.MAX_VALUE - 4, 0, Integer.MAX_VALUE, 8))
+        .isFalse();
+    assertThat(ByteVectorScan.candidateInBounds(Integer.MAX_VALUE - 8, 0, Integer.MAX_VALUE, 8))
+        .isTrue();
   }
 
   @ParameterizedTest

--- a/safere/src/test/java/org/safere/ShortScanEquivalenceTest.java
+++ b/safere/src/test/java/org/safere/ShortScanEquivalenceTest.java
@@ -65,9 +65,13 @@ class ShortScanEquivalenceTest {
 
   @Test
   void vectorCandidateBoundsDoNotOverflow() {
-    assertThat(ByteVectorScan.candidateInBounds(Integer.MAX_VALUE - 4, 0, Integer.MAX_VALUE, 8))
+    assertThat(
+            Utf8InputScanner.candidatePrefixInBounds(
+                Integer.MAX_VALUE - 4, 0, Integer.MAX_VALUE, 8))
         .isFalse();
-    assertThat(ByteVectorScan.candidateInBounds(Integer.MAX_VALUE - 8, 0, Integer.MAX_VALUE, 8))
+    assertThat(
+            Utf8InputScanner.candidatePrefixInBounds(
+                Integer.MAX_VALUE - 8, 0, Integer.MAX_VALUE, 8))
         .isTrue();
   }
 

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -416,6 +416,39 @@ class Utf8MatcherStateMachineTest {
         .isEqualTo(expectedBoundaries);
   }
 
+  @Test
+  void caseInsensitiveMultiCharPrefixMatchesAcrossVectorBoundaries() {
+    String pattern = "(?i)http_query";
+    String input =
+        "http_first http_second http_third "
+            + "HTTP_other HTTP_next "
+            + "hTtP_almost "
+            + "HTTP_QUERY_final";
+    Pattern p = Pattern.compile(pattern);
+    Utf8Matcher matcher = p.matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+
+    assertThat(matcher.find()).isTrue();
+    int expectedStart = input.indexOf("HTTP_QUERY");
+    assertThat(matcher.start()).isEqualTo(expectedStart);
+    assertThat(matcher.end()).isEqualTo(expectedStart + "http_query".length());
+    assertThat(matcher.find()).isFalse();
+  }
+
+  @Test
+  void caseInsensitivePrefixWithRareAnchorHandlesDenseFalseCandidates() {
+    // 't' is very common, 'z' is rare.
+    String pattern = "(?i)the_zone";
+    String noise = "the_alpha the_beta the_gamma the_delta ";
+    String input = noise.repeat(5) + "THE_ZONE";
+    Pattern p = Pattern.compile(pattern);
+    Utf8Matcher matcher = p.matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+
+    assertThat(matcher.find()).isTrue();
+    int expectedStart = input.indexOf("THE_ZONE");
+    assertThat(matcher.start()).isEqualTo(expectedStart);
+    assertThat(matcher.end()).isEqualTo(expectedStart + "the_zone".length());
+  }
+
   private static Utf8Matcher matcher(String pattern, String input) {
     return Pattern.compile(pattern).matcher(Utf8Input.validated(input.getBytes(UTF_8)));
   }


### PR DESCRIPTION
I found this opportunity looking at vectorized String scans (https://github.com/eaftan/safere/pull/656), this adds the optimization to the existing UTF-8 `byte[]` paths.

- Add `Ascii.regionMatchesIgnoreCase` overload for `byte[]`
- Implement 32-lane candidate first-character filtering in `ByteVectorScan.indexOfIgnoreCase` for multi-character ASCII prefixes
- Enable vector acceleration for multi-character prefixes in `Utf8InputScanner.indexOfIgnoreCase`

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline benchmark-case-insensitive-utf8 \
  --current utf8-multi-char-prefix \
  'caseInsensitiveKeywordFind.*@safere-utf8'
```

| Benchmark                                 | baseline (ns/op) | current (ns/op) | Speedup |
| ----------------------------------------- | ---------------- | --------------- | ------- |
| caseInsensitiveKeywordFind.match.1000     |         94 ± 1.4 |        95 ± 2.6 |   1.00x |
| caseInsensitiveKeywordFind.match.10000    |         99 ± 4.0 |        97 ± 5.5 |   1.02x |
| caseInsensitiveKeywordFind.match.100000   |         96 ± 2.0 |         95 ± 10 |   1.01x |
| caseInsensitiveKeywordFind.noMatch.1000   |        405 ± 2.5 |       401 ± 2.9 |   1.01x |
| caseInsensitiveKeywordFind.noMatch.10000  |        3873 ± 97 |       171 ± 3.1 |   22.7x |
| caseInsensitiveKeywordFind.noMatch.100000 |     39804 ± 1614 |       2046 ± 15 |   19.5x |