### PR TITLE
Require all CI jobs through an aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,19 +472,12 @@ jobs:
       - benchmark-smoke-test-rust
       - benchmark-smoke-test-dotnet
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Require successful CI jobs
-        env:
-          JOB_RESULTS: ${{ toJSON(needs) }}
-        run: |
-          UNSUCCESSFUL_JOBS=$(jq -r '
-            to_entries[]
-            | select(.value.result == "failure" or .value.result == "cancelled")
-            | "\(.key): \(.value.result)"
-          ' <<< "$JOB_RESULTS")
-          if [ -n "$UNSUCCESSFUL_JOBS" ]; then
-            echo "The following required CI jobs did not complete successfully:"
-            echo "$UNSUCCESSFUL_JOBS"
-            exit 1
-          fi
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-skips: >-
+            ${{ needs.changes.outputs.code == 'false' && toJSON(needs) || '' }}
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,3 +455,36 @@ jobs:
 
       - name: Check .NET planned exclusions
         run: ./run-dotnet-benchmarks.sh --list-exclusions UnicodeCompileBenchmark
+
+  ci-gate:
+    if: ${{ always() }}
+    needs:
+      - changes
+      - build
+      - build-vector-runtime-artifacts
+      - build-vector
+      - fuzz-regression
+      - benchmark-python-tests
+      - benchmark-smoke-test-java
+      - vector-benchmark-smoke
+      - benchmark-smoke-test-cpp
+      - benchmark-smoke-test-go
+      - benchmark-smoke-test-rust
+      - benchmark-smoke-test-dotnet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require successful CI jobs
+        env:
+          JOB_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          UNSUCCESSFUL_JOBS=$(jq -r '
+            to_entries[]
+            | select(.value.result == "failure" or .value.result == "cancelled")
+            | "\(.key): \(.value.result)"
+          ' <<< "$JOB_RESULTS")
+          if [ -n "$UNSUCCESSFUL_JOBS" ]; then
+            echo "The following required CI jobs did not complete successfully:"
+            echo "$UNSUCCESSFUL_JOBS"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- add a stable `ci-gate` job that waits for every top-level CI job
- use `re-actors/alls-green` pinned to the v1.2.2 commit to aggregate dependency results
- allow path-filtered jobs to be skipped only for non-code changes
- update the active `Protect main` ruleset to require only `ci-gate`

Fixes #725

## Verification

- parsed `.github/workflows/ci.yml` and verified that `ci-gate.needs` exactly matches every other job ID
- verified that the pinned action commit is the commit referenced by the signed v1.2.2 release tag
- confirmed through the GitHub API that the ruleset requires only the GitHub Actions `ci-gate` context
- ran `git diff --check`
- full Java tests were not run locally because this changes only GitHub Actions configuration; the full PR workflow is running
