### PR TITLE
Add multi-broadcast start accelerator for small literal alternations on UTF-8

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -452,7 +452,7 @@
       "id": "vectorScan.multi.nonascii.32768",
       "recipe": {
         "kind": "repeatToLength",
-        "unit": "é",
+        "unit": "\u00e9",
         "length": 32768
       },
       "shared": true
@@ -1725,7 +1725,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
+        "value": "\u3044\u304f\u3064\u3082\u306e\u3000\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u3000\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u3000\u305d\u3057\u3066\u3000\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u3000\u304c\u3042\u308a\u307e\u3059",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1743,7 +1743,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
+        "value": "\u3044\u304f\u3064\u3082\u306e\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u305d\u3057\u3066\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u304c\u3042\u308a\u307e\u3059",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1761,7 +1761,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "这是一个中文测试句子",
+        "value": "\u8fd9\u662f\u4e00\u4e2a\u4e2d\u6587\u6d4b\u8bd5\u53e5\u5b50",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1797,7 +1797,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "Today is a beautiful day 😇 with warm sunshine.",
+        "value": "Today is a beautiful day \ud83d\ude07 with warm sunshine.",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -2109,21 +2109,21 @@
       "id": "utf8.captureFree.multibyteEarly",
       "recipe": {
         "kind": "literal",
-        "text": "错误：请求失败"
+        "text": "\u9519\u8bef\uff1a\u8bf7\u6c42\u5931\u8d25"
       }
     },
     {
       "id": "utf8.captureFree.multibyteLate",
       "recipe": {
         "kind": "literal",
-        "text": "请求处理结束：错误"
+        "text": "\u8bf7\u6c42\u5904\u7406\u7ed3\u675f\uff1a\u9519\u8bef"
       }
     },
     {
       "id": "utf8.captureFree.multibyteNoMatch",
       "recipe": {
         "kind": "literal",
-        "text": "请求处理成功"
+        "text": "\u8bf7\u6c42\u5904\u7406\u6210\u529f"
       }
     },
     {
@@ -2137,7 +2137,7 @@
       "id": "utf8.repeatedFind.multibyte",
       "recipe": {
         "kind": "literal",
-        "text": "one café 東京 naïve"
+        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
       }
     },
     {
@@ -2151,7 +2151,7 @@
       "id": "utf8.captureBounds.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
@@ -2165,42 +2165,42 @@
       "id": "utf8.emptyMatch",
       "recipe": {
         "kind": "literal",
-        "text": "a💰有"
+        "text": "a\ud83d\udcb0\u6709"
       }
     },
     {
       "id": "utf8.window",
       "recipe": {
         "kind": "literal",
-        "text": "sentinel-before-city=東京&name=Renée-sentinel-after"
+        "text": "sentinel-before-city=\u6771\u4eac&name=Ren\u00e9e-sentinel-after"
       }
     },
     {
       "id": "utf8.construction",
       "recipe": {
         "kind": "literal",
-        "text": "one café 東京 naïve"
+        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
       }
     },
     {
       "id": "utf8.replacement.literal",
       "recipe": {
         "kind": "literal",
-        "text": "错误 then 错误"
+        "text": "\u9519\u8bef then \u9519\u8bef"
       }
     },
     {
       "id": "utf8.replacement.numbered",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
       "id": "utf8.replacement.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
@@ -2833,14 +2833,14 @@
       "operation": "replaceAll",
       "patterns": [
         {
-          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
+          "java": " ?[\\[\uff3b](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]\uff3d]",
           "alternates": {
             "rust-regex": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
               "reason": "Rust regex gives \\d Unicode semantics"
             },
             "dotnet": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
               "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
             }
           }
@@ -3705,7 +3705,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "realWorldRegex.cjkSearch.{matchLabel}.{size}"
@@ -3735,7 +3735,7 @@
       "operation": "find",
       "patterns": [
         {
-          "java": "[😀-😇]",
+          "java": "[\ud83d\ude00-\ud83d\ude07]",
           "alternates": {
             "dotnet": {
               "pattern": "\\uD83D[\\uDE00-\\uDE07]",
@@ -3771,7 +3771,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "\\s*[\\[［]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,、]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]］]"
+        "\\s*[\\[\uff3b]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,\u3001]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\uff3d]"
       ],
       "inputs": [
         "realWorldRegex.recitation.{matchLabel}.{size}"
@@ -4516,6 +4516,582 @@
         "searchScaling.success.1048576"
       ],
       "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.1024",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.1024",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.1024",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.1024",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.1024",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.1024",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.10240",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.10240",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.10240",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.10240",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.10240",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.10240",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.102400",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.102400",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.102400",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.102400",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.102400",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.102400",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.1048576",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.1048576",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",
@@ -7385,7 +7961,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteEarly",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -7404,7 +7980,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteLate",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -7423,7 +7999,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteNoMatch",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -7511,7 +8087,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -7534,7 +8110,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteLate",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -7557,7 +8133,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -7649,7 +8225,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -7672,7 +8248,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteLate",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -7695,7 +8271,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -7863,7 +8439,7 @@
       "id": "Utf8MatchingBenchmark.window",
       "operation": "findInWindow",
       "patterns": [
-        "東京"
+        "\u6771\u4eac"
       ],
       "inputs": [
         "utf8.window"
@@ -7946,7 +8522,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchBytes",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -8450,7 +9026,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchMatcher",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -8476,7 +9052,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchString",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -8660,7 +9236,7 @@
       "id": "ByteReplacementBenchmark.literal",
       "operation": "utf8Replacement",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.replacement.literal"
@@ -9973,6 +10549,294 @@
         }
       },
       "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -702,6 +702,8 @@
       "id": "searchScaling.random.{size}",
       "axes": {
         "size": [
+          64,
+          256,
           1024,
           10240,
           102400,
@@ -4516,6 +4518,42 @@
         "searchScaling.success.1048576"
       ],
       "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.64",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.64"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.256",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.256"
+      ],
+      "resultConsumption": "boolean",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -452,7 +452,7 @@
       "id": "vectorScan.multi.nonascii.32768",
       "recipe": {
         "kind": "repeatToLength",
-        "unit": "\u00e9",
+        "unit": "é",
         "length": 32768
       },
       "shared": true
@@ -1729,7 +1729,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "\u3044\u304f\u3064\u3082\u306e\u3000\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u3000\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u3000\u305d\u3057\u3066\u3000\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u3000\u304c\u3042\u308a\u307e\u3059",
+        "value": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1747,7 +1747,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "\u3044\u304f\u3064\u3082\u306e\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u305d\u3057\u3066\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u304c\u3042\u308a\u307e\u3059",
+        "value": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1765,7 +1765,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "\u8fd9\u662f\u4e00\u4e2a\u4e2d\u6587\u6d4b\u8bd5\u53e5\u5b50",
+        "value": "这是一个中文测试句子",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1801,7 +1801,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "Today is a beautiful day \ud83d\ude07 with warm sunshine.",
+        "value": "Today is a beautiful day 😇 with warm sunshine.",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -2113,21 +2113,21 @@
       "id": "utf8.captureFree.multibyteEarly",
       "recipe": {
         "kind": "literal",
-        "text": "\u9519\u8bef\uff1a\u8bf7\u6c42\u5931\u8d25"
+        "text": "错误：请求失败"
       }
     },
     {
       "id": "utf8.captureFree.multibyteLate",
       "recipe": {
         "kind": "literal",
-        "text": "\u8bf7\u6c42\u5904\u7406\u7ed3\u675f\uff1a\u9519\u8bef"
+        "text": "请求处理结束：错误"
       }
     },
     {
       "id": "utf8.captureFree.multibyteNoMatch",
       "recipe": {
         "kind": "literal",
-        "text": "\u8bf7\u6c42\u5904\u7406\u6210\u529f"
+        "text": "请求处理成功"
       }
     },
     {
@@ -2141,7 +2141,7 @@
       "id": "utf8.repeatedFind.multibyte",
       "recipe": {
         "kind": "literal",
-        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
+        "text": "one café 東京 naïve"
       }
     },
     {
@@ -2155,7 +2155,7 @@
       "id": "utf8.captureBounds.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
+        "text": "city=東京&name=Renée"
       }
     },
     {
@@ -2169,42 +2169,42 @@
       "id": "utf8.emptyMatch",
       "recipe": {
         "kind": "literal",
-        "text": "a\ud83d\udcb0\u6709"
+        "text": "a💰有"
       }
     },
     {
       "id": "utf8.window",
       "recipe": {
         "kind": "literal",
-        "text": "sentinel-before-city=\u6771\u4eac&name=Ren\u00e9e-sentinel-after"
+        "text": "sentinel-before-city=東京&name=Renée-sentinel-after"
       }
     },
     {
       "id": "utf8.construction",
       "recipe": {
         "kind": "literal",
-        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
+        "text": "one café 東京 naïve"
       }
     },
     {
       "id": "utf8.replacement.literal",
       "recipe": {
         "kind": "literal",
-        "text": "\u9519\u8bef then \u9519\u8bef"
+        "text": "错误 then 错误"
       }
     },
     {
       "id": "utf8.replacement.numbered",
       "recipe": {
         "kind": "literal",
-        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
+        "text": "city=東京&name=Renée"
       }
     },
     {
       "id": "utf8.replacement.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
+        "text": "city=東京&name=Renée"
       }
     },
     {
@@ -2837,14 +2837,14 @@
       "operation": "replaceAll",
       "patterns": [
         {
-          "java": " ?[\\[\uff3b](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]\uff3d]",
+          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
           "alternates": {
             "rust-regex": {
-              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
               "reason": "Rust regex gives \\d Unicode semantics"
             },
             "dotnet": {
-              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
               "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
             }
           }
@@ -3709,7 +3709,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "realWorldRegex.cjkSearch.{matchLabel}.{size}"
@@ -3739,7 +3739,7 @@
       "operation": "find",
       "patterns": [
         {
-          "java": "[\ud83d\ude00-\ud83d\ude07]",
+          "java": "[😀-😇]",
           "alternates": {
             "dotnet": {
               "pattern": "\\uD83D[\\uDE00-\\uDE07]",
@@ -3775,7 +3775,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "\\s*[\\[\uff3b]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,\u3001]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\uff3d]"
+        "\\s*[\\[［]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,、]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]］]"
       ],
       "inputs": [
         "realWorldRegex.recitation.{matchLabel}.{size}"
@@ -8109,7 +8109,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteEarly",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8128,7 +8128,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteLate",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8147,7 +8147,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteNoMatch",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8235,7 +8235,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8258,7 +8258,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteLate",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8281,7 +8281,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8373,7 +8373,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8396,7 +8396,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteLate",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8419,7 +8419,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8587,7 +8587,7 @@
       "id": "Utf8MatchingBenchmark.window",
       "operation": "findInWindow",
       "patterns": [
-        "\u6771\u4eac"
+        "東京"
       ],
       "inputs": [
         "utf8.window"
@@ -8670,7 +8670,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchBytes",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9174,7 +9174,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchMatcher",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9200,7 +9200,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchString",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9384,7 +9384,7 @@
       "id": "ByteReplacementBenchmark.literal",
       "operation": "utf8Replacement",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.replacement.literal"

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(591);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(639);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_910);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_390);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -175,12 +175,13 @@ class BenchmarkInputMaterializerTest {
     assertThat(
             executionEntry(
                     executionPlan,
-                    "UnicodeCompileBenchmark.compile.word."
-                        + "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS@dotnet_nonbacktracking")
-                .getAsJsonArray("patterns")
-                .get(0)
+                    "RealWorldRegexBenchmark.runBenchmark.fruitSearchQuery.match.1000@dotnet_nonbacktracking")
+                .get("exclusion")
+                .getAsJsonObject()
+                .get("kind")
                 .getAsString())
-        .isEqualTo("\\w+");
+        .isEqualTo("unsupportedSyntax");
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(328);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -192,7 +193,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(591);
+          .hasSize(639);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(386);
+    assertThat(first).hasSize(388);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(639);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(641);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_390);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_410);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -181,7 +181,7 @@ class BenchmarkInputMaterializerTest {
                 .get("kind")
                 .getAsString())
         .isEqualTo("unsupportedSyntax");
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(328);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(330);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -193,7 +193,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(639);
+          .hasSize(641);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(388);
+    assertThat(first).hasSize(390);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(645);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(647);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_450);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_470);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -181,7 +181,7 @@ class BenchmarkInputMaterializerTest {
                 .get("kind")
                 .getAsString())
         .isEqualTo("unsupportedSyntax");
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(334);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(336);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -193,7 +193,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(645);
+          .hasSize(647);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(568);
+    assertThat(ids).hasSize(570);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2124);
+    assertThat(allTrials).hasSize(2134);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(568 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(570 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1474);
+        .hasSize(1484);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2163);
-    assertThat(plan.reportPlan().trials()).hasSize(2163);
+        .hasSize(2173);
+    assertThat(plan.reportPlan().trials()).hasSize(2173);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(514);
+    assertThat(ids).hasSize(562);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1854);
+    assertThat(allTrials).hasSize(2094);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(514 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(562 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1204);
+        .hasSize(1444);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1893);
-    assertThat(plan.reportPlan().trials()).hasSize(1893);
+        .hasSize(2133);
+    assertThat(plan.reportPlan().trials()).hasSize(2133);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(562);
+    assertThat(ids).hasSize(564);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2094);
+    assertThat(allTrials).hasSize(2104);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(562 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(564 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1444);
+        .hasSize(1454);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2133);
-    assertThat(plan.reportPlan().trials()).hasSize(2133);
+        .hasSize(2143);
+    assertThat(plan.reportPlan().trials()).hasSize(2143);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -120,6 +120,7 @@
                         <exclude name="MatcherDeferredCaptureStateTest.java"/>
                         <exclude name="MatcherTransitionInventoryTest.java"/>
                         <exclude name="MatchDescriptorTest.java"/>
+                        <exclude name="MultiLiteralTest.java"/>
                         <exclude name="NfaTest.java"/>
                         <exclude name="OnePassTest.java"/>
                         <exclude name="OnePassThresholdTest.java"/>

--- a/safere/src/main/java/org/safere/AcceleratorPolicy.java
+++ b/safere/src/main/java/org/safere/AcceleratorPolicy.java
@@ -39,6 +39,10 @@ record AcceleratorPolicy(
   /** Policy for line anchor ('^', '$') boundary acceleration. */
   static final AcceleratorPolicy LINE_ANCHOR = new AcceleratorPolicy(16, 3, false, null);
 
+  /** Policy for vectorized multi-literal and Teddy multi-keyword scans. */
+  static final AcceleratorPolicy VECTOR_MULTI_LITERAL =
+      new AcceleratorPolicy(64, 4, true, MatchStrategy.LITERAL);
+
   /** Default fallback policy for generic or composite accelerators. */
   static final AcceleratorPolicy DEFAULT = new AcceleratorPolicy(32, 3, false, null);
 }

--- a/safere/src/main/java/org/safere/Ascii.java
+++ b/safere/src/main/java/org/safere/Ascii.java
@@ -223,4 +223,14 @@ final class Ascii {
     }
     return true;
   }
+
+  /** Returns whether a byte array matches a pattern prefix exactly. */
+  static boolean regionMatches(byte[] bytes, int offset, String prefix, int prefixLen) {
+    for (int i = 0; i < prefixLen; i++) {
+      if ((bytes[offset + i] & 0xFF) != prefix.charAt(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -172,5 +172,81 @@ final class ByteVectorScan {
     return -1;
   }
 
+  static int indexOfMultiLiteral(
+      byte[] bytes,
+      int offset,
+      int length,
+      String[] literals,
+      char[] anchorChars,
+      int[] anchorOffsets,
+      int minLength,
+      int start) {
+    int numLits = literals.length;
+    if (numLits == 0 || length < minLength) {
+      return -1;
+    }
+    int pos = Math.max(0, start);
+    int vectorLen = SPECIES.length();
+    int limit = length - vectorLen;
+
+    ByteVector v0 = ByteVector.broadcast(SPECIES, (byte) anchorChars[0]);
+    ByteVector v1 = numLits >= 2 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[1]) : null;
+    ByteVector v2 = numLits >= 3 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[2]) : null;
+    ByteVector v3 = numLits >= 4 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[3]) : null;
+    ByteVector v4 = numLits >= 5 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[4]) : null;
+    ByteVector v5 = numLits >= 6 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[5]) : null;
+
+    for (; pos <= limit; pos += vectorLen) {
+      ByteVector inputVec = ByteVector.fromArray(SPECIES, bytes, offset + pos);
+      VectorMask<Byte> matchMask = inputVec.compare(EQ, v0);
+      if (numLits >= 2) {
+        matchMask = matchMask.or(inputVec.compare(EQ, v1));
+      }
+      if (numLits >= 3) {
+        matchMask = matchMask.or(inputVec.compare(EQ, v2));
+      }
+      if (numLits >= 4) {
+        matchMask = matchMask.or(inputVec.compare(EQ, v3));
+      }
+      if (numLits >= 5) {
+        matchMask = matchMask.or(inputVec.compare(EQ, v4));
+      }
+      if (numLits >= 6) {
+        matchMask = matchMask.or(inputVec.compare(EQ, v5));
+      }
+
+      if (matchMask.anyTrue()) {
+        long activeLanes = matchMask.toLong();
+        while (activeLanes != 0) {
+          int bit = Long.numberOfTrailingZeros(activeLanes);
+          int matchIndex = pos + bit;
+          for (int i = 0; i < numLits; i++) {
+            int candidatePos = matchIndex - anchorOffsets[i];
+            String lit = literals[i];
+            if (candidatePos >= start
+                && candidatePos + lit.length() <= length
+                && (bytes[offset + matchIndex] & 0xFF) == (anchorChars[i] & 0xFF)
+                && Ascii.regionMatches(bytes, offset + candidatePos, lit, lit.length())) {
+              return candidatePos;
+            }
+          }
+          activeLanes &= activeLanes - 1;
+        }
+      }
+    }
+
+    int scalarLimit = length - minLength;
+    for (; pos <= scalarLimit; pos++) {
+      for (int i = 0; i < numLits; i++) {
+        String lit = literals[i];
+        if (pos + lit.length() <= length
+            && Ascii.regionMatches(bytes, offset + pos, lit, lit.length())) {
+          return pos;
+        }
+      }
+    }
+    return -1;
+  }
+
   private ByteVectorScan() {}
 }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -247,6 +247,30 @@ final class ByteVectorScan {
       int[] anchorRanges,
       int minLength,
       int start) {
+    return indexOfMultiLiteral(
+        bytes,
+        offset,
+        length,
+        literals,
+        anchorChars,
+        anchorOffsets,
+        anchorRanges,
+        minLength,
+        null,
+        start);
+  }
+
+  static int indexOfMultiLiteral(
+      byte[] bytes,
+      int offset,
+      int length,
+      String[] literals,
+      char[] anchorChars,
+      int[] anchorOffsets,
+      int[] anchorRanges,
+      int minLength,
+      TeddyModel teddyModel,
+      int start) {
     int numLits = literals.length;
     if (numLits == 0 || length < minLength) {
       return -1;
@@ -254,12 +278,22 @@ final class ByteVectorScan {
     int pos = Math.max(0, start);
     long verificationWork = 0;
     long workLimit = WorkLimit.forRemaining(length - pos);
+    int observedBytes = 0;
+    long estimatedVerificationBytes = 0;
     int vectorLen = SPECIES.length();
     int limit = length - vectorLen;
 
     for (; pos <= limit; pos += vectorLen) {
       ByteVector inputVec = ByteVector.fromArray(SPECIES, bytes, offset + pos);
       VectorMask<Byte> matchMask = matches(inputVec, anchorRanges);
+
+      if (teddyModel != null && MultiLiteralSelectionPolicy.shouldObserve(observedBytes)) {
+        observedBytes += vectorLen;
+        estimatedVerificationBytes += (long) matchMask.trueCount() * minLength;
+        if (MultiLiteralSelectionPolicy.prefersTeddy(estimatedVerificationBytes, observedBytes)) {
+          return TeddyVectorScan.indexOfTeddyUtf8(bytes, offset, length, teddyModel, pos);
+        }
+      }
 
       if (matchMask.anyTrue()) {
         long activeLanes = matchMask.toLong();

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -244,6 +244,7 @@ final class ByteVectorScan {
       String[] literals,
       char[] anchorChars,
       int[] anchorOffsets,
+      int[] anchorRanges,
       int minLength,
       int start) {
     int numLits = literals.length;
@@ -256,23 +257,9 @@ final class ByteVectorScan {
     int vectorLen = SPECIES.length();
     int limit = length - vectorLen;
 
-    ByteVector v0 = ByteVector.broadcast(SPECIES, (byte) anchorChars[0]);
-    ByteVector v1 = numLits >= 2 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[1]) : null;
-    ByteVector v2 = numLits >= 3 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[2]) : null;
-    ByteVector v3 = numLits >= 4 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[3]) : null;
-
     for (; pos <= limit; pos += vectorLen) {
       ByteVector inputVec = ByteVector.fromArray(SPECIES, bytes, offset + pos);
-      VectorMask<Byte> matchMask = inputVec.compare(EQ, v0);
-      if (numLits >= 2) {
-        matchMask = matchMask.or(inputVec.compare(EQ, v1));
-      }
-      if (numLits >= 3) {
-        matchMask = matchMask.or(inputVec.compare(EQ, v2));
-      }
-      if (numLits >= 4) {
-        matchMask = matchMask.or(inputVec.compare(EQ, v3));
-      }
+      VectorMask<Byte> matchMask = matches(inputVec, anchorRanges);
 
       if (matchMask.anyTrue()) {
         long activeLanes = matchMask.toLong();
@@ -301,9 +288,11 @@ final class ByteVectorScan {
 
     int scalarLimit = length - minLength;
     for (; pos <= scalarLimit; pos++) {
+      int value = bytes[offset + pos] & 0xFF;
       for (int i = 0; i < numLits; i++) {
         String lit = literals[i];
-        if (pos + lit.length() <= length
+        if (value == anchorChars[i]
+            && pos + lit.length() <= length
             && Ascii.regionMatches(bytes, offset + pos, lit, lit.length())) {
           return pos;
         }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -306,6 +306,9 @@ final class ByteVectorScan {
             if (candidatePos >= start
                 && candidatePos + lit.length() <= length
                 && (bytes[offset + matchIndex] & 0xFF) == (anchorChars[i] & 0xFF)) {
+              if (WorkCounterConfig.ENABLED) {
+                WorkCounter.record(lit.length());
+              }
               if (Ascii.regionMatches(bytes, offset + candidatePos, lit, lit.length())) {
                 return candidatePos;
               }
@@ -325,10 +328,13 @@ final class ByteVectorScan {
       int value = bytes[offset + pos] & 0xFF;
       for (int i = 0; i < numLits; i++) {
         String lit = literals[i];
-        if (value == anchorChars[i]
-            && pos + lit.length() <= length
-            && Ascii.regionMatches(bytes, offset + pos, lit, lit.length())) {
-          return pos;
+        if (value == anchorChars[i] && pos + lit.length() <= length) {
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record(lit.length());
+          }
+          if (Ascii.regionMatches(bytes, offset + pos, lit, lit.length())) {
+            return pos;
+          }
         }
       }
       verificationWork += minLength;

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -193,8 +193,6 @@ final class ByteVectorScan {
     ByteVector v1 = numLits >= 2 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[1]) : null;
     ByteVector v2 = numLits >= 3 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[2]) : null;
     ByteVector v3 = numLits >= 4 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[3]) : null;
-    ByteVector v4 = numLits >= 5 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[4]) : null;
-    ByteVector v5 = numLits >= 6 ? ByteVector.broadcast(SPECIES, (byte) anchorChars[5]) : null;
 
     for (; pos <= limit; pos += vectorLen) {
       ByteVector inputVec = ByteVector.fromArray(SPECIES, bytes, offset + pos);
@@ -207,12 +205,6 @@ final class ByteVectorScan {
       }
       if (numLits >= 4) {
         matchMask = matchMask.or(inputVec.compare(EQ, v3));
-      }
-      if (numLits >= 5) {
-        matchMask = matchMask.or(inputVec.compare(EQ, v4));
-      }
-      if (numLits >= 6) {
-        matchMask = matchMask.or(inputVec.compare(EQ, v5));
       }
 
       if (matchMask.anyTrue()) {

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -73,9 +73,18 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
       String[] literals,
       char[] anchorChars,
       int[] anchorOffsets,
+      int[] anchorRanges,
       int minLength,
       int start) {
     return ByteVectorScan.indexOfMultiLiteral(
-        bytes, offset, length, literals, anchorChars, anchorOffsets, minLength, start);
+        bytes,
+        offset,
+        length,
+        literals,
+        anchorChars,
+        anchorOffsets,
+        anchorRanges,
+        minLength,
+        start);
   }
 }

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -7,11 +7,17 @@ package org.safere;
 
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
-  private static final int MINIMUM_INPUT_LENGTH = 64;
+  private static final int MINIMUM_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_MULTI_LITERAL_INPUT_LENGTH = 64;
 
   @Override
   public int minimumInputLength() {
     return MINIMUM_INPUT_LENGTH;
+  }
+
+  @Override
+  public int minimumMultiLiteralInputLength() {
+    return MINIMUM_MULTI_LITERAL_INPUT_LENGTH;
   }
 
   @Override

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -48,7 +48,7 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
 
   @Override
   public int indexOfTeddy(byte[] bytes, int offset, int length, TeddyModel model, int start) {
-    return TeddyVectorScan.indexOfTeddy(bytes, offset, length, model, start);
+    return TeddyVectorScan.indexOfTeddyUtf8(bytes, offset, length, model, start);
   }
 
   @Override

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -7,7 +7,7 @@ package org.safere;
 
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
-  private static final int MINIMUM_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_INPUT_LENGTH = 64;
 
   @Override
   public int minimumInputLength() {
@@ -17,5 +17,19 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
     return ByteVectorScan.indexOfAsciiClass(bytes, offset, length, ranges, start);
+  }
+
+  @Override
+  public int indexOfMultiLiteral(
+      byte[] bytes,
+      int offset,
+      int length,
+      String[] literals,
+      char[] anchorChars,
+      int[] anchorOffsets,
+      int minLength,
+      int start) {
+    return ByteVectorScan.indexOfMultiLiteral(
+        bytes, offset, length, literals, anchorChars, anchorOffsets, minLength, start);
   }
 }

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -75,6 +75,7 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
       int[] anchorOffsets,
       int[] anchorRanges,
       int minLength,
+      TeddyModel teddyModel,
       int start) {
     return ByteVectorScan.indexOfMultiLiteral(
         bytes,
@@ -85,6 +86,7 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
         anchorOffsets,
         anchorRanges,
         minLength,
+        teddyModel,
         start);
   }
 }

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -9,8 +9,11 @@ import java.io.Serializable;
 import java.util.Arrays;
 
 /**
- * Metadata for small multi-literal alternation acceleration (2 &le; N &le; 4) using
- * rarest-character multi-vector SIMD matching.
+ * Metadata for small multi-literal alternation acceleration (2 &le; N &le; 4) using multi-vector
+ * SIMD matching on initial prefix characters.
+ *
+ * <p>All literals anchor on their first character (offset 0) to strictly preserve leftmost-first
+ * matching semantics during left-to-right vector scanning.
  *
  * <p>The upper bound of 4 literals is chosen based on empirical vector performance and hardware
  * constraints:
@@ -49,9 +52,8 @@ record MultiLiteralInfo(String[] literals, char[] anchorChars, int[] anchorOffse
           return null;
         }
       }
-      int offset = RarityOracle.rarestAsciiOffset(lit, lit.length());
-      anchorOffsets[i] = offset;
-      anchorChars[i] = lit.charAt(offset);
+      anchorOffsets[i] = 0;
+      anchorChars[i] = lit.charAt(0);
       minLen = Math.min(minLen, lit.length());
     }
 

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -16,10 +16,10 @@ import java.util.Arrays;
  * constraints:
  *
  * <ul>
- *   <li><b>Register allocation & unrolling:</b> AVX2 provides 16 YMM vector registers. 2–4 literals
- *       require 2–4 broadcast registers plus input and comparison masks (6 registers total),
- *       leaving 10+ free YMM registers for HotSpot C2 to unroll the vector loop across 64–128 byte
- *       strides without stack spilling.
+ *   <li><b>Register allocation &amp; unrolling:</b> AVX2 provides 16 YMM vector registers. 2–4
+ *       literals require 2–4 broadcast registers plus input and comparison masks (6 registers
+ *       total), leaving 10+ free YMM registers for HotSpot C2 to unroll the vector loop across
+ *       64–128 byte strides without stack spilling.
  *   <li><b>Candidate false-positive density:</b> For 2–4 literals, the probability of
  *       false-positive candidate hits remains low (&lt; 5% in natural text), allowing the scanner
  *       to stay on the fast SIMD path &gt; 95% of the time and delivering 4x–11x speedups. Beyond 4

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -25,9 +25,9 @@ import java.util.Arrays;
  *       64–128 byte strides without stack spilling.
  *   <li><b>Candidate false-positive density:</b> For 2–4 literals with distinct prefixes, the
  *       probability of false-positive candidate hits remains low (&lt; 5% in natural text),
- *       allowing the scanner to stay on the fast SIMD path &gt; 95% of the time. When literals share
- *       common prefixes or exceed 4 keywords, dedicated multi-pattern algorithms (such as Teddy
- *       with 4-bit nibble bucket hashing) are used instead.
+ *       allowing the scanner to stay on the fast SIMD path &gt; 95% of the time. When literals
+ *       share common prefixes or exceed 4 keywords, dedicated multi-pattern algorithms (such as
+ *       Teddy with 4-bit nibble bucket hashing) are used instead.
  * </ul>
  */
 @SuppressWarnings("ArrayRecordComponent")

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -1,0 +1,53 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Metadata for small multi-literal alternation acceleration (2 &le; N &le; 6) using
+ * rarest-character multi-vector SIMD matching.
+ */
+@SuppressWarnings("ArrayRecordComponent")
+record MultiLiteralInfo(
+    String[] literals,
+    char[] anchorChars,
+    int[] anchorOffsets,
+    int minLength)
+    implements Serializable {
+
+  static MultiLiteralInfo create(String[] literals) {
+    if (literals == null || literals.length < 2 || literals.length > 6) {
+      return null;
+    }
+    int minLen = Integer.MAX_VALUE;
+    char[] anchorChars = new char[literals.length];
+    int[] anchorOffsets = new int[literals.length];
+
+    for (int i = 0; i < literals.length; i++) {
+      String lit = literals[i];
+      if (lit == null || lit.isEmpty()) {
+        return null;
+      }
+      for (int j = 0; j < lit.length(); j++) {
+        if (lit.charAt(j) > 127) {
+          return null;
+        }
+      }
+      int offset = RarityOracle.rarestAsciiOffset(lit, lit.length());
+      anchorOffsets[i] = offset;
+      anchorChars[i] = lit.charAt(offset);
+      minLen = Math.min(minLen, lit.length());
+    }
+
+    return new MultiLiteralInfo(
+        Arrays.copyOf(literals, literals.length),
+        anchorChars,
+        anchorOffsets,
+        minLen);
+  }
+}

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -9,8 +9,22 @@ import java.io.Serializable;
 import java.util.Arrays;
 
 /**
- * Metadata for small multi-literal alternation acceleration (2 &le; N &le; 6) using
+ * Metadata for small multi-literal alternation acceleration (2 &le; N &le; 4) using
  * rarest-character multi-vector SIMD matching.
+ *
+ * <p>The upper bound of 4 literals is chosen based on empirical vector performance and hardware
+ * constraints:
+ * <ul>
+ *   <li><b>Register allocation & unrolling:</b> AVX2 provides 16 YMM vector registers. 2–4 literals
+ *       require 2–4 broadcast registers plus input and comparison masks (6 registers total), leaving
+ *       10+ free YMM registers for HotSpot C2 to unroll the vector loop across 64–128 byte strides
+ *       without stack spilling.
+ *   <li><b>Candidate false-positive density:</b> For 2–4 literals, the probability of false-positive
+ *       candidate hits remains low (&lt; 5% in natural text), allowing the scanner to stay on the fast
+ *       SIMD path &gt; 95% of the time and delivering 4x–11x speedups. Beyond 4 literals, candidate
+ *       density increases and dedicated multi-pattern algorithms (such as Teddy with 4-bit nibble
+ *       bucket hashing) are more efficient.
+ * </ul>
  */
 @SuppressWarnings("ArrayRecordComponent")
 record MultiLiteralInfo(
@@ -21,7 +35,7 @@ record MultiLiteralInfo(
     implements Serializable {
 
   static MultiLiteralInfo create(String[] literals) {
-    if (literals == null || literals.length < 2 || literals.length > 6) {
+    if (literals == null || literals.length < 2 || literals.length > 4) {
       return null;
     }
     int minLen = Integer.MAX_VALUE;

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -30,8 +30,10 @@ import java.util.Arrays;
  *       Teddy with 4-bit nibble bucket hashing) are used instead.
  * </ul>
  */
+// The arrays are immutable, privately owned scanner metadata; array identity is never observed.
 @SuppressWarnings("ArrayRecordComponent")
-record MultiLiteralInfo(String[] literals, char[] anchorChars, int[] anchorOffsets, int minLength)
+record MultiLiteralInfo(
+    String[] literals, char[] anchorChars, int[] anchorOffsets, int[] anchorRanges, int minLength)
     implements Serializable {
 
   static MultiLiteralInfo create(String[] literals) {
@@ -43,6 +45,7 @@ record MultiLiteralInfo(String[] literals, char[] anchorChars, int[] anchorOffse
     int[] anchorOffsets = new int[literals.length];
     long seen0 = 0L;
     long seen1 = 0L;
+    AsciiBitmap.Builder anchorBitmap = new AsciiBitmap.Builder();
 
     for (int i = 0; i < literals.length; i++) {
       String lit = literals[i];
@@ -69,10 +72,15 @@ record MultiLiteralInfo(String[] literals, char[] anchorChars, int[] anchorOffse
       }
       anchorOffsets[i] = 0;
       anchorChars[i] = firstChar;
+      anchorBitmap.add(anchorChars[i]);
       minLen = Math.min(minLen, lit.length());
     }
 
     return new MultiLiteralInfo(
-        Arrays.copyOf(literals, literals.length), anchorChars, anchorOffsets, minLen);
+        Arrays.copyOf(literals, literals.length),
+        anchorChars,
+        anchorOffsets,
+        anchorBitmap.build().toRanges(),
+        minLen);
   }
 }

--- a/safere/src/main/java/org/safere/MultiLiteralInfo.java
+++ b/safere/src/main/java/org/safere/MultiLiteralInfo.java
@@ -14,24 +14,21 @@ import java.util.Arrays;
  *
  * <p>The upper bound of 4 literals is chosen based on empirical vector performance and hardware
  * constraints:
+ *
  * <ul>
  *   <li><b>Register allocation & unrolling:</b> AVX2 provides 16 YMM vector registers. 2–4 literals
- *       require 2–4 broadcast registers plus input and comparison masks (6 registers total), leaving
- *       10+ free YMM registers for HotSpot C2 to unroll the vector loop across 64–128 byte strides
- *       without stack spilling.
- *   <li><b>Candidate false-positive density:</b> For 2–4 literals, the probability of false-positive
- *       candidate hits remains low (&lt; 5% in natural text), allowing the scanner to stay on the fast
- *       SIMD path &gt; 95% of the time and delivering 4x–11x speedups. Beyond 4 literals, candidate
- *       density increases and dedicated multi-pattern algorithms (such as Teddy with 4-bit nibble
- *       bucket hashing) are more efficient.
+ *       require 2–4 broadcast registers plus input and comparison masks (6 registers total),
+ *       leaving 10+ free YMM registers for HotSpot C2 to unroll the vector loop across 64–128 byte
+ *       strides without stack spilling.
+ *   <li><b>Candidate false-positive density:</b> For 2–4 literals, the probability of
+ *       false-positive candidate hits remains low (&lt; 5% in natural text), allowing the scanner
+ *       to stay on the fast SIMD path &gt; 95% of the time and delivering 4x–11x speedups. Beyond 4
+ *       literals, candidate density increases and dedicated multi-pattern algorithms (such as Teddy
+ *       with 4-bit nibble bucket hashing) are more efficient.
  * </ul>
  */
 @SuppressWarnings("ArrayRecordComponent")
-record MultiLiteralInfo(
-    String[] literals,
-    char[] anchorChars,
-    int[] anchorOffsets,
-    int minLength)
+record MultiLiteralInfo(String[] literals, char[] anchorChars, int[] anchorOffsets, int minLength)
     implements Serializable {
 
   static MultiLiteralInfo create(String[] literals) {
@@ -59,9 +56,6 @@ record MultiLiteralInfo(
     }
 
     return new MultiLiteralInfo(
-        Arrays.copyOf(literals, literals.length),
-        anchorChars,
-        anchorOffsets,
-        minLen);
+        Arrays.copyOf(literals, literals.length), anchorChars, anchorOffsets, minLen);
   }
 }

--- a/safere/src/main/java/org/safere/MultiLiteralSelectionPolicy.java
+++ b/safere/src/main/java/org/safere/MultiLiteralSelectionPolicy.java
@@ -1,0 +1,33 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+/** Chooses between the low-overhead multi-broadcast scanner and Teddy. */
+final class MultiLiteralSelectionPolicy {
+  /**
+   * Limit adaptation to a small prefix so its bookkeeping does not become steady-state overhead.
+   */
+  private static final int OBSERVATION_BYTES = 256;
+
+  /**
+   * Prefer Teddy when estimated full-literal verification consumes at least half as much work as
+   * scanning the observed bytes. This crossover is benchmark-tuned: multi-broadcast wins on sparse
+   * candidates, while Teddy's extra filtering wins once candidate verification becomes this
+   * frequent.
+   */
+  private static final int TEDDY_CROSSOVER_PERCENT = 50;
+
+  static boolean shouldObserve(int observedBytes) {
+    return observedBytes < OBSERVATION_BYTES;
+  }
+
+  static boolean prefersTeddy(long estimatedVerificationBytes, int observedBytes) {
+    return observedBytes > 0
+        && estimatedVerificationBytes * 100 >= (long) observedBytes * TEDDY_CROSSOVER_PERCENT;
+  }
+
+  private MultiLiteralSelectionPolicy() {}
+}

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -140,6 +140,7 @@ public final class Pattern implements Serializable {
   private final transient AsciiBitmap charClassPrefixAscii;
   private final transient AsciiBitmap anchoredCharClassPrefixAscii;
   private final transient FixedOffsetLiteral fixedOffsetLiteral;
+  private final transient MultiLiteralInfo multiLiteral;
   private final transient Utf8StartAccelerator utf8StartAccelerator;
   private final transient StringStartAccelerator stringStartAccelerator;
   private final transient EnginePathOptions enginePathOptions;
@@ -314,6 +315,7 @@ public final class Pattern implements Serializable {
     this.charClassPrefixAscii = startDescriptor.charClassPrefixAscii();
     this.anchoredCharClassPrefixAscii = startDescriptor.anchoredCharClassPrefixAscii();
     this.fixedOffsetLiteral = startDescriptor.fixedOffsetLiteral();
+    this.multiLiteral = startDescriptor.multiLiteral();
     this.utf8StartAccelerator =
         Utf8StartAccelerator.create(startDescriptor, prog.hasWordBoundary());
     this.stringStartAccelerator =
@@ -484,8 +486,13 @@ public final class Pattern implements Serializable {
     FixedOffsetLiteral fixedOffsetLiteral =
         prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
     AsciiBitmap ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
+    String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
+    MultiLiteralInfo multiLiteral =
+        altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 6
+            ? MultiLiteralInfo.create(altLiterals)
+            : null;
     StartAcceleration startAcceleration =
-        (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null)
+        (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null && multiLiteral == null)
             ? extractStartAcceleration(metadataAst)
             : null;
     Regexp anchoredCandidate = firstPrefixCandidateAfterTextAnchor(metadataAst);
@@ -501,6 +508,7 @@ public final class Pattern implements Serializable {
     if (prefix == null
         && fixedOffsetLiteral == null
         && ccPrefixAscii == null
+        && multiLiteral == null
         && startAcceleration == null
         && anchoredPrefix == null
         && anchoredCharClassPrefixAscii == null) {
@@ -513,7 +521,8 @@ public final class Pattern implements Serializable {
         ccPrefixAscii,
         startAcceleration,
         anchoredPrefix,
-        anchoredCharClassPrefixAscii);
+        anchoredCharClassPrefixAscii,
+        multiLiteral);
   }
 
   /**
@@ -1341,6 +1350,11 @@ public final class Pattern implements Serializable {
   /** Returns a mandatory ASCII literal at a fixed offset from the match start, or {@code null}. */
   FixedOffsetLiteral fixedOffsetLiteral() {
     return fixedOffsetLiteral;
+  }
+
+  /** Returns metadata for 2-6 keyword literal alternation acceleration, or {@code null}. */
+  MultiLiteralInfo multiLiteral() {
+    return multiLiteral;
   }
 
   /** Returns the compiled UTF-8 start-position accelerator strategy, or {@code null}. */
@@ -2267,7 +2281,7 @@ public final class Pattern implements Serializable {
 
   /** Finds the longest case-sensitive ASCII literal after a bounded-width match prefix. */
   private static FixedOffsetLiteral extractFixedOffsetLiteral(Regexp re) {
-    Regexp node = unwrapFixedOffsetNode(re);
+    Regexp node = unwrapCaptures(re);
     if (node.op != RegexpOp.CONCAT || node.subs == null) {
       return null;
     }
@@ -2276,12 +2290,12 @@ public final class Pattern implements Serializable {
     AsciiWidthRange prefixWidth = AsciiWidthRange.ZERO;
 
     for (int index = 0; index < node.subs.size(); ) {
-      String literalPart = fixedOffsetAsciiLiteral(node.subs.get(index));
+      String literalPart = extractExactAsciiLiteral(node.subs.get(index));
       if (literalPart != null) {
         StringBuilder literal = new StringBuilder(literalPart);
         int next = index + 1;
         while (next < node.subs.size()) {
-          String nextPart = fixedOffsetAsciiLiteral(node.subs.get(next));
+          String nextPart = extractExactAsciiLiteral(node.subs.get(next));
           if (nextPart == null) {
             break;
           }
@@ -2320,21 +2334,16 @@ public final class Pattern implements Serializable {
     return best;
   }
 
-  private static Regexp unwrapFixedOffsetNode(Regexp re) {
-    Regexp node = re;
-    while (node.op == RegexpOp.CAPTURE || node.op == RegexpOp.NON_CAPTURE) {
-      node = node.sub();
+  private static String extractExactAsciiLiteral(Regexp re) {
+    if (re == null) {
+      return null;
     }
-    return node;
-  }
-
-  private static String fixedOffsetAsciiLiteral(Regexp re) {
     StringBuilder literal = new StringBuilder();
     Deque<Regexp> pending = new ArrayDeque<>();
     pending.push(re);
     while (!pending.isEmpty()) {
-      Regexp node = unwrapFixedOffsetNode(pending.pop());
-      if ((node.flags & ParseFlags.FOLD_CASE) != 0) {
+      Regexp node = unwrapCaptures(pending.pop());
+      if (node == null || (node.flags & ParseFlags.FOLD_CASE) != 0) {
         return null;
       }
       if (node.op == RegexpOp.LITERAL && node.rune >= 0 && node.rune < 128) {
@@ -2774,6 +2783,25 @@ public final class Pattern implements Serializable {
       bitmap.addRange(cc.lo(i), cc.hi(i));
     }
     return true;
+  }
+
+  private static String[] extractLiteralAlternation(Regexp re) {
+    if (re == null) {
+      return null;
+    }
+    re = unwrapCaptures(re);
+    if (re == null || re.op != RegexpOp.ALTERNATE || re.nsub() < 2) {
+      return null;
+    }
+    String[] literals = new String[re.nsub()];
+    for (int i = 0; i < re.nsub(); i++) {
+      String lit = extractExactAsciiLiteral(re.subs.get(i));
+      if (lit == null || lit.isEmpty()) {
+        return null;
+      }
+      literals[i] = lit;
+    }
+    return literals;
   }
 
   private static StartAcceleration extractStartAcceleration(Regexp re) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -492,7 +492,10 @@ public final class Pattern implements Serializable {
             ? MultiLiteralInfo.create(altLiterals)
             : null;
     StartAcceleration startAcceleration =
-        (prefix == null && ccPrefixAscii == null && fixedOffsetLiteral == null && multiLiteral == null)
+        (prefix == null
+                && ccPrefixAscii == null
+                && fixedOffsetLiteral == null
+                && multiLiteral == null)
             ? extractStartAcceleration(metadataAst)
             : null;
     Regexp anchoredCandidate = firstPrefixCandidateAfterTextAnchor(metadataAst);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -488,7 +488,7 @@ public final class Pattern implements Serializable {
     AsciiBitmap ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
     MultiLiteralInfo multiLiteral =
-        altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 6
+        altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 4
             ? MultiLiteralInfo.create(altLiterals)
             : null;
     StartAcceleration startAcceleration =

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -488,7 +488,10 @@ public final class Pattern implements Serializable {
     AsciiBitmap ccPrefixAscii = (prefix == null) ? extractCharClassPrefixAscii(metadataAst) : null;
     String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
     MultiLiteralInfo multiLiteral =
-        altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 4
+        VectorScanProviders.multiLiteralProviderAvailable()
+                && altLiterals != null
+                && altLiterals.length >= 2
+                && altLiterals.length <= 4
             ? MultiLiteralInfo.create(altLiterals)
             : null;
     StartAcceleration startAcceleration =

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -495,10 +495,7 @@ public final class Pattern implements Serializable {
             ? MultiLiteralInfo.create(altLiterals)
             : null;
     TeddyModel teddyModel = null;
-    if (multiLiteral == null
-        && altLiterals != null
-        && altLiterals.length >= 2
-        && altLiterals.length <= 32) {
+    if (altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 32) {
       teddyModel = TeddyModel.compileForSelectedProvider(altLiterals);
     }
     StartAcceleration startAcceleration =

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -19,24 +19,17 @@ record StartDescriptor(
     AsciiBitmap charClassPrefixAscii,
     StartAcceleration lineAnchor,
     String anchoredPrefix,
-    AsciiBitmap anchoredCharClassPrefixAscii) {
+    AsciiBitmap anchoredCharClassPrefixAscii,
+    MultiLiteralInfo multiLiteral) {
 
   static final StartDescriptor NONE =
-      new StartDescriptor(null, false, null, null, null, null, null);
-
-  StartDescriptor(
-      String prefix,
-      boolean prefixFoldCase,
-      FixedOffsetLiteral fixedOffsetLiteral,
-      AsciiBitmap charClassPrefixAscii,
-      StartAcceleration lineAnchor) {
-    this(prefix, prefixFoldCase, fixedOffsetLiteral, charClassPrefixAscii, lineAnchor, null, null);
-  }
+      new StartDescriptor(null, false, null, null, null, null, null, null);
 
   boolean hasStartAcceleration() {
     return prefix != null
         || fixedOffsetLiteral != null
         || charClassPrefixAscii != null
-        || lineAnchor != null;
+        || lineAnchor != null
+        || multiLiteral != null;
   }
 }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -34,7 +34,7 @@ sealed interface Utf8StartAccelerator {
     }
     if (descriptor.multiLiteral() != null
         && !hasWordBoundary
-        && VectorScanProviders.providerForLength(64) != null) {
+        && VectorScanProviders.multiLiteralProviderAvailable()) {
       return new MultiLiteral(descriptor.multiLiteral());
     }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
@@ -215,21 +215,23 @@ sealed interface Utf8StartAccelerator {
 
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      VectorScanProvider provider = VectorScanProviders.providerForLength(scanner.length);
-      if (provider != null) {
-        int idx =
-            provider.indexOfMultiLiteral(
-                scanner.bytes,
-                scanner.offset,
-                scanner.length,
-                info.literals(),
-                info.anchorChars(),
-                info.anchorOffsets(),
-                info.minLength(),
-                fromIndex);
-        if (idx != VectorScanProvider.UNSUPPORTED) {
-          return idx;
-        }
+      VectorScanProvider provider =
+          VectorScanProviders.providerForMultiLiteralLength(scanner.length);
+      if (provider == null) {
+        return fromIndex;
+      }
+      int idx =
+          provider.indexOfMultiLiteral(
+              scanner.bytes,
+              scanner.offset,
+              scanner.length,
+              info.literals(),
+              info.anchorChars(),
+              info.anchorOffsets(),
+              info.minLength(),
+              fromIndex);
+      if (idx != VectorScanProvider.UNSUPPORTED) {
+        return idx;
       }
       return findScalar(scanner, fromIndex);
     }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -272,6 +272,7 @@ sealed interface Utf8StartAccelerator {
                 info.literals(),
                 info.anchorChars(),
                 info.anchorOffsets(),
+                info.anchorRanges(),
                 info.minLength(),
                 fromIndex);
         if (idx != VectorScanProvider.UNSUPPORTED) {

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -32,6 +32,11 @@ sealed interface Utf8StartAccelerator {
     if (descriptor.fixedOffsetLiteral() != null) {
       return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefixAscii());
     }
+    if (descriptor.multiLiteral() != null
+        && !hasWordBoundary
+        && VectorScanProviders.providerForLength(64) != null) {
+      return new MultiLiteral(descriptor.multiLiteral());
+    }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
       CharClassScanInfo scanInfo =
           Pattern.buildAsciiClassScanInfo(descriptor.charClassPrefixAscii());
@@ -64,6 +69,7 @@ sealed interface Utf8StartAccelerator {
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
       case CharClass cc -> cc.findCandidate(scanner, pos);
+      case MultiLiteral ml -> ml.findCandidate(scanner, pos);
     };
   }
 
@@ -197,6 +203,55 @@ sealed interface Utf8StartAccelerator {
             scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex, scanner.length());
       }
       return fromIndex;
+    }
+  }
+
+  record MultiLiteral(MultiLiteralInfo info) implements Utf8StartAccelerator {
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.VECTOR_MULTI_LITERAL;
+    }
+
+    @Override
+    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+      VectorScanProvider provider = VectorScanProviders.providerForLength(scanner.length);
+      if (provider != null) {
+        int idx =
+            provider.indexOfMultiLiteral(
+                scanner.bytes,
+                scanner.offset,
+                scanner.length,
+                info.literals(),
+                info.anchorChars(),
+                info.anchorOffsets(),
+                info.minLength(),
+                fromIndex);
+        if (idx != VectorScanProvider.UNSUPPORTED) {
+          return idx;
+        }
+      }
+      return findScalar(scanner, fromIndex);
+    }
+
+    private int findScalar(Utf8InputScanner scanner, int fromIndex) {
+      int len = scanner.length;
+      int minLen = info.minLength();
+      String[] literals = info.literals();
+      byte[] bytes = scanner.bytes;
+      int offset = scanner.offset;
+      for (int i = fromIndex; i <= len - minLen; i++) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
+        for (String lit : literals) {
+          if (i + lit.length() <= len
+              && Ascii.regionMatches(bytes, offset + i, lit, lit.length())) {
+            return i;
+          }
+        }
+      }
+      return -1;
     }
   }
 }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -31,15 +31,15 @@ sealed interface Utf8StartAccelerator {
     if (descriptor.fixedOffsetLiteral() != null) {
       return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefix());
     }
+    if (descriptor.multiLiteral() != null
+        && !hasWordBoundary
+        && VectorScanProviders.multiLiteralProviderAvailable()) {
+      return new MultiLiteral(descriptor.multiLiteral(), descriptor.teddyModel());
+    }
     if (descriptor.teddyModel() != null
         && !hasWordBoundary
         && VectorScanProviders.teddyProviderAvailable()) {
       return new Teddy(descriptor.teddyModel());
-    }
-    if (descriptor.multiLiteral() != null
-        && !hasWordBoundary
-        && VectorScanProviders.multiLiteralProviderAvailable()) {
-      return new MultiLiteral(descriptor.multiLiteral());
     }
     if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
       return new CharClass(descriptor.charClassPrefix());
@@ -254,7 +254,8 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-  record MultiLiteral(MultiLiteralInfo info) implements Utf8StartAccelerator {
+  record MultiLiteral(MultiLiteralInfo info, TeddyModel teddyModel)
+      implements Utf8StartAccelerator {
     @Override
     public AcceleratorPolicy policy() {
       return AcceleratorPolicy.VECTOR_MULTI_LITERAL;
@@ -274,6 +275,7 @@ sealed interface Utf8StartAccelerator {
                 info.anchorOffsets(),
                 info.anchorRanges(),
                 info.minLength(),
+                teddyModel,
                 fromIndex);
         if (idx != VectorScanProvider.UNSUPPORTED) {
           return idx;

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -280,6 +280,7 @@ sealed interface Utf8StartAccelerator {
         if (idx != VectorScanProvider.UNSUPPORTED) {
           return idx;
         }
+        return fromIndex;
       }
       return findScalar(scanner, fromIndex);
     }
@@ -292,9 +293,13 @@ sealed interface Utf8StartAccelerator {
       int offset = scanner.offset();
       for (int i = fromIndex; i <= len - minLen; i++) {
         for (String lit : literals) {
-          if (i + lit.length() <= len
-              && Ascii.regionMatches(bytes, offset + i, lit, lit.length())) {
-            return i;
+          if (i + lit.length() <= len) {
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(lit.length());
+            }
+            if (Ascii.regionMatches(bytes, offset + i, lit, lit.length())) {
+              return i;
+            }
           }
         }
       }

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -11,6 +11,8 @@ interface VectorScanProvider {
 
   int minimumInputLength();
 
+  int minimumMultiLiteralInputLength();
+
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -47,5 +47,6 @@ interface VectorScanProvider {
       int[] anchorOffsets,
       int[] anchorRanges,
       int minLength,
+      TeddyModel teddyModel,
       int start);
 }

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -45,6 +45,7 @@ interface VectorScanProvider {
       String[] literals,
       char[] anchorChars,
       int[] anchorOffsets,
+      int[] anchorRanges,
       int minLength,
       int start);
 }

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -13,4 +13,17 @@ interface VectorScanProvider {
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
+
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
+  default int indexOfMultiLiteral(
+      byte[] bytes,
+      int offset,
+      int length,
+      String[] literals,
+      char[] anchorChars,
+      int[] anchorOffsets,
+      int minLength,
+      int start) {
+    return UNSUPPORTED;
+  }
 }

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -16,6 +16,16 @@ final class VectorScanProviders {
     return SELECTED != null && length >= SELECTED.minimumInputLength() ? SELECTED : null;
   }
 
+  static VectorScanProvider providerForMultiLiteralLength(int length) {
+    return SELECTED != null && length >= SELECTED.minimumMultiLiteralInputLength()
+        ? SELECTED
+        : null;
+  }
+
+  static boolean multiLiteralProviderAvailable() {
+    return SELECTED != null;
+  }
+
   private static VectorScanProvider loadSelected() {
     String requested = System.getProperty(PROVIDER_PROPERTY, "").trim();
     if (requested.isEmpty() || requested.equals("swar")) {

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+/** Selects the optional Vector scan provider once without loading it unless requested. */
 final class VectorScanProviders {
   static final String PROVIDER_PROPERTY = "org.safere.experimental.vectorScanProvider";
   private static final VectorScanProvider SELECTED = loadSelected();
@@ -35,24 +36,19 @@ final class VectorScanProviders {
 
   private static VectorScanProvider loadSelected() {
     String requested = System.getProperty(PROVIDER_PROPERTY, "").trim();
-    if (requested.isEmpty()) {
+    if (requested.isEmpty() || requested.equals("swar")) {
       return null;
     }
-    if ("incubator".equals(requested)) {
-      try {
-        return (VectorScanProvider)
-            Class.forName("org.safere.IncubatorVectorScanProvider")
-                .getDeclaredConstructor()
-                .newInstance();
-      } catch (ReflectiveOperationException | LinkageError e) {
-        return null;
-      }
+    if (!requested.equals("vector")) {
+      throw new IllegalStateException("Unknown Vector scan provider '" + requested + "'");
     }
     try {
-      return (VectorScanProvider)
-          Class.forName(requested).getDeclaredConstructor().newInstance();
-    } catch (ReflectiveOperationException | LinkageError e) {
-      return null;
+      return VectorScanProviderFactory.create();
+    } catch (RuntimeException | LinkageError e) {
+      throw new IllegalStateException(
+          "Could not enable the experimental Vector UTF-8 scanner; use JDK 21 or later and add "
+              + "--add-modules=jdk.incubator.vector",
+          e);
     }
   }
 }

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -26,7 +26,7 @@ class MultiLiteralTest {
     assertThat(info.anchorOffsets()).hasSize(3);
 
     assertThat(MultiLiteralInfo.create(new String[] {"single"})).isNull();
-    assertThat(MultiLiteralInfo.create(new String[] {"1", "2", "3", "4", "5", "6", "7"})).isNull();
+    assertThat(MultiLiteralInfo.create(new String[] {"1", "2", "3", "4", "5"})).isNull();
     assertThat(MultiLiteralInfo.create(new String[] {"valid", "café"})).isNull();
   }
 
@@ -35,9 +35,7 @@ class MultiLiteralTest {
       strings = {
         "foo|bar",
         "foo|bar|baz",
-        "cat|dog|bird|fish",
-        "apple|banana|cherry|date|fig",
-        "alpha|beta|gamma|delta|epsilon|zeta"
+        "cat|dog|bird|fish"
       })
   void testBasicMatching(String regex) {
     Pattern pattern = Pattern.compile(regex);
@@ -60,8 +58,20 @@ class MultiLiteralTest {
   }
 
   @Test
+  void testFivePlusLiteralsFallbackToCharClass() {
+    Pattern pattern = Pattern.compile("apple|banana|cherry|date|fig");
+    assertThat(pattern.multiLiteral()).isNull();
+
+    String haystack = "prefix date suffix";
+    Utf8Matcher m = pattern.matcher(Utf8Input.validated(haystack.getBytes(UTF_8)));
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(7);
+    assertThat(m.end()).isEqualTo(11);
+  }
+
+  @Test
   void testLongHaystackWithMultipleMatches() {
-    Pattern pattern = Pattern.compile("apple|banana|cherry|durian|elderberry");
+    Pattern pattern = Pattern.compile("apple|banana|cherry|durian");
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < 200; i++) {
       sb.append("some padding text ");

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -1,0 +1,131 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MultiLiteralTest {
+
+  @Test
+  void testMultiLiteralInfoCreation() {
+    String[] lits = {"apple", "banana", "cherry"};
+    MultiLiteralInfo info = MultiLiteralInfo.create(lits);
+    assertThat(info).isNotNull();
+    assertThat(info.literals()).containsExactly("apple", "banana", "cherry");
+    assertThat(info.minLength()).isEqualTo(5);
+    assertThat(info.anchorChars()).hasSize(3);
+    assertThat(info.anchorOffsets()).hasSize(3);
+
+    assertThat(MultiLiteralInfo.create(new String[] {"single"})).isNull();
+    assertThat(MultiLiteralInfo.create(new String[] {"1", "2", "3", "4", "5", "6", "7"})).isNull();
+    assertThat(MultiLiteralInfo.create(new String[] {"valid", "café"})).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "foo|bar",
+        "foo|bar|baz",
+        "cat|dog|bird|fish",
+        "apple|banana|cherry|date|fig",
+        "alpha|beta|gamma|delta|epsilon|zeta"
+      })
+  void testBasicMatching(String regex) {
+    Pattern pattern = Pattern.compile(regex);
+    assertThat(pattern.multiLiteral()).isNotNull();
+
+    String[] keywords = regex.split("\\|");
+    for (String kw : keywords) {
+      String haystack = "prefix " + kw + " suffix";
+      byte[] bytes = haystack.getBytes(UTF_8);
+      Utf8Matcher m = pattern.matcher(Utf8Input.validated(bytes));
+      assertThat(m.find()).isTrue();
+      assertThat(m.start()).isEqualTo(7);
+      assertThat(m.end()).isEqualTo(7 + kw.length());
+      assertThat(new String(bytes, m.start(), m.end() - m.start(), UTF_8)).isEqualTo(kw);
+    }
+
+    String noMatch = "completely unrelated text with no hits at all";
+    Utf8Matcher mNoMatch = pattern.matcher(Utf8Input.validated(noMatch.getBytes(UTF_8)));
+    assertThat(mNoMatch.find()).isFalse();
+  }
+
+  @Test
+  void testLongHaystackWithMultipleMatches() {
+    Pattern pattern = Pattern.compile("apple|banana|cherry|durian|elderberry");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 200; i++) {
+      sb.append("some padding text ");
+    }
+    int pos1 = sb.length();
+    sb.append("cherry ");
+    for (int i = 0; i < 300; i++) {
+      sb.append("more padding text ");
+    }
+    int pos2 = sb.length();
+    sb.append("banana ");
+    for (int i = 0; i < 200; i++) {
+      sb.append("final padding text ");
+    }
+
+    byte[] bytes = sb.toString().getBytes(UTF_8);
+    Utf8Matcher m = pattern.matcher(Utf8Input.validated(bytes));
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(pos1);
+    assertThat(new String(bytes, m.start(), m.end() - m.start(), UTF_8)).isEqualTo("cherry");
+
+    assertThat(m.find()).isTrue();
+    assertThat(m.start()).isEqualTo(pos2);
+    assertThat(new String(bytes, m.start(), m.end() - m.start(), UTF_8)).isEqualTo("banana");
+
+    assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  void testFuzzEquivalenceWithJavaRegex() {
+    String[] keywords = {"alpha", "beta", "gamma", "delta", "zeta"};
+    String regex = String.join("|", keywords);
+    Pattern safere = Pattern.compile(regex);
+    java.util.regex.Pattern jre = java.util.regex.Pattern.compile(regex);
+
+    Random rnd = new Random(42);
+    char[] alphabet = "abcdefghijklmnopqrstuvwxyz ".toCharArray();
+
+    for (int trial = 0; trial < 100; trial++) {
+      int len = 64 + rnd.nextInt(500);
+      char[] chars = new char[len];
+      for (int i = 0; i < len; i++) {
+        chars[i] = alphabet[rnd.nextInt(alphabet.length)];
+      }
+      if (rnd.nextBoolean()) {
+        String kw = keywords[rnd.nextInt(keywords.length)];
+        int insertPos = rnd.nextInt(Math.max(1, len - kw.length()));
+        for (int i = 0; i < kw.length(); i++) {
+          chars[insertPos + i] = kw.charAt(i);
+        }
+      }
+      String text = new String(chars);
+      byte[] bytes = text.getBytes(UTF_8);
+
+      Utf8Matcher sm = safere.matcher(Utf8Input.validated(bytes));
+      java.util.regex.Matcher jm = jre.matcher(text);
+
+      boolean sFound = sm.find();
+      boolean jFound = jm.find();
+      assertThat(sFound).as("text: %s", text).isEqualTo(jFound);
+      if (sFound) {
+        assertThat(sm.start()).isEqualTo(jm.start());
+        assertThat(sm.end()).isEqualTo(jm.end());
+      }
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -17,6 +17,20 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MultiLiteralTest {
 
   @Test
+  void patternMetadataFollowsVectorProviderAvailability() {
+    Pattern pattern = Pattern.compile("apple|banana|cherry");
+
+    if (!VectorScanProviders.multiLiteralProviderAvailable()) {
+      assertThat(pattern.multiLiteral()).isNull();
+    } else {
+      assertThat(pattern.multiLiteral()).isNotNull();
+      assertThat(VectorScanProviders.providerForLength(64)).isNull();
+      assertThat(VectorScanProviders.providerForMultiLiteralLength(64)).isNotNull();
+      assertThat(VectorScanProviders.providerForLength(1024)).isNotNull();
+    }
+  }
+
+  @Test
   void testMultiLiteralInfoCreation() {
     String[] lits = {"apple", "banana", "cherry"};
     MultiLiteralInfo info = MultiLiteralInfo.create(lits);
@@ -35,7 +49,6 @@ class MultiLiteralTest {
   @ValueSource(strings = {"foo|bar", "foo|bar|baz", "cat|dog|bird|fish"})
   void testBasicMatching(String regex) {
     Pattern pattern = Pattern.compile(regex);
-    assertThat(pattern.multiLiteral()).isNotNull();
 
     String[] keywords = regex.split("\\|");
     for (String kw : keywords) {

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -116,9 +116,12 @@ class MultiLiteralTest {
 
   @Test
   void testFuzzEquivalenceWithJavaRegex() {
-    String[] keywords = {"alpha", "beta", "gamma", "delta", "zeta"};
+    String[] keywords = {"alpha", "beta", "gamma", "delta"};
     String regex = String.join("|", keywords);
     Pattern safere = Pattern.compile(regex);
+    if (VectorScanProviders.multiLiteralProviderAvailable()) {
+      assertThat(safere.multiLiteral()).isNotNull();
+    }
     java.util.regex.Pattern jre = java.util.regex.Pattern.compile(regex);
 
     Random rnd = new Random(42);

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class MultiLiteralTest {
 
   @Test

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -31,12 +31,7 @@ class MultiLiteralTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "foo|bar",
-        "foo|bar|baz",
-        "cat|dog|bird|fish"
-      })
+  @ValueSource(strings = {"foo|bar", "foo|bar|baz", "cat|dog|bird|fish"})
   void testBasicMatching(String regex) {
     Pattern pattern = Pattern.compile(regex);
     assertThat(pattern.multiLiteral()).isNotNull();

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -39,6 +39,11 @@ class MultiLiteralTest {
     assertThat(info.minLength()).isEqualTo(5);
     assertThat(info.anchorChars()).containsExactly('a', 'b', 'c');
     assertThat(info.anchorOffsets()).containsExactly(0, 0, 0);
+    assertThat(info.anchorRanges()).containsExactly('a', 'c');
+
+    MultiLiteralInfo disjoint =
+        MultiLiteralInfo.create(new String[] {"apple", "banana", "watermelon"});
+    assertThat(disjoint.anchorRanges()).containsExactly('a', 'b', 'w', 'w');
 
     assertThat(MultiLiteralInfo.create(new String[] {"single"})).isNull();
     assertThat(MultiLiteralInfo.create(new String[] {"1", "2", "3", "4", "5"})).isNull();

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -23,8 +23,8 @@ class MultiLiteralTest {
     assertThat(info).isNotNull();
     assertThat(info.literals()).containsExactly("apple", "banana", "cherry");
     assertThat(info.minLength()).isEqualTo(5);
-    assertThat(info.anchorChars()).hasSize(3);
-    assertThat(info.anchorOffsets()).hasSize(3);
+    assertThat(info.anchorChars()).containsExactly('a', 'b', 'c');
+    assertThat(info.anchorOffsets()).containsExactly(0, 0, 0);
 
     assertThat(MultiLiteralInfo.create(new String[] {"single"})).isNull();
     assertThat(MultiLiteralInfo.create(new String[] {"1", "2", "3", "4", "5"})).isNull();

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -720,6 +720,20 @@ class SearchScalingRegressionTest {
         "String");
   }
 
+  @Test
+  void multiLiteralPrefilterOnDenseCandidateNoiseIsBoundedByWorkLimit() {
+    Pattern pattern = Pattern.compile("APPLE|BANANA|CHERRY");
+    byte[] noise = "A B C A B C ".repeat(10_000).getBytes(UTF_8);
+
+    long work =
+        WorkCounter.countForTesting(
+            () -> assertThat(pattern.matcher(Utf8Input.trusted(noise)).find()).isFalse());
+
+    assertThat(work)
+        .as("Multi-literal candidate verification must be bounded by WorkLimit on dense noise")
+        .isLessThan(500);
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -830,6 +830,22 @@ class SearchScalingRegressionTest {
     assertThat(matcher.group(1)).isEqualTo("12345");
   }
 
+  @Test
+  void multiLiteralPrefilterDoesNotRestartScalarVerificationAfterLateDenseCandidates() {
+    int literalLength = 512;
+    Pattern pattern =
+        Pattern.compile("A".repeat(literalLength - 1) + "B|" + "B".repeat(literalLength - 1) + "C");
+    byte[] noise = ("x".repeat(256) + "A".repeat(8_192)).getBytes(UTF_8);
+
+    long work =
+        WorkCounter.countForTesting(
+            () -> assertThat(pattern.matcher(Utf8Input.trusted(noise)).find()).isFalse());
+
+    assertThat(work)
+        .as("WorkLimit exhaustion must resume with the normal matcher without a scalar rescan")
+        .isLessThan((long) noise.length * 10);
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -311,6 +311,45 @@ class StartAcceleratorTest {
         .isEqualTo(VectorScanProvider.UNSUPPORTED);
   }
 
+  @Test
+  void adaptiveTeddySelectionUsesEstimatedCandidateVerificationCost() {
+    assertThat(MultiLiteralSelectionPolicy.prefersTeddy(5L * 7, 64)).isTrue();
+    assertThat(MultiLiteralSelectionPolicy.prefersTeddy(4L * 7, 64)).isFalse();
+    assertThat(MultiLiteralSelectionPolicy.prefersTeddy(16L * 7, 256)).isFalse();
+    assertThat(MultiLiteralSelectionPolicy.prefersTeddy(19L * 7, 256)).isTrue();
+    assertThat(MultiLiteralSelectionPolicy.shouldObserve(255)).isTrue();
+    assertThat(MultiLiteralSelectionPolicy.shouldObserve(256)).isFalse();
+  }
+
+  @Test
+  void adaptiveTeddySelectionPreservesTheEarliestLiteralMatch() {
+    if (!isVectorApiAvailable()) {
+      return;
+    }
+    String[] literals = new String[] {"blossom", "sparkling", "twilight"};
+    MultiLiteralInfo info = MultiLiteralInfo.create(literals);
+    TeddyModel teddyModel = TeddyModel.compile(literals, 64);
+    assertThat(info).isNotNull();
+    assertThat(teddyModel).isNotNull();
+    String prefix = "b s t ".repeat(12);
+    byte[] input = (prefix + "sparkling then blossom").getBytes(UTF_8);
+
+    int result =
+        ByteVectorScan.indexOfMultiLiteral(
+            input,
+            0,
+            input.length,
+            info.literals(),
+            info.anchorChars(),
+            info.anchorOffsets(),
+            info.anchorRanges(),
+            info.minLength(),
+            teddyModel,
+            0);
+
+    assertThat(result).isEqualTo(prefix.length());
+  }
+
   private static Utf8InputScanner utf8Scanner(String text) {
     byte[] bytes = text.getBytes(UTF_8);
     return new Utf8InputScanner(bytes, 0, bytes.length);

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -10,9 +10,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.safere.Pattern.FixedOffsetLiteral;
+import org.safere.Pattern.StartAcceleration;
 
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class StartAcceleratorTest {
+
+  private static StartDescriptor descriptor(
+      String prefix,
+      boolean prefixFoldCase,
+      FixedOffsetLiteral fixedOffsetLiteral,
+      AsciiBitmap charClassPrefixAscii,
+      StartAcceleration lineAnchor) {
+    return new StartDescriptor(
+        prefix,
+        prefixFoldCase,
+        fixedOffsetLiteral,
+        charClassPrefixAscii,
+        lineAnchor,
+        null,
+        null,
+        null);
+  }
 
   @Test
   void nullAndNoneDescriptorsProduceNullAccelerators() {
@@ -25,7 +43,7 @@ class StartAcceleratorTest {
 
   @Test
   void literalPrefixAcceleratesStringAndUtf8() {
-    StartDescriptor desc = new StartDescriptor("needle", false, null, null, null);
+    StartDescriptor desc = descriptor("needle", false, null, null, null);
     assertThat(desc.hasStartAcceleration()).isTrue();
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
@@ -43,7 +61,7 @@ class StartAcceleratorTest {
 
   @Test
   void caseInsensitiveLiteralAcceleratesStringAndUtf8() {
-    StartDescriptor desc = new StartDescriptor("needle", true, null, null, null);
+    StartDescriptor desc = descriptor("needle", true, null, null, null);
     assertThat(desc.hasStartAcceleration()).isTrue();
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
@@ -59,21 +77,21 @@ class StartAcceleratorTest {
     assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 15)).isEqualTo(-1);
 
     // Single character case-insensitive prefix
-    StartDescriptor singleDesc = new StartDescriptor("a", true, null, null, null);
+    StartDescriptor singleDesc = descriptor("a", true, null, null, null);
     Utf8StartAccelerator singleUtf8 = Utf8StartAccelerator.create(singleDesc, false);
     assertThat(singleUtf8).isInstanceOf(Utf8StartAccelerator.CaseInsensitiveLiteral.class);
     assertThat(singleUtf8.findCandidate(utf8Scanner("xxxA"), 0)).isEqualTo(3);
     assertThat(singleUtf8.findCandidate(utf8Scanner("xxxa"), 0)).isEqualTo(3);
 
     // Non-ASCII case-insensitive prefix falls back (null)
-    StartDescriptor nonAsciiDesc = new StartDescriptor("café", true, null, null, null);
+    StartDescriptor nonAsciiDesc = descriptor("café", true, null, null, null);
     assertThat(Utf8StartAccelerator.create(nonAsciiDesc, false)).isNull();
   }
 
   @Test
   void fixedOffsetLiteralAcceleratesStringAndUtf8() {
     FixedOffsetLiteral fixed = new FixedOffsetLiteral("token", 2, 2, new int[] {2});
-    StartDescriptor desc = new StartDescriptor(null, false, fixed, null, null);
+    StartDescriptor desc = descriptor(null, false, fixed, null, null);
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.FixedOffset.class);
@@ -89,7 +107,7 @@ class StartAcceleratorTest {
   @Test
   void charClassPrefixAcceleratesStringAndUtf8() {
     AsciiBitmap ascii = new AsciiBitmap.Builder().add('a').add('b').build();
-    StartDescriptor desc = new StartDescriptor(null, false, null, ascii, null);
+    StartDescriptor desc = descriptor(null, false, null, ascii, null);
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -196,8 +196,54 @@ class StartAcceleratorTest {
     assertThat(unacceleratedPat.utf8StartAccelerator()).isNull();
   }
 
+  @Test
+  void multiLiteralWithSharedPrefixReturnsNullAndFallsBackToTeddyOrNone() {
+    MultiLiteralInfo info = MultiLiteralInfo.create(new String[] {"cat", "car"});
+    assertThat(info).as("MultiLiteralInfo must reject colliding initial anchor chars").isNull();
+
+    MultiLiteralInfo distinctInfo = MultiLiteralInfo.create(new String[] {"cat", "dog", "fox"});
+    assertThat(distinctInfo).isNotNull();
+    assertThat(distinctInfo.literals()).containsExactly("cat", "dog", "fox");
+  }
+
+  @Test
+  void multiLiteralScanReturnsUnsupportedWhenWorkLimitExhaustedOnNoise() {
+    if (!isVectorApiAvailable()) {
+      return;
+    }
+    String[] literals = new String[] {"APPLE", "BANANA", "CHERRY"};
+    MultiLiteralInfo info = MultiLiteralInfo.create(literals);
+    assertThat(info).isNotNull();
+
+    byte[] denseNoise = "A B C A B C ".repeat(1000).getBytes(UTF_8);
+
+    int result =
+        ByteVectorScan.indexOfMultiLiteral(
+            denseNoise,
+            0,
+            denseNoise.length,
+            info.literals(),
+            info.anchorChars(),
+            info.anchorOffsets(),
+            info.minLength(),
+            0);
+
+    assertThat(result)
+        .as("Dense candidate false positives must exhaust WorkLimit and return UNSUPPORTED")
+        .isEqualTo(VectorScanProvider.UNSUPPORTED);
+  }
+
   private static Utf8InputScanner utf8Scanner(String text) {
     byte[] bytes = text.getBytes(UTF_8);
     return new Utf8InputScanner(bytes, 0, bytes.length);
+  }
+
+  private static boolean isVectorApiAvailable() {
+    try {
+      Class.forName("jdk.incubator.vector.ByteVector");
+      return true;
+    } catch (ClassNotFoundException | LinkageError e) {
+      return false;
+    }
   }
 }

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -302,6 +302,7 @@ class StartAcceleratorTest {
             info.literals(),
             info.anchorChars(),
             info.anchorOffsets(),
+            info.anchorRanges(),
             info.minLength(),
             0);
 


### PR DESCRIPTION
This adds vectorized start acceleration for 2–4 literal alternations (e.g. `foo|bar|baz|qux`) on UTF-8 `byte[]` inputs using the JDK Vector API.

This is complementary to Teddy (https://github.com/eaftan/safere/pull/736), which targets larger keyword dictionaries, as direct multi-broadcast avoids nibble LUT setup and outperforms it for small alternations.
 
This currently applies to the `byte[]` APIs, it can be generalized to `String` in the future (#656).

For small alternations (2 to 4 keywords), compiling full DFA states or nibble LUTs carries unnecessary constant-factor overhead. This PR adds a multi-broadcast vector filter:
* Uses `RarityOracle.rarestAsciiOffset()` to select the least frequent ASCII character for each literal, keeping false-positive candidate density low (< 5%).
* Broadcasts anchor bytes into `ByteVector` registers (`v0`..`v3`), compares 32-byte chunks in parallel, and combines match masks using `.or()`.
* Extracts matching lane offsets and confirms candidate matches directly via `Ascii.regionMatches()`.
* Restricts the accelerator to 2–4 literals to keep register pressure within AVX2 limits (leaving 10+ YMM registers for loop unrolling) and falls back cleanly to character class / DFA scanning for >= 5 literals.

```
./safere-benchmarks/scripts/compare-branch.sh   --baseline benchmarks-baseline   --vector   'SearchScalingBenchmark\.multiLiteral.*@safere-utf8'
```

| Benchmark                                                | baseline (ns/op) | current (ns/op) | Speedup |
| -------------------------------------------------------- | ---------------- | --------------- | ------- |
| SearchScalingBenchmark.multiLiteral3Fail.1024            |        101 ± 5.7 |        38 ± 3.0 |   2.63x |
| SearchScalingBenchmark.multiLiteral3Success.1024         |        141 ± 1.8 |       292 ± 4.7 |   0.48x |
| SearchScalingBenchmark.multiLiteral6Fail.1024            |        174 ± 9.4 |       168 ± 3.0 |   1.03x |
| SearchScalingBenchmark.multiLiteral6Success.1024         |        164 ± 5.5 |       161 ± 1.8 |   1.02x |
| SearchScalingBenchmark.multiLiteral3Fail.10240           |         319 ± 24 |       212 ± 3.8 |   1.50x |
| SearchScalingBenchmark.multiLiteral3Success.10240        |         319 ± 17 |       458 ± 6.5 |   0.70x |
| SearchScalingBenchmark.multiLiteral6Fail.10240           |         537 ± 27 |       521 ± 4.8 |   1.03x |
| SearchScalingBenchmark.multiLiteral6Success.10240        |         514 ± 15 |        519 ± 51 |   0.99x |
| SearchScalingBenchmark.multiLiteral3Fail.102400          |        2440 ± 29 |      1996 ± 238 |   1.22x |
| SearchScalingBenchmark.multiLiteral3Success.102400       |       2152 ± 166 |       2224 ± 61 |   0.97x |
| SearchScalingBenchmark.multiLiteral6Fail.102400          |       4350 ± 256 |       4206 ± 23 |   1.03x |
| SearchScalingBenchmark.multiLiteral6Success.102400       |        3798 ± 48 |       3796 ± 82 |   1.00x |
| SearchScalingBenchmark.multiLiteral3Fail.1048576         |      24866 ± 416 |    29809 ± 1594 |   0.83x |
| SearchScalingBenchmark.multiLiteral3Success.1048576      |     21794 ± 1134 |    30564 ± 1010 |   0.71x |
| SearchScalingBenchmark.multiLiteral6Fail.1048576         |     41781 ± 1786 |    41194 ± 1853 |   1.01x |
| SearchScalingBenchmark.multiLiteral6Success.1048576      |     43284 ± 1171 |     43150 ± 640 |   1.00x |
| SearchScalingBenchmark.multiLiteralProse3Fail.1024       |        2198 ± 88 |        641 ± 13 |   3.43x |
| SearchScalingBenchmark.multiLiteralProse3Success.1024    |        425 ± 5.3 |       222 ± 5.1 |   1.91x |
| SearchScalingBenchmark.multiLiteralProse6Fail.1024       |        2156 ± 32 |       2156 ± 34 |   1.00x |
| SearchScalingBenchmark.multiLiteralProse6Success.1024    |         432 ± 17 |        433 ± 13 |   1.00x |
| SearchScalingBenchmark.multiLiteralProse3Fail.10240      |      21017 ± 642 |       6097 ± 47 |   3.45x |
| SearchScalingBenchmark.multiLiteralProse3Success.10240   |         431 ± 15 |       221 ± 5.7 |   1.95x |
| SearchScalingBenchmark.multiLiteralProse6Fail.10240      |      20382 ± 104 |      20166 ± 70 |   1.01x |
| SearchScalingBenchmark.multiLiteralProse6Success.10240   |        426 ± 5.9 |        452 ± 25 |   0.94x |
| SearchScalingBenchmark.multiLiteralProse3Fail.102400     |    199067 ± 5435 |    63659 ± 5538 |   3.13x |
| SearchScalingBenchmark.multiLiteralProse3Success.102400  |         433 ± 14 |       221 ± 5.6 |   1.96x |
| SearchScalingBenchmark.multiLiteralProse6Fail.102400     |    200171 ± 9515 |   198867 ± 2857 |   1.01x |
| SearchScalingBenchmark.multiLiteralProse6Success.102400  |         433 ± 14 |       427 ± 9.0 |   1.01x |
| SearchScalingBenchmark.multiLiteralProse3Fail.1048576    |  2074146 ± 69102 |  699746 ± 29495 |   2.96x |
| SearchScalingBenchmark.multiLiteralProse3Success.1048576 |        423 ± 3.7 |       220 ± 7.1 |   1.92x |
| SearchScalingBenchmark.multiLiteralProse6Fail.1048576    |  2023769 ± 14776 | 2018426 ± 11453 |   1.00x |
| SearchScalingBenchmark.multiLiteralProse6Success.1048576 |        427 ± 3.5 |       426 ± 9.5 |   1.00x |