### PR TITLE
Optimize start-anchored search rejection and fast paths

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -3967,6 +3967,78 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralFail.1024",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralSuccess.1024",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredCharClassFail.1024",
+      "operation": "find",
+      "patterns": [
+        "^[0-9]"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredFindAll.1024",
+      "operation": "findAllCount",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.searchEasyFail.10240",
       "operation": "find",
       "patterns": [
@@ -4051,6 +4123,78 @@
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralFail.10240",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralSuccess.10240",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredCharClassFail.10240",
+      "operation": "find",
+      "patterns": [
+        "^[0-9]"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredFindAll.10240",
+      "operation": "findAllCount",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
         "constraints": [
           "prematerializedInput"
         ]
@@ -4147,6 +4291,78 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralFail.102400",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralSuccess.102400",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredCharClassFail.102400",
+      "operation": "find",
+      "patterns": [
+        "^[0-9]"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredFindAll.102400",
+      "operation": "findAllCount",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.searchEasyFail.1048576",
       "operation": "find",
       "patterns": [
@@ -4231,6 +4447,78 @@
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredLiteralSuccess.1048576",
+      "operation": "find",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredCharClassFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "^[0-9]"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.startAnchoredFindAll.1048576",
+      "operation": "findAllCount",
+      "patterns": [
+        "^ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
         "constraints": [
           "prematerializedInput"
         ]

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(575);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(591);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_750);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_910);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -192,7 +192,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(575);
+          .hasSize(591);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(498);
+    assertThat(ids).hasSize(514);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1774);
+    assertThat(allTrials).hasSize(1854);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(498 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(514 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1124);
+        .hasSize(1204);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1813);
-    assertThat(plan.reportPlan().trials()).hasSize(1813);
+        .hasSize(1893);
+    assertThat(plan.reportPlan().trials()).hasSize(1893);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -26,6 +26,7 @@ final class Utf8InputFuzzer {
   @FuzzTest(maxDuration = "30s")
   void arbitraryWindow(FuzzedDataProvider data) {
     assertLiteralSearchMatchesString("XXXXXX", "..XXXXXX");
+    assertLiteralSearchMatchesString(data.consumeBoolean() ? "^XXXXXX" : "\\AXXXXXX", "..XXXXXX");
     assertBoundarySensitiveRegionCaptures();
     assertKeywordAlternationMatchesString(data);
     assertFixedOffsetAccelerationMatchesString(data);

--- a/safere/src/main/java/org/safere/MatchDescriptor.java
+++ b/safere/src/main/java/org/safere/MatchDescriptor.java
@@ -26,12 +26,13 @@ import org.safere.Pattern.KeywordAlternation;
  */
 record MatchDescriptor(
     String literalMatch,
+    boolean literalFoldCase,
     CharClassScanInfo singleCharClass,
     KeywordAlternation keywordAlternation,
     CharClassMatchInfo charClassMatch,
     int minMatchLength) {
 
-  static final MatchDescriptor NONE = new MatchDescriptor(null, null, null, null, 0);
+  static final MatchDescriptor NONE = new MatchDescriptor(null, false, null, null, null, 0);
 
   boolean hasFastPath() {
     return literalMatch != null

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1397,7 +1397,16 @@ public final class Matcher implements MatchResult {
       return doFindRegion(regionActive);
     }
     if (parentPattern.prog().anchorStart()) {
-      if (searchFrom > 0 || anchoredPrefixOrCharClassCannotMatch(0)) {
+      if (searchFrom > 0) {
+        return applyFailedMatchResult();
+      }
+      if (anchoredPrefixOrCharClassCannotMatch(0)) {
+        MatchStrategy strategy =
+            parentPattern.anchoredPrefix() != null
+                ? MatchStrategy.LITERAL
+                : MatchStrategy.CHARACTER_CLASS;
+        diagnosticParticipation(strategy, StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(strategy);
         return applyFailedMatchResult();
       }
     }
@@ -3264,7 +3273,8 @@ public final class Matcher implements MatchResult {
       return sb.toString();
     }
 
-    int firstIdx = text.indexOf(literal, searchFrom);
+    int searchFrom = 0;
+    int firstIdx = indexOfReplacementLiteral(literal, searchFrom);
     if (firstIdx < 0) {
       if (accumulator != null) {
         accumulator.boundary(MatchStrategy.LITERAL);
@@ -3275,8 +3285,7 @@ public final class Matcher implements MatchResult {
 
     StringBuilder sb = null;
     int appendPosition = 0;
-    int searchFrom = 0;
-    int matchStart;
+    int matchStart = firstIdx;
     int matchesFound = 0;
 
     int firstMatchStart = -1;
@@ -3284,7 +3293,7 @@ public final class Matcher implements MatchResult {
 
     ReplacementSegment[] compiledTemplate = null;
 
-    while (matchesFound < limit && (matchStart = text.indexOf(literal, searchFrom)) != -1) {
+    do {
       if (sb == null) {
         sb = new StringBuilder(text.length());
       }
@@ -3316,7 +3325,11 @@ public final class Matcher implements MatchResult {
       appendPosition = matchStart + literal.length();
       searchFrom = appendPosition;
       matchesFound++;
-    }
+      if (matchesFound >= limit) {
+        break;
+      }
+      matchStart = indexOfReplacementLiteral(literal, searchFrom);
+    } while (matchStart != -1);
 
     if (sb == null) {
       if (accumulator != null) {
@@ -3348,6 +3361,15 @@ public final class Matcher implements MatchResult {
     }
 
     return sb.toString();
+  }
+
+  private int indexOfReplacementLiteral(String literal, int fromIndex) {
+    int matchStart = text.indexOf(literal, fromIndex);
+    if (WorkCounterConfig.ENABLED) {
+      int examinedEnd = matchStart >= 0 ? matchStart + literal.length() : text.length();
+      WorkCounter.record(Math.max(0, examinedEnd - fromIndex));
+    }
+    return matchStart;
   }
 
   private String charClassReplaceFastPath(LazyTemplate template, int limit) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -647,7 +647,7 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean literalRegionMatches(String literal, int offset, int length) {
-    if (parentPattern.prefixFoldCase()) {
+    if (parentPattern.literalFoldCase() || parentPattern.prefixFoldCase()) {
       return regionMatchesAsciiIgnoreCase(text, offset, literal, 0, length);
     }
     return text.regionMatches(false, offset, literal, 0, length);
@@ -1396,8 +1396,10 @@ public final class Matcher implements MatchResult {
     if (regionActive) {
       return doFindRegion(regionActive);
     }
-    if (parentPattern.prog().anchorStart() && searchFrom > 0) {
-      return applyFailedMatchResult();
+    if (parentPattern.prog().anchorStart()) {
+      if (searchFrom > 0 || anchoredPrefixOrCharClassCannotMatch(0)) {
+        return applyFailedMatchResult();
+      }
     }
     return parentPattern.preparedMatchRunner(false).find(this, false);
   }
@@ -1818,7 +1820,7 @@ public final class Matcher implements MatchResult {
       fwdResult = null;
     } else {
       diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
-      fwdResult = searchForwardDfa(dfa(false), scanner, effectiveStart, false, false);
+      fwdResult = searchForwardDfa(dfa(false), scanner, effectiveStart, prog.anchorStart(), false);
       if (fwdResult != null && !fwdResult.matched()) {
         diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
@@ -2033,6 +2035,63 @@ public final class Matcher implements MatchResult {
     } else {
       return applyDeferredMatchResult(result[0], result[1], prog.numCaptures(), true, false);
     }
+  }
+
+  private boolean matchUtf8KeywordAlternationAt(
+      Pattern.KeywordAlternation keywordAlternation, int pos, int ncap) {
+    InputScanner scanner = activeScanner();
+    if (pos >= scanner.length()) {
+      return applyFailedMatchResult();
+    }
+    long match = keywordAlternation.matchAt(scanner, pos);
+    if (match < 0) {
+      return applyFailedMatchResult();
+    }
+    int keywordStart = Pattern.KeywordAlternation.matchStart(match);
+    int keywordEnd = Pattern.KeywordAlternation.matchEnd(match);
+    int[] keywordGroups = new int[2 * ncap];
+    Arrays.fill(keywordGroups, -1);
+    keywordGroups[0] = keywordAlternation.greedyWholeInput ? pos : keywordStart;
+    keywordGroups[1] = keywordAlternation.greedyWholeInput ? scanner.length() : keywordEnd;
+    if (keywordAlternation.captureGroup > 0) {
+      int group = keywordAlternation.captureGroup;
+      keywordGroups[2 * group] = keywordStart;
+      keywordGroups[2 * group + 1] = keywordEnd;
+    }
+    return applyFullMatchResult(keywordGroups);
+  }
+
+  private boolean matchKeywordAlternationAt(
+      Pattern.KeywordAlternation keywordAlternation, int pos, int ncap) {
+    if (pos >= text.length()) {
+      return applyFailedMatchResult();
+    }
+    if (WorkCounterConfig.ENABLED) {
+      WorkCounter.record();
+    }
+    char ch = text.charAt(pos);
+    if (ch < 128
+        && keywordAlternation.firstAsciiTable[Ascii.toLowerCase(ch)]
+        && isWordBoundaryAt(pos, keywordAlternation.unicodeWordBoundary)) {
+      for (String keyword : keywordAlternation.keywords) {
+        int end = pos + keyword.length();
+        if (end <= text.length()
+            && regionMatchesAsciiIgnoreCase(text, pos, keyword, 0, keyword.length())
+            && isWordBoundaryAt(end, keywordAlternation.unicodeWordBoundary)) {
+          int[] keywordGroups = new int[2 * ncap];
+          Arrays.fill(keywordGroups, -1);
+          keywordGroups[0] = pos;
+          keywordGroups[1] = keywordAlternation.greedyWholeInput ? text.length() : end;
+          if (keywordAlternation.captureGroup > 0) {
+            int group = keywordAlternation.captureGroup;
+            keywordGroups[2 * group] = pos;
+            keywordGroups[2 * group + 1] = end;
+          }
+          return applyFullMatchResult(keywordGroups);
+        }
+      }
+    }
+    return applyFailedMatchResult();
   }
 
   private boolean findUtf8KeywordAlternation(
@@ -2667,7 +2726,7 @@ public final class Matcher implements MatchResult {
       return result;
     }
 
-    if (template.needsCaptures()) {
+    if (replacement.indexOf('$') >= 0) {
       eagerFallbackCaptures = true;
     }
 
@@ -2773,7 +2832,8 @@ public final class Matcher implements MatchResult {
     boolean isStartAnchored = parentPattern.prog().anchorStart();
     String prefix = parentPattern.prefix();
     boolean foldCase = parentPattern.prefixFoldCase();
-    boolean hasStartAcceleration = enginePathOptions().startAcceleration() && prefix != null;
+    boolean hasStartAcceleration =
+        enginePathOptions().startAcceleration() && prefix != null && !isStartAnchored;
     int startPos = searchFrom;
     if (hasStartAcceleration) {
       diagnosticParticipation(MatchStrategy.LITERAL, StrategyRole.START_ACCELERATION);
@@ -2944,7 +3004,7 @@ public final class Matcher implements MatchResult {
         pos = idx;
       }
 
-      Dfa.SearchResult fwdResult = searchForwardDfa(fwdDfa, scanner, pos, false, false);
+      Dfa.SearchResult fwdResult = searchForwardDfa(fwdDfa, scanner, pos, isStartAnchored, false);
       if (fwdResult == null || !fwdResult.matched()) {
         break;
       }
@@ -3138,7 +3198,7 @@ public final class Matcher implements MatchResult {
     }
 
     String literal = parentPattern.literalMatch();
-    if (literal == null || literal.isEmpty() || text == null || parentPattern.prefixFoldCase()) {
+    if (literal == null || literal.isEmpty() || text == null || parentPattern.literalFoldCase()) {
       return null;
     }
 
@@ -3153,6 +3213,64 @@ public final class Matcher implements MatchResult {
         activeDiagnostics == null ? null : activeDiagnostics.accumulator();
     if (accumulator != null) {
       accumulator.participate(MatchStrategy.LITERAL, StrategyRole.CANDIDATE_VERIFICATION);
+    }
+
+    boolean isStartAnchored = parentPattern.prog().anchorStart();
+    if (isStartAnchored) {
+      if (searchFrom > 0 || !text.startsWith(literal)) {
+        if (accumulator != null) {
+          accumulator.boundary(MatchStrategy.LITERAL);
+        }
+        applyFailedMatchResult();
+        return text;
+      }
+      int matchStart = 0;
+      int matchEnd = literal.length();
+      StringBuilder sb = new StringBuilder(text.length());
+      if (!simpleReplacement) {
+        applyDeferredMatchResult(
+            matchStart, matchEnd, parentPattern.prog().numCaptures(), true, false);
+        ReplacementSegment[] compiledTemplate;
+        try {
+          compiledTemplate = template.get();
+        } catch (IllegalArgumentException e) {
+          applyFullMatchResult(new int[] {matchStart, matchEnd});
+          throw e;
+        }
+        groups[0] = matchStart;
+        groups[1] = matchEnd;
+        applyReplacementTemplate(sb, compiledTemplate);
+      } else {
+        sb.append(replacement);
+      }
+      int appendPosition = matchEnd;
+      this.appendPos = appendPosition;
+      sb.append(text, appendPosition, text.length());
+      if (limit == 1) {
+        if (groupCount() == 0) {
+          applyFullMatchResult(new int[] {matchStart, matchEnd});
+        } else {
+          applyDeferredMatchResult(
+              matchStart, matchEnd, parentPattern.prog().numCaptures(), true, false);
+        }
+      } else {
+        this.searchFrom = regionEnd;
+        applyFailedMatchResult();
+      }
+      if (accumulator != null) {
+        accumulator.boundary(MatchStrategy.LITERAL);
+        accumulator.matchCount(1);
+      }
+      return sb.toString();
+    }
+
+    int firstIdx = text.indexOf(literal, searchFrom);
+    if (firstIdx < 0) {
+      if (accumulator != null) {
+        accumulator.boundary(MatchStrategy.LITERAL);
+      }
+      applyFailedMatchResult();
+      return text;
     }
 
     StringBuilder sb = null;
@@ -3176,8 +3294,14 @@ public final class Matcher implements MatchResult {
         firstMatchStart = matchStart;
         firstMatchEnd = matchStart + literal.length();
         if (!simpleReplacement) {
-          applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
-          compiledTemplate = template.get();
+          applyDeferredMatchResult(
+              firstMatchStart, firstMatchEnd, parentPattern.prog().numCaptures(), true, false);
+          try {
+            compiledTemplate = template.get();
+          } catch (IllegalArgumentException e) {
+            applyFullMatchResult(new int[] {firstMatchStart, firstMatchEnd});
+            throw e;
+          }
         }
       }
 
@@ -4111,10 +4235,19 @@ public final class Matcher implements MatchResult {
     // Literal fast path
     String literal = parentPattern.literalMatch();
     if (options.literalFastPaths() && literal != null && parentPattern.numGroups() == 0) {
-      int idx =
-          parentPattern.prefixFoldCase()
-              ? indexOfIgnoreCase(text, literal, fromIndex)
-              : text.indexOf(literal, fromIndex);
+      int idx;
+      if (prog.anchorStart()) {
+        if (parentPattern.literalFoldCase()) {
+          idx = regionMatchesAsciiIgnoreCase(text, 0, literal, 0, literal.length()) ? 0 : -1;
+        } else {
+          idx = text.startsWith(literal) ? 0 : -1;
+        }
+      } else {
+        idx =
+            parentPattern.literalFoldCase()
+                ? indexOfIgnoreCase(text, literal, fromIndex)
+                : text.indexOf(literal, fromIndex);
+      }
       if (idx < 0) {
         return -1L;
       }
@@ -4124,6 +4257,19 @@ public final class Matcher implements MatchResult {
     // Char class fast path
     Pattern.CharClassScanInfo singleCharClass = parentPattern.matchDescriptor().singleCharClass();
     if (options.charClassMatchFastPaths() && singleCharClass != null) {
+      if (prog.anchorStart() && fromIndex > 0) {
+        return -1L;
+      }
+      if (prog.anchorStart()) {
+        if (scanner.length() == 0) {
+          return -1L;
+        }
+        int cp = scanner.codePointAt(0);
+        if (singleCharClass.contains(cp)) {
+          return packPositions(0, Character.charCount(cp));
+        }
+        return -1L;
+      }
       if (singleCharClass.isAscii) {
         int idx = scanner.indexOfCharClass(singleCharClass, fromIndex);
         if (idx < 0) {
@@ -4146,7 +4292,7 @@ public final class Matcher implements MatchResult {
     }
 
     int effectiveStart = fromIndex;
-    if (options.startAcceleration() && text != null) {
+    if (options.startAcceleration() && text != null && !prog.anchorStart()) {
       StringStartAccelerator accelerator = parentPattern.stringStartAccelerator();
       if (accelerator != null) {
         int idx = accelerator.findCandidate(text, fromIndex, prog.unixLines());
@@ -4159,7 +4305,7 @@ public final class Matcher implements MatchResult {
 
     Dfa.SearchResult fwdResult = null;
     if (canUseForwardDfa()) {
-      fwdResult = dfa(false).doSearch(scanner, effectiveStart, false, false);
+      fwdResult = dfa(false).doSearch(scanner, effectiveStart, prog.anchorStart(), false);
       if (fwdResult != null && !fwdResult.matched()) {
         return -1L;
       }
@@ -4274,6 +4420,9 @@ public final class Matcher implements MatchResult {
       if (isStartAnchored && matcher.searchFrom > 0) {
         return matcher.applyFailedMatchResult();
       }
+      if (isStartAnchored) {
+        return matchLiteral(matcher, false);
+      }
       if (foldCase && matcher.text == null) {
         return fallback.find(matcher, regionActive);
       }
@@ -4386,6 +4535,9 @@ public final class Matcher implements MatchResult {
       if (singleCharClass == null) {
         return matcher.doFindCore(regionActive);
       }
+      if (isStartAnchored) {
+        return matchSingleCharClass(matcher, false);
+      }
       matcher.diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);
       return matcher.singleCharClassFindFastPath(singleCharClass, matcher.searchFrom);
     }
@@ -4462,6 +4614,15 @@ public final class Matcher implements MatchResult {
       if (isStartAnchored && matcher.searchFrom > 0) {
         return matcher.applyFailedMatchResult();
       }
+      if (isStartAnchored) {
+        matcher.diagnosticBoundary(MatchStrategy.KEYWORD);
+        if (keywordAlternation.captureGroup > 0) {
+          matcher.diagnosticCapture(MatchStrategy.KEYWORD);
+        }
+        return matcher.text != null
+            ? matcher.matchKeywordAlternationAt(keywordAlternation, 0, numCaptures)
+            : matcher.matchUtf8KeywordAlternationAt(keywordAlternation, 0, numCaptures);
+      }
       matcher.diagnosticBoundary(MatchStrategy.KEYWORD);
       if (keywordAlternation.captureGroup > 0) {
         matcher.diagnosticCapture(MatchStrategy.KEYWORD);
@@ -4495,6 +4656,9 @@ public final class Matcher implements MatchResult {
           || matcher.activeScanner().length() > matcher.onePassTextLimit()) {
         return matcher.doFindCore(regionActive);
       }
+      if (matcher.searchFrom > 0 || matcher.anchoredPrefixOrCharClassCannotMatch(0)) {
+        return matcher.applyFailedMatchResult();
+      }
       matcher.diagnosticBoundary(MatchStrategy.ONE_PASS);
       if (matcher.parentPattern.numGroups() > 0) {
         matcher.diagnosticCapture(MatchStrategy.ONE_PASS);
@@ -4505,7 +4669,7 @@ public final class Matcher implements MatchResult {
               .onePass()
               .search(
                   matcher.activeScanner(),
-                  matcher.searchFrom,
+                  0,
                   matcher.activeScanner().length(),
                   false,
                   numCaptures,

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -626,6 +626,9 @@ public final class Pattern implements Serializable {
       return false;
     }
     if (literalMatchUtf8 != null && !literalFoldCase()) {
+      if (prog.anchorStart()) {
+        return scanner.startsWith(literalMatchUtf8, 0);
+      }
       return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
     }
     if (enginePathOptions.keywordAlternationFastPath()
@@ -683,7 +686,9 @@ public final class Pattern implements Serializable {
     int length = scanner.length();
     if (literalMatchUtf8 != null && !literalFoldCase()) {
       boolean matched =
-          scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
+          prog.anchorStart()
+              ? scanner.startsWith(literalMatchUtf8, 0)
+              : scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
       diagnostics.boundary(MatchStrategy.LITERAL);
       return matched;
     }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -341,7 +341,9 @@ public final class Pattern implements Serializable {
 
   private static MatchDescriptor extractMatchDescriptor(
       Regexp metadataAst, Regexp sourceAst, int flags) {
-    String literalMatch = extractLiteralMatch(metadataAst);
+    LiteralResult literalMatchResult = extractLiteralMatch(metadataAst);
+    String literalMatch = literalMatchResult.literal();
+    boolean literalFoldCase = literalMatchResult.foldCase();
     CharClassScanInfo singleCharClass = extractSingleCharClass(metadataAst);
     KeywordAlternation keywordAlternation = extractKeywordAlternation(metadataAst, flags);
     CharClassMatchInfo ccMatch = extractCharClassMatch(metadataAst);
@@ -354,7 +356,12 @@ public final class Pattern implements Serializable {
       return MatchDescriptor.NONE;
     }
     return new MatchDescriptor(
-        literalMatch, singleCharClass, keywordAlternation, ccMatch, minMatchLength);
+        literalMatch,
+        literalFoldCase,
+        singleCharClass,
+        keywordAlternation,
+        ccMatch,
+        minMatchLength);
   }
 
   private static long nextPatternId() {
@@ -618,7 +625,7 @@ public final class Pattern implements Serializable {
     if (matchDescriptor.minMatchLength() > 0 && length < matchDescriptor.minMatchLength()) {
       return false;
     }
-    if (literalMatchUtf8 != null && !prefixFoldCase) {
+    if (literalMatchUtf8 != null && !literalFoldCase()) {
       return scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
     }
     if (enginePathOptions.keywordAlternationFastPath()
@@ -674,7 +681,7 @@ public final class Pattern implements Serializable {
 
   private boolean findWithDiagnostics(Utf8InputScanner scanner, DiagnosticAccumulator diagnostics) {
     int length = scanner.length();
-    if (literalMatchUtf8 != null && !prefixFoldCase) {
+    if (literalMatchUtf8 != null && !literalFoldCase()) {
       boolean matched =
           scanner.indexOf(literalMatchUtf8, literalMatchFailure, literalMatchShifts) >= 0;
       diagnostics.boundary(MatchStrategy.LITERAL);
@@ -1000,12 +1007,12 @@ public final class Pattern implements Serializable {
     if (enginePathOptions.literalFastPaths() && literal != null && numGroups() == 0) {
       return new Matcher.LiteralPreparedRunner(
           literal,
-          prefixFoldCase,
+          matchDescriptor.literalFoldCase(),
           literalMatchUtf8,
           literalMatchFailure,
           literalMatchShifts,
           prog.anchorStart(),
-          prefixFoldCase
+          matchDescriptor.literalFoldCase()
               ? createLiteralFallbackRunner(regionActive)
               : Matcher.FallbackPreparedRunner.INSTANCE);
     }
@@ -1447,6 +1454,10 @@ public final class Pattern implements Serializable {
    */
   String literalMatch() {
     return matchDescriptor.literalMatch();
+  }
+
+  boolean literalFoldCase() {
+    return matchDescriptor.literalFoldCase();
   }
 
   byte[] literalMatchUtf8() {
@@ -2194,7 +2205,7 @@ public final class Pattern implements Serializable {
       return -1;
     }
 
-    private long matchAt(InputScanner scanner, int position) {
+    long matchAt(InputScanner scanner, int position) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();
       }
@@ -3689,14 +3700,18 @@ public final class Pattern implements Serializable {
     return false;
   }
 
+  private record LiteralResult(String literal, boolean foldCase) {
+    static final LiteralResult NONE = new LiteralResult(null, false);
+  }
+
   /**
-   * Extracts a literal match string from the AST if the pattern is entirely literal (no
-   * metacharacters, no quantifiers, no alternation). Sees through CAPTURE wrappers (group 0 is
-   * implicit) and handles LITERAL, LITERAL_STRING, and CONCAT of literals.
+   * Extracts the full literal string if this pattern is entirely literal (no metacharacters, no
+   * quantifiers, no alternation). Transparent groups (e.g. non-capturing groups) are unwrapped.
    *
-   * @return the literal string to match, or {@code null} if the pattern is not fully literal
+   * <p>Returns {@link LiteralResult#NONE} if the pattern is not fully literal. For case-insensitive
+   * patterns, returns the lowercase version and foldCase=true.
    */
-  private static String extractLiteralMatch(Regexp re) {
+  private static LiteralResult extractLiteralMatch(Regexp re) {
     Regexp node = re;
 
     // Unwrap outer CAPTURE (group 0).
@@ -3704,15 +3719,20 @@ public final class Pattern implements Serializable {
       node = node.sub();
     }
     if (node == null) {
-      return null;
+      return LiteralResult.NONE;
     }
 
-    boolean foldCase = (node.flags & ParseFlags.FOLD_CASE) != 0;
+    boolean foldCase = false;
+    boolean foldCaseInitialized = false;
     StringBuilder sb = new StringBuilder();
 
     switch (node.op) {
-      case LITERAL -> sb.appendCodePoint(node.rune);
+      case LITERAL -> {
+        foldCase = (node.flags & ParseFlags.FOLD_CASE) != 0;
+        sb.appendCodePoint(node.rune);
+      }
       case LITERAL_STRING -> {
+        foldCase = (node.flags & ParseFlags.FOLD_CASE) != 0;
         if (node.runes != null) {
           for (int r : node.runes) {
             sb.appendCodePoint(r);
@@ -3723,15 +3743,24 @@ public final class Pattern implements Serializable {
         for (Regexp child : node.subs) {
           // Each child must be LITERAL or LITERAL_STRING (not wrapped in CAPTURE etc.)
           Regexp c = child;
-          while (c != null && c.op == RegexpOp.CAPTURE) {
+          while (c != null && (c.op == RegexpOp.CAPTURE || c.op == RegexpOp.NON_CAPTURE)) {
             c = c.sub();
           }
           if (c == null) {
-            return null;
+            return LiteralResult.NONE;
+          }
+          if (c.op == RegexpOp.BEGIN_TEXT) {
+            if (sb.length() > 0) {
+              return LiteralResult.NONE;
+            }
+            continue;
           }
           boolean childFoldCase = (c.flags & ParseFlags.FOLD_CASE) != 0;
-          if (childFoldCase != foldCase) {
-            return null;
+          if (!foldCaseInitialized) {
+            foldCase = childFoldCase;
+            foldCaseInitialized = true;
+          } else if (childFoldCase != foldCase) {
+            return LiteralResult.NONE;
           }
           if (c.op == RegexpOp.LITERAL) {
             sb.appendCodePoint(c.rune);
@@ -3740,23 +3769,24 @@ public final class Pattern implements Serializable {
               sb.appendCodePoint(r);
             }
           } else {
-            return null;
+            return LiteralResult.NONE;
           }
         }
       }
       case EMPTY_MATCH -> {
         // Empty pattern matches empty string.
-        return "";
+        return new LiteralResult("", false);
       }
       default -> {
-        return null;
+        return LiteralResult.NONE;
       }
     }
 
     if (sb.isEmpty()) {
-      return "";
+      return new LiteralResult("", false);
     }
-    return foldCase ? sb.toString().toLowerCase(Locale.ROOT) : sb.toString();
+    return new LiteralResult(
+        foldCase ? sb.toString().toLowerCase(Locale.ROOT) : sb.toString(), foldCase);
   }
 
   private static final class MinMatchLengthWalker extends Walker<Integer> {

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -652,6 +652,30 @@ class DiagnosticsTest {
   }
 
   @Test
+  void startAnchoredRejectionReportsPrefilterStrategy() {
+    Pattern.setDiagnostics(diagnostics);
+    Map<String, MatchStrategy> cases =
+        Map.of("^target", MatchStrategy.LITERAL, "^[a-z]", MatchStrategy.CHARACTER_CLASS);
+
+    cases.forEach(
+        (regex, expectedStrategy) -> {
+          Pattern pattern = Pattern.compile(regex);
+
+          assertThat(pattern.matcher("9target").find()).isFalse();
+          assertThat(operationsFor(pattern))
+              .singleElement()
+              .satisfies(
+                  event -> {
+                    assertThat(event.boundaryStrategy()).isEqualTo(expectedStrategy);
+                    assertThat(event.auxiliaryStrategies())
+                        .containsExactly(
+                            new StrategyParticipation(
+                                expectedStrategy, StrategyRole.REJECT_PREFILTER));
+                  });
+        });
+  }
+
+  @Test
   void listenerCanAggregateStrategiesWithLongAdders() {
     Pattern pattern = Pattern.compile("abc");
     Map<MatchStrategy, LongAdder> counts = new ConcurrentHashMap<>();

--- a/safere/src/test/java/org/safere/LiteralFlagTest.java
+++ b/safere/src/test/java/org/safere/LiteralFlagTest.java
@@ -170,9 +170,75 @@ class LiteralFlagTest {
   }
 
   @Test
-  void multipleMetacharsInSequence() {
-    Pattern p = Pattern.compile("(a+|b*)[c-d]", Pattern.LITERAL);
-    assertThat(p.matcher("(a+|b*)[c-d]").matches()).isTrue();
-    assertThat(p.matcher("aac").matches()).isFalse();
+  void replaceAllWithLiteralCaseInsensitive() {
+    Pattern p = Pattern.compile("Foo", Pattern.LITERAL | Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher("foo FOO Foo fOO bar");
+    assertThat(m.replaceAll("baz")).isEqualTo("baz baz baz baz bar");
+    assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  void replaceFirstWithLiteralCaseInsensitive() {
+    Pattern p = Pattern.compile("Foo", Pattern.LITERAL | Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher("foo FOO Foo");
+    assertThat(m.replaceFirst("baz")).isEqualTo("baz FOO Foo");
+    assertThat(m.start()).isEqualTo(0);
+    assertThat(m.end()).isEqualTo(3);
+    assertThat(m.group()).isEqualTo("foo");
+    assertThat(m.find()).isTrue();
+    assertThat(m.group()).isEqualTo("FOO");
+    assertThat(m.start()).isEqualTo(4);
+    assertThat(m.end()).isEqualTo(7);
+  }
+
+  @Test
+  void replaceAllWithLiteralGroupZeroReference() {
+    Pattern p = Pattern.compile("foo", Pattern.LITERAL | Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher("Foo FOO");
+    assertThat(m.replaceAll("[$0]")).isEqualTo("[Foo] [FOO]");
+  }
+
+  @Test
+  void splitWithLiteralCaseInsensitive() {
+    Pattern p = Pattern.compile("x", Pattern.LITERAL | Pattern.CASE_INSENSITIVE);
+    String[] parts = p.split("aXbxcXd");
+    assertThat(parts).containsExactly("a", "b", "c", "d");
+  }
+
+  @Test
+  void splitWithDelimitersLiteralCaseInsensitive() {
+    Pattern p = Pattern.compile("SEP", Pattern.LITERAL | Pattern.CASE_INSENSITIVE);
+    String[] parts = p.splitWithDelimiters("aSepBsepC", 0);
+    assertThat(parts).containsExactly("a", "Sep", "B", "sep", "C");
+  }
+
+  @Test
+  void matcherLifecycleStatePreservation() {
+    Pattern p = Pattern.compile("abc", Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher("123 ABC 456 abc 789");
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(4);
+    assertThat(m.end()).isEqualTo(7);
+    assertThat(m.group()).isEqualTo("ABC");
+
+    m.reset();
+    assertThat(m.replaceFirst("XYZ")).isEqualTo("123 XYZ 456 abc 789");
+    assertThat(m.start()).isEqualTo(4);
+    assertThat(m.end()).isEqualTo(7);
+    assertThat(m.group()).isEqualTo("ABC");
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(12);
+    assertThat(m.end()).isEqualTo(15);
+    assertThat(m.group()).isEqualTo("abc");
+
+    assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  void singleCharLiteralCaseInsensitive() {
+    Pattern p = Pattern.compile("a", Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher("A b a B A");
+    assertThat(m.replaceAll("x")).isEqualTo("x b x B x");
   }
 }

--- a/safere/src/test/java/org/safere/PatternTest.java
+++ b/safere/src/test/java/org/safere/PatternTest.java
@@ -1306,6 +1306,16 @@ class PatternTest {
   @DisplayName("start-anchored prefix and char class fast paths")
   class StartAnchoredPrefixTests {
 
+    @ParameterizedTest
+    @ValueSource(strings = {"^target", "\\Atarget"})
+    @DisplayName("start-anchored literal rejects a later UTF-8 occurrence")
+    void startAnchoredLiteralRejectsLaterUtf8Occurrence(String regex) {
+      Pattern pattern = Pattern.compile(regex);
+
+      assertThat(pattern.find(Utf8Input.trusted("prefix target".getBytes(UTF_8)))).isFalse();
+      assertThat(pattern.find(Utf8Input.trusted("target suffix".getBytes(UTF_8)))).isTrue();
+    }
+
     @Test
     @DisplayName("start-anchored character class rejects empty UTF-8 input safely")
     void startAnchoredCharacterClassRejectsEmptyUtf8InputSafely() {

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -87,6 +87,20 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void literalReplaceFirstReusesLatePreflightMatch() {
+    Pattern pattern = Pattern.compile("(needle)");
+    String input = "x".repeat(10_000) + "needle";
+
+    long work =
+        WorkCounter.countForTesting(
+            () -> assertThat(pattern.matcher(input).replaceFirst("[$0]")).endsWith("[needle]"));
+
+    assertThat(work)
+        .as("Literal replaceFirst must not rescan the prefix after finding the first match")
+        .isLessThanOrEqualTo(input.length());
+  }
+
+  @Test
   void startAnchoredLiteralFindRejectionIsConstantWorkForStringInput() {
     Pattern pattern = Pattern.compile("^target");
     assertConstantRejectionWork(

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -87,6 +87,93 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void startAnchoredLiteralFindRejectionIsConstantWorkForStringInput() {
+    Pattern pattern = Pattern.compile("^target");
+    assertConstantRejectionWork(
+        size -> pattern.matcher("x".repeat(size) + "target").find(), "String literal");
+  }
+
+  @Test
+  void startAnchoredLiteralFindRejectionIsConstantWorkForUtf8Input() {
+    Pattern pattern = Pattern.compile("^target");
+    assertConstantRejectionWork(
+        size ->
+            pattern
+                .matcher(Utf8Input.trusted(("x".repeat(size) + "target").getBytes(UTF_8)))
+                .find(),
+        "UTF-8 literal");
+  }
+
+  @Test
+  void startAnchoredCharClassFindRejectionIsConstantWorkForStringInput() {
+    Pattern pattern = Pattern.compile("^[a-z]");
+    assertConstantRejectionWork(
+        size -> pattern.matcher("9".repeat(size) + "a").find(), "String char-class");
+  }
+
+  @Test
+  void startAnchoredCharClassFindRejectionIsConstantWorkForUtf8Input() {
+    Pattern pattern = Pattern.compile("^[a-z]");
+    assertConstantRejectionWork(
+        size -> pattern.matcher(Utf8Input.trusted(("9".repeat(size) + "a").getBytes(UTF_8))).find(),
+        "UTF-8 char-class");
+  }
+
+  @Test
+  void startAnchoredKeywordAlternationFindRejectionIsConstantWorkForStringInput() {
+    Pattern pattern = Pattern.compile("(?i)^(?:apple|banana)");
+    assertConstantRejectionWork(
+        size -> pattern.matcher("x".repeat(size) + "apple").find(), "String keyword");
+  }
+
+  @Test
+  void startAnchoredKeywordAlternationFindRejectionIsConstantWorkForUtf8Input() {
+    Pattern pattern = Pattern.compile("(?i)^(?:apple|banana)");
+    assertConstantRejectionWork(
+        size ->
+            pattern.matcher(Utf8Input.trusted(("x".repeat(size) + "apple").getBytes(UTF_8))).find(),
+        "UTF-8 keyword");
+  }
+
+  @Test
+  void startAnchoredFindFromNonZeroIsConstantWork() {
+    Pattern pattern = Pattern.compile("^abc");
+    assertConstantRejectionWork(
+        size -> pattern.matcher("abc" + "x".repeat(size)).find(1), "find(1) on ^abc");
+  }
+
+  @Test
+  void startAnchoredRepeatedFindTerminatesInConstantWork() {
+    Pattern pattern = Pattern.compile("^abc");
+    long work2000 =
+        WorkCounter.countForTesting(
+            () -> {
+              Matcher m = pattern.matcher("abc" + "x".repeat(2_000));
+              int matches = 0;
+              while (m.find()) {
+                matches++;
+              }
+              assertThat(matches).isEqualTo(1);
+            });
+    long work10000 =
+        WorkCounter.countForTesting(
+            () -> {
+              Matcher m = pattern.matcher("abc" + "x".repeat(10_000));
+              int matches = 0;
+              while (m.find()) {
+                matches++;
+              }
+              assertThat(matches).isEqualTo(1);
+            });
+
+    assertThat(work2000).as("Short input repeated find work").isLessThan(50);
+    assertThat(work10000).as("Long input repeated find work").isLessThan(50);
+    assertThat(work10000)
+        .as("Subsequent find() on start-anchored pattern must not scale with input size")
+        .isLessThanOrEqualTo(Math.max(10, work2000 * 2));
+  }
+
+  @Test
   void disjointRequiredLiteralCandidateIsScannedOnlyOnce() {
     Pattern pattern = Pattern.compile(".*(?:apple|banana|cherry).*");
     String input = "x".repeat(32_768) + "cherry";
@@ -137,6 +224,17 @@ class SearchScalingRegressionTest {
     assertThat(largerWork)
         .as("Literal selectivity scoring should scale linearly with pattern size")
         .isLessThanOrEqualTo(smallerWork * 6);
+  }
+
+  private static void assertConstantRejectionWork(IntPredicate find, String description) {
+    long work2000 = WorkCounter.countForTesting(() -> assertThat(find.test(2_000)).isFalse());
+    long work10000 = WorkCounter.countForTesting(() -> assertThat(find.test(10_000)).isFalse());
+
+    assertThat(work2000).as("%s rejection on short input", description).isLessThan(100);
+    assertThat(work10000).as("%s rejection on long input", description).isLessThan(100);
+    assertThat(work10000)
+        .as("%s rejection work should not scale with trailing input size", description)
+        .isLessThanOrEqualTo(Math.max(10, work2000 * 2));
   }
 
   private static void assertRepeatedFindWorkIsLinear(

--- a/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/Utf8DiagnosticsTest.java
@@ -154,6 +154,18 @@ class Utf8DiagnosticsTest {
   }
 
   @Test
+  void startAnchoredLiteralFindWithDiagnosticsRejectsLaterOccurrence() {
+    Pattern.setDiagnostics(diagnostics);
+    Pattern pattern = Pattern.compile("^target");
+
+    assertThat(pattern.find(input("prefix target"))).isFalse();
+
+    assertThat(operationsFor(pattern))
+        .singleElement()
+        .satisfies(event -> assertThat(event.outcome()).isEqualTo(MatchOutcome.NO_MATCH));
+  }
+
+  @Test
   void patternBooleanFindReportsAccelerationAndDfaSearch() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile("é[ab]+c");


### PR DESCRIPTION
For start-anchored patterns, matches can only ever occur at index 0. Previously, subsequent calls in search loops or searches starting from non-zero positions would rescan trailing text or run DFA passes before failing.

This change adds constant-time rejection checks and direct index-0 dispatch for start-anchored patterns across all prepared runners, DFA searches, and literal fast paths.

```
/safere-benchmarks/scripts/compare-branch.sh --baseline perf/start-anchored-benchmarks-baseline 'SearchScalingBenchmark.startAnchored.*safere-string'
```

| Benchmark                                                  | baseline (ns/op) | current (ns/op) | Speedup |
| ---------------------------------------------------------- | ---------------- | --------------- | ------- |
| SearchScalingBenchmark.startAnchoredLiteralFail.1024       |         26 ± 5.6 |       12 ± 0.30 |   2.14x |
| SearchScalingBenchmark.startAnchoredLiteralSuccess.1024    |         27 ± 6.9 |        12 ± 1.5 |   2.23x |
| SearchScalingBenchmark.startAnchoredCharClassFail.1024     |         26 ± 6.8 |       10 ± 0.97 |   2.50x |
| SearchScalingBenchmark.startAnchoredFindAll.1024           |         26 ± 5.0 |       12 ± 0.51 |   2.17x |
| SearchScalingBenchmark.startAnchoredLiteralFail.10240      |         25 ± 5.1 |        12 ± 1.3 |   2.00x |
| SearchScalingBenchmark.startAnchoredLiteralSuccess.10240   |         27 ± 5.8 |       12 ± 0.57 |   2.19x |
| SearchScalingBenchmark.startAnchoredCharClassFail.10240    |         25 ± 6.5 |       10 ± 0.40 |   2.43x |
| SearchScalingBenchmark.startAnchoredFindAll.10240          |         28 ± 7.0 |        12 ± 1.1 |   2.24x |
| SearchScalingBenchmark.startAnchoredLiteralFail.102400     |         28 ± 8.8 |       12 ± 0.47 |   2.36x |
| SearchScalingBenchmark.startAnchoredLiteralSuccess.102400  |         25 ± 5.1 |       13 ± 0.49 |   1.98x |
| SearchScalingBenchmark.startAnchoredCharClassFail.102400   |         26 ± 6.6 |       10 ± 0.41 |   2.54x |
| SearchScalingBenchmark.startAnchoredFindAll.102400         |         26 ± 5.5 |       12 ± 0.71 |   2.17x |
| SearchScalingBenchmark.startAnchoredLiteralFail.1048576    |         25 ± 5.7 |       12 ± 0.63 |   2.08x |
| SearchScalingBenchmark.startAnchoredLiteralSuccess.1048576 |         26 ± 6.4 |        12 ± 1.3 |   2.10x |
| SearchScalingBenchmark.startAnchoredCharClassFail.1048576  |         25 ± 4.0 |       10 ± 0.34 |   2.45x |
| SearchScalingBenchmark.startAnchoredFindAll.1048576        |         26 ± 5.3 |       12 ± 0.51 |   2.21x |