### PR TITLE
Introduce RarityOracle and prioritize selective literals in AST extraction

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -127,6 +127,7 @@
                         <exclude name="PatternInternalTest.java"/>
                         <exclude name="PatternSetTest.java"/>
                         <exclude name="ProgTest.java"/>
+                        <exclude name="RarityOracleTest.java"/>
                         <exclude name="RegexpOpTest.java"/>
                         <exclude name="RegexpTest.java"/>
                         <exclude name="RejectPrefilterTest.java"/>

--- a/safere/src/main/java/org/safere/Ascii.java
+++ b/safere/src/main/java/org/safere/Ascii.java
@@ -128,12 +128,4 @@ final class Ascii {
     }
     return true;
   }
-
-  /**
-   * Returns the offset of the rarest ASCII character in the prefix (up to prefixLen). If all
-   * characters have identical rank, returns 0.
-   */
-  static int rarestAsciiOffset(CharSequence prefix, int prefixLen) {
-    return RarityOracle.rarestAsciiOffset(prefix, prefixLen);
-  }
 }

--- a/safere/src/main/java/org/safere/Ascii.java
+++ b/safere/src/main/java/org/safere/Ascii.java
@@ -130,102 +130,10 @@ final class Ascii {
   }
 
   /**
-   * Approximate byte frequency ranks (0 = most common in text/code, 127 = rarest) for ASCII
-   * characters, mapping uppercase and lowercase to the same rank.
-   */
-  private static final byte[] ASCII_FREQUENCY_RANK = new byte[128];
-
-  static {
-    // Default all unlisted ASCII to high rarity
-    for (int i = 0; i < 128; i++) {
-      ASCII_FREQUENCY_RANK[i] = 100;
-    }
-    // Control characters (rare in text)
-    for (int i = 0; i < 32; i++) {
-      ASCII_FREQUENCY_RANK[i] = 120;
-    }
-    // High-frequency whitespace
-    ASCII_FREQUENCY_RANK[' '] = 0;
-    ASCII_FREQUENCY_RANK['\n'] = 15;
-    ASCII_FREQUENCY_RANK['\t'] = 45;
-    ASCII_FREQUENCY_RANK['\r'] = 55;
-
-    // Common letters (case-folded: 'a'/'A' share rank)
-    setLetterRank('e', 1);
-    setLetterRank('t', 2);
-    setLetterRank('a', 3);
-    setLetterRank('o', 4);
-    setLetterRank('i', 5);
-    setLetterRank('n', 6);
-    setLetterRank('s', 7);
-    setLetterRank('r', 8);
-    setLetterRank('h', 9);
-    setLetterRank('l', 10);
-    setLetterRank('d', 11);
-    setLetterRank('c', 12);
-    setLetterRank('u', 13);
-    setLetterRank('m', 14);
-    setLetterRank('f', 16);
-    setLetterRank('p', 17);
-    setLetterRank('g', 18);
-    setLetterRank('w', 19);
-    setLetterRank('y', 20);
-    setLetterRank('b', 21);
-    setLetterRank('v', 22);
-    setLetterRank('k', 23);
-    setLetterRank('x', 24);
-    setLetterRank('j', 25);
-    setLetterRank('q', 26);
-    setLetterRank('z', 27);
-
-    // Common code/JSON/protocol punctuation
-    ASCII_FREQUENCY_RANK['"'] = 15;
-    ASCII_FREQUENCY_RANK[':'] = 16;
-    ASCII_FREQUENCY_RANK[','] = 17;
-    ASCII_FREQUENCY_RANK['.'] = 18;
-    ASCII_FREQUENCY_RANK['/'] = 19;
-    ASCII_FREQUENCY_RANK['-'] = 20;
-    ASCII_FREQUENCY_RANK['_'] = 21;
-    ASCII_FREQUENCY_RANK['='] = 22;
-    ASCII_FREQUENCY_RANK[';'] = 23;
-    ASCII_FREQUENCY_RANK['('] = 25;
-    ASCII_FREQUENCY_RANK[')'] = 25;
-    ASCII_FREQUENCY_RANK['{'] = 26;
-    ASCII_FREQUENCY_RANK['}'] = 26;
-    ASCII_FREQUENCY_RANK['['] = 27;
-    ASCII_FREQUENCY_RANK[']'] = 27;
-
-    // Digits
-    for (char d = '0'; d <= '9'; d++) {
-      ASCII_FREQUENCY_RANK[d] = (byte) (30 + (d - '0'));
-    }
-  }
-
-  private static void setLetterRank(char c, int rank) {
-    ASCII_FREQUENCY_RANK[c] = (byte) rank;
-    ASCII_FREQUENCY_RANK[Character.toUpperCase(c)] = (byte) rank;
-  }
-
-  /** Returns the byte frequency rank for an ASCII character (higher = rarer). */
-  static int frequencyRank(char c) {
-    return c < 128 ? (ASCII_FREQUENCY_RANK[c] & 0xFF) : 127;
-  }
-
-  /**
    * Returns the offset of the rarest ASCII character in the prefix (up to prefixLen). If all
    * characters have identical rank, returns 0.
    */
-  static int rarestAsciiOffset(String prefix, int prefixLen) {
-    int bestOffset = 0;
-    int maxRank = -1;
-    for (int i = 0; i < prefixLen; i++) {
-      char c = prefix.charAt(i);
-      int rank = frequencyRank(c);
-      if (rank > maxRank) {
-        maxRank = rank;
-        bestOffset = i;
-      }
-    }
-    return bestOffset;
+  static int rarestAsciiOffset(CharSequence prefix, int prefixLen) {
+    return RarityOracle.rarestAsciiOffset(prefix, prefixLen);
   }
 }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2256,6 +2256,7 @@ public final class Pattern implements Serializable {
       return null;
     }
     FixedOffsetLiteral best = null;
+    int bestScore = 0;
     AsciiWidthRange prefixWidth = AsciiWidthRange.ZERO;
 
     for (int index = 0; index < node.subs.size(); ) {
@@ -2273,16 +2274,17 @@ public final class Pattern implements Serializable {
         }
         if (index > 0 && (prefixWidth.minWidth > 0 || prefixWidth.maxWidth > 0)) {
           int minimumLiteralLength = prefixWidth.discreteWidths != null ? 1 : 2;
-          if (literal.length() >= minimumLiteralLength
-              && (best == null
-                  || RarityOracle.literalSelectivityScore(literal)
-                      > RarityOracle.literalSelectivityScore(best.literal()))) {
-            best =
-                new FixedOffsetLiteral(
-                    literal.toString(),
-                    prefixWidth.minWidth,
-                    prefixWidth.maxWidth,
-                    prefixWidth.discreteWidths);
+          if (literal.length() >= minimumLiteralLength) {
+            int candidateScore = RarityOracle.literalSelectivityScore(literal);
+            if (best == null || candidateScore > bestScore) {
+              best =
+                  new FixedOffsetLiteral(
+                      literal.toString(),
+                      prefixWidth.minWidth,
+                      prefixWidth.maxWidth,
+                      prefixWidth.discreteWidths);
+              bestScore = candidateScore;
+            }
           }
         }
         prefixWidth = concatenateWidths(prefixWidth, AsciiWidthRange.exact(literal.length()));
@@ -3464,6 +3466,7 @@ public final class Pattern implements Serializable {
    */
   private static String extractRequiredLiteral(Regexp re) {
     String longest = null;
+    int longestScore = 0;
     Deque<Regexp> pending = new ArrayDeque<>();
     pending.addLast(re);
     while (!pending.isEmpty()) {
@@ -3487,10 +3490,10 @@ public final class Pattern implements Serializable {
               && node.runes != null
               && node.runes.length >= 2) {
             String candidate = new String(node.runes, 0, node.runes.length);
-            if (longest == null
-                || RarityOracle.literalSelectivityScore(candidate)
-                    > RarityOracle.literalSelectivityScore(longest)) {
+            int candidateScore = RarityOracle.literalSelectivityScore(candidate);
+            if (longest == null || candidateScore > longestScore) {
               longest = candidate;
+              longestScore = candidateScore;
             }
           }
         }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2193,7 +2193,9 @@ public final class Pattern implements Serializable {
         if (index > 0 && (prefixWidth.minWidth > 0 || prefixWidth.maxWidth > 0)) {
           int minimumLiteralLength = prefixWidth.discreteWidths != null ? 1 : 2;
           if (literal.length() >= minimumLiteralLength
-              && (best == null || literal.length() > best.literal().length())) {
+              && (best == null
+                  || RarityOracle.literalSelectivityScore(literal)
+                      > RarityOracle.literalSelectivityScore(best.literal()))) {
             best =
                 new FixedOffsetLiteral(
                     literal.toString(),
@@ -3389,10 +3391,13 @@ public final class Pattern implements Serializable {
         case LITERAL_STRING -> {
           if ((node.flags & ParseFlags.FOLD_CASE) == 0
               && node.runes != null
-              && node.runes.length >= 2
-              && (longest == null
-                  || node.runes.length > longest.codePointCount(0, longest.length()))) {
-            longest = new String(node.runes, 0, node.runes.length);
+              && node.runes.length >= 2) {
+            String candidate = new String(node.runes, 0, node.runes.length);
+            if (longest == null
+                || RarityOracle.literalSelectivityScore(candidate)
+                    > RarityOracle.literalSelectivityScore(longest)) {
+              longest = candidate;
+            }
           }
         }
         default -> {}

--- a/safere/src/main/java/org/safere/RarityOracle.java
+++ b/safere/src/main/java/org/safere/RarityOracle.java
@@ -120,8 +120,11 @@ final class RarityOracle {
     int score = 0;
     int maxCharRarity = 0;
     for (int i = 0; i < s.length(); i++) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       int r = byteRarity(s.charAt(i));
-      score += r;
+      score += r + 1;
       if (r > maxCharRarity) {
         maxCharRarity = r;
       }

--- a/safere/src/main/java/org/safere/RarityOracle.java
+++ b/safere/src/main/java/org/safere/RarityOracle.java
@@ -1,0 +1,133 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/**
+ * Empirical character and byte rarity oracle for regex literal and prefix acceleration.
+ *
+ * <p>Ranks characters based on empirical frequency distributions across text, source code, JSON,
+ * and network protocols. Higher rank indicates rarer characters (0 = most common, e.g. space; 127 =
+ * rarest, e.g. rare punctuation, control characters, non-ASCII).
+ */
+final class RarityOracle {
+  private static final byte[] ASCII_FREQUENCY_RANK = new byte[128];
+
+  static {
+    // Default all unlisted ASCII to high rarity
+    for (int i = 0; i < 128; i++) {
+      ASCII_FREQUENCY_RANK[i] = 100;
+    }
+    // Control characters (rare in text)
+    for (int i = 0; i < 32; i++) {
+      ASCII_FREQUENCY_RANK[i] = 120;
+    }
+    // High-frequency whitespace
+    ASCII_FREQUENCY_RANK[' '] = 0;
+    ASCII_FREQUENCY_RANK['\n'] = 10;
+    ASCII_FREQUENCY_RANK['\t'] = 30;
+    ASCII_FREQUENCY_RANK['\r'] = 35;
+
+    // Common letters (case-folded: 'a'/'A' share rank)
+    setLetterRank('e', 6);
+    setLetterRank('t', 8);
+    setLetterRank('a', 10);
+    setLetterRank('o', 11);
+    setLetterRank('i', 12);
+    setLetterRank('n', 13);
+    setLetterRank('s', 14);
+    setLetterRank('r', 15);
+    setLetterRank('h', 16);
+    setLetterRank('l', 18);
+    setLetterRank('d', 20);
+    setLetterRank('c', 22);
+    setLetterRank('u', 24);
+    setLetterRank('m', 26);
+    setLetterRank('f', 28);
+    setLetterRank('p', 30);
+    setLetterRank('g', 32);
+    setLetterRank('w', 34);
+    setLetterRank('y', 36);
+    setLetterRank('b', 38);
+    setLetterRank('v', 42);
+    setLetterRank('k', 46);
+    setLetterRank('x', 65);
+    setLetterRank('j', 70);
+    setLetterRank('q', 80);
+    setLetterRank('z', 85);
+
+    // Common code/JSON/protocol punctuation
+    ASCII_FREQUENCY_RANK['"'] = 12;
+    ASCII_FREQUENCY_RANK[':'] = 14;
+    ASCII_FREQUENCY_RANK[','] = 14;
+    ASCII_FREQUENCY_RANK['.'] = 15;
+    ASCII_FREQUENCY_RANK['/'] = 16;
+    ASCII_FREQUENCY_RANK['-'] = 18;
+    ASCII_FREQUENCY_RANK['_'] = 18;
+    ASCII_FREQUENCY_RANK['='] = 20;
+    ASCII_FREQUENCY_RANK[';'] = 20;
+    ASCII_FREQUENCY_RANK['('] = 24;
+    ASCII_FREQUENCY_RANK[')'] = 24;
+    ASCII_FREQUENCY_RANK['{'] = 24;
+    ASCII_FREQUENCY_RANK['}'] = 24;
+    ASCII_FREQUENCY_RANK['['] = 24;
+    ASCII_FREQUENCY_RANK[']'] = 24;
+
+    // Digits
+    for (char d = '0'; d <= '9'; d++) {
+      ASCII_FREQUENCY_RANK[d] = (byte) (30 + (d - '0'));
+    }
+  }
+
+  private static void setLetterRank(char c, int rank) {
+    ASCII_FREQUENCY_RANK[c] = (byte) rank;
+    ASCII_FREQUENCY_RANK[Character.toUpperCase(c)] = (byte) rank;
+  }
+
+  /** Returns the byte frequency rank for an ASCII character (higher = rarer). */
+  static int byteRarity(int c) {
+    return c >= 0 && c < 128 ? (ASCII_FREQUENCY_RANK[c] & 0xFF) : 127;
+  }
+
+  /**
+   * Returns the offset of the rarest ASCII character in the prefix (up to prefixLen). If all
+   * characters have identical rank, returns 0.
+   */
+  static int rarestAsciiOffset(CharSequence prefix, int prefixLen) {
+    int bestOffset = 0;
+    int maxRank = -1;
+    for (int i = 0; i < prefixLen; i++) {
+      char c = prefix.charAt(i);
+      int rank = byteRarity(c);
+      if (rank > maxRank) {
+        maxRank = rank;
+        bestOffset = i;
+      }
+    }
+    return bestOffset;
+  }
+
+  /**
+   * Computes a selectivity score for a literal string. Combines string length with individual
+   * character rarity.
+   */
+  static int literalSelectivityScore(CharSequence s) {
+    if (s == null || s.isEmpty()) {
+      return 0;
+    }
+    int score = 0;
+    int maxCharRarity = 0;
+    for (int i = 0; i < s.length(); i++) {
+      int r = byteRarity(s.charAt(i));
+      score += r;
+      if (r > maxCharRarity) {
+        maxCharRarity = r;
+      }
+    }
+    return score + maxCharRarity;
+  }
+
+  private RarityOracle() {}
+}

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -106,7 +106,7 @@ sealed interface Utf8StartAccelerator {
           return null;
         }
       }
-      int anchorOffset = Ascii.rarestAsciiOffset(prefix, prefix.length());
+      int anchorOffset = RarityOracle.rarestAsciiOffset(prefix, prefix.length());
       char anchor = prefix.charAt(anchorOffset);
       byte low = (byte) Ascii.toLowerCase(anchor);
       byte high = (byte) Ascii.toUpperCase(anchor);

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -587,4 +587,20 @@ class PatternInternalTest {
     Pattern p3 = Pattern.compile("(<template name>.*)([^>])");
     assertThat(p3.prefix()).isEqualTo("<template name>");
   }
+
+  @Test
+  void fixedOffsetLiteralPrefersRareTokenOverLongCommonToken() {
+    // "____" has length 4 with common underscores.
+    // "zq" has length 2 with rare letters 'z' and 'q'.
+    Pattern pattern = Pattern.compile("[0-9]{2}____[a-z]zq[a-z]");
+    assertThat(pattern.fixedOffsetLiteral()).isNotNull();
+    // "zq" has higher selectivity than "____"
+    assertThat(pattern.fixedOffsetLiteral().literal()).isEqualTo("zq");
+  }
+
+  @Test
+  void requiredLiteralPrefersRareToken() {
+    Pattern pattern = Pattern.compile(".*(____).*?(404_ERROR).*");
+    assertThat(pattern.rejectDescriptor().requiredLiteral()).isEqualTo("404_ERROR");
+  }
 }

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -603,4 +603,12 @@ class PatternInternalTest {
     Pattern pattern = Pattern.compile(".*(____).*?(404_ERROR).*");
     assertThat(pattern.rejectDescriptor().requiredLiteral()).isEqualTo("404_ERROR");
   }
+
+  @Test
+  void requiredLiteralRetainsSelectivityFromLengthWhenCharactersAreCommon() {
+    String spaces = " ".repeat(32);
+    Pattern pattern = Pattern.compile(".*(" + spaces + ").*?(ee).*");
+
+    assertThat(pattern.rejectDescriptor().requiredLiteral()).isEqualTo(spaces);
+  }
 }

--- a/safere/src/test/java/org/safere/RarityOracleTest.java
+++ b/safere/src/test/java/org/safere/RarityOracleTest.java
@@ -47,4 +47,10 @@ class RarityOracleTest {
     int commonScore = RarityOracle.literalSelectivityScore("             ");
     assertThat(rareScore).isGreaterThan(commonScore * 3);
   }
+
+  @Test
+  void literalSelectivityRetainsLengthForTheMostCommonCharacter() {
+    assertThat(RarityOracle.literalSelectivityScore(" ".repeat(32)))
+        .isGreaterThan(RarityOracle.literalSelectivityScore("ee"));
+  }
 }

--- a/safere/src/test/java/org/safere/RarityOracleTest.java
+++ b/safere/src/test/java/org/safere/RarityOracleTest.java
@@ -1,0 +1,50 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
+class RarityOracleTest {
+
+  @Test
+  void spaceIsMostCommonAndRareLettersHaveHighRank() {
+    assertThat(RarityOracle.byteRarity(' ')).isEqualTo(0);
+    assertThat(RarityOracle.byteRarity('e')).isLessThan(RarityOracle.byteRarity('z'));
+    assertThat(RarityOracle.byteRarity('t')).isLessThan(RarityOracle.byteRarity('q'));
+    assertThat(RarityOracle.byteRarity('a')).isLessThan(RarityOracle.byteRarity('x'));
+  }
+
+  @Test
+  void caseInsensitiveLettersShareIdenticalRanks() {
+    assertThat(RarityOracle.byteRarity('A')).isEqualTo(RarityOracle.byteRarity('a'));
+    assertThat(RarityOracle.byteRarity('Z')).isEqualTo(RarityOracle.byteRarity('z'));
+    assertThat(RarityOracle.byteRarity('E')).isEqualTo(RarityOracle.byteRarity('e'));
+  }
+
+  @Test
+  void rarestAsciiOffsetFindsRarestCharacter() {
+    // 't', 'h', 'e' are common, 'q' is rare
+    String prefix = "the_query";
+    int offset = RarityOracle.rarestAsciiOffset(prefix, prefix.length());
+    assertThat(offset).isEqualTo(prefix.indexOf('q'));
+
+    // 'a' is common, 'z' is rare
+    String zone = "authorization";
+    assertThat(RarityOracle.rarestAsciiOffset(zone, zone.length())).isEqualTo(zone.indexOf('z'));
+  }
+
+  @Test
+  void literalSelectivityRewardsRareCharacters() {
+    // "404_NOT_FOUND" contains digits, underscores, and rare letters
+    int rareScore = RarityOracle.literalSelectivityScore("404_NOT_FOUND");
+    // "              " (spaces of equal length) has very low score
+    int commonScore = RarityOracle.literalSelectivityScore("             ");
+    assertThat(rareScore).isGreaterThan(commonScore * 3);
+  }
+}

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -99,6 +99,36 @@ class SearchScalingRegressionTest {
         .isLessThan(input.length() * 5L);
   }
 
+  @Test
+  void fixedOffsetLiteralSelectsRareTokenToAvoidCandidateVerificationWork() {
+    // "____" has length 4 with common underscores.
+    // "zq" has length 2 with rare letters 'z' and 'q'.
+    Pattern pattern = Pattern.compile("[0-9]{2}____[a-z]zq[a-z]");
+    String input = "user_name_field_data____common_suffix\n".repeat(1_000);
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input).find()).isFalse());
+
+    assertThat(work)
+        .as("RarityOracle selection must avoid false candidate verification work on common tokens")
+        .isLessThanOrEqualTo(input.length() + 100);
+  }
+
+  @Test
+  void requiredLiteralSelectsRareTokenToRejectNoiseWithMinimalWork() {
+    // "____________" has length 12 with common underscores.
+    // "404_ERR" has length 7 with high-rarity digits and uppercase letters.
+    Pattern pattern = Pattern.compile(".*(____________).*?(404_ERR).*");
+    String input = "log_entry_line_with____________separators_and_delimiters\n".repeat(1_000);
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input).find()).isFalse());
+
+    assertThat(work)
+        .as("Required literal prefilter must reject on the selective token with minimal work")
+        .isLessThanOrEqualTo(input.length() + 100);
+  }
+
   private static void assertRepeatedFindWorkIsLinear(
       IntFunction<FindIterator> matcherFactory, String description) {
     long smallerWork = countAllMatches(matcherFactory.apply(500), 500);

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -129,6 +129,16 @@ class SearchScalingRegressionTest {
         .isLessThanOrEqualTo(input.length() + 100);
   }
 
+  @Test
+  void literalSelectivityScoringIsLinearInPatternSize() {
+    long smallerWork = WorkCounter.countForTesting(() -> Pattern.compile(selectivityPattern(100)));
+    long largerWork = WorkCounter.countForTesting(() -> Pattern.compile(selectivityPattern(400)));
+
+    assertThat(largerWork)
+        .as("Literal selectivity scoring should scale linearly with pattern size")
+        .isLessThanOrEqualTo(smallerWork * 6);
+  }
+
   private static void assertRepeatedFindWorkIsLinear(
       IntFunction<FindIterator> matcherFactory, String description) {
     long smallerWork = countAllMatches(matcherFactory.apply(500), 500);
@@ -137,6 +147,14 @@ class SearchScalingRegressionTest {
     assertThat(largerWork)
         .as("%s repeated find work should scale linearly", description)
         .isLessThan(smallerWork * 6);
+  }
+
+  private static String selectivityPattern(int size) {
+    StringBuilder pattern = new StringBuilder("[0-9]").append("z".repeat(size));
+    for (int i = 0; i < size; i++) {
+      pattern.append("[0-9]aa");
+    }
+    return pattern.toString();
   }
 
   private static long countAllMatches(FindIterator matcher, int expectedMatches) {


### PR DESCRIPTION
This generalizes the rarity heuristics added in #721 and consolidates them into `RarityOracle`.

- Introduces `RarityOracle` as the canonical source for character frequency ranks and literal selectivity scoring.
- Uses `RarityOracle.literalSelectivityScore` to prioritize selective tokens over common ones during AST extraction for fixed-offset and required literals.
- Uses `RarityOracle.rarestAsciiOffset` for rarest-character anchor selection in prefix accelerators.
- Also add a `WorkCounter` test for the prefix accelerators changes that shows the new heuristics reduce work for some pathological examples with long but common anchors

<details>
<summary>
I ran some benchmarks but the results were within the margin of error, which is expected, the heuristics are cheap and the benchmarks are not exercising cases where the current heuristics find a long / common anchor:

```
./safere-benchmarks/scripts/compare-branch.sh   --baseline origin/main   --current perf/rarity-oracle   '(ApplicationBenchmark|caseInsensitiveKeyword|RealWorldRegexBenchmark.*(metadataBlock|templateTag|jsonBlock|bracketCitation)).*@safere-string'
```

</summary>

| Benchmark                                    | baseline (ns/op) | current (ns/op) | Speedup |
| -------------------------------------------- | ---------------- | --------------- | ------- |
| ApplicationBenchmark.uuidValidation          |         505 ± 22 |        512 ± 39 |   0.99x |
| ApplicationBenchmark.logLineParse            |       2917 ± 127 |      2731 ± 115 |   1.07x |
| ApplicationBenchmark.apiRouteMatch           |         595 ± 24 |        594 ± 45 |   1.00x |
| ApplicationBenchmark.stackTraceExtract       |       4835 ± 235 |      4797 ± 192 |   1.01x |
| ApplicationBenchmark.caseInsensitiveKeywords |        474 ± 9.6 |        481 ± 30 |   0.99x |
| ApplicationBenchmark.urlExtraction           |        1149 ± 82 |       1109 ± 10 |   1.04x |
| ApplicationBenchmark.csvFieldScan            |       3566 ± 180 |       3471 ± 38 |   1.03x |
| ApplicationBenchmark.secretRedaction         |        1608 ± 37 |       1565 ± 56 |   1.03x |
| metadataBlock.match.1000                     |        4988 ± 98 |      4759 ± 222 |   1.05x |
| metadataBlock.match.10000                    |     54782 ± 1185 |    55179 ± 1212 |   0.99x |
| metadataBlock.match.100000                   |   343224 ± 10293 |   357015 ± 6156 |   0.96x |
| metadataBlock.noMatch.1000                   |         981 ± 43 |        951 ± 18 |   1.03x |
| metadataBlock.noMatch.10000                  |       8402 ± 272 |      8214 ± 135 |   1.02x |
| metadataBlock.noMatch.100000                 |    125538 ± 1001 |   126775 ± 3806 |   0.99x |
| caseInsensitiveKeyword.match.1000            |       9117 ± 417 |       8870 ± 84 |   1.03x |
| caseInsensitiveKeyword.match.10000           |     95348 ± 4953 |    94689 ± 4273 |   1.01x |
| caseInsensitiveKeyword.match.100000          |   941157 ± 21763 |  943004 ± 51158 |   1.00x |
| caseInsensitiveKeyword.noMatch.1000          |         517 ± 27 |        512 ± 13 |   1.01x |
| caseInsensitiveKeyword.noMatch.10000         |        4760 ± 44 |       4743 ± 26 |   1.00x |
| caseInsensitiveKeyword.noMatch.100000        |      35519 ± 186 |     35450 ± 199 |   1.00x |
| caseInsensitiveKeywordFind.match.1000        |        161 ± 5.8 |        166 ± 14 |   0.97x |
| caseInsensitiveKeywordFind.match.10000       |        156 ± 7.2 |        158 ± 10 |   0.99x |
| caseInsensitiveKeywordFind.match.100000      |        153 ± 6.7 |       161 ± 8.4 |   0.95x |
| caseInsensitiveKeywordFind.noMatch.1000      |         410 ± 16 |        399 ± 10 |   1.03x |
| caseInsensitiveKeywordFind.noMatch.10000     |       3624 ± 121 |      3657 ± 154 |   0.99x |
| caseInsensitiveKeywordFind.noMatch.100000    |     36525 ± 2186 |     35746 ± 635 |   1.02x |
| templateTagMatch.match.1000                  |       5000 ± 286 |      4683 ± 134 |   1.07x |
| templateTagMatch.match.10000                 |     45547 ± 2906 |    48210 ± 2443 |   0.94x |
| templateTagMatch.match.100000                |   355029 ± 15756 |   359388 ± 7170 |   0.99x |
| templateTagMatch.noMatch.1000                |        152 ± 7.3 |        156 ± 10 |   0.97x |
| templateTagMatch.noMatch.10000               |        1047 ± 18 |       1053 ± 20 |   0.99x |
| templateTagMatch.noMatch.100000              |        9900 ± 97 |     10200 ± 459 |   0.97x |
| jsonBlock.match.1000                         |       1108 ± 162 |      1043 ± 140 |   1.06x |
| jsonBlock.match.10000                        |       7410 ± 749 |      7486 ± 681 |   0.99x |
| jsonBlock.match.100000                       |     99063 ± 1430 |  104091 ± 11478 |   0.95x |
| jsonBlock.noMatch.1000                       |        147 ± 6.8 |       145 ± 5.7 |   1.01x |
| jsonBlock.noMatch.10000                      |        1035 ± 12 |       1034 ± 15 |   1.00x |
| jsonBlock.noMatch.100000                     |      10121 ± 368 |      9915 ± 168 |   1.02x |
| bracketCitation.match.1000                   |       8958 ± 289 |      8559 ± 197 |   1.05x |
| bracketCitation.match.10000                  |     84742 ± 3096 |    84623 ± 2377 |   1.00x |
| bracketCitation.match.100000                 |   834634 ± 23481 |  841368 ± 19764 |   0.99x |
| bracketCitation.noMatch.1000                 |         633 ± 15 |        636 ± 17 |   1.00x |
| bracketCitation.noMatch.10000                |       5923 ± 191 |      6020 ± 315 |   0.98x |
| bracketCitation.noMatch.100000               |      60544 ± 867 |     61287 ± 834 |   0.99x |

</details>