### PR TITLE
Add a script to run benchmarks comparing two commits

### DIFF
--- a/.agents/skills/daily-repo-assist/SKILL.md
+++ b/.agents/skills/daily-repo-assist/SKILL.md
@@ -130,12 +130,17 @@ For each trusted open non-draft PR:
      post-merge/pre-fix `HEAD` to final `HEAD`.
 
 5. For optimization PRs, reproduce only new benchmark claims made since the last review/comment.
-   Use `./run-java-benchmarks.sh` only. Never run benchmarks in parallel.
+   For targeted SafeRE nanosecond workloads with identical benchmark definitions at both revisions,
+   prefer `safere-benchmarks/scripts/compare-branch.sh`; otherwise use
+   `./run-java-benchmarks.sh` directly. Never run benchmarks in parallel.
    - Baseline: current `origin/main`.
    - Experiment: PR branch after merging current `origin/main`, plus local review fixes.
+   - Pass explicit immutable refs to the comparison script, select one String or UTF-8 execution
+     variant per invocation, and use `--long` for close, surprising, or important confirmations.
    - Use `Speedup = main ns/op / PR ns/op`; values above `1.00x` mean the PR is faster.
-   - If new PR benchmark definitions are needed to benchmark current main, state exactly which
-     benchmark-only files were overlaid onto main-library code.
+   - If the comparison script rejects changed workload or harness definitions, do not bypass its
+     check. Construct a controlled baseline with current-main production code plus the PR's
+     benchmark-only declarations, and state exactly which files were overlaid.
    - If results do not roughly match the new claim, first check whether local correctness fixes
      plausibly affected the benchmarked path. If so, run serial ablation benchmarks. If not, write
      a concrete hypothesis: baseline drift, PR revision drift, workload change, stale numbers,

--- a/.agents/skills/safere-pr-review-scout/SKILL.md
+++ b/.agents/skills/safere-pr-review-scout/SKILL.md
@@ -247,7 +247,15 @@ git diff <post-merge-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
 7. For optimization PRs only, reproduce benchmarks:
    - Baseline is current `origin/main`.
    - Experiment is the PR branch after merging current `origin/main`, plus any local review fixes.
-   - Use only `./run-java-benchmarks.sh`.
+   - For targeted SafeRE nanosecond workloads whose benchmark definitions are identical at both
+     revisions, prefer `safere-benchmarks/scripts/compare-branch.sh` with explicit immutable refs.
+     Run String and UTF-8 variants separately, add `--vector` only when the experimental provider is
+     part of the claim, and use `--long` for close, surprising, or important confirmation results.
+     The comparison script invokes `./run-java-benchmarks.sh`; otherwise use that wrapper directly.
+   - If the comparison script rejects changed workload data, harness code, runner settings, or build
+     definitions, do not bypass its comparability check. Build a controlled baseline with current
+     main production code plus the PR's benchmark-only declarations, record its exact commit, and
+     run paired wrapper commands in isolated clean worktrees.
    - Never run benchmarks in parallel.
    - Prefer benchmark filters claimed in the PR description or comments. If unclear, choose the
      smallest relevant benchmark set and state the inference.
@@ -504,8 +512,10 @@ the post-merge/pre-fix HEAD to final HEAD so the patch contains only scout fixes
 changes.
 
 For optimization PRs, reproduce benchmark claims using current origin/main as baseline and the PR
-branch plus local review fixes as experiment. Use ./run-java-benchmarks.sh only. Never run tests or
-benchmarks concurrently. If benchmark results do not roughly reproduce the PR claim, check whether
+branch plus local review fixes as experiment. Prefer
+safere-benchmarks/scripts/compare-branch.sh for comparable targeted SafeRE nanosecond workloads;
+otherwise use ./run-java-benchmarks.sh directly. Never run tests or benchmarks concurrently. If
+benchmark results do not roughly reproduce the PR claim, check whether
 local correctness fixes caused the difference by running serial ablation benchmarks where
 applicable; if not, include a concrete hypothesis for the discrepancy such as baseline drift, PR
 revision drift, workload changes, stale PR numbers, command differences, or measurement variance.

--- a/.agents/skills/write-benchmark-report/SKILL.md
+++ b/.agents/skills/write-benchmark-report/SKILL.md
@@ -58,6 +58,23 @@ selected suite. Preserve the exact command and whether standard, long, smoke, cr
 external-suite modes were used. If the run failed, preserve its output, diagnose the failure, and
 continue only when doing so does not compromise comparability.
 
+### Targeted Revision Comparisons
+
+For a focused before/after comparison of two SafeRE revisions, prefer
+`safere-benchmarks/scripts/compare-branch.sh` when both revisions contain identical workload data,
+benchmark harnesses, runner settings, and relevant build definitions. Pass explicit refs, select
+exactly one `@safere-string` or `@safere-utf8` execution variant per invocation, and run separate
+invocations serially when both representations matter. Use `--vector` only when both revisions
+should enable the experimental Vector provider. Use standard mode first and `--long` to confirm
+close, surprising, or important results.
+
+The comparison script covers targeted SafeRE nanosecond workloads; it does not replace full
+collections, published evidence, cross-engine or cross-runtime comparisons, specialized timing
+modes, or memory measurements. If it rejects the revisions because benchmark definitions differ,
+do not bypass the check. Construct a controlled baseline carrying the experiment's benchmark-only
+declarations while keeping baseline production code, record that exact baseline commit, and run the
+project wrappers serially in isolated clean worktrees.
+
 ## Normalize And Audit
 
 Prefer `normalized-results.jsonl` for calculations and retain the original harness output as the

--- a/README.md
+++ b/README.md
@@ -604,6 +604,24 @@ development iteration or focused investigation; use
 ./run-java-memory-benchmarks.sh --declared
 ```
 
+For a controlled before/after comparison of two commits that share the same workload and benchmark
+harness definitions, use:
+
+```bash
+./safere-benchmarks/scripts/compare-branch.sh \
+  --baseline origin/main \
+  --current HEAD \
+  'RegexBenchmark\.emailFind@safere-string'
+```
+
+The command resolves both refs before switching revisions, rebuilds each revision, and prints a
+normalized comparison table. Each invocation must select exactly one SafeRE execution variant;
+run String and UTF-8 comparisons separately. Use `--vector` when both revisions should enable the
+experimental Vector provider, and use `--long` to confirm close, surprising, or important results.
+The command deliberately refuses comparisons when workload data, runner settings, harness code, or
+relevant build definitions differ. In those cases, construct a controlled baseline that uses the
+same benchmark definitions, or use the full collection workflow when preparing a published report.
+
 Use `BenchmarkCollectionPlan trials` to discover trial IDs by mode, timing
 unit, workload prefix, or execution variant. Benchmark regexes select generic
 JMH entry points, and arguments after `--` can select a specific trial or pass

--- a/safere-benchmarks/scripts/compare-benchmarks.py
+++ b/safere-benchmarks/scripts/compare-benchmarks.py
@@ -352,9 +352,9 @@ def _simplify_benchmark_name(benchmark):
         # If followed by a generic harness runner method, strip class + runner
         if len(remaining) >= 3 and remaining[1] in _GENERIC_RUNNER_METHODS:
             return ".".join(remaining[2:])
-        # Otherwise, strip just the class name
+        # Otherwise retain the class so methods shared by multiple classes remain distinct.
         elif len(remaining) >= 2:
-            return ".".join(remaining[1:])
+            return ".".join(remaining)
 
     return ".".join(remaining)
 
@@ -401,19 +401,48 @@ def load_declared_plan(path):
     return statuses
 
 
+_TIME_UNIT_SECONDS = {
+    "ns/op": 1e-9,
+    "us/op": 1e-6,
+    "ms/op": 1e-3,
+    "s/op": 1.0,
+}
+_THROUGHPUT_UNIT_PER_SECOND = {
+    "ops/ns": 1e9,
+    "ops/us": 1e6,
+    "ops/ms": 1e3,
+    "ops/s": 1.0,
+}
+
+
+def _canonical_measurement(result):
+    unit = (result.unit or "").lower().replace("µ", "u").replace("μ", "u")
+    if unit in _TIME_UNIT_SECONDS:
+        return "time", result.score * _TIME_UNIT_SECONDS[unit]
+    if unit in _THROUGHPUT_UNIT_PER_SECOND:
+        return "throughput", result.score * _THROUGHPUT_UNIT_PER_SECOND[unit]
+    return None
+
+
 def _format_speedup(r_base, r_curr):
-    """Computes and formats the speedup ratio between a baseline and current measurement."""
+    """Computes and formats a unit-normalized speedup ratio."""
     if not r_base or not r_curr or r_base.score <= 0 or r_curr.score <= 0:
         return "—"
-    unit = (r_base.unit or r_curr.unit or "").lower()
-    if "ops" in unit or "thrpt" in unit:
-        ratio = r_curr.score / r_base.score
+
+    base = _canonical_measurement(r_base)
+    current = _canonical_measurement(r_curr)
+    if base is None or current is None or base[0] != current[0]:
+        return "—"
+    if base[0] == "throughput":
+        ratio = current[1] / base[1]
     else:
-        ratio = r_base.score / r_curr.score
+        ratio = base[1] / current[1]
     if ratio >= 10.0:
         return f"{ratio:.1f}x"
     elif ratio >= 1.0:
         return f"{ratio:.2f}x"
+    elif ratio < 0.01:
+        return f"{ratio:.2g}x"
     else:
         return f"{ratio:.2f}x"
 
@@ -483,16 +512,17 @@ def generate_tables(
             lines.append(f"### {cls}")
             lines.append("")
 
-        # Determine the unit from the first available result for this group.
-        unit = ""
-        for bench in benchmarks:
-            for eng in engines:
-                r = index.get((bench, eng))
-                if r and r.unit:
-                    unit = r.unit
-                    break
-            if unit:
-                break
+        # A grouped table normally has one unit. A unified table may combine benchmark families,
+        # so preserve mixed units explicitly per row rather than mislabeling every measurement with
+        # the first result's unit.
+        units = {
+            r.unit
+            for bench in benchmarks
+            for eng in engines
+            if (r := index.get((bench, eng))) and r.unit
+        }
+        mixed_units = len(units) > 1
+        unit = next(iter(units), "") if not mixed_units else ""
 
         # Build header.
         header_bench = "Benchmark"
@@ -508,7 +538,8 @@ def generate_tables(
             for eng in engines:
                 r = index.get((bench, eng))
                 if r:
-                    cells.append(_fmt_cell(r.score, r.error))
+                    cell = _fmt_cell(r.score, r.error)
+                    cells.append(f"{cell} {r.unit}" if mixed_units and r.unit else cell)
                 elif declared_statuses and declared_statuses.get((bench, eng)) == "excluded":
                     cells.append("excluded")
                 elif declared_statuses and declared_statuses.get((bench, eng)) == "declared":

--- a/safere-benchmarks/scripts/compare-benchmarks.py
+++ b/safere-benchmarks/scripts/compare-benchmarks.py
@@ -320,6 +320,45 @@ def _fmt_cell(score, error):
 # ---------------------------------------------------------------------------
 
 
+_GENERIC_RUNNER_METHODS = frozenset({
+    "run",
+    "runBenchmark",
+    "runDeclared",
+    "runScaling",
+    "runNoFork",
+    "runColdStart",
+    "runSpecialized",
+})
+
+
+def _simplify_benchmark_name(benchmark):
+    """Dynamically strip package, class, and generic harness runner prefixes."""
+    parts = benchmark.split(".")
+
+    # 1. Skip leading lowercase package segments (e.g., 'org.safere.benchmark')
+    start_idx = 0
+    while start_idx < len(parts) and parts[start_idx] and parts[start_idx][0].islower():
+        if start_idx + 1 < len(parts) and parts[start_idx + 1] and parts[start_idx + 1][0].isupper():
+            start_idx += 1
+            break
+        start_idx += 1
+
+    remaining = parts[start_idx:]
+    if not remaining:
+        return benchmark
+
+    # 2. If the first segment is a Java class name (starts with uppercase)
+    if remaining[0] and remaining[0][0].isupper():
+        # If followed by a generic harness runner method, strip class + runner
+        if len(remaining) >= 3 and remaining[1] in _GENERIC_RUNNER_METHODS:
+            return ".".join(remaining[2:])
+        # Otherwise, strip just the class name
+        elif len(remaining) >= 2:
+            return ".".join(remaining[1:])
+
+    return ".".join(remaining)
+
+
 def _benchmark_class(benchmark):
     """Return the class portion of a ``ClassName.method`` benchmark name."""
     dot = benchmark.rfind(".")
@@ -362,15 +401,41 @@ def load_declared_plan(path):
     return statuses
 
 
-def generate_tables(results, engines, declared_statuses=None):
-    """Generate markdown tables from *results*, one per benchmark class.
+def _format_speedup(r_base, r_curr):
+    """Computes and formats the speedup ratio between a baseline and current measurement."""
+    if not r_base or not r_curr or r_base.score <= 0 or r_curr.score <= 0:
+        return "—"
+    unit = (r_base.unit or r_curr.unit or "").lower()
+    if "ops" in unit or "thrpt" in unit:
+        ratio = r_curr.score / r_base.score
+    else:
+        ratio = r_base.score / r_curr.score
+    if ratio >= 10.0:
+        return f"{ratio:.1f}x"
+    elif ratio >= 1.0:
+        return f"{ratio:.2f}x"
+    else:
+        return f"{ratio:.2f}x"
+
+
+def generate_tables(
+    results,
+    engines=None,
+    declared_statuses=None,
+    show_speedup=False,
+    single_table=False,
+):
+    """Generate markdown comparison tables from a list of Results.
 
     Args:
-        results: iterable of ``Result`` objects.
-        engines: ordered list of engine names for column layout.
+        results: list of Result namedtuples.
+        engines: list of engine names in column order, or None to auto-detect.
+        declared_statuses: optional dict from (benchmark, engine) to status.
+        show_speedup: if True and exactly 2 engines are compared, include Speedup column.
+        single_table: if True, render all results in one unified table with full names.
 
     Returns:
-        A string containing the full markdown output.
+        Markdown string containing one or more tables.
     """
     # Index: (benchmark, engine) → Result
     index = {}
@@ -396,21 +461,27 @@ def generate_tables(results, engines, declared_statuses=None):
             if e not in engines:
                 engines.append(e)
 
-    # Group benchmarks by class.
-    groups = collections.OrderedDict()
-    for bench in all_benchmarks:
-        cls = _benchmark_class(bench)
-        groups.setdefault(cls, []).append(bench)
+    # Group benchmarks by class (or single group if single_table is True).
+    if single_table:
+        groups = collections.OrderedDict([("", list(all_benchmarks.keys()))])
+    else:
+        groups = collections.OrderedDict()
+        for bench in all_benchmarks:
+            cls = _benchmark_class(bench)
+            groups.setdefault(cls, []).append(bench)
+
+    include_speedup = show_speedup and len(engines) == 2
 
     lines = []
     first_group = True
     for cls, benchmarks in groups.items():
-        if not first_group:
+        if not first_group and cls:
             lines.append("")
         first_group = False
 
-        lines.append(f"### {cls}")
-        lines.append("")
+        if cls:
+            lines.append(f"### {cls}")
+            lines.append("")
 
         # Determine the unit from the first available result for this group.
         unit = ""
@@ -426,11 +497,13 @@ def generate_tables(results, engines, declared_statuses=None):
         # Build header.
         header_bench = "Benchmark"
         engine_headers = [f"{eng} ({unit})" if unit else eng for eng in engines]
+        if include_speedup:
+            engine_headers.append("Speedup")
 
         # Compute cell contents so we can measure column widths.
         rows = []
         for bench in benchmarks:
-            method = _benchmark_method(bench)
+            name = _simplify_benchmark_name(bench) if single_table else _benchmark_method(bench)
             cells = []
             for eng in engines:
                 r = index.get((bench, eng))
@@ -442,7 +515,11 @@ def generate_tables(results, engines, declared_statuses=None):
                     cells.append("missing")
                 else:
                     cells.append("—")
-            rows.append((method, cells))
+            if include_speedup:
+                r1 = index.get((bench, engines[0]))
+                r2 = index.get((bench, engines[1]))
+                cells.append(_format_speedup(r1, r2))
+            rows.append((name, cells))
 
         # Column widths.
         bench_width = max(len(header_bench), *(len(row[0]) for row in rows))
@@ -466,8 +543,8 @@ def generate_tables(results, engines, declared_statuses=None):
         lines.append("| " + " | ".join(sep_parts) + " |")
 
         # Emit data rows.
-        for method, cells in rows:
-            parts = [_pad(method, bench_width)]
+        for name, cells in rows:
+            parts = [_pad(name, bench_width)]
             for i, cell in enumerate(cells):
                 parts.append(_rpad(cell, col_widths[i]))
             lines.append("| " + " | ".join(parts) + " |")
@@ -512,6 +589,16 @@ def main(argv=None):
         metavar="FILE",
         help="Write all parsed results in the normalized JSON-lines format.",
     )
+    parser.add_argument(
+        "--speedup",
+        action="store_true",
+        help="Include a Speedup column when comparing exactly two engines.",
+    )
+    parser.add_argument(
+        "--single-table",
+        action="store_true",
+        help="Emit all results in a single unified table with full benchmark names.",
+    )
     args = parser.parse_args(argv)
 
     if not args.jmh and not args.json:
@@ -536,7 +623,15 @@ def main(argv=None):
     declared_statuses = (
         load_declared_plan(args.declared_plan) if args.declared_plan else None
     )
-    print(generate_tables(results, engines, declared_statuses))
+    print(
+        generate_tables(
+            results,
+            engines,
+            declared_statuses,
+            show_speedup=args.speedup,
+            single_table=args.single_table,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/safere-benchmarks/scripts/compare-branch.sh
+++ b/safere-benchmarks/scripts/compare-branch.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Copyright (c) 2025 Eddie Aftandilian. Licensed under the MIT License.
+# See LICENSE file in the project root for details.
+#
+# Compare JMH benchmarks between two git branches or commits.
+#
+# Usage:
+#   ./safere-benchmarks/scripts/compare-branch.sh [OPTIONS] [FILTER]
+#
+# Options:
+#   --baseline <ref>    Baseline git ref to compare against (default: main)
+#   --current <ref>     Target git ref to evaluate (default: current branch)
+#   --grouped-tables    Emit separate tables grouped by benchmark class
+#   --no-speedup        Do not include speedup ratio column
+#   --vector            Force enabling vector JVM flags (default: true if branch has vector)
+#
+# Examples:
+#   ./safere-benchmarks/scripts/compare-branch.sh --baseline main
+#   ./safere-benchmarks/scripts/compare-branch.sh '(jsonBlock|templateTagMatch)'
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD)"
+COMPARE_PY="$(mktemp /tmp/compare_benchmarks_XXXXXX.py)"
+cp "$SCRIPT_DIR/compare-benchmarks.py" "$COMPARE_PY"
+
+cleanup() {
+  rm -f "$COMPARE_PY"
+  current_head="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD)"
+  if [ "$current_head" != "$ORIGINAL_BRANCH" ]; then
+    git checkout -q "$ORIGINAL_BRANCH" || true
+  fi
+}
+trap cleanup EXIT
+
+BASELINE_REF="main"
+CURRENT_REF="$ORIGINAL_BRANCH"
+SINGLE_TABLE=true
+SHOW_SPEEDUP=true
+FORCE_VECTOR=false
+FILTER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      BASELINE_REF="$2"
+      shift 2
+      ;;
+    --current)
+      CURRENT_REF="$2"
+      shift 2
+      ;;
+    --single-table)
+      SINGLE_TABLE=true
+      shift
+      ;;
+    --grouped-tables|--no-single-table)
+      SINGLE_TABLE=false
+      shift
+      ;;
+    --no-speedup)
+      SHOW_SPEEDUP=false
+      shift
+      ;;
+    --vector)
+      FORCE_VECTOR=true
+      shift
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      FILTER="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$FILTER" ]; then
+  FILTER='(SingleCharClassBenchmark\.findDigitAbsent|RealWorldRegexBenchmark\.runBenchmark\.(bracketCitation\.noMatch|mapFieldPath\.(noMatch|match)|caseInsensitiveKeyword\.noMatch|customProtocolLink\.noMatch|metadataBlock\.(noMatch|match)|jsonBlock\.match|templateTagMatch\.match)|RegexBenchmark\.(literalMatch|charClassMatch|captureGroups|emailFind)|ApplicationBenchmark\.(uuidValidation|secretRedaction)).*@safere-string'
+fi
+
+VECTOR_JVM_ARGS="--add-modules=jdk.incubator.vector --add-opens=java.base/java.lang=ALL-UNNAMED -Dorg.safere.experimental.vectorScanProvider=vector"
+
+# 1. Checkout baseline and discover trials
+echo "=== Discovering benchmark trials on $BASELINE_REF / $CURRENT_REF ==="
+git checkout -q "$BASELINE_REF"
+if [ ! -f "safere-benchmarks/target/benchmarks.jar" ] || [ ! -f "safere-benchmarks/target/benchmark-corpus/manifest.json" ]; then
+  mvn -pl safere-benchmarks -am package \
+    -DskipTests \
+    -Dpmd.skip=true \
+    -Dspotless.check.skip=true \
+    -Dcheckstyle.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dexec.skip=true \
+    -q
+  ./materialize-benchmark-inputs.sh --no-build
+fi
+
+TRIALS="$(java \
+  -Dsafere.benchmark.corpus=safere-benchmarks/target/benchmark-corpus \
+  -cp safere-benchmarks/target/benchmarks.jar \
+  org.safere.benchmark.CrossEngineBenchmarkPlan nanoseconds \
+  | tr ',' '\n' \
+  | grep -E "$FILTER" \
+  | paste -sd, - || true)"
+
+if [ -z "$TRIALS" ]; then
+  # Try discovering trials on the current branch (e.g. if the branch added new benchmarks)
+  git checkout -q "$CURRENT_REF"
+  mvn -pl safere-benchmarks -am package \
+    -DskipTests \
+    -Dpmd.skip=true \
+    -Dspotless.check.skip=true \
+    -Dcheckstyle.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dexec.skip=true \
+    -q
+  ./materialize-benchmark-inputs.sh --no-build
+  TRIALS="$(java \
+    -Dsafere.benchmark.corpus=safere-benchmarks/target/benchmark-corpus \
+    -cp safere-benchmarks/target/benchmarks.jar \
+    org.safere.benchmark.CrossEngineBenchmarkPlan nanoseconds \
+    | tr ',' '\n' \
+    | grep -E "$FILTER" \
+    | paste -sd, - || true)"
+fi
+
+if [ -z "$TRIALS" ]; then
+  echo "Error: No trials matched filter: $FILTER" >&2
+  exit 1
+fi
+
+BASELINE_TXT="$(mktemp /tmp/baseline_XXXXXX.txt)"
+CURRENT_TXT="$(mktemp /tmp/current_XXXXXX.txt)"
+BASELINE_JSONL="$(mktemp /tmp/baseline_XXXXXX.jsonl)"
+CURRENT_JSONL="$(mktemp /tmp/current_XXXXXX.jsonl)"
+
+# 2. Run Baseline
+echo "=== Running Baseline: $BASELINE_REF ==="
+git checkout -q "$BASELINE_REF"
+./run-java-benchmarks.sh CrossEngineBenchmark.run --fastbuild -- \
+  -p crossEngineTrial="$TRIALS" \
+  -jvmArgsPrepend "$VECTOR_JVM_ARGS" | tee "$BASELINE_TXT"
+python3 "$COMPARE_PY" --jmh "$BASELINE_TXT" --output-jsonl "$BASELINE_JSONL"
+sed -i -E 's/"engine"[[:space:]]*:[[:space:]]*"[^"]+"/"engine":"baseline"/' "$BASELINE_JSONL"
+
+# 3. Run Current
+echo "=== Running Current: $CURRENT_REF ==="
+git checkout -q "$CURRENT_REF"
+./run-java-benchmarks.sh CrossEngineBenchmark.run --fastbuild -- \
+  -p crossEngineTrial="$TRIALS" \
+  -jvmArgsPrepend "$VECTOR_JVM_ARGS" | tee "$CURRENT_TXT"
+python3 "$COMPARE_PY" --jmh "$CURRENT_TXT" --output-jsonl "$CURRENT_JSONL"
+sed -i -E 's/"engine"[[:space:]]*:[[:space:]]*"[^"]+"/"engine":"current"/' "$CURRENT_JSONL"
+
+# 4. Render Table
+echo ""
+echo "=== Benchmark Comparison Results ==="
+EXTRA_ARGS=()
+if [ "$SHOW_SPEEDUP" = true ]; then
+  EXTRA_ARGS+=(--speedup)
+fi
+if [ "$SINGLE_TABLE" = true ]; then
+  EXTRA_ARGS+=(--single-table)
+fi
+
+python3 "$COMPARE_PY" \
+  --json "$BASELINE_JSONL" "$CURRENT_JSONL" \
+  --engines baseline,current \
+  "${EXTRA_ARGS[@]}"
+
+rm -f "$BASELINE_TXT" "$CURRENT_TXT" "$BASELINE_JSONL" "$CURRENT_JSONL"

--- a/safere-benchmarks/scripts/compare-branch.sh
+++ b/safere-benchmarks/scripts/compare-branch.sh
@@ -10,9 +10,10 @@
 # Options:
 #   --baseline <ref>    Baseline git ref to compare against (default: main)
 #   --current <ref>     Target git ref to evaluate (default: current branch)
+#   --long              Use the longer confirmation benchmark configuration
 #   --grouped-tables    Emit separate tables grouped by benchmark class
 #   --no-speedup        Do not include speedup ratio column
-#   --vector            Force enabling vector JVM flags (default: true if branch has vector)
+#   --vector            Enable the experimental vector provider for both revisions
 #
 # Examples:
 #   ./safere-benchmarks/scripts/compare-branch.sh --baseline main
@@ -25,12 +26,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 cd "$REPO_ROOT"
 
-ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD)"
+ORIGINAL_BRANCH="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
 COMPARE_PY="$(mktemp /tmp/compare_benchmarks_XXXXXX.py)"
 cp "$SCRIPT_DIR/compare-benchmarks.py" "$COMPARE_PY"
+TEMP_FILES=("$COMPARE_PY")
 
 cleanup() {
-  rm -f "$COMPARE_PY"
+  rm -f "${TEMP_FILES[@]}"
   current_head="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD)"
   if [ "$current_head" != "$ORIGINAL_BRANCH" ]; then
     git checkout -q "$ORIGINAL_BRANCH" || true
@@ -38,11 +40,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: compare-branch.sh requires a clean working tree" >&2
+  exit 1
+fi
+
 BASELINE_REF="main"
 CURRENT_REF="$ORIGINAL_BRANCH"
 SINGLE_TABLE=true
 SHOW_SPEEDUP=true
 FORCE_VECTOR=false
+LONG_MODE=false
 FILTER=""
 
 while [[ $# -gt 0 ]]; do
@@ -71,6 +79,10 @@ while [[ $# -gt 0 ]]; do
       FORCE_VECTOR=true
       shift
       ;;
+    --long)
+      LONG_MODE=true
+      shift
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       exit 1
@@ -86,22 +98,49 @@ if [ -z "$FILTER" ]; then
   FILTER='(SingleCharClassBenchmark\.findDigitAbsent|RealWorldRegexBenchmark\.runBenchmark\.(bracketCitation\.noMatch|mapFieldPath\.(noMatch|match)|caseInsensitiveKeyword\.noMatch|customProtocolLink\.noMatch|metadataBlock\.(noMatch|match)|jsonBlock\.match|templateTagMatch\.match)|RegexBenchmark\.(literalMatch|charClassMatch|captureGroups|emailFind)|ApplicationBenchmark\.(uuidValidation|secretRedaction)).*@safere-string'
 fi
 
+# Resolve relative refs while HEAD still identifies the caller's revision.
+BASELINE_COMMIT="$(git rev-parse --verify "${BASELINE_REF}^{commit}")"
+CURRENT_COMMIT="$(git rev-parse --verify "${CURRENT_REF}^{commit}")"
+BASELINE_DATA="$(git rev-parse "${BASELINE_COMMIT}:safere-benchmarks/benchmark-data.json")"
+CURRENT_DATA="$(git rev-parse "${CURRENT_COMMIT}:safere-benchmarks/benchmark-data.json")"
+if [ "$BASELINE_DATA" != "$CURRENT_DATA" ]; then
+  echo "Error: benchmark-data.json differs between the requested revisions" >&2
+  echo "Refusing to compare scores from different workload definitions." >&2
+  exit 1
+fi
+BASELINE_RUNNER="$(git rev-parse "${BASELINE_COMMIT}:run-java-benchmarks.sh")"
+CURRENT_RUNNER="$(git rev-parse "${CURRENT_COMMIT}:run-java-benchmarks.sh")"
+if [ "$BASELINE_RUNNER" != "$CURRENT_RUNNER" ]; then
+  echo "Error: run-java-benchmarks.sh differs between the requested revisions" >&2
+  echo "Refusing to compare results collected with different benchmark settings." >&2
+  exit 1
+fi
+if ! git diff --quiet "$BASELINE_COMMIT" "$CURRENT_COMMIT" -- \
+  pom.xml safere-benchmarks materialize-benchmark-inputs.sh run-java-benchmarks.sh \
+  ':(exclude)safere-benchmarks/scripts/compare-benchmarks.py' \
+  ':(exclude)safere-benchmarks/scripts/compare-branch.sh' \
+  ':(exclude)safere-benchmarks/scripts/test_compare_benchmarks.py'; then
+  echo "Error: the benchmark harness or its build definition differs between revisions" >&2
+  echo "Refusing to attribute harness changes to library performance." >&2
+  exit 1
+fi
+
 VECTOR_JVM_ARGS="--add-modules=jdk.incubator.vector --add-opens=java.base/java.lang=ALL-UNNAMED -Dorg.safere.experimental.vectorScanProvider=vector"
 
 # 1. Checkout baseline and discover trials
 echo "=== Discovering benchmark trials on $BASELINE_REF / $CURRENT_REF ==="
-git checkout -q "$BASELINE_REF"
-if [ ! -f "safere-benchmarks/target/benchmarks.jar" ] || [ ! -f "safere-benchmarks/target/benchmark-corpus/manifest.json" ]; then
-  mvn -pl safere-benchmarks -am package \
-    -DskipTests \
-    -Dpmd.skip=true \
-    -Dspotless.check.skip=true \
-    -Dcheckstyle.skip=true \
-    -Dmaven.javadoc.skip=true \
-    -Dexec.skip=true \
-    -q
-  ./materialize-benchmark-inputs.sh --no-build
-fi
+mvn -pl safere-benchmarks -am clean -q
+git checkout -q --detach "$BASELINE_COMMIT"
+mvn -pl safere-benchmarks -am clean -q
+mvn -pl safere-benchmarks -am package \
+  -DskipTests \
+  -Dpmd.skip=true \
+  -Dspotless.check.skip=true \
+  -Dcheckstyle.skip=true \
+  -Dmaven.javadoc.skip=true \
+  -Dexec.skip=true \
+  -q
+./materialize-benchmark-inputs.sh --no-build
 
 TRIALS="$(java \
   -Dsafere.benchmark.corpus=safere-benchmarks/target/benchmark-corpus \
@@ -112,51 +151,61 @@ TRIALS="$(java \
   | paste -sd, - || true)"
 
 if [ -z "$TRIALS" ]; then
-  # Try discovering trials on the current branch (e.g. if the branch added new benchmarks)
-  git checkout -q "$CURRENT_REF"
-  mvn -pl safere-benchmarks -am package \
-    -DskipTests \
-    -Dpmd.skip=true \
-    -Dspotless.check.skip=true \
-    -Dcheckstyle.skip=true \
-    -Dmaven.javadoc.skip=true \
-    -Dexec.skip=true \
-    -q
-  ./materialize-benchmark-inputs.sh --no-build
-  TRIALS="$(java \
-    -Dsafere.benchmark.corpus=safere-benchmarks/target/benchmark-corpus \
-    -cp safere-benchmarks/target/benchmarks.jar \
-    org.safere.benchmark.CrossEngineBenchmarkPlan nanoseconds \
-    | tr ',' '\n' \
-    | grep -E "$FILTER" \
-    | paste -sd, - || true)"
-fi
-
-if [ -z "$TRIALS" ]; then
-  echo "Error: No trials matched filter: $FILTER" >&2
+  echo "Error: no baseline trials matched filter: $FILTER" >&2
+  echo "Current-only benchmark definitions cannot be compared with this script." >&2
   exit 1
 fi
+
+VARIANT_COUNT="$(printf '%s' "$TRIALS" \
+  | tr ',' '\n' \
+  | sed -n -E 's/.*@([^@]+)$/\1/p' \
+  | sort -u \
+  | wc -l)"
+if [ "$VARIANT_COUNT" -ne 1 ]; then
+  echo "Error: filter must select exactly one execution variant (for example, @safere-string)" >&2
+  exit 1
+fi
+VARIANT="$(printf '%s' "$TRIALS" | sed -n -E 's/.*@([^@,]+).*/\1/p')"
+case "$VARIANT" in
+  safere-string|safere-utf8) ;;
+  *)
+    echo "Error: branch comparisons support only SafeRE execution variants" >&2
+    exit 1
+    ;;
+esac
 
 BASELINE_TXT="$(mktemp /tmp/baseline_XXXXXX.txt)"
 CURRENT_TXT="$(mktemp /tmp/current_XXXXXX.txt)"
 BASELINE_JSONL="$(mktemp /tmp/baseline_XXXXXX.jsonl)"
 CURRENT_JSONL="$(mktemp /tmp/current_XXXXXX.jsonl)"
+TEMP_FILES+=("$BASELINE_TXT" "$CURRENT_TXT" "$BASELINE_JSONL" "$CURRENT_JSONL")
+
+VECTOR_ARGS=()
+if [ "$FORCE_VECTOR" = true ]; then
+  VECTOR_ARGS=(-jvmArgsPrepend "$VECTOR_JVM_ARGS")
+fi
+MODE_ARGS=()
+if [ "$LONG_MODE" = true ]; then
+  MODE_ARGS=(--long)
+fi
 
 # 2. Run Baseline
 echo "=== Running Baseline: $BASELINE_REF ==="
-git checkout -q "$BASELINE_REF"
-./run-java-benchmarks.sh CrossEngineBenchmark.run --fastbuild -- \
+git checkout -q --detach "$BASELINE_COMMIT"
+./run-java-benchmarks.sh "${MODE_ARGS[@]}" --fastbuild CrossEngineBenchmark.run -- \
   -p crossEngineTrial="$TRIALS" \
-  -jvmArgsPrepend "$VECTOR_JVM_ARGS" | tee "$BASELINE_TXT"
+  "${VECTOR_ARGS[@]}" | tee "$BASELINE_TXT"
 python3 "$COMPARE_PY" --jmh "$BASELINE_TXT" --output-jsonl "$BASELINE_JSONL"
 sed -i -E 's/"engine"[[:space:]]*:[[:space:]]*"[^"]+"/"engine":"baseline"/' "$BASELINE_JSONL"
 
 # 3. Run Current
 echo "=== Running Current: $CURRENT_REF ==="
-git checkout -q "$CURRENT_REF"
-./run-java-benchmarks.sh CrossEngineBenchmark.run --fastbuild -- \
+mvn -pl safere-benchmarks -am clean -q
+git checkout -q --detach "$CURRENT_COMMIT"
+mvn -pl safere-benchmarks -am clean -q
+./run-java-benchmarks.sh "${MODE_ARGS[@]}" --fastbuild CrossEngineBenchmark.run -- \
   -p crossEngineTrial="$TRIALS" \
-  -jvmArgsPrepend "$VECTOR_JVM_ARGS" | tee "$CURRENT_TXT"
+  "${VECTOR_ARGS[@]}" | tee "$CURRENT_TXT"
 python3 "$COMPARE_PY" --jmh "$CURRENT_TXT" --output-jsonl "$CURRENT_JSONL"
 sed -i -E 's/"engine"[[:space:]]*:[[:space:]]*"[^"]+"/"engine":"current"/' "$CURRENT_JSONL"
 
@@ -175,5 +224,3 @@ python3 "$COMPARE_PY" \
   --json "$BASELINE_JSONL" "$CURRENT_JSONL" \
   --engines baseline,current \
   "${EXTRA_ARGS[@]}"
-
-rm -f "$BASELINE_TXT" "$CURRENT_TXT" "$BASELINE_JSONL" "$CURRENT_JSONL"

--- a/safere-benchmarks/scripts/test_compare_benchmarks.py
+++ b/safere-benchmarks/scripts/test_compare_benchmarks.py
@@ -203,5 +203,65 @@ class CrossEngineResultParsingTest(unittest.TestCase):
             ],
         )
 
+    def test_generate_tables_with_speedup(self):
+        results = [
+            COMPARE.Result("baseline", "RegexBenchmark.literalMatch", 100.0, 5.0, "ns/op"),
+            COMPARE.Result("current", "RegexBenchmark.literalMatch", 25.0, 1.0, "ns/op"),
+        ]
+        table = COMPARE.generate_tables(
+            results,
+            engines=["baseline", "current"],
+            show_speedup=True,
+        )
+        self.assertIn("Speedup", table)
+        self.assertIn("4.00x", table)
+
+    def test_generate_tables_single_table(self):
+        results = [
+            COMPARE.Result(
+                "baseline",
+                "RealWorldRegexBenchmark.runBenchmark.jsonBlock.match.1000",
+                100.0,
+                5.0,
+                "ns/op",
+            ),
+            COMPARE.Result(
+                "current",
+                "RealWorldRegexBenchmark.runBenchmark.jsonBlock.match.1000",
+                25.0,
+                1.0,
+                "ns/op",
+            ),
+        ]
+        table = COMPARE.generate_tables(
+            results,
+            engines=["baseline", "current"],
+            single_table=True,
+        )
+        self.assertNotIn("### RealWorldRegexBenchmark", table)
+        self.assertIn("jsonBlock.match.1000", table)
+        self.assertNotIn("RealWorldRegexBenchmark.runBenchmark.", table)
+
+    def test_simplify_benchmark_name_dynamic(self):
+        self.assertEqual(
+            COMPARE._simplify_benchmark_name(
+                "org.safere.benchmark.RealWorldRegexBenchmark.runBenchmark.caseInsensitiveKeywordFind.match.1000"
+            ),
+            "caseInsensitiveKeywordFind.match.1000",
+        )
+        self.assertEqual(
+            COMPARE._simplify_benchmark_name("ApplicationBenchmark.uuidValidation"),
+            "uuidValidation",
+        )
+        self.assertEqual(
+            COMPARE._simplify_benchmark_name("SingleCharClassBenchmark.findDigitAbsent.1048576"),
+            "findDigitAbsent.1048576",
+        )
+        self.assertEqual(
+            COMPARE._simplify_benchmark_name("CustomClassBenchmark.run.specialTrial"),
+            "specialTrial",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/safere-benchmarks/scripts/test_compare_benchmarks.py
+++ b/safere-benchmarks/scripts/test_compare_benchmarks.py
@@ -216,6 +216,24 @@ class CrossEngineResultParsingTest(unittest.TestCase):
         self.assertIn("Speedup", table)
         self.assertIn("4.00x", table)
 
+    def test_speedup_normalizes_compatible_units(self):
+        baseline = COMPARE.Result("baseline", "Benchmark.run", 1000.0, 10.0, "ns/op")
+        current = COMPARE.Result("current", "Benchmark.run", 1.0, 0.01, "us/op")
+
+        self.assertEqual(COMPARE._format_speedup(baseline, current), "1.00x")
+
+    def test_speedup_rejects_incompatible_units(self):
+        latency = COMPARE.Result("baseline", "Benchmark.run", 100.0, 1.0, "ns/op")
+        throughput = COMPARE.Result("current", "Benchmark.run", 100.0, 1.0, "ops/s")
+
+        self.assertEqual(COMPARE._format_speedup(latency, throughput), "—")
+
+    def test_speedup_preserves_very_small_nonzero_ratios(self):
+        baseline = COMPARE.Result("baseline", "Benchmark.run", 100.0, 1.0, "ns/op")
+        current = COMPARE.Result("current", "Benchmark.run", 100000.0, 1.0, "ns/op")
+
+        self.assertEqual(COMPARE._format_speedup(baseline, current), "0.001x")
+
     def test_generate_tables_single_table(self):
         results = [
             COMPARE.Result(
@@ -242,6 +260,36 @@ class CrossEngineResultParsingTest(unittest.TestCase):
         self.assertIn("jsonBlock.match.1000", table)
         self.assertNotIn("RealWorldRegexBenchmark.runBenchmark.", table)
 
+    def test_generate_single_table_preserves_mixed_units(self):
+        results = [
+            COMPARE.Result("baseline", "Benchmark.latency", 100.0, 5.0, "ns/op"),
+            COMPARE.Result("current", "Benchmark.latency", 50.0, 2.0, "ns/op"),
+            COMPARE.Result("baseline", "Benchmark.throughput", 10.0, 0.5, "ops/s"),
+            COMPARE.Result("current", "Benchmark.throughput", 20.0, 1.0, "ops/s"),
+        ]
+
+        table = COMPARE.generate_tables(
+            results,
+            engines=["baseline", "current"],
+            show_speedup=True,
+            single_table=True,
+        )
+
+        self.assertIn("100 ± 5.0 ns/op", table)
+        self.assertIn("10 ± 0.50 ops/s", table)
+        self.assertIn("2.00x", table)
+
+    def test_single_table_preserves_class_identity(self):
+        results = [
+            COMPARE.Result("baseline", "FooBenchmark.match", 10.0, 1.0, "ns/op"),
+            COMPARE.Result("baseline", "BarBenchmark.match", 20.0, 2.0, "ns/op"),
+        ]
+
+        table = COMPARE.generate_tables(results, single_table=True)
+
+        self.assertIn("FooBenchmark.match", table)
+        self.assertIn("BarBenchmark.match", table)
+
     def test_simplify_benchmark_name_dynamic(self):
         self.assertEqual(
             COMPARE._simplify_benchmark_name(
@@ -251,11 +299,11 @@ class CrossEngineResultParsingTest(unittest.TestCase):
         )
         self.assertEqual(
             COMPARE._simplify_benchmark_name("ApplicationBenchmark.uuidValidation"),
-            "uuidValidation",
+            "ApplicationBenchmark.uuidValidation",
         )
         self.assertEqual(
             COMPARE._simplify_benchmark_name("SingleCharClassBenchmark.findDigitAbsent.1048576"),
-            "findDigitAbsent.1048576",
+            "SingleCharClassBenchmark.findDigitAbsent.1048576",
         )
         self.assertEqual(
             COMPARE._simplify_benchmark_name("CustomClassBenchmark.run.specialTrial"),


### PR DESCRIPTION
This supports comparing two branches or commits and presenting the results, e.g.

```
./safere-benchmarks/scripts/compare-branch.sh   --baseline main   --current dfa-char-class-acceleration   '(jsonBlock|templateTagMatch)\.match.*@safere-string'
```

This is a slightly cleaned up version of a workflow I'd been using to benchmark PRs. I'm not opinionated about the details here if you have suggestions for a better workflow or better ways to share benchmark results.