### PR TITLE
Generalize character-class prefix acceleration to Unicode (#564)

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -9763,7 +9763,15 @@
       "id": "UnicodePrefixBenchmark.alphabetic.absent.{size}",
       "operation": "find",
       "patterns": [
-        "[\\p{IsAlphabetic}]+\\d+"
+        {
+          "java": "[\\p{IsAlphabetic}]+\\d+",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET does not expose Java's IsAlphabetic Unicode property"
+            }
+          }
+        }
       ],
       "inputs": [
         "unicodePrefix.digitsAbsent.{size}"
@@ -9794,7 +9802,15 @@
       "id": "UnicodePrefixBenchmark.alphabetic.late.{size}",
       "operation": "find",
       "patterns": [
-        "[\\p{IsAlphabetic}]+\\d+"
+        {
+          "java": "[\\p{IsAlphabetic}]+\\d+",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET does not expose Java's IsAlphabetic Unicode property"
+            }
+          }
+        }
       ],
       "inputs": [
         "unicodePrefix.alphabeticLate.{size}"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -2379,6 +2379,72 @@
         "suffix": ":8080",
         "length": "{size}"
       }
+    },
+    {
+      "id": "unicodePrefix.digitsAbsent.{size}",
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "0123456789 9876543210 1357924680 ",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "unicodePrefix.alphabeticLate.{size}",
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "0123456789 9876543210 1357924680 ",
+        "suffix": "é123",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "unicodePrefix.englishProseAbsent.{size}",
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "The quick brown fox jumps over the lazy dog. Standard English prose without CJK characters. ",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "unicodePrefix.cjkLate.{size}",
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "The quick brown fox jumps over the lazy dog. Standard English prose without CJK characters. ",
+        "suffix": "你好123",
+        "length": "{size}"
+      },
+      "shared": true
     }
   ],
   "workloads": [
@@ -9685,6 +9751,130 @@
         }
       },
       "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "UnicodePrefixBenchmark.alphabetic.absent.{size}",
+      "operation": "find",
+      "patterns": [
+        "[\\p{IsAlphabetic}]+\\d+"
+      ],
+      "inputs": [
+        "unicodePrefix.digitsAbsent.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures Unicode alphabetic prefix acceleration scanning over non-matching digits.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "UnicodePrefixBenchmark.alphabetic.late.{size}",
+      "operation": "find",
+      "patterns": [
+        "[\\p{IsAlphabetic}]+\\d+"
+      ],
+      "inputs": [
+        "unicodePrefix.alphabeticLate.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures Unicode alphabetic prefix acceleration scanning to a late non-ASCII match.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "UnicodePrefixBenchmark.cjk.absent.{size}",
+      "operation": "find",
+      "patterns": [
+        "[\\u4E00-\\u9FFF]+\\d+"
+      ],
+      "inputs": [
+        "unicodePrefix.englishProseAbsent.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures CJK prefix acceleration scanning over non-matching English prose.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "UnicodePrefixBenchmark.cjk.late.{size}",
+      "operation": "find",
+      "patterns": [
+        "[\\u4E00-\\u9FFF]+\\d+"
+      ],
+      "inputs": [
+        "unicodePrefix.cjkLate.{size}"
+      ],
+      "axes": {
+        "size": [
+          1024,
+          32768,
+          1048576
+        ]
+      },
+      "inputRepresentations": [
+        "javaString",
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Measures CJK prefix acceleration scanning to a late CJK match.",
+      "requirements": [],
+      "resultConsumption": "boolean",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -10054,6 +10054,18 @@
         {
           "java": "[\\p{IsAlphabetic}]+\\d+",
           "alternates": {
+            "re2": {
+              "unsupported": true,
+              "reason": "RE2 and Go do not expose the Unicode Alphabetic binary property"
+            },
+            "rust-regex": {
+              "pattern": "[\\p{Alphabetic}]+[0-9]+",
+              "reason": "Rust regex uses the Unicode binary property name without Java's Is prefix and gives \\d Unicode semantics"
+            },
+            "pcre2": {
+              "unsupported": true,
+              "reason": "PCRE2 does not expose the Unicode Alphabetic binary property"
+            },
             "dotnet": {
               "unsupported": true,
               "reason": ".NET does not expose Java's IsAlphabetic Unicode property"
@@ -10093,6 +10105,18 @@
         {
           "java": "[\\p{IsAlphabetic}]+\\d+",
           "alternates": {
+            "re2": {
+              "unsupported": true,
+              "reason": "RE2 and Go do not expose the Unicode Alphabetic binary property"
+            },
+            "rust-regex": {
+              "pattern": "[\\p{Alphabetic}]+[0-9]+",
+              "reason": "Rust regex uses the Unicode binary property name without Java's Is prefix and gives \\d Unicode semantics"
+            },
+            "pcre2": {
+              "unsupported": true,
+              "reason": "PCRE2 does not expose the Unicode Alphabetic binary property"
+            },
             "dotnet": {
               "unsupported": true,
               "reason": ".NET does not expose Java's IsAlphabetic Unicode property"
@@ -10129,7 +10153,27 @@
       "id": "UnicodePrefixBenchmark.cjk.absent.{size}",
       "operation": "find",
       "patterns": [
-        "[\\u4E00-\\u9FFF]+\\d+"
+        {
+          "java": "[\\u4E00-\\u9FFF]+\\d+",
+          "alternates": {
+            "re2": {
+              "pattern": "[\\x{4E00}-\\x{9FFF}]+[0-9]+",
+              "reason": "RE2 and Go use braced hexadecimal code point escapes"
+            },
+            "rust-regex": {
+              "pattern": "[\\x{4E00}-\\x{9FFF}]+[0-9]+",
+              "reason": "Rust regex uses braced hexadecimal code point escapes and gives \\d Unicode semantics"
+            },
+            "pcre2": {
+              "pattern": "[\\x{4E00}-\\x{9FFF}]+[0-9]+",
+              "reason": "PCRE2 uses braced hexadecimal code point escapes"
+            },
+            "dotnet": {
+              "pattern": "[\\u4E00-\\u9FFF]+[0-9]+",
+              "reason": ".NET gives \\d Unicode semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "unicodePrefix.englishProseAbsent.{size}"
@@ -10160,7 +10204,27 @@
       "id": "UnicodePrefixBenchmark.cjk.late.{size}",
       "operation": "find",
       "patterns": [
-        "[\\u4E00-\\u9FFF]+\\d+"
+        {
+          "java": "[\\u4E00-\\u9FFF]+\\d+",
+          "alternates": {
+            "re2": {
+              "pattern": "[\\x{4E00}-\\x{9FFF}]+[0-9]+",
+              "reason": "RE2 and Go use braced hexadecimal code point escapes"
+            },
+            "rust-regex": {
+              "pattern": "[\\x{4E00}-\\x{9FFF}]+[0-9]+",
+              "reason": "Rust regex uses braced hexadecimal code point escapes and gives \\d Unicode semantics"
+            },
+            "pcre2": {
+              "pattern": "[\\x{4E00}-\\x{9FFF}]+[0-9]+",
+              "reason": "PCRE2 uses braced hexadecimal code point escapes"
+            },
+            "dotnet": {
+              "pattern": "[\\u4E00-\\u9FFF]+[0-9]+",
+              "reason": ".NET gives \\d Unicode semantics"
+            }
+          }
+        }
       ],
       "inputs": [
         "unicodePrefix.cjkLate.{size}"

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -149,9 +149,9 @@ class BenchmarkInputMaterializerTest {
     assertThat(entry.get("sha256").getAsString())
         .isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
     JsonObject resolvedData = manifest.getAsJsonObject("benchmarkData");
-    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(6);
+    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(8);
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("rust-regex"))
-        .hasSize(26);
+        .hasSize(28);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("go-regexp"))
         .hasSize(1);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("re2-cpp"))
@@ -159,7 +159,7 @@ class BenchmarkInputMaterializerTest {
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("rust-regex"))
         .hasSize(1);
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("dotnet"))
-        .hasSize(39);
+        .hasSize(40);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
     assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(603);
@@ -188,7 +188,60 @@ class BenchmarkInputMaterializerTest {
               "UnicodePrefixBenchmark.alphabetic." + input + ".1024@dotnet_nonbacktracking");
       assertThat(dotnetAlphabetic.get("status").getAsString()).isEqualTo("excluded");
       assertThat(dotnetAlphabetic.getAsJsonObject("exclusion").get("reason").getAsString())
-          .contains("IsAlphabetic Unicode property");
+          .contains("Alphabetic");
+
+      for (String engineId : new String[] {"re2_cpp", "go_regexp", "pcre2_jit"}) {
+        JsonObject excludedAlphabetic =
+            executionEntry(
+                executionPlan, "UnicodePrefixBenchmark.alphabetic." + input + ".1024@" + engineId);
+        assertThat(excludedAlphabetic.get("status").getAsString()).isEqualTo("excluded");
+        assertThat(excludedAlphabetic.getAsJsonObject("exclusion").get("reason").getAsString())
+            .contains("Alphabetic");
+      }
+      assertThat(
+              executionEntry(
+                      executionPlan,
+                      "UnicodePrefixBenchmark.alphabetic." + input + ".1024@rust_regex")
+                  .getAsJsonArray("patterns")
+                  .get(0)
+                  .getAsString())
+          .isEqualTo("[\\p{Alphabetic}]+[0-9]+");
+
+      assertThat(
+              executionEntry(executionPlan, "UnicodePrefixBenchmark.cjk." + input + ".1024@re2_cpp")
+                  .getAsJsonArray("patterns")
+                  .get(0)
+                  .getAsString())
+          .isEqualTo("[\\x{4E00}-\\x{9FFF}]+[0-9]+");
+      assertThat(
+              executionEntry(
+                      executionPlan, "UnicodePrefixBenchmark.cjk." + input + ".1024@go_regexp")
+                  .getAsJsonArray("patterns")
+                  .get(0)
+                  .getAsString())
+          .isEqualTo("[\\x{4E00}-\\x{9FFF}]+[0-9]+");
+      assertThat(
+              executionEntry(
+                      executionPlan, "UnicodePrefixBenchmark.cjk." + input + ".1024@rust_regex")
+                  .getAsJsonArray("patterns")
+                  .get(0)
+                  .getAsString())
+          .isEqualTo("[\\x{4E00}-\\x{9FFF}]+[0-9]+");
+      assertThat(
+              executionEntry(
+                      executionPlan, "UnicodePrefixBenchmark.cjk." + input + ".1024@pcre2_jit")
+                  .getAsJsonArray("patterns")
+                  .get(0)
+                  .getAsString())
+          .isEqualTo("[\\x{4E00}-\\x{9FFF}]+[0-9]+");
+      assertThat(
+              executionEntry(
+                      executionPlan,
+                      "UnicodePrefixBenchmark.cjk." + input + ".1024@dotnet_nonbacktracking")
+                  .getAsJsonArray("patterns")
+                  .get(0)
+                  .getAsString())
+          .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -159,7 +159,7 @@ class BenchmarkInputMaterializerTest {
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("rust-regex"))
         .hasSize(1);
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("dotnet"))
-        .hasSize(38);
+        .hasSize(39);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
     assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(587);
@@ -181,6 +181,15 @@ class BenchmarkInputMaterializerTest {
                 .get(0)
                 .getAsString())
         .isEqualTo("\\w+");
+    for (String input : new String[] {"absent", "late"}) {
+      JsonObject dotnetAlphabetic =
+          executionEntry(
+              executionPlan,
+              "UnicodePrefixBenchmark.alphabetic." + input + ".1024@dotnet_nonbacktracking");
+      assertThat(dotnetAlphabetic.get("status").getAsString()).isEqualTo("excluded");
+      assertThat(dotnetAlphabetic.getAsJsonObject("exclusion").get("reason").getAsString())
+          .contains("IsAlphabetic Unicode property");
+    }
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(386);
+    assertThat(first).hasSize(398);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(575);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(587);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_750);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_870);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -192,7 +192,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(575);
+          .hasSize(587);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(498);
+    assertThat(ids).hasSize(510);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1774);
-    assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(498 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(1822);
+    assertThat(plan.exclusions()).hasSize(728);
+    assertThat(accounted).hasSize(510 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1124);
+        .hasSize(1172);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1813);
-    assertThat(plan.reportPlan().trials()).hasSize(1813);
+        .hasSize(1861);
+    assertThat(plan.reportPlan().trials()).hasSize(1861);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -77,8 +77,8 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1902);
-    assertThat(plan.exclusions()).hasSize(728);
+    assertThat(allTrials).hasSize(1896);
+    assertThat(plan.exclusions()).hasSize(734);
     assertThat(accounted).hasSize(526 * RegexEngineVariant.values().length);
   }
 
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1252);
+        .hasSize(1246);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -428,8 +428,8 @@ class CrossEngineBenchmarkPlanTest {
     assertThat(plan.runners())
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
-        .hasSize(1941);
-    assertThat(plan.reportPlan().trials()).hasSize(1941);
+        .hasSize(1935);
+    assertThat(plan.reportPlan().trials()).hasSize(1935);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.safere.Pattern.CharClassScanInfo;
 
 /**
  * An engine that performs match operations on a {@linkplain CharSequence character sequence} by
@@ -935,14 +936,14 @@ public final class Matcher implements MatchResult {
           return true;
         }
       }
-    } else if (parentPattern.charClassPrefixAscii() != null) {
-      AsciiBitmap cc = parentPattern.charClassPrefixAscii();
+    } else if (parentPattern.charClassPrefix() != null) {
+      CharClassScanInfo cc = parentPattern.charClassPrefix();
       if (text != null) {
         if (searchFrom >= text.length()) {
           return true;
         }
-        char c = text.charAt(searchFrom);
-        if (!cc.contains(c)) {
+        int cp = text.codePointAt(searchFrom);
+        if (!cc.contains(cp)) {
           if (WorkCounterConfig.ENABLED) {
             WorkCounter.record(1);
           }
@@ -952,8 +953,8 @@ public final class Matcher implements MatchResult {
         if (searchFrom >= utf8Scanner.length()) {
           return true;
         }
-        int ascii = utf8Scanner.asciiAt(searchFrom);
-        if (!cc.contains(ascii)) {
+        int cp = utf8Scanner.codePointAt(searchFrom);
+        if (!cc.contains(cp)) {
           return true;
         }
       }
@@ -975,14 +976,14 @@ public final class Matcher implements MatchResult {
           return true;
         }
       }
-    } else if (parentPattern.anchoredCharClassPrefixAscii() != null) {
-      AsciiBitmap cc = parentPattern.anchoredCharClassPrefixAscii();
+    } else if (parentPattern.anchoredCharClassPrefix() != null) {
+      CharClassScanInfo cc = parentPattern.anchoredCharClassPrefix();
       if (text != null) {
         if (searchFrom >= text.length()) {
           return true;
         }
-        char c = text.charAt(searchFrom);
-        if (!cc.contains(c)) {
+        int cp = text.codePointAt(searchFrom);
+        if (!cc.contains(cp)) {
           if (WorkCounterConfig.ENABLED) {
             WorkCounter.record(1);
           }
@@ -992,8 +993,8 @@ public final class Matcher implements MatchResult {
         if (searchFrom >= utf8Scanner.length()) {
           return true;
         }
-        int ascii = utf8Scanner.asciiAt(searchFrom);
-        if (!cc.contains(ascii)) {
+        int cp = utf8Scanner.codePointAt(searchFrom);
+        if (!cc.contains(cp)) {
           return true;
         }
       }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -2732,6 +2732,21 @@ public final class Pattern implements Serializable {
     return buildCharClassScanInfo(cc);
   }
 
+  private static boolean addAsciiCharClass(CharClass cc, AsciiBitmap.Builder bitmap) {
+    if (cc == null || cc.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < cc.numRanges(); i++) {
+      if (cc.hi(i) >= 128) {
+        return false;
+      }
+    }
+    for (int i = 0; i < cc.numRanges(); i++) {
+      bitmap.addRange(cc.lo(i), cc.hi(i));
+    }
+    return true;
+  }
+
   private static StartAcceleration extractStartAcceleration(Regexp re) {
     Regexp node = unwrapCaptures(re);
     if (node == null) {
@@ -3332,21 +3347,6 @@ public final class Pattern implements Serializable {
       return new EndAnchoredCharClassInfo(builder.build(), wasDollar, unixLines);
     }
     return null;
-  }
-
-  private static boolean addAsciiCharClass(CharClass cc, AsciiBitmap.Builder bitmap) {
-    if (cc == null || cc.isEmpty()) {
-      return false;
-    }
-    for (int i = 0; i < cc.numRanges(); i++) {
-      if (cc.hi(i) >= 128) {
-        return false;
-      }
-    }
-    for (int i = 0; i < cc.numRanges(); i++) {
-      bitmap.addRange(cc.lo(i), cc.hi(i));
-    }
-    return true;
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -3197,8 +3197,7 @@ public final class Pattern implements Serializable {
     EndAnchoredCharClassInfo endAnchoredCharClass =
         endAnchoredSuffix == null ? extractEndAnchoredCharClass(metadataAst, flags) : null;
     String prefix = startDescriptor != null ? startDescriptor.prefix() : null;
-    CharClassScanInfo ccPrefix =
-        startDescriptor != null ? startDescriptor.charClassPrefix() : null;
+    CharClassScanInfo ccPrefix = startDescriptor != null ? startDescriptor.charClassPrefix() : null;
     String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
     CharClassScanInfo requiredMatchClass = null;
     if (prefix == null && endAnchoredCharClass == null) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -137,8 +137,8 @@ public final class Pattern implements Serializable {
   private final transient boolean canMatchEmpty;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
-  private final transient AsciiBitmap charClassPrefixAscii;
-  private final transient AsciiBitmap anchoredCharClassPrefixAscii;
+  private final transient CharClassScanInfo charClassPrefix;
+  private final transient CharClassScanInfo anchoredCharClassPrefix;
   private final transient FixedOffsetLiteral fixedOffsetLiteral;
   private final transient Utf8StartAccelerator utf8StartAccelerator;
   private final transient StringStartAccelerator stringStartAccelerator;
@@ -311,8 +311,8 @@ public final class Pattern implements Serializable {
     this.canMatchEmpty = canMatchEmpty;
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
-    this.charClassPrefixAscii = startDescriptor.charClassPrefixAscii();
-    this.anchoredCharClassPrefixAscii = startDescriptor.anchoredCharClassPrefixAscii();
+    this.charClassPrefix = startDescriptor.charClassPrefix();
+    this.anchoredCharClassPrefix = startDescriptor.anchoredCharClassPrefix();
     this.fixedOffsetLiteral = startDescriptor.fixedOffsetLiteral();
     this.utf8StartAccelerator =
         Utf8StartAccelerator.create(startDescriptor, prog.hasWordBoundary());
@@ -476,9 +476,9 @@ public final class Pattern implements Serializable {
     boolean prefixFoldCase = prefixResult.foldCase();
     FixedOffsetLiteral fixedOffsetLiteral =
         prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
-    AsciiBitmap ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
+    CharClassScanInfo ccPrefix = (prefix == null) ? extractCharClassPrefix(metadataAst) : null;
     StartAcceleration startAcceleration =
-        (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null)
+        (prefix == null && ccPrefix == null && fixedOffsetLiteral == null)
             ? extractStartAcceleration(metadataAst)
             : null;
     Regexp anchoredCandidate = firstPrefixCandidateAfterTextAnchor(metadataAst);
@@ -487,26 +487,26 @@ public final class Pattern implements Serializable {
         anchoredPrefixResult.prefix() != null && !anchoredPrefixResult.foldCase()
             ? anchoredPrefixResult.prefix()
             : null;
-    AsciiBitmap anchoredCharClassPrefixAscii =
+    CharClassScanInfo anchoredCharClassPrefix =
         anchoredPrefix == null && anchoredCandidate != null
-            ? extractCharClassPrefixAscii(anchoredCandidate)
+            ? extractCharClassPrefix(anchoredCandidate)
             : null;
     if (prefix == null
         && fixedOffsetLiteral == null
-        && ccPrefixAscii == null
+        && ccPrefix == null
         && startAcceleration == null
         && anchoredPrefix == null
-        && anchoredCharClassPrefixAscii == null) {
+        && anchoredCharClassPrefix == null) {
       return StartDescriptor.NONE;
     }
     return new StartDescriptor(
         prefix,
         prefixFoldCase,
         fixedOffsetLiteral,
-        ccPrefixAscii,
+        ccPrefix,
         startAcceleration,
         anchoredPrefix,
-        anchoredCharClassPrefixAscii);
+        anchoredCharClassPrefix);
   }
 
   /**
@@ -630,12 +630,12 @@ public final class Pattern implements Serializable {
         if (!scanner.startsWith(anchoredPrefixUtf8, 0)) {
           return false;
         }
-      } else if (anchoredCharClassPrefixAscii != null) {
+      } else if (anchoredCharClassPrefix != null) {
         if (scanner.length() == 0) {
           return false;
         }
-        int ascii = scanner.asciiAt(0);
-        if (!anchoredCharClassPrefixAscii.contains(ascii)) {
+        int cp = scanner.codePointAt(0);
+        if (!anchoredCharClassPrefix.contains(cp)) {
           return false;
         }
       }
@@ -693,14 +693,14 @@ public final class Pattern implements Serializable {
           diagnostics.boundary(MatchStrategy.LITERAL);
           return false;
         }
-      } else if (anchoredCharClassPrefixAscii != null) {
+      } else if (anchoredCharClassPrefix != null) {
         if (scanner.length() == 0) {
           diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
           return false;
         }
-        int ascii = scanner.asciiAt(0);
-        if (!anchoredCharClassPrefixAscii.contains(ascii)) {
+        int cp = scanner.codePointAt(0);
+        if (!anchoredCharClassPrefix.contains(cp)) {
           diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
           return false;
@@ -1306,12 +1306,12 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Returns an {@link AsciiBitmap} of the character-class prefix, or {@code null} if the pattern
-   * has no character-class prefix. Used for prefix acceleration in {@link Matcher#doFind()} when no
-   * literal prefix exists.
+   * Returns a {@link CharClassScanInfo} of the character-class prefix, or {@code null} if the
+   * pattern has no character-class prefix. Used for prefix acceleration in {@link Matcher#doFind()}
+   * when no literal prefix exists.
    */
-  AsciiBitmap charClassPrefixAscii() {
-    return charClassPrefixAscii;
+  CharClassScanInfo charClassPrefix() {
+    return charClassPrefix;
   }
 
   String anchoredPrefix() {
@@ -1322,8 +1322,8 @@ public final class Pattern implements Serializable {
     return anchoredPrefixUtf8;
   }
 
-  AsciiBitmap anchoredCharClassPrefixAscii() {
-    return anchoredCharClassPrefixAscii;
+  CharClassScanInfo anchoredCharClassPrefix() {
+    return anchoredCharClassPrefix;
   }
 
   /** Returns a mandatory ASCII literal at a fixed offset from the match start, or {@code null}. */
@@ -2661,18 +2661,13 @@ public final class Pattern implements Serializable {
    * Extracts a character-class prefix bitmap for ASCII acceleration. Walks the AST (through CAPTURE
    * and CONCAT wrappers) to find a required character class at the start of the pattern. If found
    * and the class contains only ASCII code points, returns a {@code boolean[128]} bitmap where
-   * {@code true} entries indicate matching code points. This allows {@link Matcher#doFind()} to
-   * skip ahead to positions where the first character could start a match, avoiding unnecessary
-   * engine invocations.
+   * Extracts a character-class prefix from the AST, supporting both ASCII and Unicode character
+   * classes.
    *
-   * <p>Handles bare {@link RegexpOp#CHAR_CLASS}, {@link RegexpOp#PLUS} and {@link RegexpOp#REPEAT}
-   * (with {@code min >= 1}) wrapping a character class, since these all require at least one
-   * character from the class.
-   *
-   * @return an {@link AsciiBitmap}, or {@code null} if no suitable prefix exists
+   * @return a {@link CharClassScanInfo}, or {@code null} if no suitable prefix exists
    */
-  private static AsciiBitmap extractCharClassPrefixAscii(Regexp re) {
-    AsciiBitmap.Builder bitmap = new AsciiBitmap.Builder();
+  private static CharClassScanInfo extractCharClassPrefix(Regexp re) {
+    CharClassBuilder builder = new CharClassBuilder();
     Deque<Regexp> work = new ArrayDeque<>();
     work.add(re);
 
@@ -2697,21 +2692,19 @@ public final class Pattern implements Serializable {
 
       switch (node.op) {
         case LITERAL -> {
-          if (!addLiteralPrefixAscii(node.rune, node.flags, bitmap)) {
-            return null;
-          }
+          builder.addCharClass(literalCharClass(node.rune, node.flags));
         }
         case LITERAL_STRING -> {
-          if (node.runes == null
-              || node.runes.length == 0
-              || !addLiteralPrefixAscii(node.runes[0], node.flags, bitmap)) {
+          if (node.runes == null || node.runes.length == 0) {
             return null;
           }
+          builder.addCharClass(literalCharClass(node.runes[0], node.flags));
         }
         case CHAR_CLASS -> {
-          if (!addCharClassPrefixAscii(node.charClass, bitmap)) {
+          if (node.charClass == null || node.charClass.isEmpty()) {
             return null;
           }
+          builder.addCharClass(node.charClass);
         }
         case ALTERNATE -> {
           if (node.nsub() == 0) {
@@ -2727,37 +2720,16 @@ public final class Pattern implements Serializable {
       }
     }
 
-    return bitmap.build();
-  }
-
-  private static boolean addLiteralPrefixAscii(int r, int flags, AsciiBitmap.Builder bitmap) {
-    if (r >= 128) {
-      return false;
+    CharClass cc = builder.build();
+    if (cc.isEmpty()) {
+      return null;
     }
-    bitmap.add(r);
-    if ((flags & ParseFlags.FOLD_CASE) != 0) {
-      if (r >= 'a' && r <= 'z') {
-        bitmap.add(r - 32);
-      } else if (r >= 'A' && r <= 'Z') {
-        bitmap.add(r + 32);
-      }
+    // Selectivity check: If the character class matches more than 50% of the Unicode space,
+    // scanning for it will cause high false-positive rates. Skip prefix acceleration.
+    if (cc.numRunes() > 0x80000) {
+      return null;
     }
-    return true;
-  }
-
-  private static boolean addCharClassPrefixAscii(CharClass cc, AsciiBitmap.Builder bitmap) {
-    if (cc == null || cc.isEmpty()) {
-      return false;
-    }
-    for (int i = 0; i < cc.numRanges(); i++) {
-      if (cc.hi(i) >= 128) {
-        return false;
-      }
-    }
-    for (int i = 0; i < cc.numRanges(); i++) {
-      bitmap.addRange(cc.lo(i), cc.hi(i));
-    }
-    return true;
+    return buildCharClassScanInfo(cc);
   }
 
   private static StartAcceleration extractStartAcceleration(Regexp re) {
@@ -3210,12 +3182,12 @@ public final class Pattern implements Serializable {
     EndAnchoredCharClassInfo endAnchoredCharClass =
         endAnchoredSuffix == null ? extractEndAnchoredCharClass(metadataAst, flags) : null;
     String prefix = startDescriptor != null ? startDescriptor.prefix() : null;
-    AsciiBitmap ccPrefixAscii =
-        startDescriptor != null ? startDescriptor.charClassPrefixAscii() : null;
+    CharClassScanInfo ccPrefix =
+        startDescriptor != null ? startDescriptor.charClassPrefix() : null;
     String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
     CharClassScanInfo requiredMatchClass = null;
     if (prefix == null && endAnchoredCharClass == null) {
-      if (ccPrefixAscii == null) {
+      if (ccPrefix == null) {
         requiredMatchClass = extractRequiredMatchClass(metadataAst, true);
       } else {
         CharClassScanInfo candidate = extractRequiredMatchClass(metadataAst, false);
@@ -3224,7 +3196,11 @@ public final class Pattern implements Serializable {
           for (int i = 0; i < candidate.ranges.length; i += 2) {
             candidateRunes += (candidate.ranges[i + 1] - candidate.ranges[i] + 1);
           }
-          if (candidateRunes < ccPrefixAscii.cardinality()) {
+          int prefixRunes = 0;
+          for (int i = 0; i < ccPrefix.ranges.length; i += 2) {
+            prefixRunes += (ccPrefix.ranges[i + 1] - ccPrefix.ranges[i] + 1);
+          }
+          if (candidateRunes < prefixRunes) {
             requiredMatchClass = candidate;
           }
         }
@@ -3351,11 +3327,26 @@ public final class Pattern implements Serializable {
       }
     }
     AsciiBitmap.Builder builder = new AsciiBitmap.Builder();
-    if (sub.op == RegexpOp.CHAR_CLASS && addCharClassPrefixAscii(sub.charClass, builder)) {
+    if (sub.op == RegexpOp.CHAR_CLASS && addAsciiCharClass(sub.charClass, builder)) {
       boolean unixLines = (flags & UNIX_LINES) != 0;
       return new EndAnchoredCharClassInfo(builder.build(), wasDollar, unixLines);
     }
     return null;
+  }
+
+  private static boolean addAsciiCharClass(CharClass cc, AsciiBitmap.Builder bitmap) {
+    if (cc == null || cc.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < cc.numRanges(); i++) {
+      if (cc.hi(i) >= 128) {
+        return false;
+      }
+    }
+    for (int i = 0; i < cc.numRanges(); i++) {
+      bitmap.addRange(cc.lo(i), cc.hi(i));
+    }
+    return true;
   }
 
   /**

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -41,4 +41,3 @@ record StartDescriptor(
         || lineAnchor != null;
   }
 }
-

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.FixedOffsetLiteral;
 import org.safere.Pattern.StartAcceleration;
 
@@ -16,10 +17,10 @@ record StartDescriptor(
     String prefix,
     boolean prefixFoldCase,
     FixedOffsetLiteral fixedOffsetLiteral,
-    AsciiBitmap charClassPrefixAscii,
+    CharClassScanInfo charClassPrefix,
     StartAcceleration lineAnchor,
     String anchoredPrefix,
-    AsciiBitmap anchoredCharClassPrefixAscii) {
+    CharClassScanInfo anchoredCharClassPrefix) {
 
   static final StartDescriptor NONE =
       new StartDescriptor(null, false, null, null, null, null, null);
@@ -28,15 +29,16 @@ record StartDescriptor(
       String prefix,
       boolean prefixFoldCase,
       FixedOffsetLiteral fixedOffsetLiteral,
-      AsciiBitmap charClassPrefixAscii,
+      CharClassScanInfo charClassPrefix,
       StartAcceleration lineAnchor) {
-    this(prefix, prefixFoldCase, fixedOffsetLiteral, charClassPrefixAscii, lineAnchor, null, null);
+    this(prefix, prefixFoldCase, fixedOffsetLiteral, charClassPrefix, lineAnchor, null, null);
   }
 
   boolean hasStartAcceleration() {
     return prefix != null
         || fixedOffsetLiteral != null
-        || charClassPrefixAscii != null
+        || charClassPrefix != null
         || lineAnchor != null;
   }
 }
+

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.FixedOffsetLiteral;
 import org.safere.Pattern.StartAcceleration;
 
@@ -26,10 +27,10 @@ sealed interface StringStartAccelerator {
       return new Literal(descriptor.prefix(), descriptor.prefixFoldCase());
     }
     if (descriptor.fixedOffsetLiteral() != null) {
-      return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefixAscii());
+      return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefix());
     }
-    if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
-      return new CharClass(descriptor.charClassPrefixAscii());
+    if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
+      return new CharClass(descriptor.charClassPrefix());
     }
     if (descriptor.lineAnchor() != null && !hasWordBoundary) {
       return new LineAnchor(descriptor.lineAnchor());
@@ -103,19 +104,19 @@ sealed interface StringStartAccelerator {
 
   final class FixedOffset implements StringStartAccelerator {
     private final FixedOffsetLiteral fixedOffset;
-    private final AsciiBitmap firstAscii;
+    private final CharClassScanInfo firstCharClass;
 
-    FixedOffset(FixedOffsetLiteral fixedOffset, AsciiBitmap firstAscii) {
+    FixedOffset(FixedOffsetLiteral fixedOffset, CharClassScanInfo firstCharClass) {
       this.fixedOffset = fixedOffset;
-      this.firstAscii = firstAscii;
+      this.firstCharClass = firstCharClass;
     }
 
     public FixedOffsetLiteral fixedOffset() {
       return fixedOffset;
     }
 
-    public AsciiBitmap firstAscii() {
-      return firstAscii;
+    public CharClassScanInfo firstCharClass() {
+      return firstCharClass;
     }
 
     @Override
@@ -125,11 +126,14 @@ sealed interface StringStartAccelerator {
 
     @Override
     public int findCandidate(String text, int fromIndex, boolean unixLines) {
-      return nextFixedOffsetCandidate(text, fixedOffset, firstAscii, fromIndex);
+      return nextFixedOffsetCandidate(text, fixedOffset, firstCharClass, fromIndex);
     }
 
     private static int nextFixedOffsetCandidate(
-        String text, FixedOffsetLiteral fixedOffsetLiteral, AsciiBitmap firstAscii, int fromIndex) {
+        String text,
+        FixedOffsetLiteral fixedOffsetLiteral,
+        CharClassScanInfo firstCharClass,
+        int fromIndex) {
       int minOffset = fixedOffsetLiteral.minOffset();
       if (minOffset > text.length() - fromIndex) {
         return -1;
@@ -149,14 +153,14 @@ sealed interface StringStartAccelerator {
         if (literalStart < 0) {
           return -1;
         }
-        if (discreteOffsets != null && discreteOffsets.length == 1 && firstAscii != null) {
+        if (discreteOffsets != null && discreteOffsets.length == 1 && firstCharClass != null) {
           boolean matchFound = false;
           int earliestValid = -1;
           for (int offset : discreteOffsets) {
             int candidateStart = literalStart - offset;
             if (candidateStart >= fromIndex) {
               int first = candidateStart < text.length() ? text.charAt(candidateStart) : -1;
-              if (first >= 0 && firstAscii.contains(first)) {
+              if (first >= 0 && firstCharClass.contains(first)) {
                 matchFound = true;
                 if (earliestValid < 0 || candidateStart < earliestValid) {
                   earliestValid = candidateStart;
@@ -193,16 +197,16 @@ sealed interface StringStartAccelerator {
   }
 
   final class CharClass implements StringStartAccelerator {
-    private final AsciiBitmap asciiMap;
+    private final CharClassScanInfo scanInfo;
     private final boolean[] asciiTable;
 
-    CharClass(AsciiBitmap asciiMap) {
-      this.asciiMap = asciiMap;
-      this.asciiTable = asciiMap.toBooleanArray();
+    CharClass(CharClassScanInfo scanInfo) {
+      this.scanInfo = scanInfo;
+      this.asciiTable = buildAsciiTable(scanInfo);
     }
 
-    public AsciiBitmap asciiMap() {
-      return asciiMap;
+    public CharClassScanInfo scanInfo() {
+      return scanInfo;
     }
 
     @Override
@@ -212,20 +216,36 @@ sealed interface StringStartAccelerator {
 
     @Override
     public int findCandidate(String text, int fromIndex, boolean unixLines) {
-      return indexOfCharClass(text, asciiTable, fromIndex);
+      return indexOfCharClass(text, asciiTable, scanInfo.ranges, scanInfo.isAscii, fromIndex);
     }
 
-    private static int indexOfCharClass(String text, boolean[] asciiTable, int fromIndex) {
+    private static int indexOfCharClass(
+        String text, boolean[] asciiTable, int[] ranges, boolean isAscii, int fromIndex) {
       for (int i = fromIndex; i < text.length(); i++) {
         if (WorkCounterConfig.ENABLED) {
           WorkCounter.record();
         }
         char ch = text.charAt(i);
-        if (ch < 128 && asciiTable[ch]) {
-          return i;
+        if (ch < 128) {
+          if (asciiTable[ch]) {
+            return i;
+          }
+        } else if (!isAscii) {
+          int cp = text.codePointAt(i);
+          if (Matcher.binarySearchRanges(ranges, cp)) {
+            return i;
+          }
         }
       }
       return -1;
+    }
+
+    private static boolean[] buildAsciiTable(CharClassScanInfo scanInfo) {
+      boolean[] table = new boolean[128];
+      for (int i = 0; i < 128; i++) {
+        table[i] = scanInfo.contains(i);
+      }
+      return table;
     }
   }
 

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -221,23 +221,51 @@ sealed interface StringStartAccelerator {
 
     private static int indexOfCharClass(
         String text, boolean[] asciiTable, int[] ranges, boolean isAscii, int fromIndex) {
-      for (int i = fromIndex; i < text.length(); i++) {
+      int length = text.length();
+      int index = fromIndex;
+      while (index < length) {
+        int asciiResult = scanAsciiRun(text, asciiTable, index);
+        if (asciiResult >= 0) {
+          return asciiResult;
+        }
+        index = ~asciiResult;
+        if (index >= length) {
+          return -1;
+        }
+
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
+        int cp = text.codePointAt(index);
+        if (!isAscii && Matcher.binarySearchRanges(ranges, cp)) {
+          return index;
+        }
+        index += Character.charCount(cp);
+      }
+      return -1;
+    }
+
+    /**
+     * Scans one contiguous ASCII run. A nonnegative result is a matching position; a negative
+     * result is the complement of either the first non-ASCII position or the text length. Keeping
+     * Unicode decoding and range lookup outside this loop allows HotSpot to optimize the common
+     * ASCII path independently.
+     */
+    private static int scanAsciiRun(String text, boolean[] asciiTable, int fromIndex) {
+      int length = text.length();
+      for (int i = fromIndex; i < length; i++) {
         if (WorkCounterConfig.ENABLED) {
           WorkCounter.record();
         }
         char ch = text.charAt(i);
-        if (ch < 128) {
-          if (asciiTable[ch]) {
-            return i;
-          }
-        } else if (!isAscii) {
-          int cp = text.codePointAt(i);
-          if (Matcher.binarySearchRanges(ranges, cp)) {
-            return i;
-          }
+        if (ch >= 128) {
+          return ~i;
+        }
+        if (asciiTable[ch]) {
+          return i;
         }
       }
-      return -1;
+      return ~length;
     }
 
     private static boolean[] buildAsciiTable(CharClassScanInfo scanInfo) {

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -30,14 +30,10 @@ sealed interface Utf8StartAccelerator {
       return Literal.create(descriptor.prefix());
     }
     if (descriptor.fixedOffsetLiteral() != null) {
-      return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefixAscii());
+      return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefix());
     }
-    if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
-      CharClassScanInfo scanInfo =
-          Pattern.buildAsciiClassScanInfo(descriptor.charClassPrefixAscii());
-      if (scanInfo != null) {
-        return new CharClass(scanInfo);
-      }
+    if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
+      return new CharClass(descriptor.charClassPrefix());
     }
     return null;
   }
@@ -126,7 +122,7 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-  record FixedOffset(FixedOffsetLiteral fixedOffset, AsciiBitmap charClassPrefixAscii)
+  record FixedOffset(FixedOffsetLiteral fixedOffset, CharClassScanInfo charClassPrefix)
       implements Utf8StartAccelerator {
 
     @Override
@@ -136,13 +132,13 @@ sealed interface Utf8StartAccelerator {
 
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      return nextFixedOffsetCandidate(scanner, fixedOffset, charClassPrefixAscii, fromIndex);
+      return nextFixedOffsetCandidate(scanner, fixedOffset, charClassPrefix, fromIndex);
     }
 
     private static int nextFixedOffsetCandidate(
         Utf8InputScanner scanner,
         FixedOffsetLiteral fixedOffsetLiteral,
-        AsciiBitmap charClassPrefixAscii,
+        CharClassScanInfo charClassPrefix,
         int searchFrom) {
       int literalFrom = searchFrom + fixedOffsetLiteral.minOffset();
       int[] discreteOffsets = fixedOffsetLiteral.discreteOffsets();
@@ -158,13 +154,14 @@ sealed interface Utf8StartAccelerator {
         }
         if (discreteOffsets != null
             && discreteOffsets.length == 1
-            && charClassPrefixAscii != null) {
+            && charClassPrefix != null) {
           int earliestValid = -1;
           for (int offset : discreteOffsets) {
             int candidateStart = literalStart - offset;
             if (candidateStart >= searchFrom) {
-              int first = scanner.asciiAt(candidateStart);
-              if (charClassPrefixAscii.contains(first)
+              int first = candidateStart < scanner.length() ? scanner.codePointAt(candidateStart) : -1;
+              if (first >= 0
+                  && charClassPrefix.contains(first)
                   && (earliestValid < 0 || candidateStart < earliestValid)) {
                 earliestValid = candidateStart;
               }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -152,14 +152,13 @@ sealed interface Utf8StartAccelerator {
         if (literalStart < 0) {
           return -1;
         }
-        if (discreteOffsets != null
-            && discreteOffsets.length == 1
-            && charClassPrefix != null) {
+        if (discreteOffsets != null && discreteOffsets.length == 1 && charClassPrefix != null) {
           int earliestValid = -1;
           for (int offset : discreteOffsets) {
             int candidateStart = literalStart - offset;
             if (candidateStart >= searchFrom) {
-              int first = candidateStart < scanner.length() ? scanner.codePointAt(candidateStart) : -1;
+              int first =
+                  candidateStart < scanner.length() ? scanner.codePointAt(candidateStart) : -1;
               if (first >= 0
                   && charClassPrefix.contains(first)
                   && (earliestValid < 0 || candidateStart < earliestValid)) {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.safere.Pattern.CharClassScanInfo;
 
 /** Tests for package-private {@link Pattern} metadata. */
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
@@ -58,7 +59,7 @@ class PatternInternalTest {
   void transparentGroupsPreserveCharacterClassAccelerators() {
     Pattern p = Pattern.compile("(?:[A-Z]+)");
 
-    AsciiBitmap prefix = p.charClassPrefixAscii();
+    CharClassScanInfo prefix = p.charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('A')).isTrue();
     assertThat(p.matchDescriptor().charClassMatch()).isNotNull();
@@ -69,7 +70,7 @@ class PatternInternalTest {
     assertThat(Pattern.compile("^https://.*").anchoredPrefix()).isEqualTo("https://");
     assertThat(Pattern.compile("\\Ahttps://.*").anchoredPrefix()).isEqualTo("https://");
 
-    AsciiBitmap prefix = Pattern.compile("^[0-9]+").anchoredCharClassPrefixAscii();
+    CharClassScanInfo prefix = Pattern.compile("^[0-9]+").anchoredCharClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('0')).isTrue();
     assertThat(prefix.contains('9')).isTrue();
@@ -93,7 +94,7 @@ class PatternInternalTest {
 
   @Test
   void asciiPrefixScanInfoPreservesMembersAcrossBitmapBoundary() {
-    Pattern.CharClassScanInfo info =
+    CharClassScanInfo info =
         assertAsciiScanInfo(new int[] {62, 63, 64, 65}, new int[] {62, 65});
 
     assertThat(info.bitmap0).isEqualTo((1L << 62) | (1L << 63));
@@ -159,7 +160,7 @@ class PatternInternalTest {
   @Test
   void alternatePrefixAcceleration() {
     Pattern p = Pattern.compile("(?:cat|dog|bird)s?");
-    AsciiBitmap prefix = p.charClassPrefixAscii();
+    CharClassScanInfo prefix = p.charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('c')).isTrue();
     assertThat(prefix.contains('d')).isTrue();
@@ -170,7 +171,7 @@ class PatternInternalTest {
   @Test
   void alternatePrefixCaseInsensitiveAcceleration() {
     Pattern p = Pattern.compile("(?i)(?:cat|dog|bird)s?");
-    AsciiBitmap prefix = p.charClassPrefixAscii();
+    CharClassScanInfo prefix = p.charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('c')).isTrue();
     assertThat(prefix.contains('C')).isTrue();
@@ -182,10 +183,24 @@ class PatternInternalTest {
   }
 
   @Test
+  void unicodeCharacterClassPrefixAcceleration() {
+    Pattern p = Pattern.compile("[\\p{IsAlphabetic}]+");
+    CharClassScanInfo prefix = p.charClassPrefix();
+    assertThat(prefix).isNotNull();
+    assertThat(prefix.isAscii).isFalse();
+    assertThat(prefix.contains('a')).isTrue();
+    assertThat(prefix.contains('Z')).isTrue();
+    assertThat(prefix.contains('\u00e9')).isTrue(); // é
+    assertThat(prefix.contains('\u03b1')).isTrue(); // α
+    assertThat(prefix.contains('1')).isFalse();
+    assertThat(prefix.contains(' ')).isFalse();
+  }
+
+  @Test
   void deeplyNestedRequiredQuantifierPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedRequiredPlusPattern(1_000, "[ab]"));
 
-    AsciiBitmap prefix = p.charClassPrefixAscii();
+    CharClassScanInfo prefix = p.charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('a')).isTrue();
     assertThat(prefix.contains('b')).isTrue();
@@ -196,7 +211,7 @@ class PatternInternalTest {
   void deeplyNestedAlternationPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedAlternationPattern(1_000));
 
-    AsciiBitmap prefix = p.charClassPrefixAscii();
+    CharClassScanInfo prefix = p.charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('a')).isTrue();
     assertThat(prefix.contains('b')).isTrue();

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -94,8 +94,7 @@ class PatternInternalTest {
 
   @Test
   void asciiPrefixScanInfoPreservesMembersAcrossBitmapBoundary() {
-    CharClassScanInfo info =
-        assertAsciiScanInfo(new int[] {62, 63, 64, 65}, new int[] {62, 65});
+    CharClassScanInfo info = assertAsciiScanInfo(new int[] {62, 63, 64, 65}, new int[] {62, 65});
 
     assertThat(info.bitmap0).isEqualTo((1L << 62) | (1L << 63));
     assertThat(info.bitmap1).isEqualTo((1L << 0) | (1L << 1));

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -9,6 +9,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.FixedOffsetLiteral;
 
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
@@ -88,8 +89,8 @@ class StartAcceleratorTest {
 
   @Test
   void charClassPrefixAcceleratesStringAndUtf8() {
-    AsciiBitmap ascii = new AsciiBitmap.Builder().add('a').add('b').build();
-    StartDescriptor desc = new StartDescriptor(null, false, null, ascii, null);
+    CharClassScanInfo scanInfo = Pattern.compile("[ab]").charClassPrefix();
+    StartDescriptor desc = new StartDescriptor(null, false, null, scanInfo, null);
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
@@ -100,6 +101,34 @@ class StartAcceleratorTest {
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
     assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(utf8Acc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
+  }
+
+  @Test
+  void unicodeCharClassPrefixAcceleratesStringAndUtf8() {
+    Pattern pattern = Pattern.compile("[\\p{IsAlphabetic}]+");
+    StringStartAccelerator strAcc = pattern.stringStartAccelerator();
+    assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
+    assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(strAcc.findCandidate("123\u00e945", 0, false)).isEqualTo(3);
+
+    Utf8StartAccelerator utf8Acc = pattern.utf8StartAccelerator();
+    assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
+    assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(utf8Acc.findCandidate(utf8Scanner("123\u00e945"), 0)).isEqualTo(3);
+  }
+
+  @Test
+  void supplementaryUnicodeCharClassPrefixAcceleratesStringAndUtf8() {
+    Pattern pattern = Pattern.compile("[(é)|(😀)]");
+    StringStartAccelerator strAcc = pattern.stringStartAccelerator();
+    assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
+    assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(strAcc.findCandidate("x\uD83D\uDE00y", 0, false)).isEqualTo(1);
+
+    Utf8StartAccelerator utf8Acc = pattern.utf8StartAccelerator();
+    assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
+    assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(utf8Acc.findCandidate(utf8Scanner("x😀y"), 0)).isEqualTo(1);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -132,6 +132,17 @@ class StartAcceleratorTest {
   }
 
   @Test
+  void unicodeCharClassPrefixResumesAsciiScanningAfterNonAsciiCodePoints() {
+    StringStartAccelerator accelerator =
+        Pattern.compile("[\\p{IsAlphabetic}]+").stringStartAccelerator();
+
+    assertThat(accelerator.findCandidate("000©000", 0, false)).isEqualTo(-1);
+    assertThat(accelerator.findCandidate("000©000Ā", 0, false)).isEqualTo(7);
+    assertThat(accelerator.findCandidate("000😀000a", 0, false)).isEqualTo(8);
+    assertThat(accelerator.findCandidate("000😀000a", 4, false)).isEqualTo(8);
+  }
+
+  @Test
   void compiledPatternAcceleratorsInSync() {
     String[] testPatterns = {
       "(?i)needle.*", "(?i)a.*", "(?i)HTTP://.*", "needle.*", "[a-z].*", "[0-9].*", "ab+c.*"


### PR DESCRIPTION
See #564. This is a re-do of https://github.com/eaftan/safere/commit/37f5e828a157c203bfd47125e1c69f91cd5316d0, but updated to integrate into the new structure for accelerators, and preserving ASCII fast paths to ensure it doesn't regress.

- Replace ASCII-only AsciiBitmap prefix representation with CharClassScanInfo in StartDescriptor, Pattern, StringStartAccelerator, and Utf8StartAccelerator.
- Extract full Unicode character-class prefix range info in Pattern.extractCharClassPrefix with selectivity guard.
- In StringStartAccelerator, use precomputed 128-boolean lookup for ASCII characters and binary range search on code points for non-ASCII.
- Preserve zero extra branch overhead in the hot ASCII scanning loop.
- Support supplementary code points (surrogate pairs) in String candidate scanning.
- Add unit and cross-check tests for Unicode and supplementary character-class prefix acceleration.

---

The optimization shows a ~3.4x speedup for rejecting non-matching inputs with non-ASCII character class prefixes.

`cjk.absent` is neutral because it was already being rejected by `RejectPrefilter`.

The slowdown for late, long matches is the expected tradeoff with the accelerator, which has to do an extra loop over the input before failing to reject the input and falling through to the DFA. Future work to vectorize accelerators will reduce that penalty (and increase the benefit of the cases where it helps).

```
./safere-benchmarks/scripts/compare-branch.sh --baseline bench/unicode-prefix-baseline 'UnicodePrefixBenchmark.*@safere-string'
```

| Benchmark                                        | baseline (ns/op) |  current (ns/op) | Speedup |
| ------------------------------------------------ | ---------------- | ---------------- | ------- |
| UnicodePrefixBenchmark.alphabetic.absent.1024    |        2085 ± 34 |         615 ± 28 |   3.39x |
| UnicodePrefixBenchmark.alphabetic.absent.32768   |      62441 ± 296 |      18361 ± 581 |   3.40x |
| UnicodePrefixBenchmark.alphabetic.absent.1048576 |  1998883 ± 23660 |   592322 ± 34292 |   3.37x |
| UnicodePrefixBenchmark.alphabetic.late.1024      |        2075 ± 65 |         741 ± 51 |   2.80x |
| UnicodePrefixBenchmark.alphabetic.late.32768     |      62341 ± 587 |     32815 ± 1979 |   1.90x |
| UnicodePrefixBenchmark.alphabetic.late.1048576   |  2157491 ± 56179 | 2832737 ± 120769 |   0.76x |
| UnicodePrefixBenchmark.cjk.absent.1024           |         639 ± 36 |        625 ± 9.2 |   1.02x |
| UnicodePrefixBenchmark.cjk.absent.32768          |      19019 ± 646 |     19371 ± 1166 |   0.98x |
| UnicodePrefixBenchmark.cjk.absent.1048576        |    988076 ± 3940 |    991033 ± 5549 |   1.00x |
| UnicodePrefixBenchmark.cjk.late.1024             |        3287 ± 73 |        2994 ± 76 |   1.10x |
| UnicodePrefixBenchmark.cjk.late.32768            |     99256 ± 4991 |    123994 ± 1532 |   0.80x |
| UnicodePrefixBenchmark.cjk.late.1048576          |  3037570 ± 97053 |  3005064 ± 47037 |   1.01x |

Results for ASCII look neutral:

```
./safere-benchmarks/scripts/compare-branch.sh --baseline origin/main '(versionList|recitation|charClassMatch|literalMatch).*@safere-string'
```

| Benchmark                     | baseline (ns/op) | current (ns/op) | Speedup |
| ----------------------------- | ---------------- | --------------- | ------- |
| RegexBenchmark.literalMatch   |         27 ± 4.9 |        28 ± 5.0 |   0.97x |
| RegexBenchmark.charClassMatch |         41 ± 4.5 |        41 ± 5.7 |   1.00x |
| versionList.match.1000        |      12627 ± 417 |     11768 ± 528 |   1.07x |
| versionList.match.10000       |    121533 ± 3764 |   119359 ± 3675 |   1.02x |
| versionList.match.100000      |  1210596 ± 31325 | 1237781 ± 57823 |   0.98x |
| versionList.noMatch.1000      |       3925 ± 136 |      3877 ± 127 |   1.01x |
| versionList.noMatch.10000     |     36867 ± 1272 |    37338 ± 2714 |   0.99x |
| versionList.noMatch.100000    |    357464 ± 3359 |  365956 ± 16294 |   0.98x |
| recitation.match.1000         |       8327 ± 228 |      8538 ± 385 |   0.98x |
| recitation.match.10000        |     76567 ± 3612 |    75454 ± 1084 |   1.01x |
| recitation.match.100000       |   786209 ± 41879 |  773831 ± 29598 |   1.02x |
| recitation.noMatch.1000       |       3877 ± 168 |      3851 ± 107 |   1.01x |
| recitation.noMatch.10000      |     36648 ± 1915 |     36050 ± 493 |   1.02x |
| recitation.noMatch.100000     |   363327 ± 13048 |   357283 ± 4494 |   1.02x |

