### PR TITLE
Add Teddy SIMD multi-literal start accelerator for UTF-8 byte arrays

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -737,6 +737,8 @@
       "id": "searchScaling.prose.{size}",
       "axes": {
         "size": [
+          64,
+          256,
           1024,
           10240,
           102400,
@@ -3961,6 +3963,42 @@
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.alternationScaled.64",
+      "operation": "find",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.64"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.alternationScaled.256",
+      "operation": "find",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.256"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
         "constraints": [
           "prematerializedInput"
         ]

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -3967,6 +3967,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.alternationScaled.1024",
+      "operation": "find",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.searchEasyFail.10240",
       "operation": "find",
       "patterns": [
@@ -4051,6 +4069,24 @@
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.alternationScaled.10240",
+      "operation": "find",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
         "constraints": [
           "prematerializedInput"
         ]
@@ -4147,6 +4183,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.alternationScaled.102400",
+      "operation": "find",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.searchEasyFail.1048576",
       "operation": "find",
       "patterns": [
@@ -4231,6 +4285,24 @@
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "microseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.alternationScaled.1048576",
+      "operation": "find",
+      "patterns": [
+        "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
         "constraints": [
           "prematerializedInput"
         ]

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(575);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(579);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_750);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_790);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -192,7 +192,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(575);
+          .hasSize(579);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(386);
+    assertThat(first).hasSize(388);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(595);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(597);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_950);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_970);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -192,7 +192,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(595);
+          .hasSize(597);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(498);
+    assertThat(ids).hasSize(502);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1774);
+    assertThat(allTrials).hasSize(1794);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(498 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(502 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1124);
+        .hasSize(1144);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1813);
-    assertThat(plan.reportPlan().trials()).hasSize(1813);
+        .hasSize(1833);
+    assertThat(plan.reportPlan().trials()).hasSize(1833);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(518);
+    assertThat(ids).hasSize(520);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1874);
+    assertThat(allTrials).hasSize(1884);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(518 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(520 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1224);
+        .hasSize(1234);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -428,8 +428,9 @@ class CrossEngineBenchmarkPlanTest {
     assertThat(plan.runners())
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
-        .hasSize(1913);
-    assertThat(plan.reportPlan().trials()).hasSize(1913);
+        .doesNotHaveDuplicates()
+        .hasSize(1923);
+    assertThat(plan.reportPlan().trials()).hasSize(1923);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -138,6 +138,7 @@
                         <exclude name="SimplifierTest.java"/>
                         <exclude name="StartAcceleratorDifferentialTest.java"/>
                         <exclude name="StartAcceleratorTest.java"/>
+                        <exclude name="TeddyModelTest.java"/>
                         <exclude name="UnicodeJdkConsistencyTest.java"/>
                         <exclude name="UnicodeTablesTest.java"/>
                         <exclude name="Utf8AllocationScalingTest.java"/>

--- a/safere/src/main/java/org/safere/AcceleratorPolicy.java
+++ b/safere/src/main/java/org/safere/AcceleratorPolicy.java
@@ -32,6 +32,10 @@ record AcceleratorPolicy(
   static final AcceleratorPolicy LITERAL =
       new AcceleratorPolicy(16, 4, true, MatchStrategy.LITERAL);
 
+  /** Policy for vectorized multi-literal and Teddy SIMD filters. */
+  static final AcceleratorPolicy VECTOR_MULTI_LITERAL =
+      new AcceleratorPolicy(64, 4, true, MatchStrategy.LITERAL);
+
   /** Policy for character class bitmap and range table scanning. */
   static final AcceleratorPolicy CHAR_CLASS =
       new AcceleratorPolicy(24, 3, false, MatchStrategy.CHARACTER_CLASS);

--- a/safere/src/main/java/org/safere/Ascii.java
+++ b/safere/src/main/java/org/safere/Ascii.java
@@ -128,4 +128,14 @@ final class Ascii {
     }
     return true;
   }
+
+  /** Returns whether a byte array matches an exact ASCII pattern prefix. */
+  static boolean regionMatches(byte[] bytes, int offset, String prefix, int prefixLen) {
+    for (int i = 0; i < prefixLen; i++) {
+      if ((bytes[offset + i] & 0xFF) != prefix.charAt(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -7,11 +7,17 @@ package org.safere;
 
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
-  private static final int MINIMUM_INPUT_LENGTH = 64;
+  private static final int MINIMUM_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_TEDDY_INPUT_LENGTH = 1024;
 
   @Override
   public int minimumInputLength() {
     return MINIMUM_INPUT_LENGTH;
+  }
+
+  @Override
+  public int minimumTeddyInputLength() {
+    return MINIMUM_TEDDY_INPUT_LENGTH;
   }
 
   @Override

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -7,7 +7,7 @@ package org.safere;
 
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
-  private static final int MINIMUM_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_INPUT_LENGTH = 64;
 
   @Override
   public int minimumInputLength() {
@@ -17,5 +17,10 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
     return ByteVectorScan.indexOfAsciiClass(bytes, offset, length, ranges, start);
+  }
+
+  @Override
+  public int indexOfTeddy(byte[] bytes, int offset, int length, TeddyModel model, int start) {
+    return TeddyVectorScan.indexOfTeddyUtf8(bytes, offset, length, model, start);
   }
 }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -477,8 +477,16 @@ public final class Pattern implements Serializable {
     FixedOffsetLiteral fixedOffsetLiteral =
         prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
     AsciiBitmap ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
+    String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
+    TeddyModel teddyModel = null;
+    if (altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 32) {
+      teddyModel = TeddyModel.compile(altLiterals, 32);
+    }
     StartAcceleration startAcceleration =
-        (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null)
+        (prefix == null
+                && ccPrefixAscii == null
+                && fixedOffsetLiteral == null
+                && teddyModel == null)
             ? extractStartAcceleration(metadataAst)
             : null;
     Regexp anchoredCandidate = firstPrefixCandidateAfterTextAnchor(metadataAst);
@@ -496,7 +504,8 @@ public final class Pattern implements Serializable {
         && ccPrefixAscii == null
         && startAcceleration == null
         && anchoredPrefix == null
-        && anchoredCharClassPrefixAscii == null) {
+        && anchoredCharClassPrefixAscii == null
+        && teddyModel == null) {
       return StartDescriptor.NONE;
     }
     return new StartDescriptor(
@@ -506,7 +515,8 @@ public final class Pattern implements Serializable {
         ccPrefixAscii,
         startAcceleration,
         anchoredPrefix,
-        anchoredCharClassPrefixAscii);
+        anchoredCharClassPrefixAscii,
+        teddyModel);
   }
 
   /**
@@ -2251,8 +2261,8 @@ public final class Pattern implements Serializable {
 
   /** Finds the longest case-sensitive ASCII literal after a bounded-width match prefix. */
   private static FixedOffsetLiteral extractFixedOffsetLiteral(Regexp re) {
-    Regexp node = unwrapFixedOffsetNode(re);
-    if (node.op != RegexpOp.CONCAT || node.subs == null) {
+    Regexp node = unwrapCaptures(re);
+    if (node == null || node.op != RegexpOp.CONCAT || node.subs == null) {
       return null;
     }
     FixedOffsetLiteral best = null;
@@ -2260,12 +2270,12 @@ public final class Pattern implements Serializable {
     AsciiWidthRange prefixWidth = AsciiWidthRange.ZERO;
 
     for (int index = 0; index < node.subs.size(); ) {
-      String literalPart = fixedOffsetAsciiLiteral(node.subs.get(index));
+      String literalPart = extractExactAsciiLiteral(node.subs.get(index));
       if (literalPart != null) {
         StringBuilder literal = new StringBuilder(literalPart);
         int next = index + 1;
         while (next < node.subs.size()) {
-          String nextPart = fixedOffsetAsciiLiteral(node.subs.get(next));
+          String nextPart = extractExactAsciiLiteral(node.subs.get(next));
           if (nextPart == null) {
             break;
           }
@@ -2304,21 +2314,16 @@ public final class Pattern implements Serializable {
     return best;
   }
 
-  private static Regexp unwrapFixedOffsetNode(Regexp re) {
-    Regexp node = re;
-    while (node.op == RegexpOp.CAPTURE || node.op == RegexpOp.NON_CAPTURE) {
-      node = node.sub();
+  private static String extractExactAsciiLiteral(Regexp re) {
+    if (re == null) {
+      return null;
     }
-    return node;
-  }
-
-  private static String fixedOffsetAsciiLiteral(Regexp re) {
     StringBuilder literal = new StringBuilder();
     Deque<Regexp> pending = new ArrayDeque<>();
     pending.push(re);
     while (!pending.isEmpty()) {
-      Regexp node = unwrapFixedOffsetNode(pending.pop());
-      if ((node.flags & ParseFlags.FOLD_CASE) != 0) {
+      Regexp node = unwrapCaptures(pending.pop());
+      if (node == null || (node.flags & ParseFlags.FOLD_CASE) != 0) {
         return null;
       }
       if (node.op == RegexpOp.LITERAL && node.rune >= 0 && node.rune < 128) {
@@ -2758,6 +2763,25 @@ public final class Pattern implements Serializable {
       bitmap.addRange(cc.lo(i), cc.hi(i));
     }
     return true;
+  }
+
+  private static String[] extractLiteralAlternation(Regexp re) {
+    if (re == null) {
+      return null;
+    }
+    re = unwrapCaptures(re);
+    if (re == null || re.op != RegexpOp.ALTERNATE || re.nsub() < 2) {
+      return null;
+    }
+    String[] literals = new String[re.nsub()];
+    for (int i = 0; i < re.nsub(); i++) {
+      String lit = extractExactAsciiLiteral(re.subs.get(i));
+      if (lit == null || lit.isEmpty()) {
+        return null;
+      }
+      literals[i] = lit;
+    }
+    return literals;
   }
 
   private static StartAcceleration extractStartAcceleration(Regexp re) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -487,7 +487,7 @@ public final class Pattern implements Serializable {
     String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
     TeddyModel teddyModel = null;
     if (altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 32) {
-      teddyModel = TeddyModel.compile(altLiterals, 64);
+      teddyModel = TeddyModel.compileForSelectedProvider(altLiterals);
     }
     StartAcceleration startAcceleration =
         (prefix == null

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -487,7 +487,7 @@ public final class Pattern implements Serializable {
     String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
     TeddyModel teddyModel = null;
     if (altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 32) {
-      teddyModel = TeddyModel.compile(altLiterals, 32);
+      teddyModel = TeddyModel.compile(altLiterals, 64);
     }
     StartAcceleration startAcceleration =
         (prefix == null

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -19,24 +19,17 @@ record StartDescriptor(
     AsciiBitmap charClassPrefixAscii,
     StartAcceleration lineAnchor,
     String anchoredPrefix,
-    AsciiBitmap anchoredCharClassPrefixAscii) {
+    AsciiBitmap anchoredCharClassPrefixAscii,
+    TeddyModel teddyModel) {
 
   static final StartDescriptor NONE =
-      new StartDescriptor(null, false, null, null, null, null, null);
-
-  StartDescriptor(
-      String prefix,
-      boolean prefixFoldCase,
-      FixedOffsetLiteral fixedOffsetLiteral,
-      AsciiBitmap charClassPrefixAscii,
-      StartAcceleration lineAnchor) {
-    this(prefix, prefixFoldCase, fixedOffsetLiteral, charClassPrefixAscii, lineAnchor, null, null);
-  }
+      new StartDescriptor(null, false, null, null, null, null, null, null);
 
   boolean hasStartAcceleration() {
     return prefix != null
         || fixedOffsetLiteral != null
         || charClassPrefixAscii != null
-        || lineAnchor != null;
+        || lineAnchor != null
+        || teddyModel != null;
   }
 }

--- a/safere/src/main/java/org/safere/TeddyModel.java
+++ b/safere/src/main/java/org/safere/TeddyModel.java
@@ -105,7 +105,7 @@ final class TeddyModel implements Serializable {
 
   /** Compiles a Teddy model only when the optional vector provider is active. */
   static TeddyModel compileForSelectedProvider(String[] literals) {
-    return VectorScanProviders.providerForLength(64) == null ? null : compile(literals, 64);
+    return VectorScanProviders.teddyProviderAvailable() ? compile(literals, 64) : null;
   }
 
   /**

--- a/safere/src/main/java/org/safere/TeddyModel.java
+++ b/safere/src/main/java/org/safere/TeddyModel.java
@@ -1,0 +1,210 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable precomputed lookup tables and metadata for Teddy SIMD vector-shuffle multi-literal
+ * acceleration.
+ *
+ * <p>Teddy compresses up to 32 literal search patterns into parallel 16-byte nibble lookup tables,
+ * enabling simultaneous multi-keyword matching in 3 SIMD instructions (2 {@code rearrange} + 1
+ * {@code and}) on {@code ByteVector}.
+ */
+final class TeddyModel implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private static final int MAX_BUCKETS = 8;
+  private static final int NIBBLE_TABLE_SIZE = 16;
+
+  private final byte[] lutLo;
+  private final byte[] lutHi;
+  private final byte[] lutLo1;
+  private final byte[] lutHi1;
+  private final byte[] lutLo2;
+  private final byte[] lutHi2;
+  private final String[] literals;
+  private final int[] literalBuckets;
+  private final int minLength;
+  private final boolean is2Byte;
+  private final boolean is3Byte;
+
+  private TeddyModel(
+      byte[] lutLo,
+      byte[] lutHi,
+      byte[] lutLo1,
+      byte[] lutHi1,
+      byte[] lutLo2,
+      byte[] lutHi2,
+      String[] literals,
+      int[] literalBuckets,
+      int minLength,
+      boolean is2Byte,
+      boolean is3Byte) {
+    this.lutLo = lutLo;
+    this.lutHi = lutHi;
+    this.lutLo1 = lutLo1;
+    this.lutHi1 = lutHi1;
+    this.lutLo2 = lutLo2;
+    this.lutHi2 = lutHi2;
+    this.literals = literals;
+    this.literalBuckets = literalBuckets;
+    this.minLength = minLength;
+    this.is2Byte = is2Byte;
+    this.is3Byte = is3Byte;
+  }
+
+  byte[] lutLo() {
+    return lutLo;
+  }
+
+  byte[] lutHi() {
+    return lutHi;
+  }
+
+  byte[] lutLo1() {
+    return lutLo1;
+  }
+
+  byte[] lutHi1() {
+    return lutHi1;
+  }
+
+  byte[] lutLo2() {
+    return lutLo2;
+  }
+
+  byte[] lutHi2() {
+    return lutHi2;
+  }
+
+  String[] literals() {
+    return literals;
+  }
+
+  int[] literalBuckets() {
+    return literalBuckets;
+  }
+
+  int minLength() {
+    return minLength;
+  }
+
+  boolean is2Byte() {
+    return is2Byte;
+  }
+
+  boolean is3Byte() {
+    return is3Byte;
+  }
+
+  /**
+   * Compiles up to 32 ASCII literal keywords into a {@link TeddyModel}.
+   *
+   * @param literals the array of literal keywords
+   * @param vectorLength the preferred vector lane width (16, 32, or 64 bytes)
+   * @return the compiled model, or {@code null} if inputs are ineligible for Teddy
+   */
+  static TeddyModel compile(String[] literals, int vectorLength) {
+    if (literals == null || literals.length < 2 || literals.length > 32) {
+      return null;
+    }
+    int minLen = Integer.MAX_VALUE;
+    for (String lit : literals) {
+      if (lit == null || lit.isEmpty()) {
+        return null;
+      }
+      for (int i = 0; i < lit.length(); i++) {
+        if (lit.charAt(i) > 127) {
+          return null;
+        }
+      }
+      minLen = Math.min(minLen, lit.length());
+    }
+
+    int numBuckets = Math.min(literals.length, MAX_BUCKETS);
+    int[] literalBuckets = new int[literals.length];
+    byte[] baseLutLo0 = new byte[NIBBLE_TABLE_SIZE];
+    byte[] baseLutHi0 = new byte[NIBBLE_TABLE_SIZE];
+
+    for (int i = 0; i < literals.length; i++) {
+      int bucket = i % numBuckets;
+      literalBuckets[i] = bucket;
+      byte mask = (byte) (1 << bucket);
+
+      char c0 = literals[i].charAt(0);
+      int lo0 = c0 & 0x0F;
+      int hi0 = (c0 >> 4) & 0x0F;
+      baseLutLo0[lo0] |= mask;
+      baseLutHi0[hi0] |= mask;
+    }
+
+    boolean is2Byte = minLen >= 2;
+    byte[] baseLutLo1 = is2Byte ? new byte[NIBBLE_TABLE_SIZE] : null;
+    byte[] baseLutHi1 = is2Byte ? new byte[NIBBLE_TABLE_SIZE] : null;
+
+    if (is2Byte) {
+      for (int i = 0; i < literals.length; i++) {
+        int bucket = literalBuckets[i];
+        byte mask = (byte) (1 << bucket);
+
+        char c1 = literals[i].charAt(1);
+        int lo1 = c1 & 0x0F;
+        int hi1 = (c1 >> 4) & 0x0F;
+        baseLutLo1[lo1] |= mask;
+        baseLutHi1[hi1] |= mask;
+      }
+    }
+
+    boolean is3Byte = minLen >= 3;
+    byte[] baseLutLo2 = is3Byte ? new byte[NIBBLE_TABLE_SIZE] : null;
+    byte[] baseLutHi2 = is3Byte ? new byte[NIBBLE_TABLE_SIZE] : null;
+
+    if (is3Byte) {
+      for (int i = 0; i < literals.length; i++) {
+        int bucket = literalBuckets[i];
+        byte mask = (byte) (1 << bucket);
+
+        char c2 = literals[i].charAt(2);
+        int lo2 = c2 & 0x0F;
+        int hi2 = (c2 >> 4) & 0x0F;
+        baseLutLo2[lo2] |= mask;
+        baseLutHi2[hi2] |= mask;
+      }
+    }
+
+    int tableSize = Math.max(NIBBLE_TABLE_SIZE, vectorLength);
+    byte[] repeatedLo0 = repeatTable(baseLutLo0, tableSize);
+    byte[] repeatedHi0 = repeatTable(baseLutHi0, tableSize);
+    byte[] repeatedLo1 = is2Byte ? repeatTable(baseLutLo1, tableSize) : null;
+    byte[] repeatedHi1 = is2Byte ? repeatTable(baseLutHi1, tableSize) : null;
+    byte[] repeatedLo2 = is3Byte ? repeatTable(baseLutLo2, tableSize) : null;
+    byte[] repeatedHi2 = is3Byte ? repeatTable(baseLutHi2, tableSize) : null;
+
+    return new TeddyModel(
+        repeatedLo0,
+        repeatedHi0,
+        repeatedLo1,
+        repeatedHi1,
+        repeatedLo2,
+        repeatedHi2,
+        Arrays.copyOf(literals, literals.length),
+        literalBuckets,
+        minLen,
+        is2Byte,
+        is3Byte);
+  }
+
+  private static byte[] repeatTable(byte[] base16, int totalSize) {
+    byte[] result = new byte[totalSize];
+    for (int i = 0; i < totalSize; i += NIBBLE_TABLE_SIZE) {
+      System.arraycopy(base16, 0, result, i, Math.min(NIBBLE_TABLE_SIZE, totalSize - i));
+    }
+    return result;
+  }
+}

--- a/safere/src/main/java/org/safere/TeddyModel.java
+++ b/safere/src/main/java/org/safere/TeddyModel.java
@@ -178,7 +178,7 @@ final class TeddyModel implements Serializable {
       }
     }
 
-    int tableSize = Math.max(NIBBLE_TABLE_SIZE, vectorLength);
+    int tableSize = Math.max(64, Math.max(NIBBLE_TABLE_SIZE, vectorLength));
     byte[] repeatedLo0 = repeatTable(baseLutLo0, tableSize);
     byte[] repeatedHi0 = repeatTable(baseLutHi0, tableSize);
     byte[] repeatedLo1 = is2Byte ? repeatTable(baseLutLo1, tableSize) : null;

--- a/safere/src/main/java/org/safere/TeddyModel.java
+++ b/safere/src/main/java/org/safere/TeddyModel.java
@@ -103,6 +103,11 @@ final class TeddyModel implements Serializable {
     return is3Byte;
   }
 
+  /** Compiles a Teddy model only when the optional vector provider is active. */
+  static TeddyModel compileForSelectedProvider(String[] literals) {
+    return VectorScanProviders.providerForLength(64) == null ? null : compile(literals, 64);
+  }
+
   /**
    * Compiles up to 32 ASCII literal keywords into a {@link TeddyModel}.
    *

--- a/safere/src/main/java/org/safere/TeddyVectorScan.java
+++ b/safere/src/main/java/org/safere/TeddyVectorScan.java
@@ -1,0 +1,103 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static jdk.incubator.vector.VectorOperators.LSHR;
+import static jdk.incubator.vector.VectorOperators.NE;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+/**
+ * Stateless SIMD Teddy multi-keyword vector-shuffle scanning kernels using the Vector API.
+ */
+final class TeddyVectorScan {
+  private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
+
+  static int indexOfTeddyUtf8(byte[] bytes, int offset, int length, TeddyModel model, int start) {
+    int minLen = model.minLength();
+    int pos = Math.max(0, start);
+    int vectorLen = SPECIES.length();
+    int limit = length - vectorLen;
+
+    ByteVector lutLo0 = ByteVector.fromArray(SPECIES, model.lutLo(), 0);
+    ByteVector lutHi0 = ByteVector.fromArray(SPECIES, model.lutHi(), 0);
+    boolean is2Byte = model.is2Byte();
+    ByteVector lutLo1 = is2Byte ? ByteVector.fromArray(SPECIES, model.lutLo1(), 0) : null;
+    ByteVector lutHi1 = is2Byte ? ByteVector.fromArray(SPECIES, model.lutHi1(), 0) : null;
+    boolean is3Byte = model.is3Byte();
+    ByteVector lutLo2 = is3Byte ? ByteVector.fromArray(SPECIES, model.lutLo2(), 0) : null;
+    ByteVector lutHi2 = is3Byte ? ByteVector.fromArray(SPECIES, model.lutHi2(), 0) : null;
+
+    String[] literals = model.literals();
+    int[] buckets = model.literalBuckets();
+
+    for (; pos <= limit; pos += vectorLen) {
+      // Stage 1: 2-byte primary SIMD filter (discards ~85% of non-matching blocks)
+      ByteVector input0 = ByteVector.fromArray(SPECIES, bytes, offset + pos);
+      ByteVector lo0 = input0.and((byte) 0x0F);
+      ByteVector hi0 = input0.lanewise(LSHR, 4).and((byte) 0x0F);
+      ByteVector match0 = lo0.selectFrom(lutLo0).and(hi0.selectFrom(lutHi0));
+
+      if (is2Byte && pos + 1 <= limit) {
+        ByteVector input1 = ByteVector.fromArray(SPECIES, bytes, offset + pos + 1);
+        ByteVector lo1 = input1.and((byte) 0x0F);
+        ByteVector hi1 = input1.lanewise(LSHR, 4).and((byte) 0x0F);
+        ByteVector match1 = lo1.selectFrom(lutLo1).and(hi1.selectFrom(lutHi1));
+        match0 = match0.and(match1);
+      }
+
+      VectorMask<Byte> matchMask = match0.compare(NE, (byte) 0);
+      if (matchMask.anyTrue()) {
+        // Stage 2: 3-byte confirmation filter (evaluated only on ~15% candidate blocks)
+        if (is3Byte && pos + 2 <= limit) {
+          ByteVector input2 = ByteVector.fromArray(SPECIES, bytes, offset + pos + 2);
+          ByteVector lo2 = input2.and((byte) 0x0F);
+          ByteVector hi2 = input2.lanewise(LSHR, 4).and((byte) 0x0F);
+          ByteVector match2 = lo2.selectFrom(lutLo2).and(hi2.selectFrom(lutHi2));
+          match0 = match0.and(match2);
+          matchMask = match0.compare(NE, (byte) 0);
+        }
+
+        if (matchMask.anyTrue()) {
+          // Stage 3: Candidate extraction and verification (< 0.1% of blocks)
+          long activeLanes = matchMask.toLong();
+          while (activeLanes != 0) {
+            int bit = Long.numberOfTrailingZeros(activeLanes);
+            int candidatePos = pos + bit;
+            byte bucketMask = match0.lane(bit);
+
+            for (int litIdx = 0; litIdx < literals.length; litIdx++) {
+              int b = buckets[litIdx];
+              if ((bucketMask & (1 << b)) != 0) {
+                String lit = literals[litIdx];
+                if (candidatePos + lit.length() <= length
+                    && Ascii.regionMatches(bytes, offset + candidatePos, lit, lit.length())) {
+                  return candidatePos;
+                }
+              }
+            }
+            activeLanes &= activeLanes - 1;
+          }
+        }
+      }
+    }
+
+    int scalarLimit = length - minLen;
+    for (; pos <= scalarLimit; pos++) {
+      for (String lit : literals) {
+        if (pos + lit.length() <= length
+            && Ascii.regionMatches(bytes, offset + pos, lit, lit.length())) {
+          return pos;
+        }
+      }
+    }
+    return -1;
+  }
+
+  private TeddyVectorScan() {}
+}

--- a/safere/src/main/java/org/safere/TeddyVectorScan.java
+++ b/safere/src/main/java/org/safere/TeddyVectorScan.java
@@ -12,9 +12,7 @@ import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorSpecies;
 
-/**
- * Stateless SIMD Teddy multi-keyword vector-shuffle scanning kernels using the Vector API.
- */
+/** Stateless SIMD Teddy multi-keyword vector-shuffle scanning kernels using the Vector API. */
 final class TeddyVectorScan {
   private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
 

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -34,7 +34,7 @@ sealed interface Utf8StartAccelerator {
     }
     if (descriptor.teddyModel() != null
         && !hasWordBoundary
-        && VectorScanProviders.providerForLength(64) != null) {
+        && VectorScanProviders.teddyProviderAvailable()) {
       return new Teddy(descriptor.teddyModel());
     }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
@@ -214,14 +214,15 @@ sealed interface Utf8StartAccelerator {
 
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      VectorScanProvider provider = VectorScanProviders.providerForLength(scanner.length());
-      if (provider != null) {
-        int idx =
-            provider.indexOfTeddy(
-                scanner.bytes(), scanner.offset(), scanner.length(), model, fromIndex);
-        if (idx != VectorScanProvider.UNSUPPORTED) {
-          return idx;
-        }
+      VectorScanProvider provider = VectorScanProviders.providerForTeddyLength(scanner.length());
+      if (provider == null) {
+        return fromIndex;
+      }
+      int idx =
+          provider.indexOfTeddy(
+              scanner.bytes(), scanner.offset(), scanner.length(), model, fromIndex);
+      if (idx != VectorScanProvider.UNSUPPORTED) {
+        return idx;
       }
       int len = scanner.length();
       int minLen = model.minLength();

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -206,7 +206,6 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-  @SuppressWarnings("ArrayRecordComponent")
   record Teddy(TeddyModel model) implements Utf8StartAccelerator {
     @Override
     public AcceleratorPolicy policy() {

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -32,6 +32,11 @@ sealed interface Utf8StartAccelerator {
     if (descriptor.fixedOffsetLiteral() != null) {
       return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefixAscii());
     }
+    if (descriptor.teddyModel() != null
+        && !hasWordBoundary
+        && VectorScanProviders.providerForLength(64) != null) {
+      return new Teddy(descriptor.teddyModel());
+    }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
       CharClassScanInfo scanInfo =
           Pattern.buildAsciiClassScanInfo(descriptor.charClassPrefixAscii());
@@ -64,6 +69,7 @@ sealed interface Utf8StartAccelerator {
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
       case CharClass cc -> cc.findCandidate(scanner, pos);
+      case Teddy t -> t.findCandidate(scanner, pos);
     };
   }
 
@@ -197,6 +203,44 @@ sealed interface Utf8StartAccelerator {
             scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex, scanner.length());
       }
       return fromIndex;
+    }
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  record Teddy(TeddyModel model) implements Utf8StartAccelerator {
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.VECTOR_MULTI_LITERAL;
+    }
+
+    @Override
+    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+      VectorScanProvider provider = VectorScanProviders.providerForLength(scanner.length());
+      if (provider != null) {
+        int idx =
+            provider.indexOfTeddy(
+                scanner.bytes(),
+                scanner.offset(),
+                scanner.length(),
+                model,
+                fromIndex);
+        if (idx != VectorScanProvider.UNSUPPORTED) {
+          return idx;
+        }
+      }
+      int len = scanner.length();
+      int minLen = model.minLength();
+      byte[] bytes = scanner.bytes();
+      int offset = scanner.offset();
+      for (int i = fromIndex; i <= len - minLen; i++) {
+        for (String lit : model.literals()) {
+          if (i + lit.length() <= len
+              && Ascii.regionMatches(bytes, offset + i, lit, lit.length())) {
+            return i;
+          }
+        }
+      }
+      return -1;
     }
   }
 }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -219,11 +219,7 @@ sealed interface Utf8StartAccelerator {
       if (provider != null) {
         int idx =
             provider.indexOfTeddy(
-                scanner.bytes(),
-                scanner.offset(),
-                scanner.length(),
-                model,
-                fromIndex);
+                scanner.bytes(), scanner.offset(), scanner.length(), model, fromIndex);
         if (idx != VectorScanProvider.UNSUPPORTED) {
           return idx;
         }

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -13,4 +13,7 @@ interface VectorScanProvider {
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
+
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
+  int indexOfTeddy(byte[] bytes, int offset, int length, TeddyModel model, int start);
 }

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -11,6 +11,8 @@ interface VectorScanProvider {
 
   int minimumInputLength();
 
+  int minimumTeddyInputLength();
+
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -16,6 +16,14 @@ final class VectorScanProviders {
     return SELECTED != null && length >= SELECTED.minimumInputLength() ? SELECTED : null;
   }
 
+  static VectorScanProvider providerForTeddyLength(int length) {
+    return SELECTED != null && length >= SELECTED.minimumTeddyInputLength() ? SELECTED : null;
+  }
+
+  static boolean teddyProviderAvailable() {
+    return SELECTED != null;
+  }
+
   private static VectorScanProvider loadSelected() {
     String requested = System.getProperty(PROVIDER_PROPERTY, "").trim();
     if (requested.isEmpty() || requested.equals("swar")) {

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -25,7 +25,7 @@ class StartAcceleratorTest {
 
   @Test
   void literalPrefixAcceleratesStringAndUtf8() {
-    StartDescriptor desc = new StartDescriptor("needle", false, null, null, null);
+    StartDescriptor desc = descriptor("needle", false, null, null);
     assertThat(desc.hasStartAcceleration()).isTrue();
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
@@ -43,7 +43,7 @@ class StartAcceleratorTest {
 
   @Test
   void caseInsensitiveLiteralAcceleratesStringAndUtf8() {
-    StartDescriptor desc = new StartDescriptor("needle", true, null, null, null);
+    StartDescriptor desc = descriptor("needle", true, null, null);
     assertThat(desc.hasStartAcceleration()).isTrue();
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
@@ -59,21 +59,21 @@ class StartAcceleratorTest {
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 15)).isEqualTo(-1);
 
     // Single character case-insensitive prefix
-    StartDescriptor singleDesc = new StartDescriptor("a", true, null, null, null);
+    StartDescriptor singleDesc = descriptor("a", true, null, null);
     Utf8StartAccelerator singleUtf8 = Utf8StartAccelerator.create(singleDesc, false);
     assertThat(singleUtf8).isInstanceOf(Utf8StartAccelerator.CaseInsensitiveLiteral.class);
     assertThat(singleUtf8.findCandidate(utf8Scanner("xxxA"), 0)).isEqualTo(3);
     assertThat(singleUtf8.findCandidate(utf8Scanner("xxxa"), 0)).isEqualTo(3);
 
     // Non-ASCII case-insensitive prefix falls back (null)
-    StartDescriptor nonAsciiDesc = new StartDescriptor("café", true, null, null, null);
+    StartDescriptor nonAsciiDesc = descriptor("café", true, null, null);
     assertThat(Utf8StartAccelerator.create(nonAsciiDesc, false)).isNull();
   }
 
   @Test
   void fixedOffsetLiteralAcceleratesStringAndUtf8() {
     FixedOffsetLiteral fixed = new FixedOffsetLiteral("token", 2, 2, new int[] {2});
-    StartDescriptor desc = new StartDescriptor(null, false, fixed, null, null);
+    StartDescriptor desc = descriptor(null, false, fixed, null);
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.FixedOffset.class);
@@ -89,7 +89,7 @@ class StartAcceleratorTest {
   @Test
   void charClassPrefixAcceleratesStringAndUtf8() {
     AsciiBitmap ascii = new AsciiBitmap.Builder().add('a').add('b').build();
-    StartDescriptor desc = new StartDescriptor(null, false, null, ascii, null);
+    StartDescriptor desc = descriptor(null, false, null, ascii);
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
@@ -100,6 +100,15 @@ class StartAcceleratorTest {
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
     assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(utf8Acc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
+  }
+
+  private static StartDescriptor descriptor(
+      String prefix,
+      boolean prefixFoldCase,
+      FixedOffsetLiteral fixedOffsetLiteral,
+      AsciiBitmap charClassPrefixAscii) {
+    return new StartDescriptor(
+        prefix, prefixFoldCase, fixedOffsetLiteral, charClassPrefixAscii, null, null, null, null);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/TeddyModelTest.java
+++ b/safere/src/test/java/org/safere/TeddyModelTest.java
@@ -1,0 +1,30 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+@DisabledForCrosscheck("implementation test uses package-private Teddy and Vector provider APIs")
+class TeddyModelTest {
+
+  @Test
+  void compilationFollowsVectorProviderAvailability() {
+    TeddyModel model = TeddyModel.compileForSelectedProvider(new String[] {"INFO", "WARN"});
+
+    if (!VectorScanProviders.teddyProviderAvailable()) {
+      assertThat(model).isNull();
+    } else {
+      assertThat(model).isNotNull();
+      assertThat(VectorScanProviders.providerForLength(64)).isNull();
+      assertThat(VectorScanProviders.providerForTeddyLength(64)).isNull();
+      assertThat(VectorScanProviders.providerForTeddyLength(256)).isNull();
+      assertThat(VectorScanProviders.providerForLength(1024)).isNotNull();
+      assertThat(VectorScanProviders.providerForTeddyLength(1024)).isNotNull();
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/TeddyTest.java
+++ b/safere/src/test/java/org/safere/TeddyTest.java
@@ -144,6 +144,32 @@ class TeddyTest {
     assertThat(matches).containsExactly("POST", "GET");
   }
 
+  @Test
+  void sevenAlternationsMatch() {
+    Pattern p = Pattern.compile("MON|TUE|WED|THU|FRI|SAT|SUN");
+    String text = "Schedule: MON at 9am, WED at 2pm, and SUN at 8pm";
+
+    Matcher m = p.matcher(text);
+    List<String> matches = new ArrayList<>();
+    List<Integer> starts = new ArrayList<>();
+    while (m.find()) {
+      matches.add(m.group());
+      starts.add(m.start());
+    }
+
+    assertThat(matches).containsExactly("MON", "WED", "SUN");
+    assertThat(starts).containsExactly(10, 22, 38);
+
+    byte[] bytes = text.getBytes(UTF_8);
+    Utf8Matcher utf8Matcher = p.matcher(Utf8Input.validated(bytes));
+    List<String> utf8Matches = new ArrayList<>();
+    while (utf8Matcher.find()) {
+      utf8Matches.add(
+          new String(bytes, utf8Matcher.start(), utf8Matcher.end() - utf8Matcher.start(), UTF_8));
+    }
+    assertThat(utf8Matches).containsExactly("MON", "WED", "SUN");
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 15, 16, 31, 32, 63, 64, 127, 128, 255})
   void teddyMatchAtVariableOffsets(int padding) {

--- a/safere/src/test/java/org/safere/TeddyTest.java
+++ b/safere/src/test/java/org/safere/TeddyTest.java
@@ -21,22 +21,6 @@ class TeddyTest {
           + "|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY";
 
   @Test
-  void teddyModelCompilationFollowsVectorProviderAvailability() {
-    TeddyModel model = TeddyModel.compileForSelectedProvider(new String[] {"INFO", "WARN"});
-
-    if (!VectorScanProviders.teddyProviderAvailable()) {
-      assertThat(model).isNull();
-    } else {
-      assertThat(model).isNotNull();
-      assertThat(VectorScanProviders.providerForLength(64)).isNull();
-      assertThat(VectorScanProviders.providerForTeddyLength(64)).isNull();
-      assertThat(VectorScanProviders.providerForTeddyLength(256)).isNull();
-      assertThat(VectorScanProviders.providerForLength(1024)).isNotNull();
-      assertThat(VectorScanProviders.providerForTeddyLength(1024)).isNotNull();
-    }
-  }
-
-  @Test
   void smallMultiLiteralStringMatch() {
     Pattern p = Pattern.compile("INFO|WARN|ERROR");
     String text = "2026-08-18 [WARN] system running normally, no ERROR reported";

--- a/safere/src/test/java/org/safere/TeddyTest.java
+++ b/safere/src/test/java/org/safere/TeddyTest.java
@@ -24,10 +24,15 @@ class TeddyTest {
   void teddyModelCompilationFollowsVectorProviderAvailability() {
     TeddyModel model = TeddyModel.compileForSelectedProvider(new String[] {"INFO", "WARN"});
 
-    if (VectorScanProviders.providerForLength(64) == null) {
+    if (!VectorScanProviders.teddyProviderAvailable()) {
       assertThat(model).isNull();
     } else {
       assertThat(model).isNotNull();
+      assertThat(VectorScanProviders.providerForLength(64)).isNull();
+      assertThat(VectorScanProviders.providerForTeddyLength(64)).isNull();
+      assertThat(VectorScanProviders.providerForTeddyLength(256)).isNull();
+      assertThat(VectorScanProviders.providerForLength(1024)).isNotNull();
+      assertThat(VectorScanProviders.providerForTeddyLength(1024)).isNotNull();
     }
   }
 

--- a/safere/src/test/java/org/safere/TeddyTest.java
+++ b/safere/src/test/java/org/safere/TeddyTest.java
@@ -1,0 +1,273 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TeddyTest {
+
+  private static final String US_STATES =
+      "AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ"
+          + "|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY";
+
+  @Test
+  void smallMultiLiteralStringMatch() {
+    Pattern p = Pattern.compile("INFO|WARN|ERROR");
+    String text = "2026-08-18 [WARN] system running normally, no ERROR reported";
+
+    Matcher m = p.matcher(text);
+    List<String> matches = new ArrayList<>();
+    List<Integer> starts = new ArrayList<>();
+    while (m.find()) {
+      matches.add(m.group());
+      starts.add(m.start());
+    }
+
+    assertThat(matches).containsExactly("WARN", "ERROR");
+    assertThat(starts).containsExactly(12, 46);
+  }
+
+  @Test
+  void smallMultiLiteralUtf16Match() {
+    Pattern p = Pattern.compile("東京|大阪|京都|福岡");
+    String text = "日本の都市: 東京と京都と大阪を訪問しました。";
+
+    Matcher m = p.matcher(text);
+    List<String> matches = new ArrayList<>();
+    List<Integer> starts = new ArrayList<>();
+    while (m.find()) {
+      matches.add(m.group());
+      starts.add(m.start());
+    }
+
+    assertThat(matches).containsExactly("東京", "京都", "大阪");
+    assertThat(starts).containsExactly(7, 10, 13);
+  }
+
+  @Test
+  void smallMultiLiteralUtf8Match() {
+    Pattern p = Pattern.compile("cat|dog|bird");
+    byte[] text = "the quick brown dog jumped over the lazy bird".getBytes(UTF_8);
+
+    Utf8Matcher m = p.matcher(Utf8Input.validated(text));
+    List<String> matches = new ArrayList<>();
+    while (m.find()) {
+      matches.add(new String(text, m.start(), m.end() - m.start(), UTF_8));
+    }
+
+    assertThat(matches).containsExactly("dog", "bird");
+  }
+
+  @Test
+  void smallMultiLiteralAbsent() {
+    Pattern p = Pattern.compile("true|false");
+    String text = "none of the boolean values are present in this long sentence of text";
+
+    Matcher m = p.matcher(text);
+    assertThat(m.find()).isFalse();
+
+    Utf8Matcher utf8Matcher = p.matcher(Utf8Input.validated(text.getBytes(UTF_8)));
+    assertThat(utf8Matcher.find()).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 14, 15, 16, 31, 32, 63, 64, 127, 128, 255})
+  void smallMultiLiteralAtVariableOffsets(int padding) {
+    Pattern p = Pattern.compile("INFO|WARN|ERROR");
+    String pad = "x".repeat(padding);
+    String text = pad + "ERROR" + pad + "WARN";
+
+    Matcher m = p.matcher(text);
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding);
+    assertThat(m.group()).isEqualTo("ERROR");
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding + 5 + padding);
+    assertThat(m.group()).isEqualTo("WARN");
+
+    assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  void teddyUsStatesMatch() {
+    Pattern p = Pattern.compile(US_STATES);
+    String text = "Packages shipped from CA and NY arrived in TX safely.";
+
+    Matcher m = p.matcher(text);
+    List<String> matches = new ArrayList<>();
+    List<Integer> starts = new ArrayList<>();
+    while (m.find()) {
+      matches.add(m.group());
+      starts.add(m.start());
+    }
+
+    assertThat(matches).containsExactly("CA", "NY", "TX");
+    assertThat(starts).containsExactly(22, 29, 43);
+  }
+
+  @Test
+  void teddyUsStatesUtf8Match() {
+    Pattern p = Pattern.compile(US_STATES);
+    byte[] text = "Orders processed in WA, OR, and NV yesterday.".getBytes(UTF_8);
+
+    Utf8Matcher m = p.matcher(Utf8Input.validated(text));
+    List<String> matches = new ArrayList<>();
+    while (m.find()) {
+      matches.add(new String(text, m.start(), m.end() - m.start(), UTF_8));
+    }
+
+    assertThat(matches).containsExactly("WA", "OR", "NV");
+  }
+
+  @Test
+  void teddyHttpVerbsLongText() {
+    Pattern p = Pattern.compile("GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH|TRACE");
+    String text = "200 OK after receiving POST /api/v1/resource followed by GET /api/v1/resource";
+
+    Matcher m = p.matcher(text);
+    List<String> matches = new ArrayList<>();
+    while (m.find()) {
+      matches.add(m.group());
+    }
+
+    assertThat(matches).containsExactly("POST", "GET");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 15, 16, 31, 32, 63, 64, 127, 128, 255})
+  void teddyMatchAtVariableOffsets(int padding) {
+    Pattern p = Pattern.compile("GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH|TRACE");
+    String pad = "-".repeat(padding);
+    String text = pad + "DELETE" + pad + "POST";
+
+    Matcher m = p.matcher(text);
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding);
+    assertThat(m.group()).isEqualTo("DELETE");
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding + 6 + padding);
+    assertThat(m.group()).isEqualTo("POST");
+
+    assertThat(m.find()).isFalse();
+
+    byte[] bytes = text.getBytes(UTF_8);
+    Utf8Matcher utf8Matcher = p.matcher(Utf8Input.validated(bytes));
+    assertThat(utf8Matcher.find()).isTrue();
+    assertThat(utf8Matcher.start()).isEqualTo(padding);
+    assertThat(utf8Matcher.find()).isTrue();
+    assertThat(utf8Matcher.start()).isEqualTo(padding + 6 + padding);
+    assertThat(utf8Matcher.find()).isFalse();
+  }
+
+  @Test
+  void teddyAbsentLongText() {
+    Pattern p = Pattern.compile(US_STATES);
+    String text = "abcdefghijklmnopqrstuvwxyz ".repeat(100);
+
+    Matcher m = p.matcher(text);
+    assertThat(m.find()).isFalse();
+
+    Utf8Matcher utf8Matcher = p.matcher(Utf8Input.validated(text.getBytes(UTF_8)));
+    assertThat(utf8Matcher.find()).isFalse();
+  }
+
+  @Test
+  void teddyEquivalenceWithJdk() {
+    String[] testPatterns = {
+      "cat|dog|bird",
+      "INFO|WARN|ERROR",
+      "GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH",
+      "foo|foobar|foot|foothold|football",
+      US_STATES
+    };
+
+    String[] testInputs = {
+      "hello world CA and NY are states",
+      "POST /index.html HTTP/1.1",
+      "nothing matching here whatsoever",
+      "cat dog bird",
+      "12345 ERROR at line 42 with WARN warning",
+      "playing football on foot with a foothold"
+    };
+
+    for (String pat : testPatterns) {
+      Pattern safeRe = Pattern.compile(pat);
+      java.util.regex.Pattern jdk = java.util.regex.Pattern.compile(pat);
+
+      for (String input : testInputs) {
+        Matcher m1 = safeRe.matcher(input);
+        java.util.regex.Matcher m2 = jdk.matcher(input);
+
+        while (m1.find()) {
+          assertThat(m2.find()).isTrue();
+          assertThat(m1.group()).isEqualTo(m2.group());
+          assertThat(m1.start()).isEqualTo(m2.start());
+          assertThat(m1.end()).isEqualTo(m2.end());
+        }
+        assertThat(m2.find()).isFalse();
+      }
+    }
+  }
+
+  @Test
+  void teddyUtf16NonLatin1StringMatch() {
+    Pattern p = Pattern.compile("GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH|TRACE");
+    // Non-Latin-1 string (UTF-16 coder = 1) containing Japanese text and emojis
+    String text = "リクエストログ: POST /api/v1/user 📦 レスポンス受信後に GET /api/v1/user 🚀 完了";
+
+    Matcher m = p.matcher(text);
+    List<String> matches = new ArrayList<>();
+    List<Integer> starts = new ArrayList<>();
+    while (m.find()) {
+      matches.add(m.group());
+      starts.add(m.start());
+    }
+
+    assertThat(matches).containsExactly("POST", "GET");
+    assertThat(starts).containsExactly(9, 40);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 15, 16, 31, 32, 63, 64, 127, 128})
+  void teddyUtf16WithNonAsciiPadding(int padding) {
+    Pattern p = Pattern.compile(US_STATES);
+    String nonAsciiPad = "あ".repeat(padding);
+    String text = nonAsciiPad + "CA" + nonAsciiPad + "NY" + nonAsciiPad + "TX";
+
+    Matcher m = p.matcher(text);
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding);
+    assertThat(m.group()).isEqualTo("CA");
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding + 2 + padding);
+    assertThat(m.group()).isEqualTo("NY");
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(padding + 2 + padding + 2 + padding);
+    assertThat(m.group()).isEqualTo("TX");
+
+    assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  void teddyUtf16AbsentWithNonAsciiText() {
+    Pattern p = Pattern.compile(US_STATES);
+    String text = "こんにちは世界！これは日本語のテキストです。".repeat(50);
+
+    Matcher m = p.matcher(text);
+    assertThat(m.find()).isFalse();
+  }
+}

--- a/safere/src/test/java/org/safere/TeddyTest.java
+++ b/safere/src/test/java/org/safere/TeddyTest.java
@@ -21,6 +21,17 @@ class TeddyTest {
           + "|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY";
 
   @Test
+  void teddyModelCompilationFollowsVectorProviderAvailability() {
+    TeddyModel model = TeddyModel.compileForSelectedProvider(new String[] {"INFO", "WARN"});
+
+    if (VectorScanProviders.providerForLength(64) == null) {
+      assertThat(model).isNull();
+    } else {
+      assertThat(model).isNotNull();
+    }
+  }
+
+  @Test
   void smallMultiLiteralStringMatch() {
     Pattern p = Pattern.compile("INFO|WARN|ERROR");
     String text = "2026-08-18 [WARN] system running normally, no ERROR reported";


### PR DESCRIPTION
See #700

This adds multi-literal start acceleration (of patterns like `foo|bar|baz|...`) using Hyperscan's Teddy algorithm.

This also drops `IncubatorVectorScanProvider.MINIMUM_INPUT_LENGTH` from 1024 down to 64, the conclusion I came to in #656 was that the setup overhead for the JDK Vector APIs is low enough that's a good threshold.

I experimented with some variations of this. Hyperscan's Teddy3 calculates 3 byte offsets unconditionally on every 16/32-byte block, which hotspot didn't seem to optimize well. This landed on a tiered approach with a 2-byte primary filter and a 3-byte confirmation filter.

Similar to existing vector accelerators this only handles `byte[]`, but could be generalized to `String` if it becomes possible to get a zero-copy vector view of a string's UTF-16 data (#656). When generalizing this to UTF-16, the implementation here can be used as-is for latin1. For non-latin1 UTF-16, it can use a SIMD Narrowing / Pack (load 32 bytes $\to$ pack 16 ASCII chars into 16 bytes $\to$ run 8-bit Teddy kernel).

```
./safere-benchmarks/scripts/compare-branch.sh   --baseline vector-benchmark-baseline   --vector 'SearchScalingBenchmark\.alternationScaled.*@safere-utf8'
```

| Benchmark                                        | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------------------------ | ---------------- | --------------- | ------- |
| SearchScalingBenchmark.alternationScaled.1024    |        2217 ± 74 |        471 ± 33 |   4.70x |
| SearchScalingBenchmark.alternationScaled.10240   |      20159 ± 107 |       3914 ± 45 |   5.15x |
| SearchScalingBenchmark.alternationScaled.102400  |    197098 ± 1446 |     32405 ± 711 |   6.08x |
| SearchScalingBenchmark.alternationScaled.1048576 |  2028547 ± 18363 | 839162 ± 820365 |   2.42x |
