### PR TITLE
Optimize trivial matches

### DIFF
--- a/safere/src/main/java/org/safere/MatchDescriptor.java
+++ b/safere/src/main/java/org/safere/MatchDescriptor.java
@@ -28,14 +28,16 @@ record MatchDescriptor(
     String literalMatch,
     CharClassScanInfo singleCharClass,
     KeywordAlternation keywordAlternation,
-    CharClassMatchInfo charClassMatch) {
+    CharClassMatchInfo charClassMatch,
+    int minMatchLength) {
 
-  static final MatchDescriptor NONE = new MatchDescriptor(null, null, null, null);
+  static final MatchDescriptor NONE = new MatchDescriptor(null, null, null, null, 0);
 
   boolean hasFastPath() {
     return literalMatch != null
         || singleCharClass != null
         || keywordAlternation != null
-        || charClassMatch != null;
+        || charClassMatch != null
+        || minMatchLength > 0;
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -470,6 +470,14 @@ public final class Matcher implements MatchResult {
     clearDeferredCaptureState();
   }
 
+  private boolean cannotMatchLength(int availableLength) {
+    if (diagnosticOperation != null) {
+      return false;
+    }
+    int min = parentPattern.matchDescriptor().minMatchLength();
+    return min > 0 && availableLength < min;
+  }
+
   private EnginePathOptions enginePathOptions() {
     return parentPattern.enginePathOptions();
   }
@@ -622,7 +630,7 @@ public final class Matcher implements MatchResult {
   }
 
   /** Binary search through sorted [lo, hi] ranges to check if {@code cp} is in any range. */
-  private static boolean binarySearchRanges(int[] ranges, int cp) {
+  static boolean binarySearchRanges(int[] ranges, int cp) {
     int lo = 0;
     int hi = ranges.length / 2 - 1;
     while (lo <= hi) {
@@ -834,6 +842,10 @@ public final class Matcher implements MatchResult {
     modCount++;
     findExhaustedAfterTerminalEmptyMatch = false;
     searchFrom = regionStart;
+
+    if (cannotMatchLength(regionEnd - regionStart)) {
+      return applyFailedMatchResult();
+    }
 
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
@@ -1084,6 +1096,10 @@ public final class Matcher implements MatchResult {
     modCount++;
     findExhaustedAfterTerminalEmptyMatch = false;
     searchFrom = regionStart;
+
+    if (cannotMatchLength(regionEnd - regionStart)) {
+      return applyFailedMatchResult();
+    }
 
     // --- Region setup ---
     boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
@@ -1349,6 +1365,9 @@ public final class Matcher implements MatchResult {
 
   /** Runs the engine search from {@link #searchFrom} and stores the result. */
   private boolean doFind() {
+    if (cannotMatchLength(getTextLength() - searchFrom)) {
+      return applyFailedMatchResult();
+    }
     boolean regionActive = (regionStart != 0 || regionEnd != getTextLength());
     if (regionActive) {
       return doFindRegion(regionActive);
@@ -1365,6 +1384,9 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean doFindRegion(boolean regionActive) {
+    if (cannotMatchLength(regionEnd - searchFrom)) {
+      return applyFailedMatchResult();
+    }
     // --- Region setup: temporarily substitute text with the region substring ---
     String savedText = text;
     InputScanner savedTextScanner = textScanner;
@@ -4206,33 +4228,15 @@ public final class Matcher implements MatchResult {
 
     @Override
     public boolean matches(Matcher matcher) {
-      if (isStartAnchored && matcher.searchFrom > 0) {
-        return matcher.applyFailedMatchResult();
-      }
-      matcher.capturesResolved = true;
-      if (matcher.text != null) {
-        matcher.diagnosticBoundary(MatchStrategy.LITERAL);
-        boolean matched;
-        if (foldCase) {
-          matched =
-              matcher.text.length() == literal.length()
-                  && matcher.literalRegionMatches(literal, 0, literal.length());
-        } else {
-          matched = matcher.text.equals(literal);
-        }
-        if (matched) {
-          matcher.applyFullMatchResult(new int[] {0, matcher.text.length()});
-        } else {
-          if (matcher.isPartialLiteralMatch(literal, 0)) {}
-          matcher.applyFailedMatchResult();
-        }
-        return matcher.hasMatch;
-      }
-      return matcher.matchesCore();
+      return matchLiteral(matcher, true);
     }
 
     @Override
     public boolean lookingAt(Matcher matcher) {
+      return matchLiteral(matcher, false);
+    }
+
+    private boolean matchLiteral(Matcher matcher, boolean fullMatch) {
       if (isStartAnchored && matcher.searchFrom > 0) {
         return matcher.applyFailedMatchResult();
       }
@@ -4242,20 +4246,47 @@ public final class Matcher implements MatchResult {
         boolean matched;
         if (foldCase) {
           matched =
-              matcher.text.length() >= literal.length()
+              (fullMatch
+                      ? matcher.text.length() == literal.length()
+                      : matcher.text.length() >= literal.length())
                   && matcher.literalRegionMatches(literal, 0, literal.length());
         } else {
-          matched = matcher.text.startsWith(literal);
+          matched = fullMatch ? matcher.text.equals(literal) : matcher.text.startsWith(literal);
         }
         if (matched) {
-          matcher.applyFullMatchResult(new int[] {0, literal.length()});
+          matcher.applyFullMatchResult(
+              new int[] {0, fullMatch ? matcher.text.length() : literal.length()});
         } else {
           if (matcher.isPartialLiteralMatch(literal, 0)) {}
           matcher.applyFailedMatchResult();
         }
         return matcher.hasMatch;
+      } else if (matcher.activeScanner() instanceof Utf8InputScanner utf8Scanner) {
+        matcher.diagnosticBoundary(MatchStrategy.LITERAL);
+        if (foldCase) {
+          return fullMatch ? matcher.matchesCore() : matcher.lookingAtCore();
+        }
+        boolean matched;
+        if (literalUtf8 != null) {
+          matched =
+              (fullMatch
+                      ? utf8Scanner.length() == literalUtf8.length
+                      : utf8Scanner.length() >= literalUtf8.length)
+                  && utf8Scanner.startsWith(literalUtf8, 0);
+        } else {
+          matched = literal.isEmpty() && (!fullMatch || utf8Scanner.length() == 0);
+        }
+        if (matched) {
+          matcher.applyFullMatchResult(
+              new int[] {
+                0, fullMatch ? utf8Scanner.length() : (literalUtf8 == null ? 0 : literalUtf8.length)
+              });
+        } else {
+          matcher.applyFailedMatchResult();
+        }
+        return matcher.hasMatch;
       }
-      return matcher.lookingAtCore();
+      return fullMatch ? matcher.matchesCore() : matcher.lookingAtCore();
     }
   }
 
@@ -4287,20 +4318,56 @@ public final class Matcher implements MatchResult {
 
     @Override
     public boolean matches(Matcher matcher) {
-      if (isStartAnchored && matcher.searchFrom > 0) {
-        return matcher.applyFailedMatchResult();
-      }
-      matcher.capturesResolved = true;
-      if (charClassMatch != null && matcher.text != null) {
-        matcher.diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
-        return matcher.charClassMatchFastPath(charClassMatch);
-      }
-      return matcher.matchesCore();
+      return matchSingleCharClass(matcher, true);
     }
 
     @Override
     public boolean lookingAt(Matcher matcher) {
-      return matcher.lookingAtCore();
+      return matchSingleCharClass(matcher, false);
+    }
+
+    private boolean matchSingleCharClass(Matcher matcher, boolean fullMatch) {
+      if (isStartAnchored && matcher.searchFrom > 0) {
+        return matcher.applyFailedMatchResult();
+      }
+      matcher.capturesResolved = true;
+      if (charClassMatch != null && fullMatch && matcher.text != null) {
+        matcher.diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
+        return matcher.charClassMatchFastPath(charClassMatch);
+      }
+      if (singleCharClass != null) {
+        matcher.diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
+        if (matcher.text != null) {
+          int len = matcher.text.length();
+          if (len >= 1) {
+            char c0 = matcher.text.charAt(0);
+            if (len >= 2 && Character.isSurrogatePair(c0, matcher.text.charAt(1))) {
+              int cp = matcher.text.codePointAt(0);
+              if ((!fullMatch || len == 2) && singleCharClass.contains(cp)) {
+                return matcher.applyFullMatchResult(new int[] {0, 2});
+              }
+            } else {
+              int cp = c0;
+              if ((!fullMatch || len == 1) && singleCharClass.contains(cp)) {
+                return matcher.applyFullMatchResult(new int[] {0, 1});
+              }
+            }
+          }
+          return matcher.applyFailedMatchResult();
+        } else if (matcher.activeScanner() instanceof Utf8InputScanner utf8Scanner) {
+          int len = utf8Scanner.length();
+          if (len > 0) {
+            long decoded = utf8Scanner.decodeForward(0);
+            int cp = InputScanner.codePoint(decoded);
+            int nextPos = InputScanner.position(decoded);
+            if ((!fullMatch || len == nextPos) && singleCharClass.contains(cp)) {
+              return matcher.applyFullMatchResult(new int[] {0, nextPos});
+            }
+          }
+          return matcher.applyFailedMatchResult();
+        }
+      }
+      return fullMatch ? matcher.matchesCore() : matcher.lookingAtCore();
     }
   }
 

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -4189,10 +4189,11 @@ public final class Matcher implements MatchResult {
       matcher.diagnosticBoundary(MatchStrategy.LITERAL);
       int idx;
       if (foldCase) {
-        idx =
-            matcher.text == null
-                ? -1
-                : indexOfIgnoreCase(matcher.text, literal, matcher.searchFrom);
+        if (matcher.text != null) {
+          idx = indexOfIgnoreCase(matcher.text, literal, matcher.searchFrom);
+        } else {
+          return matcher.doFindCore(regionActive);
+        }
       } else if (matcher.activeScanner() instanceof Utf8InputScanner utf8Scanner) {
         idx = utf8Scanner.indexOf(literalUtf8, failure, shifts, matcher.searchFrom);
       } else if (matcher.text != null) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -4161,7 +4161,8 @@ public final class Matcher implements MatchResult {
     private final byte[] literalUtf8;
     private final int[] failure;
     private final int[] shifts;
-    private final int matchLength;
+    private final int matchLengthChars;
+    private final int matchLengthBytes;
     private final boolean isStartAnchored;
 
     LiteralPreparedRunner(
@@ -4176,8 +4177,8 @@ public final class Matcher implements MatchResult {
       this.literalUtf8 = literalUtf8;
       this.failure = failure;
       this.shifts = shifts;
-      this.matchLength =
-          literal != null ? literal.length() : (literalUtf8 != null ? literalUtf8.length : 0);
+      this.matchLengthChars = literal != null ? literal.length() : 0;
+      this.matchLengthBytes = literalUtf8 != null ? literalUtf8.length : 0;
       this.isStartAnchored = isStartAnchored;
     }
 
@@ -4188,19 +4189,23 @@ public final class Matcher implements MatchResult {
       }
       matcher.diagnosticBoundary(MatchStrategy.LITERAL);
       int idx;
+      int matchLength;
       if (foldCase) {
         if (matcher.text != null) {
           idx = indexOfIgnoreCase(matcher.text, literal, matcher.searchFrom);
+          matchLength = matchLengthChars;
         } else {
           return matcher.doFindCore(regionActive);
         }
       } else if (matcher.activeScanner() instanceof Utf8InputScanner utf8Scanner) {
         idx = utf8Scanner.indexOf(literalUtf8, failure, shifts, matcher.searchFrom);
+        matchLength = matchLengthBytes;
       } else if (matcher.text != null) {
         if (WorkCounterConfig.ENABLED) {
           WorkCounter.record(Math.max(0, matcher.text.length() - matcher.searchFrom));
         }
         idx = matcher.text.indexOf(literal, matcher.searchFrom);
+        matchLength = matchLengthChars;
       } else {
         return matcher.doFindCore(regionActive);
       }
@@ -4232,15 +4237,15 @@ public final class Matcher implements MatchResult {
         if (foldCase) {
           matched =
               (fullMatch
-                      ? matcher.text.length() == literal.length()
-                      : matcher.text.length() >= literal.length())
-                  && matcher.literalRegionMatches(literal, 0, literal.length());
+                      ? matcher.text.length() == matchLengthChars
+                      : matcher.text.length() >= matchLengthChars)
+                  && matcher.literalRegionMatches(literal, 0, matchLengthChars);
         } else {
           matched = fullMatch ? matcher.text.equals(literal) : matcher.text.startsWith(literal);
         }
         if (matched) {
           matcher.applyFullMatchResult(
-              new int[] {0, fullMatch ? matcher.text.length() : literal.length()});
+              new int[] {0, fullMatch ? matcher.text.length() : matchLengthChars});
         } else {
           if (matcher.isPartialLiteralMatch(literal, 0)) {}
           matcher.applyFailedMatchResult();
@@ -4255,17 +4260,15 @@ public final class Matcher implements MatchResult {
         if (literalUtf8 != null) {
           matched =
               (fullMatch
-                      ? utf8Scanner.length() == literalUtf8.length
-                      : utf8Scanner.length() >= literalUtf8.length)
+                      ? utf8Scanner.length() == matchLengthBytes
+                      : utf8Scanner.length() >= matchLengthBytes)
                   && utf8Scanner.startsWith(literalUtf8, 0);
         } else {
           matched = literal.isEmpty() && (!fullMatch || utf8Scanner.length() == 0);
         }
         if (matched) {
           matcher.applyFullMatchResult(
-              new int[] {
-                0, fullMatch ? utf8Scanner.length() : (literalUtf8 == null ? 0 : literalUtf8.length)
-              });
+              new int[] {0, fullMatch ? utf8Scanner.length() : matchLengthBytes});
         } else {
           matcher.applyFailedMatchResult();
         }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -4173,6 +4173,7 @@ public final class Matcher implements MatchResult {
     private final int matchLengthChars;
     private final int matchLengthBytes;
     private final boolean isStartAnchored;
+    private final PreparedMatchRunner fallback;
 
     LiteralPreparedRunner(
         String literal,
@@ -4180,7 +4181,8 @@ public final class Matcher implements MatchResult {
         byte[] literalUtf8,
         int[] failure,
         int[] shifts,
-        boolean isStartAnchored) {
+        boolean isStartAnchored,
+        PreparedMatchRunner fallback) {
       this.literal = literal;
       this.foldCase = foldCase;
       this.literalUtf8 = literalUtf8;
@@ -4189,6 +4191,7 @@ public final class Matcher implements MatchResult {
       this.matchLengthChars = literal != null ? literal.length() : 0;
       this.matchLengthBytes = literalUtf8 != null ? literalUtf8.length : 0;
       this.isStartAnchored = isStartAnchored;
+      this.fallback = fallback;
     }
 
     @Override
@@ -4196,16 +4199,15 @@ public final class Matcher implements MatchResult {
       if (isStartAnchored && matcher.searchFrom > 0) {
         return matcher.applyFailedMatchResult();
       }
+      if (foldCase && matcher.text == null) {
+        return fallback.find(matcher, regionActive);
+      }
       matcher.diagnosticBoundary(MatchStrategy.LITERAL);
       int idx;
       int matchLength;
       if (foldCase) {
-        if (matcher.text != null) {
-          idx = indexOfIgnoreCase(matcher.text, literal, matcher.searchFrom);
-          matchLength = matchLengthChars;
-        } else {
-          return matcher.doFindCore(regionActive);
-        }
+        idx = indexOfIgnoreCase(matcher.text, literal, matcher.searchFrom);
+        matchLength = matchLengthChars;
       } else if (matcher.activeScanner() instanceof Utf8InputScanner utf8Scanner) {
         idx = utf8Scanner.indexOf(literalUtf8, failure, shifts, matcher.searchFrom);
         matchLength = matchLengthBytes;
@@ -4239,6 +4241,9 @@ public final class Matcher implements MatchResult {
       if (isStartAnchored && matcher.searchFrom > 0) {
         return matcher.applyFailedMatchResult();
       }
+      if (foldCase && matcher.text == null) {
+        return fullMatch ? fallback.matches(matcher) : fallback.lookingAt(matcher);
+      }
       matcher.capturesResolved = true;
       if (matcher.text != null) {
         matcher.diagnosticBoundary(MatchStrategy.LITERAL);
@@ -4262,9 +4267,6 @@ public final class Matcher implements MatchResult {
         return matcher.hasMatch;
       } else if (matcher.activeScanner() instanceof Utf8InputScanner utf8Scanner) {
         matcher.diagnosticBoundary(MatchStrategy.LITERAL);
-        if (foldCase) {
-          return fullMatch ? matcher.matchesCore() : matcher.lookingAtCore();
-        }
         boolean matched;
         if (literalUtf8 != null) {
           matched =

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -421,19 +421,15 @@ public final class Matcher implements MatchResult {
     eagerFallbackCaptures = false;
   }
 
-  private PreparedMatchRunner preparedMatchRunner;
-
   private void resetStateForRegion(int start, int end) {
     regionStart = start;
     regionEnd = end;
-    preparedMatchRunner = null;
     resetSearchStateForRegionStart();
     resetReplacementState();
     clearCurrentResult();
   }
 
   private void invalidatePatternCaches() {
-    preparedMatchRunner = null;
     cachedForwardFirstMatchDfa = null;
     cachedForwardLongestMatchDfa = null;
     cachedReverseDfa = null;
@@ -452,7 +448,6 @@ public final class Matcher implements MatchResult {
   }
 
   private void invalidateInputDependentCaches() {
-    preparedMatchRunner = null;
     textScanner = null;
     bitStateBorrowed = false;
     cachedBitState = null;
@@ -869,12 +864,7 @@ public final class Matcher implements MatchResult {
         }
         regionSubstituted = true;
       }
-      PreparedMatchRunner runner = preparedMatchRunner;
-      if (runner == null) {
-        runner = createPreparedRunner(regionActive);
-        preparedMatchRunner = runner;
-      }
-      return runner.matches(this);
+      return parentPattern.preparedMatchRunner(regionActive).matches(this);
     } finally {
       if (regionSubstituted) {
         resolveCapturesBeforeRestoringRegion();
@@ -1123,12 +1113,7 @@ public final class Matcher implements MatchResult {
         }
         regionSubstituted = true;
       }
-      PreparedMatchRunner runner = preparedMatchRunner;
-      if (runner == null) {
-        runner = createPreparedRunner(regionActive);
-        preparedMatchRunner = runner;
-      }
-      return runner.lookingAt(this);
+      return parentPattern.preparedMatchRunner(regionActive).lookingAt(this);
     } finally {
       if (regionSubstituted) {
         resolveCapturesBeforeRestoringRegion();
@@ -1375,12 +1360,7 @@ public final class Matcher implements MatchResult {
     if (parentPattern.prog().anchorStart() && searchFrom > 0) {
       return applyFailedMatchResult();
     }
-    PreparedMatchRunner runner = preparedMatchRunner;
-    if (runner == null) {
-      runner = createPreparedRunner(false);
-      preparedMatchRunner = runner;
-    }
-    return runner.find(this, false);
+    return parentPattern.preparedMatchRunner(false).find(this, false);
   }
 
   private boolean doFindRegion(boolean regionActive) {
@@ -1410,8 +1390,7 @@ public final class Matcher implements MatchResult {
         searchFrom = Math.max(0, savedSearchFrom - regionStart);
         regionSubstituted = true;
       }
-      PreparedMatchRunner runner = createPreparedRunner(regionActive);
-      return runner.find(this, regionActive);
+      return parentPattern.preparedMatchRunner(regionActive).find(this, regionActive);
     } finally {
       if (regionSubstituted) {
         resolveCapturesBeforeRestoringRegion();
@@ -4163,7 +4142,7 @@ public final class Matcher implements MatchResult {
   // Prepared Match Runner (Fast Path Dispatch & Setup Elimination)
   // ---------------------------------------------------------------------------
 
-  private sealed interface PreparedMatchRunner
+  sealed interface PreparedMatchRunner
       permits LiteralPreparedRunner,
           SingleCharClassPreparedRunner,
           KeywordAlternationPreparedRunner,
@@ -4176,7 +4155,7 @@ public final class Matcher implements MatchResult {
     boolean lookingAt(Matcher matcher);
   }
 
-  private static final class LiteralPreparedRunner implements PreparedMatchRunner {
+  static final class LiteralPreparedRunner implements PreparedMatchRunner {
     private final String literal;
     private final boolean foldCase;
     private final byte[] literalUtf8;
@@ -4185,16 +4164,21 @@ public final class Matcher implements MatchResult {
     private final int matchLength;
     private final boolean isStartAnchored;
 
-    LiteralPreparedRunner(Matcher matcher) {
-      Pattern pattern = matcher.parentPattern;
-      this.literal = pattern.literalMatch();
-      this.foldCase = pattern.prefixFoldCase();
-      this.literalUtf8 = pattern.literalMatchUtf8();
-      this.failure = pattern.literalMatchFailure();
-      this.shifts = pattern.literalMatchShifts();
+    LiteralPreparedRunner(
+        String literal,
+        boolean foldCase,
+        byte[] literalUtf8,
+        int[] failure,
+        int[] shifts,
+        boolean isStartAnchored) {
+      this.literal = literal;
+      this.foldCase = foldCase;
+      this.literalUtf8 = literalUtf8;
+      this.failure = failure;
+      this.shifts = shifts;
       this.matchLength =
-          matcher.text == null ? (literalUtf8 == null ? 0 : literalUtf8.length) : literal.length();
-      this.isStartAnchored = pattern.prog().anchorStart();
+          literal != null ? literal.length() : (literalUtf8 != null ? literalUtf8.length : 0);
+      this.isStartAnchored = isStartAnchored;
     }
 
     @Override
@@ -4290,7 +4274,7 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  private static final class SingleCharClassPreparedRunner implements PreparedMatchRunner {
+  static final class SingleCharClassPreparedRunner implements PreparedMatchRunner {
     private final Pattern.CharClassScanInfo singleCharClass;
     private final Pattern.CharClassMatchInfo charClassMatch;
     private final boolean isStartAnchored;
@@ -4371,7 +4355,7 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  private static final class KeywordAlternationPreparedRunner implements PreparedMatchRunner {
+  static final class KeywordAlternationPreparedRunner implements PreparedMatchRunner {
     private final Pattern.KeywordAlternation keywordAlternation;
     private final int numCaptures;
     private final boolean isStartAnchored;
@@ -4408,7 +4392,7 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  private static final class OnePassAnchoredPreparedRunner implements PreparedMatchRunner {
+  static final class OnePassAnchoredPreparedRunner implements PreparedMatchRunner {
     private final int numCaptures;
 
     OnePassAnchoredPreparedRunner(int numCaptures) {
@@ -4417,7 +4401,8 @@ public final class Matcher implements MatchResult {
 
     @Override
     public boolean find(Matcher matcher, boolean regionActive) {
-      if (!matcher.parentPattern.canOnePassFind()) {
+      if (!matcher.parentPattern.canOnePassFind()
+          || matcher.activeScanner().length() > ONEPASS_ANCHORED_TEXT_LIMIT) {
         return matcher.doFindCore(regionActive);
       }
       matcher.diagnosticBoundary(MatchStrategy.ONE_PASS);
@@ -4440,6 +4425,9 @@ public final class Matcher implements MatchResult {
 
     @Override
     public boolean matches(Matcher matcher) {
+      if (matcher.activeScanner().length() > ONEPASS_ANCHORED_TEXT_LIMIT) {
+        return matcher.matchesCore();
+      }
       matcher.capturesResolved = true;
       Pattern pattern = matcher.parentPattern;
       Prog prog = pattern.prog();
@@ -4460,6 +4448,9 @@ public final class Matcher implements MatchResult {
 
     @Override
     public boolean lookingAt(Matcher matcher) {
+      if (matcher.activeScanner().length() > ONEPASS_ANCHORED_TEXT_LIMIT) {
+        return matcher.lookingAtCore();
+      }
       matcher.capturesResolved = true;
       Pattern pattern = matcher.parentPattern;
       Prog prog = pattern.prog();
@@ -4479,7 +4470,7 @@ public final class Matcher implements MatchResult {
     }
   }
 
-  private static final class FallbackPreparedRunner implements PreparedMatchRunner {
+  static final class FallbackPreparedRunner implements PreparedMatchRunner {
     static final FallbackPreparedRunner INSTANCE = new FallbackPreparedRunner();
 
     @Override
@@ -4496,47 +4487,5 @@ public final class Matcher implements MatchResult {
     public boolean lookingAt(Matcher matcher) {
       return matcher.lookingAtCore();
     }
-  }
-
-  private PreparedMatchRunner createPreparedRunner(boolean regionActive) {
-    EnginePathOptions options = enginePathOptions();
-    Prog prog = parentPattern.prog();
-    MatchDescriptor matchDescriptor = parentPattern.matchDescriptor();
-
-    // Literal runner
-    String literal = matchDescriptor.literalMatch();
-    if (options.literalFastPaths()
-        && literal != null
-        && parentPattern.numGroups() == 0
-        && (!parentPattern.prefixFoldCase() || text != null)) {
-      return new LiteralPreparedRunner(this);
-    }
-
-    // Single char class runner
-    Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
-    Pattern.CharClassMatchInfo charClassMatch = matchDescriptor.charClassMatch();
-    if (options.charClassMatchFastPaths() && (singleCharClass != null || charClassMatch != null)) {
-      return new SingleCharClassPreparedRunner(singleCharClass, charClassMatch, prog.anchorStart());
-    }
-
-    if (regionActive) {
-      return FallbackPreparedRunner.INSTANCE;
-    }
-
-    // Keyword alternation runner
-    Pattern.KeywordAlternation keywordAlternation = matchDescriptor.keywordAlternation();
-    if (options.keywordAlternationFastPath() && keywordAlternation != null) {
-      return new KeywordAlternationPreparedRunner(
-          keywordAlternation, prog.numCaptures(), prog.anchorStart());
-    }
-
-    // Anchored OnePass runner
-    if (options.onePass()
-        && (parentPattern.canOnePassFind() || parentPattern.canOnePassPrimary())
-        && activeScanner().length() <= ONEPASS_ANCHORED_TEXT_LIMIT) {
-      return new OnePassAnchoredPreparedRunner(prog.numCaptures());
-    }
-
-    return FallbackPreparedRunner.INSTANCE;
   }
 }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -351,18 +351,22 @@ public final class Pattern implements Serializable {
     }
   }
 
-  private static MatchDescriptor extractMatchDescriptor(Regexp metadataAst, int flags) {
+  private static MatchDescriptor extractMatchDescriptor(
+      Regexp metadataAst, Regexp sourceAst, int flags) {
     String literalMatch = extractLiteralMatch(metadataAst);
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
     KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
+    int minMatchLength = extractMinMatchLength(sourceAst);
     if (literalMatch == null
         && singleCharClass == null
         && keywordAlternation == null
-        && ccMatch == null) {
+        && ccMatch == null
+        && minMatchLength <= 0) {
       return MatchDescriptor.NONE;
     }
-    return new MatchDescriptor(literalMatch, singleCharClass, keywordAlternation, ccMatch);
+    return new MatchDescriptor(
+        literalMatch, singleCharClass, keywordAlternation, ccMatch, minMatchLength);
   }
 
   private static long nextPatternId() {
@@ -451,7 +455,7 @@ public final class Pattern implements Serializable {
     }
     Map<String, Integer> named = extractNamedGroups(re);
     StartDescriptor startDescriptor = extractStartDescriptor(metadataAst);
-    MatchDescriptor matchDescriptor = extractMatchDescriptor(metadataAst, flags);
+    MatchDescriptor matchDescriptor = extractMatchDescriptor(metadataAst, re, flags);
     boolean hasLazy = hasLazyQuantifiers(re);
     boolean hasAlt = hasAlternation(re);
     boolean canMatchEmpty = canMatchEmpty(re);
@@ -627,6 +631,9 @@ public final class Pattern implements Serializable {
 
   boolean findWithoutDiagnostics(Utf8InputScanner scanner) {
     int length = scanner.length();
+    if (matchDescriptor.minMatchLength() > 0 && length < matchDescriptor.minMatchLength()) {
+      return false;
+    }
     if (literalMatchUtf8 != null && !prefixFoldCase) {
       return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
     }
@@ -2967,6 +2974,19 @@ public final class Pattern implements Serializable {
       this.bitmap1 = bitmap1;
       this.isAscii = isAscii;
     }
+
+    boolean contains(int cp) {
+      if (cp < 64) {
+        return cp >= 0 && (bitmap0 & (1L << cp)) != 0;
+      }
+      if (cp < 128) {
+        return (bitmap1 & (1L << (cp - 64))) != 0;
+      }
+      if (isAscii) {
+        return false;
+      }
+      return Matcher.binarySearchRanges(ranges, cp);
+    }
   }
 
   static CharClassScanInfo buildAsciiClassScanInfo(AsciiBitmap asciiClass) {
@@ -3663,6 +3683,69 @@ public final class Pattern implements Serializable {
       return "";
     }
     return foldCase ? sb.toString().toLowerCase(Locale.ROOT) : sb.toString();
+  }
+
+  private static final class MinMatchLengthWalker extends Walker<Integer> {
+    @Override
+    protected Integer shortVisit(Regexp re, Integer parentArg) {
+      return 0;
+    }
+
+    @Override
+    protected Integer postVisit(
+        Regexp re, Integer parentArg, Integer preArg, List<Integer> childArgs) {
+      return switch (re.op) {
+        case NO_MATCH -> Integer.MAX_VALUE / 2;
+        case EMPTY_MATCH,
+            BEGIN_LINE,
+            END_LINE,
+            BEGIN_TEXT,
+            END_TEXT,
+            WORD_BOUNDARY,
+            NO_WORD_BOUNDARY,
+            GRAPHEME_CLUSTER_BOUNDARY,
+            HAVE_MATCH,
+            QUEST,
+            STAR -> 0;
+        case LITERAL -> Character.charCount(re.rune);
+        case LITERAL_STRING -> {
+          int count = 0;
+          if (re.runes != null) {
+            for (int r : re.runes) {
+              count += Character.charCount(r);
+            }
+          }
+          yield count;
+        }
+        case CHAR_CLASS, ANY_CHAR, ANY_BYTE, GRAPHEME_CLUSTER -> 1;
+        case CAPTURE, NON_CAPTURE, PLUS -> childArgs.isEmpty() ? 0 : childArgs.getFirst();
+        case REPEAT -> {
+          int subMin = childArgs.isEmpty() ? 0 : childArgs.getFirst();
+          yield (int) Math.min((long) subMin * Math.max(0, re.min), Integer.MAX_VALUE / 2);
+        }
+        case CONCAT -> {
+          long sum = 0;
+          for (int child : childArgs) {
+            sum += child;
+          }
+          yield (int) Math.min(sum, Integer.MAX_VALUE / 2);
+        }
+        case ALTERNATE -> {
+          int min = Integer.MAX_VALUE / 2;
+          for (int child : childArgs) {
+            min = Math.min(min, child);
+          }
+          yield min == Integer.MAX_VALUE / 2 ? 0 : min;
+        }
+      };
+    }
+  }
+
+  private static int extractMinMatchLength(Regexp re) {
+    if (re == null) {
+      return 0;
+    }
+    return new MinMatchLengthWalker().walk(re, 0);
   }
 
   /** Deserialization: recompile the pattern from the stored string and flags. */

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1017,9 +1017,7 @@ public final class Pattern implements Serializable {
 
   private Matcher.PreparedMatchRunner createPreparedRunner(boolean regionActive) {
     String literal = matchDescriptor.literalMatch();
-    if (enginePathOptions.literalFastPaths()
-        && literal != null
-        && numGroups() == 0) {
+    if (enginePathOptions.literalFastPaths() && literal != null && numGroups() == 0) {
       return new Matcher.LiteralPreparedRunner(
           literal,
           prefixFoldCase,
@@ -3753,7 +3751,8 @@ public final class Pattern implements Serializable {
             GRAPHEME_CLUSTER_BOUNDARY,
             HAVE_MATCH,
             QUEST,
-            STAR -> 0;
+            STAR ->
+            0;
         case LITERAL -> Character.charCount(re.rune);
         case LITERAL_STRING -> {
           int count = 0;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1004,7 +1004,10 @@ public final class Pattern implements Serializable {
           literalMatchUtf8,
           literalMatchFailure,
           literalMatchShifts,
-          prog.anchorStart());
+          prog.anchorStart(),
+          prefixFoldCase
+              ? createLiteralFallbackRunner(regionActive)
+              : Matcher.FallbackPreparedRunner.INSTANCE);
     }
 
     Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
@@ -1026,6 +1029,32 @@ public final class Pattern implements Serializable {
     }
 
     if (enginePathOptions.onePass() && (canOnePassFind() || canOnePassPrimary())) {
+      return new Matcher.OnePassAnchoredPreparedRunner(prog.numCaptures());
+    }
+
+    return Matcher.FallbackPreparedRunner.INSTANCE;
+  }
+
+  private Matcher.PreparedMatchRunner createLiteralFallbackRunner(boolean regionActive) {
+    Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
+    Pattern.CharClassMatchInfo charClassMatch = matchDescriptor.charClassMatch();
+    if (enginePathOptions.charClassMatchFastPaths()
+        && (singleCharClass != null || charClassMatch != null)) {
+      return new Matcher.SingleCharClassPreparedRunner(
+          singleCharClass, charClassMatch, prog.anchorStart());
+    }
+
+    if (regionActive) {
+      return Matcher.FallbackPreparedRunner.INSTANCE;
+    }
+
+    Pattern.KeywordAlternation keywordAlternation = matchDescriptor.keywordAlternation();
+    if (enginePathOptions.keywordAlternationFastPath() && keywordAlternation != null) {
+      return new Matcher.KeywordAlternationPreparedRunner(
+          keywordAlternation, prog.numCaptures(), prog.anchorStart());
+    }
+
+    if (enginePathOptions.onePass()) {
       return new Matcher.OnePassAnchoredPreparedRunner(prog.numCaptures());
     }
 

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -161,6 +161,8 @@ public final class Pattern implements Serializable {
   private final transient Utf8StartAccelerator utf8StartAccelerator;
   private final transient StringStartAccelerator stringStartAccelerator;
   private final transient EnginePathOptions enginePathOptions;
+  private final transient Matcher.PreparedMatchRunner defaultPreparedMatchRunner;
+  private final transient Matcher.PreparedMatchRunner regionPreparedMatchRunner;
   private final long patternId;
   private transient volatile PatternAnalysis patternAnalysis;
   private transient volatile PatternDescriptor patternDescriptor;
@@ -337,6 +339,8 @@ public final class Pattern implements Serializable {
     this.enginePathOptions = enginePathOptions;
     this.rejectDescriptor = rejectDescriptor != null ? rejectDescriptor : RejectDescriptor.NONE;
     this.rejectPrefilter = RejectPrefilter.create(this.rejectDescriptor);
+    this.defaultPreparedMatchRunner = createPreparedRunner(false);
+    this.regionPreparedMatchRunner = createPreparedRunner(true);
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
     onePassAnalysis();
@@ -1005,6 +1009,49 @@ public final class Pattern implements Serializable {
 
   EnginePathOptions enginePathOptions() {
     return enginePathOptions;
+  }
+
+  Matcher.PreparedMatchRunner preparedMatchRunner(boolean regionActive) {
+    return regionActive ? regionPreparedMatchRunner : defaultPreparedMatchRunner;
+  }
+
+  private Matcher.PreparedMatchRunner createPreparedRunner(boolean regionActive) {
+    String literal = matchDescriptor.literalMatch();
+    if (enginePathOptions.literalFastPaths()
+        && literal != null
+        && numGroups() == 0) {
+      return new Matcher.LiteralPreparedRunner(
+          literal,
+          prefixFoldCase,
+          literalMatchUtf8,
+          literalMatchFailure,
+          literalMatchShifts,
+          prog.anchorStart());
+    }
+
+    Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
+    Pattern.CharClassMatchInfo charClassMatch = matchDescriptor.charClassMatch();
+    if (enginePathOptions.charClassMatchFastPaths()
+        && (singleCharClass != null || charClassMatch != null)) {
+      return new Matcher.SingleCharClassPreparedRunner(
+          singleCharClass, charClassMatch, prog.anchorStart());
+    }
+
+    if (regionActive) {
+      return Matcher.FallbackPreparedRunner.INSTANCE;
+    }
+
+    Pattern.KeywordAlternation keywordAlternation = matchDescriptor.keywordAlternation();
+    if (enginePathOptions.keywordAlternationFastPath() && keywordAlternation != null) {
+      return new Matcher.KeywordAlternationPreparedRunner(
+          keywordAlternation, prog.numCaptures(), prog.anchorStart());
+    }
+
+    if (enginePathOptions.onePass() && (canOnePassFind() || canOnePassPrimary())) {
+      return new Matcher.OnePassAnchoredPreparedRunner(prog.numCaptures());
+    }
+
+    return Matcher.FallbackPreparedRunner.INSTANCE;
   }
 
   boolean innerCapturesObserved() {

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -115,11 +115,24 @@ class DiagnosticsTest {
     assertThat(operationsFor(lookingAtPattern).getLast().boundaryStrategy())
         .isEqualTo(MatchStrategy.ONE_PASS);
 
-    Pattern foldedUtf8Pattern = Pattern.compile("(?i)foo");
-    assertThat(foldedUtf8Pattern.matcher(Utf8Input.validated("FOObar".getBytes(UTF_8))).lookingAt())
+    Pattern foldedUtf8LookingAt = Pattern.compile("(?i)foo");
+    assertThat(
+            foldedUtf8LookingAt.matcher(Utf8Input.validated("FOObar".getBytes(UTF_8))).lookingAt())
         .isTrue();
-    assertThat(operationsFor(foldedUtf8Pattern).getLast().boundaryStrategy())
+    assertThat(operationsFor(foldedUtf8LookingAt).getLast().boundaryStrategy())
         .isEqualTo(MatchStrategy.ONE_PASS);
+
+    Pattern foldedUtf8Matches = Pattern.compile("(?i)foo");
+    assertThat(foldedUtf8Matches.matcher(Utf8Input.validated("FOO".getBytes(UTF_8))).matches())
+        .isTrue();
+    assertThat(operationsFor(foldedUtf8Matches).getLast().boundaryStrategy())
+        .isEqualTo(MatchStrategy.ONE_PASS);
+
+    Pattern foldedUtf8Find = Pattern.compile("(?i)foo");
+    assertThat(foldedUtf8Find.matcher(Utf8Input.validated("xxFOO".getBytes(UTF_8))).find())
+        .isTrue();
+    assertThat(operationsFor(foldedUtf8Find).getLast().boundaryStrategy())
+        .isEqualTo(MatchStrategy.DFA);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -8,6 +8,7 @@
 package org.safere;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
@@ -3232,5 +3233,204 @@ class MatcherTest {
 
   private static void assertCompletesWithinPerformanceTimeout(Runnable task) {
     assertTimeoutPreemptively(PERFORMANCE_SCENARIO_TIMEOUT, task::run);
+  }
+
+  @Nested
+  @DisplayName("Tier 1 Trivial match specializations")
+  class TrivialMatchSpecializationTests {
+
+    @Test
+    @DisplayName("exact literal matches and lookingAt on String")
+    void literalStringMatches() {
+      Pattern p = Pattern.compile("hello");
+      Matcher m = p.matcher("hello");
+
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group(0)).isEqualTo("hello");
+      assertThat(m.start(0)).isEqualTo(0);
+      assertThat(m.end(0)).isEqualTo(5);
+
+      assertThat(m.reset("hell").matches()).isFalse();
+      assertThat(m.reset("hello world").matches()).isFalse();
+      assertThat(m.reset("hello world").lookingAt()).isTrue();
+      assertThat(m.group(0)).isEqualTo("hello");
+      assertThat(m.start(0)).isEqualTo(0);
+      assertThat(m.end(0)).isEqualTo(5);
+
+      assertThat(m.reset("").matches()).isFalse();
+      assertThat(m.reset("").lookingAt()).isFalse();
+    }
+
+    @Test
+    @DisplayName("exact literal matches and lookingAt on Utf8Input")
+    void literalUtf8Matches() {
+      Pattern p = Pattern.compile("hello");
+      Utf8Input exact = Utf8Input.validated("hello".getBytes(UTF_8));
+      Utf8Input prefix = Utf8Input.validated("hello world".getBytes(UTF_8));
+      Utf8Input mismatch = Utf8Input.validated("world".getBytes(UTF_8));
+
+      Utf8Matcher mExact = p.matcher(exact);
+      assertThat(mExact.matches()).isTrue();
+      assertThat(mExact.start()).isEqualTo(0);
+      assertThat(mExact.end()).isEqualTo(5);
+
+      Utf8Matcher mPrefix = p.matcher(prefix);
+      assertThat(mPrefix.matches()).isFalse();
+      assertThat(mPrefix.lookingAt()).isTrue();
+      assertThat(mPrefix.start()).isEqualTo(0);
+      assertThat(mPrefix.end()).isEqualTo(5);
+
+      Utf8Matcher mMismatch = p.matcher(mismatch);
+      assertThat(mMismatch.matches()).isFalse();
+      assertThat(mMismatch.lookingAt()).isFalse();
+    }
+
+    @Test
+    @DisplayName("empty literal matches empty input")
+    void emptyLiteralMatches() {
+      Pattern p = Pattern.compile("");
+      Matcher m = p.matcher("");
+
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group(0)).isEmpty();
+      assertThat(m.start(0)).isEqualTo(0);
+      assertThat(m.end(0)).isEqualTo(0);
+
+      assertThat(m.reset("a").matches()).isFalse();
+      assertThat(m.reset("a").lookingAt()).isTrue();
+    }
+
+    @Test
+    @DisplayName("single character class matches BMP characters")
+    void singleCharClassBmp() {
+      Pattern p = Pattern.compile("[a-z]");
+      Matcher m = p.matcher("a");
+
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group(0)).isEqualTo("a");
+      assertThat(m.start(0)).isEqualTo(0);
+      assertThat(m.end(0)).isEqualTo(1);
+
+      assertThat(m.reset("z").matches()).isTrue();
+      assertThat(m.reset("A").matches()).isFalse();
+      assertThat(m.reset("").matches()).isFalse();
+      assertThat(m.reset("ab").matches()).isFalse();
+      assertThat(m.reset("ab").lookingAt()).isTrue();
+      assertThat(m.group(0)).isEqualTo("a");
+    }
+
+    @Test
+    @DisplayName("single character class matches supplementary surrogate pairs")
+    void singleCharClassSupplementary() {
+      Pattern p = Pattern.compile("[\\uD83D\\uDE00-\\uD83D\\uDE4F]");
+      String emoji = "\uD83D\uDE00";
+      Matcher m = p.matcher(emoji);
+
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group(0)).isEqualTo(emoji);
+      assertThat(m.start(0)).isEqualTo(0);
+      assertThat(m.end(0)).isEqualTo(2);
+
+      assertThat(m.reset(emoji + " abc").matches()).isFalse();
+      assertThat(m.reset(emoji + " abc").lookingAt()).isTrue();
+      assertThat(m.group(0)).isEqualTo(emoji);
+
+      assertThat(m.reset("a").matches()).isFalse();
+      assertThat(m.reset("").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("single character class on Utf8Input")
+    void singleCharClassUtf8() {
+      Pattern p = Pattern.compile("\\d");
+      Utf8Input digit = Utf8Input.validated("7".getBytes(UTF_8));
+      Utf8Input letter = Utf8Input.validated("x".getBytes(UTF_8));
+      Utf8Input multi = Utf8Input.validated("78".getBytes(UTF_8));
+
+      assertThat(p.matcher(digit).matches()).isTrue();
+      assertThat(p.matcher(letter).matches()).isFalse();
+      assertThat(p.matcher(multi).matches()).isFalse();
+      assertThat(p.matcher(multi).lookingAt()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "a", "12", "abc"})
+    @DisplayName("rejects strings strictly shorter than minimum match length")
+    void rejectsShortStrings(String input) {
+      Pattern p = Pattern.compile("[0-9]{4,8}");
+      Matcher m = p.matcher(input);
+
+      assertThat(m.matches()).isFalse();
+      assertThat(m.lookingAt()).isFalse();
+      assertThat(m.find()).isFalse();
+      assertThatThrownBy(() -> m.group(0)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("accepts valid-length strings and matches correctly")
+    void acceptsValidLength() {
+      Pattern p = Pattern.compile("[0-9]{4,8}");
+      Matcher m = p.matcher("1234");
+
+      assertThat(m.matches()).isTrue();
+      assertThat(m.group(0)).isEqualTo("1234");
+      assertThat(m.start(0)).isEqualTo(0);
+      assertThat(m.end(0)).isEqualTo(4);
+
+      assertThat(m.reset("12345678").matches()).isTrue();
+      assertThat(m.reset("123456789").matches()).isFalse();
+      assertThat(m.reset("123456789").lookingAt()).isTrue();
+      assertThat(m.group(0)).isEqualTo("12345678");
+    }
+
+    @Test
+    @DisplayName("alternation minimum length lower bound is accurate")
+    void alternationMinLength() {
+      Pattern p = Pattern.compile("a{5}|b{10}");
+      Matcher m = p.matcher("aaaa");
+
+      assertThat(m.matches()).isFalse();
+      assertThat(m.lookingAt()).isFalse();
+      assertThat(m.find()).isFalse();
+
+      assertThat(m.reset("aaaaa").matches()).isTrue();
+      assertThat(m.reset("bbbbbbbbbb").matches()).isTrue();
+    }
+
+    @Test
+    @DisplayName("custom region boundaries work with fast paths")
+    void customRegions() {
+      Pattern p = Pattern.compile("hello");
+      Matcher m = p.matcher("---hello---");
+
+      m.region(3, 8);
+      assertThat(m.matches()).isTrue();
+      assertThat(m.start(0)).isEqualTo(3);
+      assertThat(m.end(0)).isEqualTo(8);
+      assertThat(m.group(0)).isEqualTo("hello");
+
+      m.region(0, 5);
+      assertThat(m.matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("chained matcher operations preserve state correctly")
+    void chainedOperations() {
+      Pattern p = Pattern.compile("\\d");
+      Matcher m = p.matcher("a1b2c");
+
+      assertThat(m.matches()).isFalse();
+      assertThat(m.find()).isTrue();
+      assertThat(m.group(0)).isEqualTo("1");
+      assertThat(m.start(0)).isEqualTo(1);
+
+      assertThat(m.find()).isTrue();
+      assertThat(m.group(0)).isEqualTo("2");
+      assertThat(m.start(0)).isEqualTo(3);
+
+      assertThat(m.find()).isFalse();
+
+      assertThat(m.replaceAll("X")).isEqualTo("aXbXc");
+    }
   }
 }


### PR DESCRIPTION
This optimizes some trivial patterns on short inputs. This adds fast paths for pure literal patterns and single-character classes to bypass some of the `Matcher` setup, and also recognizes length-bounded patterns where positive matches are required to be longer than a certain length to early return on short inputs.

Also, move initialization of immutable `PreparedMatchRunner` classes into `Pattern.compile` instead of repeating it when `Matcher`s are constructed.

I noticed this taking a look at the overall benchmarks comparing SafeRE to JDK and re2-ffm, I think this might close the gap a bit with the JDK for some trivial patterns on short inputs. I'm not sure how general this is, but trivial patterns like pure literals do sometimes get used, and this doesn't add that much additional logic. Moving `PreparedMatchRunner` to `Pattern` is probably a more unambiguous win if the other fast paths seem too specialized though.

```
./safere-benchmarks/scripts/compare-branch.sh   --baseline main   --current perf/trivial-match-specialization   '(literalMatch|charClassMatch|uuidValidation|apiRouteMatch|httpSmall).*@safere-string'
```

| Benchmark      | baseline (ns/op) | current (ns/op) | Speedup |
| -------------- | ---------------- | --------------- | ------- |
| literalMatch   |         28 ± 5.7 |        26 ± 4.4 |   1.05x |
| charClassMatch |         42 ± 5.1 |        39 ± 3.5 |   1.08x |
| uuidValidation |         691 ± 57 |        579 ± 24 |   1.19x |
| apiRouteMatch  |         923 ± 27 |       595 ± 8.0 |   1.55x |
| httpSmall      |         105 ± 13 |        77 ± 2.0 |   1.36x |