### PR TITLE
Vectorize ASCII pair and triple scanning on UTF-8 inputs

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -452,7 +452,7 @@
       "id": "vectorScan.multi.nonascii.32768",
       "recipe": {
         "kind": "repeatToLength",
-        "unit": "é",
+        "unit": "\u00e9",
         "length": 32768
       },
       "shared": true
@@ -1725,7 +1725,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
+        "value": "\u3044\u304f\u3064\u3082\u306e\u3000\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u3000\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u3000\u305d\u3057\u3066\u3000\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u3000\u304c\u3042\u308a\u307e\u3059",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1743,7 +1743,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
+        "value": "\u3044\u304f\u3064\u3082\u306e\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u305d\u3057\u3066\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u304c\u3042\u308a\u307e\u3059",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1761,7 +1761,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "这是一个中文测试句子",
+        "value": "\u8fd9\u662f\u4e00\u4e2a\u4e2d\u6587\u6d4b\u8bd5\u53e5\u5b50",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1797,7 +1797,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "Today is a beautiful day 😇 with warm sunshine.",
+        "value": "Today is a beautiful day \ud83d\ude07 with warm sunshine.",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -2109,21 +2109,21 @@
       "id": "utf8.captureFree.multibyteEarly",
       "recipe": {
         "kind": "literal",
-        "text": "错误：请求失败"
+        "text": "\u9519\u8bef\uff1a\u8bf7\u6c42\u5931\u8d25"
       }
     },
     {
       "id": "utf8.captureFree.multibyteLate",
       "recipe": {
         "kind": "literal",
-        "text": "请求处理结束：错误"
+        "text": "\u8bf7\u6c42\u5904\u7406\u7ed3\u675f\uff1a\u9519\u8bef"
       }
     },
     {
       "id": "utf8.captureFree.multibyteNoMatch",
       "recipe": {
         "kind": "literal",
-        "text": "请求处理成功"
+        "text": "\u8bf7\u6c42\u5904\u7406\u6210\u529f"
       }
     },
     {
@@ -2137,7 +2137,7 @@
       "id": "utf8.repeatedFind.multibyte",
       "recipe": {
         "kind": "literal",
-        "text": "one café 東京 naïve"
+        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
       }
     },
     {
@@ -2151,7 +2151,7 @@
       "id": "utf8.captureBounds.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
@@ -2165,42 +2165,42 @@
       "id": "utf8.emptyMatch",
       "recipe": {
         "kind": "literal",
-        "text": "a💰有"
+        "text": "a\ud83d\udcb0\u6709"
       }
     },
     {
       "id": "utf8.window",
       "recipe": {
         "kind": "literal",
-        "text": "sentinel-before-city=東京&name=Renée-sentinel-after"
+        "text": "sentinel-before-city=\u6771\u4eac&name=Ren\u00e9e-sentinel-after"
       }
     },
     {
       "id": "utf8.construction",
       "recipe": {
         "kind": "literal",
-        "text": "one café 東京 naïve"
+        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
       }
     },
     {
       "id": "utf8.replacement.literal",
       "recipe": {
         "kind": "literal",
-        "text": "错误 then 错误"
+        "text": "\u9519\u8bef then \u9519\u8bef"
       }
     },
     {
       "id": "utf8.replacement.numbered",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
       "id": "utf8.replacement.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
@@ -2833,14 +2833,14 @@
       "operation": "replaceAll",
       "patterns": [
         {
-          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
+          "java": " ?[\\[\uff3b](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]\uff3d]",
           "alternates": {
             "rust-regex": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
               "reason": "Rust regex gives \\d Unicode semantics"
             },
             "dotnet": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
               "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
             }
           }
@@ -3705,7 +3705,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "realWorldRegex.cjkSearch.{matchLabel}.{size}"
@@ -3735,7 +3735,7 @@
       "operation": "find",
       "patterns": [
         {
-          "java": "[😀-😇]",
+          "java": "[\ud83d\ude00-\ud83d\ude07]",
           "alternates": {
             "dotnet": {
               "pattern": "\\uD83D[\\uDE00-\\uDE07]",
@@ -3771,7 +3771,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "\\s*[\\[［]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,、]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]］]"
+        "\\s*[\\[\uff3b]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,\u3001]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\uff3d]"
       ],
       "inputs": [
         "realWorldRegex.recitation.{matchLabel}.{size}"
@@ -4516,6 +4516,582 @@
         "searchScaling.success.1048576"
       ],
       "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.1024",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.1024",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.1024",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.1024",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.1024",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.1024",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.10240",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.10240",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.10240",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.10240",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.10240",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.10240",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.102400",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.102400",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.102400",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.102400",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.102400",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.102400",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|CHERRY"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral3Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "APPLE|BANANA|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|ZETA"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteral6Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "ALPHA|BETA|GAMMA|DELTA|EPSILON|WXYZ"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiPairSuccess.1048576",
+      "operation": "find",
+      "patterns": [
+        "[YZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleFail.1048576",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.random.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.asciiTripleSuccess.1048576",
+      "operation": "find",
+      "patterns": [
+        "[XYZ]"
+      ],
+      "inputs": [
+        "searchScaling.success.1048576"
+      ],
+      "resultConsumption": "boolean",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",
@@ -7385,7 +7961,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteEarly",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -7404,7 +7980,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteLate",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -7423,7 +7999,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteNoMatch",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -7511,7 +8087,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -7534,7 +8110,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteLate",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -7557,7 +8133,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -7649,7 +8225,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -7672,7 +8248,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteLate",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -7695,7 +8271,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -7863,7 +8439,7 @@
       "id": "Utf8MatchingBenchmark.window",
       "operation": "findInWindow",
       "patterns": [
-        "東京"
+        "\u6771\u4eac"
       ],
       "inputs": [
         "utf8.window"
@@ -7946,7 +8522,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchBytes",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -8450,7 +9026,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchMatcher",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -8476,7 +9052,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchString",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -8660,7 +9236,7 @@
       "id": "ByteReplacementBenchmark.literal",
       "operation": "utf8Replacement",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.replacement.literal"
@@ -9973,6 +10549,294 @@
         }
       },
       "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.1024",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.10240",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.102400",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse3Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Fail.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gossamer"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.multiLiteralProse6Success.1048576",
+      "operation": "find",
+      "patterns": [
+        "blossom|sparkling|twilight|whisper|crystal|gardens"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4746,7 +4746,7 @@
       "id": "SearchScalingBenchmark.asciiTripleFail.1024",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.random.1024"
@@ -4764,7 +4764,7 @@
       "id": "SearchScalingBenchmark.asciiTripleSuccess.1024",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.success.1024"
@@ -4890,7 +4890,7 @@
       "id": "SearchScalingBenchmark.asciiTripleFail.10240",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.random.10240"
@@ -4908,7 +4908,7 @@
       "id": "SearchScalingBenchmark.asciiTripleSuccess.10240",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.success.10240"
@@ -5034,7 +5034,7 @@
       "id": "SearchScalingBenchmark.asciiTripleFail.102400",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.random.102400"
@@ -5052,7 +5052,7 @@
       "id": "SearchScalingBenchmark.asciiTripleSuccess.102400",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.success.102400"
@@ -5178,7 +5178,7 @@
       "id": "SearchScalingBenchmark.asciiTripleFail.1048576",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.random.1048576"
@@ -5196,7 +5196,7 @@
       "id": "SearchScalingBenchmark.asciiTripleSuccess.1048576",
       "operation": "find",
       "patterns": [
-        "[XYZ]"
+        "[XZ_]"
       ],
       "inputs": [
         "searchScaling.success.1048576"

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(38);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(591);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(639);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(5_910);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_390);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -175,12 +175,13 @@ class BenchmarkInputMaterializerTest {
     assertThat(
             executionEntry(
                     executionPlan,
-                    "UnicodeCompileBenchmark.compile.word."
-                        + "CASE_INSENSITIVE_UNICODE_CHARACTER_CLASS@dotnet_nonbacktracking")
-                .getAsJsonArray("patterns")
-                .get(0)
+                    "RealWorldRegexBenchmark.runBenchmark.fruitSearchQuery.match.1000@dotnet_nonbacktracking")
+                .get("exclusion")
+                .getAsJsonObject()
+                .get("kind")
                 .getAsString())
-        .isEqualTo("\\w+");
+        .isEqualTo("unsupportedSyntax");
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(328);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -192,7 +193,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(591);
+          .hasSize(639);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(514);
+    assertThat(ids).hasSize(562);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(1854);
+    assertThat(allTrials).hasSize(2094);
     assertThat(plan.exclusions()).hasSize(716);
-    assertThat(accounted).hasSize(514 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(562 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1204);
+        .hasSize(1444);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(1893);
-    assertThat(plan.reportPlan().trials()).hasSize(1893);
+        .hasSize(2133);
+    assertThat(plan.reportPlan().trials()).hasSize(2133);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -146,6 +146,7 @@
                         <exclude name="Utf8InputScannerTest.java"/>
                         <exclude name="Utf8InputTest.java"/>
                         <exclude name="Utf8LinearTimeTest.java"/>
+                        <exclude name="Utf8VectorPairTripleTest.java"/>
                         <exclude name="UtilsTest.java"/>
                         <exclude name="WalkerTest.java"/>
                         <exclude name="WorkCounterTest.java"/>

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -40,6 +40,51 @@ final class ByteVectorScan {
     return -1;
   }
 
+  static int indexOfAsciiPair(byte[] bytes, int offset, int length, byte b0, byte b1, int start) {
+    int position = Math.max(0, start);
+    int limit = position + SPECIES.loopBound(length - position);
+    ByteVector v0 = ByteVector.broadcast(SPECIES, b0);
+    ByteVector v1 = ByteVector.broadcast(SPECIES, b1);
+    for (; position < limit; position += SPECIES.length()) {
+      ByteVector values = ByteVector.fromArray(SPECIES, bytes, offset + position);
+      VectorMask<Byte> matches = values.compare(EQ, v0).or(values.compare(EQ, v1));
+      if (matches.anyTrue()) {
+        return position + matches.firstTrue();
+      }
+    }
+    for (; position < length; position++) {
+      byte val = bytes[offset + position];
+      if (val == b0 || val == b1) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
+  static int indexOfAsciiTriple(
+      byte[] bytes, int offset, int length, byte b0, byte b1, byte b2, int start) {
+    int position = Math.max(0, start);
+    int limit = position + SPECIES.loopBound(length - position);
+    ByteVector v0 = ByteVector.broadcast(SPECIES, b0);
+    ByteVector v1 = ByteVector.broadcast(SPECIES, b1);
+    ByteVector v2 = ByteVector.broadcast(SPECIES, b2);
+    for (; position < limit; position += SPECIES.length()) {
+      ByteVector values = ByteVector.fromArray(SPECIES, bytes, offset + position);
+      VectorMask<Byte> matches =
+          values.compare(EQ, v0).or(values.compare(EQ, v1)).or(values.compare(EQ, v2));
+      if (matches.anyTrue()) {
+        return position + matches.firstTrue();
+      }
+    }
+    for (; position < length; position++) {
+      byte val = bytes[offset + position];
+      if (val == b0 || val == b1 || val == b2) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
   private static VectorMask<Byte> matches(ByteVector values, int[] ranges) {
     VectorMask<Byte> matches = matches(values, ranges[0], ranges[1]);
     if (ranges.length >= 4) {

--- a/safere/src/main/java/org/safere/CharClassScanInfo.java
+++ b/safere/src/main/java/org/safere/CharClassScanInfo.java
@@ -1,0 +1,229 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Arrays;
+
+/**
+ * Encapsulates pre-computed character class metadata for scanning, start acceleration, and
+ * rejection.
+ */
+sealed interface CharClassScanInfo {
+
+  boolean contains(int cp);
+
+  long bitmap0();
+
+  long bitmap1();
+
+  boolean isAscii();
+
+  int[] ranges();
+
+  /** Matches 1, 2, or 3 exact ASCII characters via single-instruction SIMD equality. */
+  @SuppressWarnings("ArrayRecordComponent")
+  record AsciiSmallSet(char[] chars, long bitmap0, long bitmap1) implements CharClassScanInfo {
+    @Override
+    public boolean contains(int cp) {
+      if (cp < 64) {
+        return cp >= 0 && (bitmap0 & (1L << cp)) != 0;
+      }
+      if (cp < 128) {
+        return (bitmap1 & (1L << (cp - 64))) != 0;
+      }
+      return false;
+    }
+
+    @Override
+    public boolean isAscii() {
+      return true;
+    }
+
+    @Override
+    public int[] ranges() {
+      return CharClassScanInfo.buildRangesFromBitmaps(bitmap0, bitmap1);
+    }
+  }
+
+  /** Matches contiguous ASCII intervals (1-4 ranges, e.g. [a-zA-Z0-9_]) via SIMD range tests. */
+  @SuppressWarnings("ArrayRecordComponent")
+  record AsciiRanges(int[] ranges, long bitmap0, long bitmap1) implements CharClassScanInfo {
+    @Override
+    public boolean contains(int cp) {
+      if (cp < 64) {
+        return cp >= 0 && (bitmap0 & (1L << cp)) != 0;
+      }
+      if (cp < 128) {
+        return (bitmap1 & (1L << (cp - 64))) != 0;
+      }
+      return false;
+    }
+
+    @Override
+    public boolean isAscii() {
+      return true;
+    }
+  }
+
+  /** Matches arbitrary ASCII character distributions via 128-bit bitmap lookup. */
+  record AsciiBitmapClass(long bitmap0, long bitmap1) implements CharClassScanInfo {
+    @Override
+    public boolean contains(int cp) {
+      if (cp < 64) {
+        return cp >= 0 && (bitmap0 & (1L << cp)) != 0;
+      }
+      if (cp < 128) {
+        return (bitmap1 & (1L << (cp - 64))) != 0;
+      }
+      return false;
+    }
+
+    @Override
+    public boolean isAscii() {
+      return true;
+    }
+
+    @Override
+    public int[] ranges() {
+      return CharClassScanInfo.buildRangesFromBitmaps(bitmap0, bitmap1);
+    }
+  }
+
+  /**
+   * Matches BMP/Unicode character classes with ASCII acceleration bitmap + binary search ranges.
+   */
+  @SuppressWarnings("ArrayRecordComponent")
+  record UnicodeGeneral(int[] ranges, long bitmap0, long bitmap1) implements CharClassScanInfo {
+    @Override
+    public boolean contains(int cp) {
+      if (cp < 64) {
+        return cp >= 0 && (bitmap0 & (1L << cp)) != 0;
+      }
+      if (cp < 128) {
+        return (bitmap1 & (1L << (cp - 64))) != 0;
+      }
+      return Matcher.binarySearchRanges(ranges, cp);
+    }
+
+    @Override
+    public boolean isAscii() {
+      return false;
+    }
+  }
+
+  static CharClassScanInfo fromAsciiBitmap(AsciiBitmap asciiClass) {
+    if (asciiClass == null || asciiClass.isEmpty()) {
+      return null;
+    }
+    long b0 = asciiClass.bitmap0();
+    long b1 = asciiClass.bitmap1();
+    int count = Long.bitCount(b0) + Long.bitCount(b1);
+    if (count > 0 && count <= 3) {
+      char[] chars = new char[count];
+      int idx = 0;
+      for (int i = 0; i < 64; i++) {
+        if ((b0 & (1L << i)) != 0) {
+          chars[idx++] = (char) i;
+        }
+      }
+      for (int i = 0; i < 64; i++) {
+        if ((b1 & (1L << i)) != 0) {
+          chars[idx++] = (char) (i + 64);
+        }
+      }
+      return new AsciiSmallSet(chars, b0, b1);
+    }
+
+    int[] ranges = buildRangesFromBitmaps(b0, b1);
+    if (ranges != null && ranges.length / 2 <= 4) {
+      return new AsciiRanges(ranges, b0, b1);
+    }
+    return new AsciiBitmapClass(b0, b1);
+  }
+
+  static CharClassScanInfo fromCharClass(CharClass cc) {
+    if (cc == null || cc.isEmpty()) {
+      return null;
+    }
+    int numRanges = cc.numRanges();
+    int[] ranges = new int[numRanges * 2];
+    long b0 = 0L;
+    long b1 = 0L;
+    for (int i = 0; i < numRanges; i++) {
+      int lo = cc.lo(i);
+      int hi = cc.hi(i);
+      ranges[i * 2] = lo;
+      ranges[i * 2 + 1] = hi;
+      int start = Math.max(0, lo);
+      int end = Math.min(127, hi);
+      for (int cp = start; cp <= end; cp++) {
+        if (cp < 64) {
+          b0 |= (1L << cp);
+        } else {
+          b1 |= (1L << (cp - 64));
+        }
+      }
+    }
+
+    boolean isAscii = numRanges > 0 && cc.hi(numRanges - 1) <= 127;
+    if (isAscii) {
+      int count = Long.bitCount(b0) + Long.bitCount(b1);
+      if (count > 0 && count <= 3) {
+        char[] chars = new char[count];
+        int idx = 0;
+        for (int i = 0; i < 64; i++) {
+          if ((b0 & (1L << i)) != 0) {
+            chars[idx++] = (char) i;
+          }
+        }
+        for (int i = 0; i < 64; i++) {
+          if ((b1 & (1L << i)) != 0) {
+            chars[idx++] = (char) (i + 64);
+          }
+        }
+        return new AsciiSmallSet(chars, b0, b1);
+      }
+      if (numRanges <= 4) {
+        return new AsciiRanges(ranges, b0, b1);
+      }
+      return new AsciiBitmapClass(b0, b1);
+    }
+
+    return new UnicodeGeneral(ranges, b0, b1);
+  }
+
+  static int[] buildRangesFromBitmaps(long b0, long b1) {
+    int[] temp = new int[128 * 2];
+    int rangeCount = 0;
+    int value = 0;
+    while (value < 128) {
+      boolean contains = value < 64 ? (b0 & (1L << value)) != 0 : (b1 & (1L << (value - 64))) != 0;
+      if (!contains) {
+        value++;
+        continue;
+      }
+      int low = value;
+      while (value + 1 < 128) {
+        int next = value + 1;
+        boolean nextContains =
+            next < 64 ? (b0 & (1L << next)) != 0 : (b1 & (1L << (next - 64))) != 0;
+        if (!nextContains) {
+          break;
+        }
+        value++;
+      }
+      int high = value;
+      temp[rangeCount * 2] = low;
+      temp[rangeCount * 2 + 1] = high;
+      rangeCount++;
+      value++;
+    }
+    if (rangeCount == 0) {
+      return new int[0];
+    }
+    return Arrays.copyOf(temp, rangeCount * 2);
+  }
+}

--- a/safere/src/main/java/org/safere/CharClassScanInfo.java
+++ b/safere/src/main/java/org/safere/CharClassScanInfo.java
@@ -24,8 +24,10 @@ sealed interface CharClassScanInfo {
   int[] ranges();
 
   /** Matches 1, 2, or 3 exact ASCII characters via single-instruction SIMD equality. */
+  // Arrays are immutable, privately owned scanner metadata; array identity is never observed.
   @SuppressWarnings("ArrayRecordComponent")
-  record AsciiSmallSet(char[] chars, long bitmap0, long bitmap1) implements CharClassScanInfo {
+  record AsciiSmallSet(char[] chars, int[] ranges, long bitmap0, long bitmap1)
+      implements CharClassScanInfo {
     @Override
     public boolean contains(int cp) {
       if (cp < 64) {
@@ -41,14 +43,10 @@ sealed interface CharClassScanInfo {
     public boolean isAscii() {
       return true;
     }
-
-    @Override
-    public int[] ranges() {
-      return CharClassScanInfo.buildRangesFromBitmaps(bitmap0, bitmap1);
-    }
   }
 
   /** Matches contiguous ASCII intervals (1-4 ranges, e.g. [a-zA-Z0-9_]) via SIMD range tests. */
+  // The array is immutable, privately owned scanner metadata; array identity is never observed.
   @SuppressWarnings("ArrayRecordComponent")
   record AsciiRanges(int[] ranges, long bitmap0, long bitmap1) implements CharClassScanInfo {
     @Override
@@ -69,7 +67,9 @@ sealed interface CharClassScanInfo {
   }
 
   /** Matches arbitrary ASCII character distributions via 128-bit bitmap lookup. */
-  record AsciiBitmapClass(long bitmap0, long bitmap1) implements CharClassScanInfo {
+  // The array is immutable, privately owned scanner metadata; array identity is never observed.
+  @SuppressWarnings("ArrayRecordComponent")
+  record AsciiBitmapClass(int[] ranges, long bitmap0, long bitmap1) implements CharClassScanInfo {
     @Override
     public boolean contains(int cp) {
       if (cp < 64) {
@@ -85,16 +85,12 @@ sealed interface CharClassScanInfo {
     public boolean isAscii() {
       return true;
     }
-
-    @Override
-    public int[] ranges() {
-      return CharClassScanInfo.buildRangesFromBitmaps(bitmap0, bitmap1);
-    }
   }
 
   /**
    * Matches BMP/Unicode character classes with ASCII acceleration bitmap + binary search ranges.
    */
+  // The array is immutable, privately owned scanner metadata; array identity is never observed.
   @SuppressWarnings("ArrayRecordComponent")
   record UnicodeGeneral(int[] ranges, long bitmap0, long bitmap1) implements CharClassScanInfo {
     @Override
@@ -121,6 +117,7 @@ sealed interface CharClassScanInfo {
     long b0 = asciiClass.bitmap0();
     long b1 = asciiClass.bitmap1();
     int count = Long.bitCount(b0) + Long.bitCount(b1);
+    int[] ranges = buildRangesFromBitmaps(b0, b1);
     if (count > 0 && count <= 3) {
       char[] chars = new char[count];
       int idx = 0;
@@ -134,14 +131,13 @@ sealed interface CharClassScanInfo {
           chars[idx++] = (char) (i + 64);
         }
       }
-      return new AsciiSmallSet(chars, b0, b1);
+      return new AsciiSmallSet(chars, ranges, b0, b1);
     }
 
-    int[] ranges = buildRangesFromBitmaps(b0, b1);
     if (ranges != null && ranges.length / 2 <= 4) {
       return new AsciiRanges(ranges, b0, b1);
     }
-    return new AsciiBitmapClass(b0, b1);
+    return new AsciiBitmapClass(ranges, b0, b1);
   }
 
   static CharClassScanInfo fromCharClass(CharClass cc) {
@@ -184,12 +180,12 @@ sealed interface CharClassScanInfo {
             chars[idx++] = (char) (i + 64);
           }
         }
-        return new AsciiSmallSet(chars, b0, b1);
+        return new AsciiSmallSet(chars, ranges, b0, b1);
       }
       if (numRanges <= 4) {
         return new AsciiRanges(ranges, b0, b1);
       }
-      return new AsciiBitmapClass(b0, b1);
+      return new AsciiBitmapClass(ranges, b0, b1);
     }
 
     return new UnicodeGeneral(ranges, b0, b1);

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -7,7 +7,7 @@ package org.safere;
 
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
-  private static final int MINIMUM_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_INPUT_LENGTH = 64;
 
   @Override
   public int minimumInputLength() {
@@ -17,5 +17,16 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
     return ByteVectorScan.indexOfAsciiClass(bytes, offset, length, ranges, start);
+  }
+
+  @Override
+  public int indexOfAsciiPair(byte[] bytes, int offset, int length, byte b0, byte b1, int start) {
+    return ByteVectorScan.indexOfAsciiPair(bytes, offset, length, b0, b1, start);
+  }
+
+  @Override
+  public int indexOfAsciiTriple(
+      byte[] bytes, int offset, int length, byte b0, byte b1, byte b2, int start) {
+    return ByteVectorScan.indexOfAsciiTriple(bytes, offset, length, b0, b1, b2, start);
   }
 }

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -7,11 +7,29 @@ package org.safere;
 
 /** Experimental scan operations implemented with the incubating Vector API. */
 final class IncubatorVectorScanProvider implements VectorScanProvider {
-  private static final int MINIMUM_INPUT_LENGTH = 64;
+  private static final int MINIMUM_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_PAIR_INPUT_LENGTH = 64;
+  private static final int MINIMUM_TRIPLE_INPUT_LENGTH = 64;
+  private static final int MAXIMUM_TRIPLE_INPUT_LENGTH = 10_240;
 
   @Override
   public int minimumInputLength() {
     return MINIMUM_INPUT_LENGTH;
+  }
+
+  @Override
+  public int minimumPairInputLength() {
+    return MINIMUM_PAIR_INPUT_LENGTH;
+  }
+
+  @Override
+  public int minimumTripleInputLength() {
+    return MINIMUM_TRIPLE_INPUT_LENGTH;
+  }
+
+  @Override
+  public int maximumTripleInputLength() {
+    return MAXIMUM_TRIPLE_INPUT_LENGTH;
   }
 
   @Override

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -56,6 +56,6 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
 
   @Override
   public int indexOfTeddy(byte[] bytes, int offset, int length, TeddyModel model, int start) {
-    return TeddyVectorScan.indexOfTeddy(bytes, offset, length, model, start);
+    return TeddyVectorScan.indexOfTeddyUtf8(bytes, offset, length, model, start);
   }
 }

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -9,6 +9,9 @@ package org.safere;
 final class IncubatorVectorScanProvider implements VectorScanProvider {
   private static final int MINIMUM_INPUT_LENGTH = 1024;
   private static final int MINIMUM_TEDDY_INPUT_LENGTH = 1024;
+  private static final int MINIMUM_PAIR_INPUT_LENGTH = 64;
+  private static final int MINIMUM_TRIPLE_INPUT_LENGTH = 64;
+  private static final int MAXIMUM_TRIPLE_INPUT_LENGTH = 10_240;
 
   @Override
   public int minimumInputLength() {
@@ -18,6 +21,21 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   @Override
   public int minimumTeddyInputLength() {
     return MINIMUM_TEDDY_INPUT_LENGTH;
+  }
+
+  @Override
+  public int minimumPairInputLength() {
+    return MINIMUM_PAIR_INPUT_LENGTH;
+  }
+
+  @Override
+  public int minimumTripleInputLength() {
+    return MINIMUM_TRIPLE_INPUT_LENGTH;
+  }
+
+  @Override
+  public int maximumTripleInputLength() {
+    return MAXIMUM_TRIPLE_INPUT_LENGTH;
   }
 
   @Override
@@ -38,6 +56,6 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
 
   @Override
   public int indexOfTeddy(byte[] bytes, int offset, int length, TeddyModel model, int start) {
-    return TeddyVectorScan.indexOfTeddyUtf8(bytes, offset, length, model, start);
+    return TeddyVectorScan.indexOfTeddy(bytes, offset, length, model, start);
   }
 }

--- a/safere/src/main/java/org/safere/InputScanner.java
+++ b/safere/src/main/java/org/safere/InputScanner.java
@@ -94,7 +94,7 @@ sealed interface InputScanner permits StringInputScanner, Utf8InputScanner {
     return (int) (decoded >> 32);
   }
 
-  default int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
+  default int indexOfCharClass(CharClassScanInfo scanInfo, int start) {
     return -1;
   }
 

--- a/safere/src/main/java/org/safere/MatchDescriptor.java
+++ b/safere/src/main/java/org/safere/MatchDescriptor.java
@@ -6,7 +6,6 @@
 package org.safere;
 
 import org.safere.Pattern.CharClassMatchInfo;
-import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.KeywordAlternation;
 
 /**

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -625,8 +625,8 @@ public final class Matcher implements MatchResult {
    * Fast path for {@code find()} when the pattern is exactly one character class. Scans code points
    * directly and returns the first matching code point as group 0.
    */
-  private boolean singleCharClassFindFastPath(Pattern.CharClassScanInfo scanInfo, int fromIndex) {
-    if (scanInfo.isAscii) {
+  private boolean singleCharClassFindFastPath(CharClassScanInfo scanInfo, int fromIndex) {
+    if (scanInfo.isAscii()) {
       int idx = activeScanner().indexOfCharClass(scanInfo, fromIndex);
       if (idx >= 0) {
         return applyFullMatchResult(new int[] {idx, idx + 1});
@@ -636,9 +636,9 @@ public final class Matcher implements MatchResult {
     int idx =
         activeScanner()
             .indexOfCodePointClass(
-                scanInfo.ranges,
-                scanInfo.bitmap0,
-                scanInfo.bitmap1,
+                scanInfo.ranges(),
+                scanInfo.bitmap0(),
+                scanInfo.bitmap1(),
                 fromIndex,
                 activeScanner().length());
     if (idx >= 0) {
@@ -4419,7 +4419,7 @@ public final class Matcher implements MatchResult {
     }
 
     // Char class fast path
-    Pattern.CharClassScanInfo singleCharClass = parentPattern.matchDescriptor().singleCharClass();
+    CharClassScanInfo singleCharClass = parentPattern.matchDescriptor().singleCharClass();
     if (options.charClassMatchFastPaths() && singleCharClass != null) {
       if (prog.anchorStart() && fromIndex > 0) {
         return -1L;
@@ -4434,7 +4434,7 @@ public final class Matcher implements MatchResult {
         }
         return -1L;
       }
-      if (singleCharClass.isAscii) {
+      if (singleCharClass.isAscii()) {
         int idx = scanner.indexOfCharClass(singleCharClass, fromIndex);
         if (idx < 0) {
           return -1L;
@@ -4443,9 +4443,9 @@ public final class Matcher implements MatchResult {
       }
       int idx =
           scanner.indexOfCodePointClass(
-              singleCharClass.ranges,
-              singleCharClass.bitmap0,
-              singleCharClass.bitmap1,
+              singleCharClass.ranges(),
+              singleCharClass.bitmap0(),
+              singleCharClass.bitmap1(),
               fromIndex,
               scanner.length());
       if (idx < 0) {
@@ -4727,12 +4727,12 @@ public final class Matcher implements MatchResult {
   }
 
   static final class SingleCharClassPreparedRunner implements PreparedMatchRunner {
-    private final Pattern.CharClassScanInfo singleCharClass;
+    private final CharClassScanInfo singleCharClass;
     private final Pattern.CharClassMatchInfo charClassMatch;
     private final boolean isStartAnchored;
 
     SingleCharClassPreparedRunner(
-        Pattern.CharClassScanInfo singleCharClass,
+        CharClassScanInfo singleCharClass,
         Pattern.CharClassMatchInfo charClassMatch,
         boolean isStartAnchored) {
       this.singleCharClass = singleCharClass;

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -3071,10 +3071,6 @@ public final class Pattern implements Serializable {
   @SuppressWarnings("ArrayRecordComponent")
   record CharClassMatchInfo(int[] ranges, long bitmap0, long bitmap1, boolean allowEmpty) {}
 
-  static CharClassScanInfo buildAsciiClassScanInfo(AsciiBitmap asciiClass) {
-    return CharClassScanInfo.fromAsciiBitmap(asciiClass);
-  }
-
   /**
    * Detects patterns that are structurally a single character class under a quantifier covering the
    * entire string — e.g., {@code [a-zA-Z]+}, {@code \d*}, {@code \w{1,}}, {@code [0-9]+}. When
@@ -3171,7 +3167,7 @@ public final class Pattern implements Serializable {
     if (cc.isEmpty()) {
       return null;
     }
-    return buildCharClassScanInfo(cc);
+    return CharClassScanInfo.fromCharClass(cc);
   }
 
   record SuffixInfo(String suffix, boolean wasDollar, boolean unixLines, boolean foldCase) {
@@ -3362,7 +3358,7 @@ public final class Pattern implements Serializable {
     }
     if (node.op != RegexpOp.CONCAT || node.subs == null) {
       CharClass required = requiredCharClass(node, inspectAlternation);
-      return required != null ? buildCharClassScanInfo(required) : null;
+      return required != null ? CharClassScanInfo.fromCharClass(required) : null;
     }
     CharClass mostSelective = null;
     for (Regexp sub : node.subs) {
@@ -3372,7 +3368,7 @@ public final class Pattern implements Serializable {
         mostSelective = required;
       }
     }
-    return mostSelective != null ? buildCharClassScanInfo(mostSelective) : null;
+    return mostSelective != null ? CharClassScanInfo.fromCharClass(mostSelective) : null;
   }
 
   private static CharClass requiredCharClass(Regexp re, boolean inspectAlternation) {
@@ -3629,10 +3625,6 @@ public final class Pattern implements Serializable {
       UnicodeCaseFolding.addUnicodeFoldedRange(ccb, cp, cp);
     }
     return ccb.build();
-  }
-
-  private static CharClassScanInfo buildCharClassScanInfo(CharClass cc) {
-    return CharClassScanInfo.fromCharClass(cc);
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -1032,7 +1032,7 @@ public final class Pattern implements Serializable {
               : Matcher.FallbackPreparedRunner.INSTANCE);
     }
 
-    Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
+    CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
     Pattern.CharClassMatchInfo charClassMatch = matchDescriptor.charClassMatch();
     if (enginePathOptions.charClassMatchFastPaths()
         && (singleCharClass != null || charClassMatch != null)) {
@@ -1058,7 +1058,7 @@ public final class Pattern implements Serializable {
   }
 
   private Matcher.PreparedMatchRunner createLiteralFallbackRunner(boolean regionActive) {
-    Pattern.CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
+    CharClassScanInfo singleCharClass = matchDescriptor.singleCharClass();
     Pattern.CharClassMatchInfo charClassMatch = matchDescriptor.charClassMatch();
     if (enginePathOptions.charClassMatchFastPaths()
         && (singleCharClass != null || charClassMatch != null)) {
@@ -3071,61 +3071,8 @@ public final class Pattern implements Serializable {
   @SuppressWarnings("ArrayRecordComponent")
   record CharClassMatchInfo(int[] ranges, long bitmap0, long bitmap1, boolean allowEmpty) {}
 
-  /** Holds precomputed data for scanning one character class. */
-  static final class CharClassScanInfo {
-    final int[] ranges;
-    final long bitmap0;
-    final long bitmap1;
-    final boolean isAscii;
-
-    CharClassScanInfo(int[] ranges, long bitmap0, long bitmap1, boolean isAscii) {
-      this.ranges = ranges;
-      this.bitmap0 = bitmap0;
-      this.bitmap1 = bitmap1;
-      this.isAscii = isAscii;
-    }
-
-    boolean contains(int cp) {
-      if (cp < 64) {
-        return cp >= 0 && (bitmap0 & (1L << cp)) != 0;
-      }
-      if (cp < 128) {
-        return (bitmap1 & (1L << (cp - 64))) != 0;
-      }
-      if (isAscii) {
-        return false;
-      }
-      return Matcher.binarySearchRanges(ranges, cp);
-    }
-  }
-
   static CharClassScanInfo buildAsciiClassScanInfo(AsciiBitmap asciiClass) {
-    if (asciiClass == null || asciiClass.isEmpty()) {
-      return null;
-    }
-    int[] ranges = new int[128 * 2];
-    int rangeCount = 0;
-    int value = 0;
-    while (value < 128) {
-      if (!asciiClass.containsAscii(value)) {
-        value++;
-        continue;
-      }
-      int low = value;
-      while (value + 1 < 128 && asciiClass.containsAscii(value + 1)) {
-        value++;
-      }
-      int high = value;
-      ranges[rangeCount * 2] = low;
-      ranges[rangeCount * 2 + 1] = high;
-      rangeCount++;
-      value++;
-    }
-    if (rangeCount == 0) {
-      return null;
-    }
-    return new CharClassScanInfo(
-        Arrays.copyOf(ranges, rangeCount * 2), asciiClass.bitmap0(), asciiClass.bitmap1(), true);
+    return CharClassScanInfo.fromAsciiBitmap(asciiClass);
   }
 
   /**
@@ -3259,10 +3206,10 @@ public final class Pattern implements Serializable {
         requiredMatchClass = extractRequiredMatchClass(metadataAst, true);
       } else {
         CharClassScanInfo candidate = extractRequiredMatchClass(metadataAst, false);
-        if (candidate != null && candidate.ranges != null) {
+        if (candidate != null && candidate.ranges() != null) {
           int candidateRunes = 0;
-          for (int i = 0; i < candidate.ranges.length; i += 2) {
-            candidateRunes += (candidate.ranges[i + 1] - candidate.ranges[i] + 1);
+          for (int i = 0; i < candidate.ranges().length; i += 2) {
+            candidateRunes += (candidate.ranges()[i + 1] - candidate.ranges()[i] + 1);
           }
           if (candidateRunes < ccPrefixAscii.cardinality()) {
             requiredMatchClass = candidate;
@@ -3685,27 +3632,7 @@ public final class Pattern implements Serializable {
   }
 
   private static CharClassScanInfo buildCharClassScanInfo(CharClass cc) {
-    int numRanges = cc.numRanges();
-    int[] ranges = new int[numRanges * 2];
-    long b0 = 0;
-    long b1 = 0;
-    for (int i = 0; i < numRanges; i++) {
-      int lo = cc.lo(i);
-      int hi = cc.hi(i);
-      ranges[i * 2] = lo;
-      ranges[i * 2 + 1] = hi;
-      int start = Math.max(lo, 0);
-      int end = Math.min(hi, 127);
-      for (int cp = start; cp <= end; cp++) {
-        if (cp < 64) {
-          b0 |= 1L << cp;
-        } else {
-          b1 |= 1L << (cp - 64);
-        }
-      }
-    }
-    boolean isAscii = numRanges > 0 && cc.hi(numRanges - 1) <= 127;
-    return new CharClassScanInfo(ranges, b0, b1, isAscii);
+    return CharClassScanInfo.fromCharClass(cc);
   }
 
   /**

--- a/safere/src/main/java/org/safere/RejectDescriptor.java
+++ b/safere/src/main/java/org/safere/RejectDescriptor.java
@@ -5,7 +5,6 @@
 
 package org.safere;
 
-import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.DisjointRequiredLiterals;
 import org.safere.Pattern.EndAnchoredCharClassInfo;
 import org.safere.Pattern.SuffixInfo;

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -6,7 +6,6 @@
 package org.safere;
 
 import java.nio.charset.StandardCharsets;
-import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.DisjointRequiredLiterals;
 import org.safere.Pattern.EndAnchoredCharClassInfo;
 import org.safere.Pattern.SuffixInfo;
@@ -159,7 +158,7 @@ sealed interface RejectPrefilter
   record CharClass(int[] ranges, long bitmap0, long bitmap1) implements RejectPrefilter {
 
     static CharClass create(CharClassScanInfo scanInfo) {
-      return new CharClass(scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1);
+      return new CharClass(scanInfo.ranges(), scanInfo.bitmap0(), scanInfo.bitmap1());
     }
 
     @Override

--- a/safere/src/main/java/org/safere/StringInputScanner.java
+++ b/safere/src/main/java/org/safere/StringInputScanner.java
@@ -94,11 +94,11 @@ final class StringInputScanner implements InputScanner {
   }
 
   @Override
-  public int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
+  public int indexOfCharClass(CharClassScanInfo scanInfo, int start) {
     int position = Math.max(0, start);
-    int[] ranges = scanInfo.ranges;
-    long bitmap0 = scanInfo.bitmap0;
-    long bitmap1 = scanInfo.bitmap1;
+    int[] ranges = scanInfo.ranges();
+    long bitmap0 = scanInfo.bitmap0();
+    long bitmap1 = scanInfo.bitmap1();
     while (position < text.length()) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record();

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -89,7 +89,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       }
       return -1;
     }
-    int res = ByteSwarScan.indexOfBytePair(bytes, offset, scanLen, (byte) c1, (byte) c2, start);
+    int res = scanBytePair(scanLen, (byte) c1, (byte) c2, start);
     return (res >= 0 && res < limit) ? res : -1;
   }
 
@@ -110,10 +110,28 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       }
       return -1;
     }
-    int res =
-        ByteSwarScan.indexOfByteTriple(
-            bytes, offset, scanLen, (byte) c1, (byte) c2, (byte) c3, start);
+    int res = scanByteTriple(scanLen, (byte) c1, (byte) c2, (byte) c3, start);
     return (res >= 0 && res < limit) ? res : -1;
+  }
+
+  private int scanBytePair(int scanLen, byte b0, byte b1, int start) {
+    if (scanProvider != null) {
+      int idx = scanProvider.indexOfAsciiPair(bytes, offset, scanLen, b0, b1, start);
+      if (idx != VectorScanProvider.UNSUPPORTED) {
+        return idx;
+      }
+    }
+    return ByteSwarScan.indexOfBytePair(bytes, offset, scanLen, b0, b1, start);
+  }
+
+  private int scanByteTriple(int scanLen, byte b0, byte b1, byte b2, int start) {
+    if (scanProvider != null) {
+      int idx = scanProvider.indexOfAsciiTriple(bytes, offset, scanLen, b0, b1, b2, start);
+      if (idx != VectorScanProvider.UNSUPPORTED) {
+        return idx;
+      }
+    }
+    return ByteSwarScan.indexOfByteTriple(bytes, offset, scanLen, b0, b1, b2, start);
   }
 
   Utf8InputScanner slice(int start, int end) {
@@ -286,7 +304,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
         return (res >= 0 && res < scanLen) ? res : -1;
       }
       if (high == low + 1) {
-        return ByteSwarScan.indexOfBytePair(bytes, offset, scanLen, (byte) low, (byte) high, start);
+        return scanBytePair(scanLen, (byte) low, (byte) high, start);
       }
       return ByteSwarScan.indexOfByteRange(bytes, offset, scanLen, low, high, start);
     }
@@ -295,8 +313,8 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
         && ranges[2] == ranges[3]
         && ranges[0] >= 0
         && ranges[3] < 0x80) {
-      return ByteSwarScan.indexOfBytePair(
-          bytes, offset, scanLen, (byte) ranges[0], (byte) ranges[2], start);
+      return scanBytePair(
+          scanLen, (byte) ranges[0], (byte) ranges[2], start);
     }
     return -2;
   }
@@ -475,8 +493,8 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       return indexOfByte((byte) first, start);
     }
     if (last == second) {
-      return ByteSwarScan.indexOfBytePair(
-          bytes, offset, length, (byte) first, (byte) second, start);
+      return scanBytePair(
+          length, (byte) first, (byte) second, start);
     }
     return contiguous
         ? ByteSwarScan.indexOfByteRange(bytes, offset, length, first, last, start)

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -723,8 +723,8 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   }
 
   @Override
-  public int indexOfCharClass(Pattern.CharClassScanInfo scanInfo, int start) {
+  public int indexOfCharClass(CharClassScanInfo scanInfo, int start) {
     return indexOfCodePointClass(
-        scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, start, length);
+        scanInfo.ranges(), scanInfo.bitmap0(), scanInfo.bitmap1(), start, length);
   }
 }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -502,8 +502,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       return indexOfByte((byte) first, start);
     }
     if (last == second) {
-      return scanBytePair(
-          length, (byte) first, (byte) second, start);
+      return scanBytePair(length, (byte) first, (byte) second, start);
     }
     return contiguous
         ? ByteSwarScan.indexOfByteRange(bytes, offset, length, first, last, start)

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -305,7 +305,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
         }
       }
       case 6 -> {
-        if (ranges[0] == ranges[1] && ranges[2] == ranges[3] && ranges[4] == ranges[5]) {
+        if (useSpecializedAsciiTriple(ranges, scanLen - start)) {
           return scanByteTriple(
               scanLen, (byte) ranges[0], (byte) ranges[2], (byte) ranges[4], start);
         }
@@ -329,6 +329,19 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       return ByteSwarScan.indexOfByteRange(bytes, offset, scanLen, ranges[0], ranges[1], start);
     }
     return -2;
+  }
+
+  static boolean isAsciiTriple(int[] ranges) {
+    return ranges.length == 6
+        && ranges[0] == ranges[1]
+        && ranges[2] == ranges[3]
+        && ranges[4] == ranges[5];
+  }
+
+  static boolean useSpecializedAsciiTriple(int[] ranges, int remaining) {
+    return isAsciiTriple(ranges)
+        && (VectorScanProviders.providerForTripleLength(remaining) != null
+            || VectorScanProviders.providerForLength(remaining) == null);
   }
 
   private int indexOfNonAsciiCodePointClass(int[] ranges, int start, int scanLen) {

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -115,8 +115,9 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   }
 
   private int scanBytePair(int scanLen, byte b0, byte b1, int start) {
-    if (scanProvider != null) {
-      int idx = scanProvider.indexOfAsciiPair(bytes, offset, scanLen, b0, b1, start);
+    VectorScanProvider pairProvider = VectorScanProviders.providerForPairLength(scanLen - start);
+    if (pairProvider != null) {
+      int idx = pairProvider.indexOfAsciiPair(bytes, offset, scanLen, b0, b1, start);
       if (idx != VectorScanProvider.UNSUPPORTED) {
         return idx;
       }
@@ -125,8 +126,10 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
   }
 
   private int scanByteTriple(int scanLen, byte b0, byte b1, byte b2, int start) {
-    if (scanProvider != null) {
-      int idx = scanProvider.indexOfAsciiTriple(bytes, offset, scanLen, b0, b1, b2, start);
+    VectorScanProvider tripleProvider =
+        VectorScanProviders.providerForTripleLength(scanLen - start);
+    if (tripleProvider != null) {
+      int idx = tripleProvider.indexOfAsciiTriple(bytes, offset, scanLen, b0, b1, b2, start);
       if (idx != VectorScanProvider.UNSUPPORTED) {
         return idx;
       }

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -281,40 +281,49 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
    *     requires the general code-point scan
    */
   private int indexOfAsciiRanges(int[] ranges, long bitmap0, long bitmap1, int start, int scanLen) {
-    if (ranges.length >= 2 && ranges[0] >= 0 && ranges[ranges.length - 1] < 0x80) {
-      if (scanProvider != null && scanLen - start >= scanProvider.minimumInputLength()) {
-        int position = start;
-        int scalarLimit = Math.min(scanLen, position + VECTOR_SCALAR_PROLOGUE_LENGTH);
-        for (; position < scalarLimit; position++) {
-          if (InputScanner.classContains(ranges, bitmap0, bitmap1, unsignedByteAt(position))) {
-            return position;
-          }
+    if (ranges.length < 2 || ranges[0] < 0 || ranges[ranges.length - 1] >= 0x80) {
+      return -2;
+    }
+    switch (ranges.length) {
+      case 2 -> {
+        int low = ranges[0];
+        int high = ranges[1];
+        if (low == high) {
+          int res = indexOfByte((byte) low, start);
+          return (res >= 0 && res < scanLen) ? res : -1;
         }
-        int result = scanProvider.indexOfAsciiClass(bytes, offset, scanLen, ranges, position);
-        if (result != VectorScanProvider.UNSUPPORTED) {
-          return result;
+        if (high == low + 1) {
+          return scanBytePair(scanLen, (byte) low, (byte) high, start);
         }
+      }
+      case 4 -> {
+        if (ranges[0] == ranges[1] && ranges[2] == ranges[3]) {
+          return scanBytePair(scanLen, (byte) ranges[0], (byte) ranges[2], start);
+        }
+      }
+      case 6 -> {
+        if (ranges[0] == ranges[1] && ranges[2] == ranges[3] && ranges[4] == ranges[5]) {
+          return scanByteTriple(
+              scanLen, (byte) ranges[0], (byte) ranges[2], (byte) ranges[4], start);
+        }
+      }
+      default -> {}
+    }
+    if (scanProvider != null && scanLen - start >= scanProvider.minimumInputLength()) {
+      int position = start;
+      int scalarLimit = Math.min(scanLen, position + VECTOR_SCALAR_PROLOGUE_LENGTH);
+      for (; position < scalarLimit; position++) {
+        if (InputScanner.classContains(ranges, bitmap0, bitmap1, unsignedByteAt(position))) {
+          return position;
+        }
+      }
+      int result = scanProvider.indexOfAsciiClass(bytes, offset, scanLen, ranges, position);
+      if (result != VectorScanProvider.UNSUPPORTED) {
+        return result;
       }
     }
-    if (ranges.length == 2 && ranges[0] >= 0 && ranges[1] < 0x80) {
-      int low = ranges[0];
-      int high = ranges[1];
-      if (low == high) {
-        int res = indexOfByte((byte) low, start);
-        return (res >= 0 && res < scanLen) ? res : -1;
-      }
-      if (high == low + 1) {
-        return scanBytePair(scanLen, (byte) low, (byte) high, start);
-      }
-      return ByteSwarScan.indexOfByteRange(bytes, offset, scanLen, low, high, start);
-    }
-    if (ranges.length == 4
-        && ranges[0] == ranges[1]
-        && ranges[2] == ranges[3]
-        && ranges[0] >= 0
-        && ranges[3] < 0x80) {
-      return scanBytePair(
-          scanLen, (byte) ranges[0], (byte) ranges[2], start);
+    if (ranges.length == 2) {
+      return ByteSwarScan.indexOfByteRange(bytes, offset, scanLen, ranges[0], ranges[1], start);
     }
     return -2;
   }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -207,8 +207,12 @@ sealed interface Utf8StartAccelerator {
             case 1 -> scanner.indexOfAscii(chars[0], fromIndex, scanner.length());
             case 2 -> scanner.indexOfAsciiPair(chars[0], chars[1], fromIndex, scanner.length());
             case 3 ->
-                scanner.indexOfAsciiTriple(
-                    chars[0], chars[1], chars[2], fromIndex, scanner.length());
+                scanner.indexOfCodePointClass(
+                    smallSet.ranges(),
+                    smallSet.bitmap0(),
+                    smallSet.bitmap1(),
+                    fromIndex,
+                    scanner.length());
             default ->
                 scanner.indexOfCodePointClass(
                     smallSet.ranges(),

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -67,10 +67,6 @@ sealed interface Utf8StartAccelerator {
       case Literal lit -> lit.findCandidate(scanner, pos);
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
-=======
-      case AsciiPair pair -> pair.findCandidate(scanner, pos);
-      case AsciiTriple triple -> triple.findCandidate(scanner, pos);
->>>>>>> 71b16554 (Use a dedicated pair and triple vector cutoff)
       case CharClass cc -> cc.findCandidate(scanner, pos);
       case Teddy t -> t.findCandidate(scanner, pos);
     };
@@ -192,7 +188,6 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-<<<<<<< HEAD
   record CharClass(CharClassScanInfo scanInfo) implements Utf8StartAccelerator {
 
     @Override

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -67,6 +67,10 @@ sealed interface Utf8StartAccelerator {
       case Literal lit -> lit.findCandidate(scanner, pos);
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
+=======
+      case AsciiPair pair -> pair.findCandidate(scanner, pos);
+      case AsciiTriple triple -> triple.findCandidate(scanner, pos);
+>>>>>>> 71b16554 (Use a dedicated pair and triple vector cutoff)
       case CharClass cc -> cc.findCandidate(scanner, pos);
       case Teddy t -> t.findCandidate(scanner, pos);
     };
@@ -188,6 +192,7 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
+<<<<<<< HEAD
   record CharClass(CharClassScanInfo scanInfo) implements Utf8StartAccelerator {
 
     @Override

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -197,24 +197,31 @@ sealed interface Utf8StartAccelerator {
 
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      if (scanInfo != null) {
-        if (scanInfo instanceof CharClassScanInfo.AsciiSmallSet smallSet) {
-          char[] chars = smallSet.chars();
-          if (chars.length == 1) {
-            return scanner.indexOfAscii(chars[0], fromIndex, scanner.length());
-          }
-          if (chars.length == 2) {
-            return scanner.indexOfAsciiPair(chars[0], chars[1], fromIndex, scanner.length());
-          }
-          if (chars.length == 3) {
-            return scanner.indexOfAsciiTriple(
-                chars[0], chars[1], chars[2], fromIndex, scanner.length());
-          }
-        }
-        return scanner.indexOfCodePointClass(
-            scanInfo.ranges(), scanInfo.bitmap0(), scanInfo.bitmap1(), fromIndex, scanner.length());
+      if (scanInfo == null) {
+        return fromIndex;
       }
-      return fromIndex;
+      return switch (scanInfo) {
+        case CharClassScanInfo.AsciiSmallSet smallSet -> {
+          char[] chars = smallSet.chars();
+          yield switch (chars.length) {
+            case 1 -> scanner.indexOfAscii(chars[0], fromIndex, scanner.length());
+            case 2 -> scanner.indexOfAsciiPair(chars[0], chars[1], fromIndex, scanner.length());
+            case 3 ->
+                scanner.indexOfAsciiTriple(
+                    chars[0], chars[1], chars[2], fromIndex, scanner.length());
+            default ->
+                scanner.indexOfCodePointClass(
+                    smallSet.ranges(),
+                    smallSet.bitmap0(),
+                    smallSet.bitmap1(),
+                    fromIndex,
+                    scanner.length());
+          };
+        }
+        case CharClassScanInfo other ->
+            scanner.indexOfCodePointClass(
+                other.ranges(), other.bitmap0(), other.bitmap1(), fromIndex, scanner.length());
+      };
     }
   }
 

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -6,7 +6,6 @@
 package org.safere;
 
 import java.nio.charset.StandardCharsets;
-import org.safere.Pattern.CharClassScanInfo;
 import org.safere.Pattern.FixedOffsetLiteral;
 
 /**
@@ -38,39 +37,8 @@ sealed interface Utf8StartAccelerator {
       return new Teddy(descriptor.teddyModel());
     }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
-      AsciiBitmap bitmap = descriptor.charClassPrefixAscii();
-      int card = bitmap.cardinality();
-      if (card == 2) {
-        int b0 = -1, b1 = -1;
-        for (int i = 0; i < 128; i++) {
-          if (bitmap.containsAscii(i)) {
-            if (b0 == -1) {
-              b0 = i;
-            } else {
-              b1 = i;
-              break;
-            }
-          }
-        }
-        return new AsciiPair((byte) b0, (byte) b1);
-      }
-      if (card == 3) {
-        int b0 = -1, b1 = -1, b2 = -1;
-        for (int i = 0; i < 128; i++) {
-          if (bitmap.containsAscii(i)) {
-            if (b0 == -1) {
-              b0 = i;
-            } else if (b1 == -1) {
-              b1 = i;
-            } else {
-              b2 = i;
-              break;
-            }
-          }
-        }
-        return new AsciiTriple((byte) b0, (byte) b1, (byte) b2);
-      }
-      CharClassScanInfo scanInfo = Pattern.buildAsciiClassScanInfo(bitmap);
+      CharClassScanInfo scanInfo =
+          CharClassScanInfo.fromAsciiBitmap(descriptor.charClassPrefixAscii());
       if (scanInfo != null) {
         return new CharClass(scanInfo);
       }
@@ -99,9 +67,6 @@ sealed interface Utf8StartAccelerator {
       case Literal lit -> lit.findCandidate(scanner, pos);
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
-      case AsciiPair pair -> scanner.indexOfAsciiPair(pair.b0(), pair.b1(), pos, scanner.length());
-      case AsciiTriple triple ->
-          scanner.indexOfAsciiTriple(triple.b0(), triple.b1(), triple.b2(), pos, scanner.length());
       case CharClass cc -> cc.findCandidate(scanner, pos);
       case Teddy t -> t.findCandidate(scanner, pos);
     };
@@ -223,32 +188,6 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-  record AsciiPair(byte b0, byte b1) implements Utf8StartAccelerator {
-
-    @Override
-    public AcceleratorPolicy policy() {
-      return AcceleratorPolicy.CHAR_CLASS;
-    }
-
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      return scanner.indexOfAsciiPair(b0, b1, fromIndex, scanner.length());
-    }
-  }
-
-  record AsciiTriple(byte b0, byte b1, byte b2) implements Utf8StartAccelerator {
-
-    @Override
-    public AcceleratorPolicy policy() {
-      return AcceleratorPolicy.CHAR_CLASS;
-    }
-
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
-      return scanner.indexOfAsciiTriple(b0, b1, b2, fromIndex, scanner.length());
-    }
-  }
-
   record CharClass(CharClassScanInfo scanInfo) implements Utf8StartAccelerator {
 
     @Override
@@ -259,8 +198,21 @@ sealed interface Utf8StartAccelerator {
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       if (scanInfo != null) {
+        if (scanInfo instanceof CharClassScanInfo.AsciiSmallSet smallSet) {
+          char[] chars = smallSet.chars();
+          if (chars.length == 1) {
+            return scanner.indexOfAscii(chars[0], fromIndex, scanner.length());
+          }
+          if (chars.length == 2) {
+            return scanner.indexOfAsciiPair(chars[0], chars[1], fromIndex, scanner.length());
+          }
+          if (chars.length == 3) {
+            return scanner.indexOfAsciiTriple(
+                chars[0], chars[1], chars[2], fromIndex, scanner.length());
+          }
+        }
         return scanner.indexOfCodePointClass(
-            scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex, scanner.length());
+            scanInfo.ranges(), scanInfo.bitmap0(), scanInfo.bitmap1(), fromIndex, scanner.length());
       }
       return fromIndex;
     }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -34,6 +34,7 @@ sealed interface Utf8StartAccelerator {
     }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
       AsciiBitmap bitmap = descriptor.charClassPrefixAscii();
+      CharClassScanInfo scanInfo = Pattern.buildAsciiClassScanInfo(bitmap);
       int card = bitmap.cardinality();
       if (card == 2) {
         int b0 = -1, b1 = -1;
@@ -63,9 +64,8 @@ sealed interface Utf8StartAccelerator {
             }
           }
         }
-        return new AsciiTriple((byte) b0, (byte) b1, (byte) b2);
+        return new AsciiTriple((byte) b0, (byte) b1, (byte) b2, scanInfo);
       }
-      CharClassScanInfo scanInfo = Pattern.buildAsciiClassScanInfo(bitmap);
       if (scanInfo != null) {
         return new CharClass(scanInfo);
       }
@@ -94,9 +94,8 @@ sealed interface Utf8StartAccelerator {
       case Literal lit -> lit.findCandidate(scanner, pos);
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
-      case AsciiPair pair -> scanner.indexOfAsciiPair(pair.b0(), pair.b1(), pos, scanner.length());
-      case AsciiTriple triple ->
-          scanner.indexOfAsciiTriple(triple.b0(), triple.b1(), triple.b2(), pos, scanner.length());
+      case AsciiPair pair -> pair.findCandidate(scanner, pos);
+      case AsciiTriple triple -> triple.findCandidate(scanner, pos);
       case CharClass cc -> cc.findCandidate(scanner, pos);
     };
   }
@@ -230,7 +229,8 @@ sealed interface Utf8StartAccelerator {
     }
   }
 
-  record AsciiTriple(byte b0, byte b1, byte b2) implements Utf8StartAccelerator {
+  record AsciiTriple(byte b0, byte b1, byte b2, CharClassScanInfo fallback)
+      implements Utf8StartAccelerator {
 
     @Override
     public AcceleratorPolicy policy() {
@@ -239,6 +239,10 @@ sealed interface Utf8StartAccelerator {
 
     @Override
     public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+      if (VectorScanProviders.providerForTripleLength(scanner.length() - fromIndex) == null) {
+        return scanner.indexOfCodePointClass(
+            fallback.ranges, fallback.bitmap0, fallback.bitmap1, fromIndex, scanner.length());
+      }
       return scanner.indexOfAsciiTriple(b0, b1, b2, fromIndex, scanner.length());
     }
   }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -33,8 +33,39 @@ sealed interface Utf8StartAccelerator {
       return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefixAscii());
     }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
-      CharClassScanInfo scanInfo =
-          Pattern.buildAsciiClassScanInfo(descriptor.charClassPrefixAscii());
+      AsciiBitmap bitmap = descriptor.charClassPrefixAscii();
+      int card = bitmap.cardinality();
+      if (card == 2) {
+        int b0 = -1, b1 = -1;
+        for (int i = 0; i < 128; i++) {
+          if (bitmap.containsAscii(i)) {
+            if (b0 == -1) {
+              b0 = i;
+            } else {
+              b1 = i;
+              break;
+            }
+          }
+        }
+        return new AsciiPair((byte) b0, (byte) b1);
+      }
+      if (card == 3) {
+        int b0 = -1, b1 = -1, b2 = -1;
+        for (int i = 0; i < 128; i++) {
+          if (bitmap.containsAscii(i)) {
+            if (b0 == -1) {
+              b0 = i;
+            } else if (b1 == -1) {
+              b1 = i;
+            } else {
+              b2 = i;
+              break;
+            }
+          }
+        }
+        return new AsciiTriple((byte) b0, (byte) b1, (byte) b2);
+      }
+      CharClassScanInfo scanInfo = Pattern.buildAsciiClassScanInfo(bitmap);
       if (scanInfo != null) {
         return new CharClass(scanInfo);
       }
@@ -63,6 +94,9 @@ sealed interface Utf8StartAccelerator {
       case Literal lit -> lit.findCandidate(scanner, pos);
       case CaseInsensitiveLiteral cil -> cil.findCandidate(scanner, pos);
       case FixedOffset fo -> fo.findCandidate(scanner, pos);
+      case AsciiPair pair -> scanner.indexOfAsciiPair(pair.b0(), pair.b1(), pos, scanner.length());
+      case AsciiTriple triple ->
+          scanner.indexOfAsciiTriple(triple.b0(), triple.b1(), triple.b2(), pos, scanner.length());
       case CharClass cc -> cc.findCandidate(scanner, pos);
     };
   }
@@ -180,6 +214,32 @@ sealed interface Utf8StartAccelerator {
             searchFrom, scanner.retreatByCodePoints(literalStart, fixedOffsetLiteral.maxOffset()));
       }
       return -1;
+    }
+  }
+
+  record AsciiPair(byte b0, byte b1) implements Utf8StartAccelerator {
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
+    }
+
+    @Override
+    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+      return scanner.indexOfAsciiPair(b0, b1, fromIndex, scanner.length());
+    }
+  }
+
+  record AsciiTriple(byte b0, byte b1, byte b2) implements Utf8StartAccelerator {
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
+    }
+
+    @Override
+    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+      return scanner.indexOfAsciiTriple(b0, b1, b2, fromIndex, scanner.length());
     }
   }
 

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -13,4 +13,15 @@ interface VectorScanProvider {
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
+
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
+  default int indexOfAsciiPair(byte[] bytes, int offset, int length, byte b0, byte b1, int start) {
+    return UNSUPPORTED;
+  }
+
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
+  default int indexOfAsciiTriple(
+      byte[] bytes, int offset, int length, byte b0, byte b1, byte b2, int start) {
+    return UNSUPPORTED;
+  }
 }

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -11,6 +11,12 @@ interface VectorScanProvider {
 
   int minimumInputLength();
 
+  int minimumPairInputLength();
+
+  int minimumTripleInputLength();
+
+  int maximumTripleInputLength();
+
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -13,6 +13,12 @@ interface VectorScanProvider {
 
   int minimumTeddyInputLength();
 
+  int minimumPairInputLength();
+
+  int minimumTripleInputLength();
+
+  int maximumTripleInputLength();
+
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -42,7 +42,7 @@ final class VectorScanProviders {
       return null;
     }
     if (!requested.equals("vector")) {
-      throw new IllegalStateException("Unknown Vector scan provider  + requested + ");
+      throw new IllegalStateException(unknownProviderMessage(requested));
     }
     try {
       return VectorScanProviderFactory.create();
@@ -52,5 +52,9 @@ final class VectorScanProviders {
               + "--add-modules=jdk.incubator.vector",
           e);
     }
+  }
+
+  static String unknownProviderMessage(String requested) {
+    return "Unknown Vector scan provider " + requested;
   }
 }

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -24,13 +24,25 @@ final class VectorScanProviders {
     return SELECTED != null;
   }
 
+  static VectorScanProvider providerForPairLength(int length) {
+    return SELECTED != null && length >= SELECTED.minimumPairInputLength() ? SELECTED : null;
+  }
+
+  static VectorScanProvider providerForTripleLength(int length) {
+    return SELECTED != null
+            && length >= SELECTED.minimumTripleInputLength()
+            && length <= SELECTED.maximumTripleInputLength()
+        ? SELECTED
+        : null;
+  }
+
   private static VectorScanProvider loadSelected() {
     String requested = System.getProperty(PROVIDER_PROPERTY, "").trim();
     if (requested.isEmpty() || requested.equals("swar")) {
       return null;
     }
     if (!requested.equals("vector")) {
-      throw new IllegalStateException("Unknown Vector scan provider '" + requested + "'");
+      throw new IllegalStateException("Unknown Vector scan provider  + requested + ");
     }
     try {
       return VectorScanProviderFactory.create();

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -16,6 +16,18 @@ final class VectorScanProviders {
     return SELECTED != null && length >= SELECTED.minimumInputLength() ? SELECTED : null;
   }
 
+  static VectorScanProvider providerForPairLength(int length) {
+    return SELECTED != null && length >= SELECTED.minimumPairInputLength() ? SELECTED : null;
+  }
+
+  static VectorScanProvider providerForTripleLength(int length) {
+    return SELECTED != null
+            && length >= SELECTED.minimumTripleInputLength()
+            && length <= SELECTED.maximumTripleInputLength()
+        ? SELECTED
+        : null;
+  }
+
   private static VectorScanProvider loadSelected() {
     String requested = System.getProperty(PROVIDER_PROPERTY, "").trim();
     if (requested.isEmpty() || requested.equals("swar")) {

--- a/safere/src/test/java/org/safere/CharClassTest.java
+++ b/safere/src/test/java/org/safere/CharClassTest.java
@@ -399,6 +399,18 @@ class CharClassTest {
     assertThat(cc.contains(0x1F5FF)).isFalse();
   }
 
+  @Test
+  void scanInfoRetainsPrecomputedRanges() {
+    CharClassScanInfo smallSet =
+        CharClassScanInfo.fromCharClass(new CharClassBuilder().addRune('a').addRune('z').build());
+    CharClassScanInfo bitmap =
+        CharClassScanInfo.fromCharClass(
+            new CharClassBuilder().addRune('a').addRune('c').addRune('e').addRune('g').build());
+
+    assertThat(smallSet.ranges()).isSameAs(smallSet.ranges());
+    assertThat(bitmap.ranges()).isSameAs(bitmap.ranges());
+  }
+
   private static void assertRanges(CharClass cc, int... endpoints) {
     assertThat(endpoints.length).isEven();
     assertThat(cc.numRanges()).isEqualTo(endpoints.length / 2);

--- a/safere/src/test/java/org/safere/MatchDescriptorTest.java
+++ b/safere/src/test/java/org/safere/MatchDescriptorTest.java
@@ -36,7 +36,7 @@ class MatchDescriptorTest {
     MatchDescriptor desc = p.matchDescriptor();
     assertThat(desc.hasFastPath()).isTrue();
     assertThat(desc.singleCharClass()).isNotNull();
-    assertThat(desc.singleCharClass().isAscii).isTrue();
+    assertThat(desc.singleCharClass().isAscii()).isTrue();
   }
 
   @Test

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -78,8 +78,8 @@ class PatternInternalTest {
 
   @Test
   void asciiPrefixScanInfoHandlesMissingAndEmptyClasses() {
-    assertThat(Pattern.buildAsciiClassScanInfo(null)).isNull();
-    assertThat(Pattern.buildAsciiClassScanInfo(AsciiBitmap.EMPTY)).isNull();
+    assertThat(CharClassScanInfo.fromAsciiBitmap(null)).isNull();
+    assertThat(CharClassScanInfo.fromAsciiBitmap(AsciiBitmap.EMPTY)).isNull();
   }
 
   @Test
@@ -487,7 +487,7 @@ class PatternInternalTest {
     }
     AsciiBitmap asciiClass = builder.build();
 
-    CharClassScanInfo info = Pattern.buildAsciiClassScanInfo(asciiClass);
+    CharClassScanInfo info = CharClassScanInfo.fromAsciiBitmap(asciiClass);
 
     assertThat(info).isNotNull();
     assertThat(info.ranges()).containsExactly(expectedRanges);

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -93,11 +93,10 @@ class PatternInternalTest {
 
   @Test
   void asciiPrefixScanInfoPreservesMembersAcrossBitmapBoundary() {
-    Pattern.CharClassScanInfo info =
-        assertAsciiScanInfo(new int[] {62, 63, 64, 65}, new int[] {62, 65});
+    CharClassScanInfo info = assertAsciiScanInfo(new int[] {62, 63, 64, 65}, new int[] {62, 65});
 
-    assertThat(info.bitmap0).isEqualTo((1L << 62) | (1L << 63));
-    assertThat(info.bitmap1).isEqualTo((1L << 0) | (1L << 1));
+    assertThat(info.bitmap0()).isEqualTo((1L << 62) | (1L << 63));
+    assertThat(info.bitmap1()).isEqualTo((1L << 0) | (1L << 1));
   }
 
   @Test
@@ -476,25 +475,25 @@ class PatternInternalTest {
   }
 
   private static boolean requiredClassContains(Pattern pattern, int codePoint) {
-    Pattern.CharClassScanInfo info = pattern.rejectDescriptor().requiredCharClass();
+    CharClassScanInfo info = pattern.rejectDescriptor().requiredCharClass();
     return info != null
-        && InputScanner.classContains(info.ranges, info.bitmap0, info.bitmap1, codePoint);
+        && InputScanner.classContains(info.ranges(), info.bitmap0(), info.bitmap1(), codePoint);
   }
 
-  private static Pattern.CharClassScanInfo assertAsciiScanInfo(
-      int[] members, int[] expectedRanges) {
+  private static CharClassScanInfo assertAsciiScanInfo(int[] members, int[] expectedRanges) {
     AsciiBitmap.Builder builder = new AsciiBitmap.Builder();
     for (int member : members) {
       builder.add(member);
     }
     AsciiBitmap asciiClass = builder.build();
 
-    Pattern.CharClassScanInfo info = Pattern.buildAsciiClassScanInfo(asciiClass);
+    CharClassScanInfo info = Pattern.buildAsciiClassScanInfo(asciiClass);
 
     assertThat(info).isNotNull();
-    assertThat(info.ranges).containsExactly(expectedRanges);
+    assertThat(info.ranges()).containsExactly(expectedRanges);
     for (int codePoint = 0; codePoint < 128; codePoint++) {
-      assertThat(InputScanner.classContains(info.ranges, info.bitmap0, info.bitmap1, codePoint))
+      assertThat(
+              InputScanner.classContains(info.ranges(), info.bitmap0(), info.bitmap1(), codePoint))
           .as("ASCII member %s", codePoint)
           .isEqualTo(asciiClass.containsAscii(codePoint));
     }

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -9,7 +9,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.safere.Pattern.CharClassScanInfo;
 
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class RejectPrefilterTest {
@@ -59,7 +58,7 @@ class RejectPrefilterTest {
     int[] ranges = new int[] {'0', '9'};
     long b0 = 0x03FF000000000000L; // digits 0-9
     long b1 = 0L;
-    CharClassScanInfo scanInfo = new CharClassScanInfo(ranges, b0, b1, true);
+    CharClassScanInfo scanInfo = new CharClassScanInfo.AsciiRanges(ranges, b0, b1);
 
     RejectDescriptor desc = new RejectDescriptor(null, scanInfo);
     assertThat(desc.hasRejectionFilter()).isTrue();
@@ -89,7 +88,7 @@ class RejectPrefilterTest {
     int[] ranges = new int[] {'0', '9'};
     long b0 = 0x03FF000000000000L;
     long b1 = 0L;
-    CharClassScanInfo scanInfo = new CharClassScanInfo(ranges, b0, b1, true);
+    CharClassScanInfo scanInfo = new CharClassScanInfo.AsciiRanges(ranges, b0, b1);
 
     RejectDescriptor desc = new RejectDescriptor("token", scanInfo);
     RejectPrefilter prefilter = RejectPrefilter.create(desc);

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -630,6 +630,13 @@ class SearchScalingRegressionTest {
       assertThat(ByteSwarScan.indexOfAsciiClass(matchAtEnd, 0, len, ranges, 0))
           .as("SWAR end match for length %d", len)
           .isEqualTo(len - 1);
+      assertThat(ByteSwarScan.indexOfBytePair(absent, 0, len, (byte) 'y', (byte) 'z', 0))
+          .as("SWAR pair absent result for length %d", len)
+          .isEqualTo(-1);
+      assertThat(ByteSwarScan.indexOfByteTriple(absent, 0, len, (byte) 'x', (byte) 'y', (byte) 'z', 0))
+          .as("SWAR triple absent result for length %d", len)
+          .isEqualTo(-1);
+
       if (isVectorApiAvailable()) {
         assertThat(ByteVectorScan.indexOfAsciiClass(absent, 0, len, ranges, 0))
             .as("vector absent result for length %d", len)
@@ -637,6 +644,12 @@ class SearchScalingRegressionTest {
         assertThat(ByteVectorScan.indexOfAsciiClass(matchAtEnd, 0, len, ranges, 0))
             .as("vector end match for length %d", len)
             .isEqualTo(len - 1);
+        assertThat(ByteVectorScan.indexOfAsciiPair(absent, 0, len, (byte) 'y', (byte) 'z', 0))
+            .as("vector pair absent result for length %d", len)
+            .isEqualTo(-1);
+        assertThat(ByteVectorScan.indexOfAsciiTriple(absent, 0, len, (byte) 'x', (byte) 'y', (byte) 'z', 0))
+            .as("vector triple absent result for length %d", len)
+            .isEqualTo(-1);
       }
     }
   }

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -633,7 +633,8 @@ class SearchScalingRegressionTest {
       assertThat(ByteSwarScan.indexOfBytePair(absent, 0, len, (byte) 'y', (byte) 'z', 0))
           .as("SWAR pair absent result for length %d", len)
           .isEqualTo(-1);
-      assertThat(ByteSwarScan.indexOfByteTriple(absent, 0, len, (byte) 'x', (byte) 'y', (byte) 'z', 0))
+      assertThat(
+              ByteSwarScan.indexOfByteTriple(absent, 0, len, (byte) 'x', (byte) 'y', (byte) 'z', 0))
           .as("SWAR triple absent result for length %d", len)
           .isEqualTo(-1);
 
@@ -647,7 +648,9 @@ class SearchScalingRegressionTest {
         assertThat(ByteVectorScan.indexOfAsciiPair(absent, 0, len, (byte) 'y', (byte) 'z', 0))
             .as("vector pair absent result for length %d", len)
             .isEqualTo(-1);
-        assertThat(ByteVectorScan.indexOfAsciiTriple(absent, 0, len, (byte) 'x', (byte) 'y', (byte) 'z', 0))
+        assertThat(
+                ByteVectorScan.indexOfAsciiTriple(
+                    absent, 0, len, (byte) 'x', (byte) 'y', (byte) 'z', 0))
             .as("vector triple absent result for length %d", len)
             .isEqualTo(-1);
       }

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -97,7 +97,9 @@ class StartAcceleratorTest {
     assertThat(strAcc.findCandidate("xxxa", 0, false)).isEqualTo(3);
 
     Utf8StartAccelerator utf8PairAcc = Utf8StartAccelerator.create(descPair, false);
-    assertThat(utf8PairAcc).isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+    assertThat(utf8PairAcc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
+    assertThat(((Utf8StartAccelerator.CharClass) utf8PairAcc).scanInfo())
+        .isInstanceOf(CharClassScanInfo.AsciiSmallSet.class);
     assertThat(utf8PairAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(utf8PairAcc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
 

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -88,18 +88,25 @@ class StartAcceleratorTest {
 
   @Test
   void charClassPrefixAcceleratesStringAndUtf8() {
-    AsciiBitmap ascii = new AsciiBitmap.Builder().add('a').add('b').build();
-    StartDescriptor desc = new StartDescriptor(null, false, null, ascii, null);
+    AsciiBitmap asciiPair = new AsciiBitmap.Builder().add('a').add('b').build();
+    StartDescriptor descPair = new StartDescriptor(null, false, null, asciiPair, null);
 
-    StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
+    StringStartAccelerator strAcc = StringStartAccelerator.create(descPair, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
     assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(strAcc.findCandidate("xxxa", 0, false)).isEqualTo(3);
 
-    Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
-    assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
-    assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
+    Utf8StartAccelerator utf8PairAcc = Utf8StartAccelerator.create(descPair, false);
+    assertThat(utf8PairAcc).isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+    assertThat(utf8PairAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(utf8PairAcc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
+
+    AsciiBitmap asciiMulti = new AsciiBitmap.Builder().add('a').add('b').add('c').add('d').build();
+    StartDescriptor descMulti = new StartDescriptor(null, false, null, asciiMulti, null);
+    Utf8StartAccelerator utf8MultiAcc = Utf8StartAccelerator.create(descMulti, false);
+    assertThat(utf8MultiAcc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
+    assertThat(utf8MultiAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(utf8MultiAcc.findCandidate(utf8Scanner("xxxd"), 0)).isEqualTo(3);
   }
 
   @Test

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class Utf8VectorPairTripleTest {
 
   private static boolean isVectorApiAvailable() {

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -18,6 +18,30 @@ import org.junit.jupiter.params.provider.ValueSource;
 class Utf8VectorPairTripleTest {
 
   @Test
+  void tripleScannerRequiresThreeDisjointCharacters() {
+    assertThat(Utf8InputScanner.isAsciiTriple(new int[] {'X', 'X', 'Z', 'Z', '_', '_'})).isTrue();
+    assertThat(Utf8InputScanner.isAsciiTriple(new int[] {'X', 'Z'})).isFalse();
+    assertThat(Utf8InputScanner.isAsciiTriple(new int[] {'X', 'X', 'Z', 'Z'})).isFalse();
+  }
+
+  @Test
+  void disjointTripleDispatchHonorsVectorCrossover() {
+    int[] ranges = {'X', 'X', 'Z', 'Z', '_', '_'};
+    if (VectorScanProviders.providerForTripleLength(64) != null) {
+      assertThat(Utf8InputScanner.useSpecializedAsciiTriple(ranges, 64)).isTrue();
+      assertThat(Utf8InputScanner.useSpecializedAsciiTriple(ranges, 10_240)).isTrue();
+    }
+    if (VectorScanProviders.providerForLength(10_241) != null) {
+      assertThat(Utf8InputScanner.useSpecializedAsciiTriple(ranges, 10_241)).isFalse();
+    }
+  }
+
+  @Test
+  void unknownProviderDiagnosticIncludesRequestedValue() {
+    assertThat(VectorScanProviders.unknownProviderMessage("typo")).contains("typo");
+  }
+
+  @Test
   void pairAndTripleScansHaveIndependentVectorCutoffs() {
     if (VectorScanProviders.providerForPairLength(64) != null) {
       assertThat(VectorScanProviders.providerForLength(64)).isNull();

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -112,4 +112,59 @@ class Utf8VectorPairTripleTest {
     assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 23, 61)).isEqualTo(-1);
     assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 23, 62)).isEqualTo(61);
   }
+
+  @Test
+  void testStartAcceleratorSelection() {
+    Pattern pPairClass = Pattern.compile("[YZ]");
+    assertThat(pPairClass.utf8StartAccelerator())
+        .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+
+    Pattern pPairAlt = Pattern.compile("Y|Z");
+    assertThat(pPairAlt.utf8StartAccelerator())
+        .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+
+    Pattern pConsecutivePair = Pattern.compile("[ab]");
+    assertThat(pConsecutivePair.utf8StartAccelerator())
+        .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+
+    Pattern pTripleClass = Pattern.compile("[XYZ]");
+    assertThat(pTripleClass.utf8StartAccelerator())
+        .isInstanceOf(Utf8StartAccelerator.AsciiTriple.class);
+
+    Pattern pTripleAlt = Pattern.compile("X|Y|Z");
+    assertThat(pTripleAlt.utf8StartAccelerator())
+        .isInstanceOf(Utf8StartAccelerator.AsciiTriple.class);
+  }
+
+  @Test
+  void testPatternMatchingWithPairAndTriple() {
+    byte[] input = "the quick brown fox jumps over the lazy dog".getBytes(UTF_8);
+    Utf8Input utf8 = Utf8Input.trusted(input);
+
+    Pattern pPair = Pattern.compile("[jx]");
+    Utf8Matcher mPair = pPair.matcher(utf8);
+    assertThat(mPair.find()).isTrue();
+    assertThat(mPair.start()).isEqualTo(18); // 'j' in jumps
+
+    Pattern pTriple = Pattern.compile("[xyz]");
+    Utf8Matcher mTriple = pTriple.matcher(utf8);
+    assertThat(mTriple.find()).isTrue();
+    assertThat(mTriple.start()).isEqualTo(18); // 'x' in fox is at 18? No, 'x' is at 18
+  }
+
+  @Test
+  void testDfaSelfLoopPairAndTriple() {
+    byte[] input = "START some arbitrary payload with delimiters Y and Z".getBytes(UTF_8);
+    Utf8Input utf8 = Utf8Input.trusted(input);
+
+    Pattern pPair = Pattern.compile("(?s)START.*?[YZ]");
+    Utf8Matcher mPair = pPair.matcher(utf8);
+    assertThat(mPair.find()).isTrue();
+    assertThat(mPair.end()).isEqualTo(46); // index after 'Y'
+
+    Pattern pTriple = Pattern.compile("(?s)START.*?[XYZ]");
+    Utf8Matcher mTriple = pTriple.matcher(utf8);
+    assertThat(mTriple.find()).isTrue();
+    assertThat(mTriple.end()).isEqualTo(46);
+  }
 }

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -118,28 +118,28 @@ class Utf8VectorPairTripleTest {
   void testStartAcceleratorSelection() {
     Pattern pPairClass = Pattern.compile("[YZ]");
     assertThat(pPairClass.utf8StartAccelerator())
-        .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+        .isInstanceOf(Utf8StartAccelerator.CharClass.class);
 
     Pattern pPairAlt = Pattern.compile("Y|Z");
     Class<?> expectedPairAltClass =
         VectorScanProviders.teddyProviderAvailable()
             ? Utf8StartAccelerator.Teddy.class
-            : Utf8StartAccelerator.AsciiPair.class;
+            : Utf8StartAccelerator.CharClass.class;
     assertThat(pPairAlt.utf8StartAccelerator()).isInstanceOf(expectedPairAltClass);
 
     Pattern pConsecutivePair = Pattern.compile("[ab]");
     assertThat(pConsecutivePair.utf8StartAccelerator())
-        .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+        .isInstanceOf(Utf8StartAccelerator.CharClass.class);
 
     Pattern pTripleClass = Pattern.compile("[XYZ]");
     assertThat(pTripleClass.utf8StartAccelerator())
-        .isInstanceOf(Utf8StartAccelerator.AsciiTriple.class);
+        .isInstanceOf(Utf8StartAccelerator.CharClass.class);
 
     Pattern pTripleAlt = Pattern.compile("X|Y|Z");
     Class<?> expectedTripleAltClass =
         VectorScanProviders.teddyProviderAvailable()
             ? Utf8StartAccelerator.Teddy.class
-            : Utf8StartAccelerator.AsciiTriple.class;
+            : Utf8StartAccelerator.CharClass.class;
     assertThat(pTripleAlt.utf8StartAccelerator()).isInstanceOf(expectedTripleAltClass);
   }
 

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -1,0 +1,115 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class Utf8VectorPairTripleTest {
+
+  private static boolean isVectorApiAvailable() {
+    try {
+      Class.forName("jdk.incubator.vector.ByteVector");
+      return true;
+    } catch (ClassNotFoundException | LinkageError e) {
+      return false;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 15, 16, 31, 32, 63, 64, 100, 128, 256, 500})
+  void testPairEquivalenceWithSwar(int length) {
+    assumeTrue(isVectorApiAvailable(), "Vector API not available on module path");
+
+    byte b0 = 'x';
+    byte b1 = 'y';
+    Random rnd = new Random(1000 + length);
+
+    for (int trial = 0; trial < 50; trial++) {
+      byte[] bytes = new byte[length];
+      for (int i = 0; i < length; i++) {
+        bytes[i] = (byte) ('a' + rnd.nextInt(20)); // 'a'..'t' (no 'x' or 'y')
+      }
+      int start = length == 0 ? 0 : rnd.nextInt(length);
+
+      // Absent check
+      int swarAbsent = ByteSwarScan.indexOfBytePair(bytes, 0, length, b0, b1, start);
+      int vectorAbsent = ByteVectorScan.indexOfAsciiPair(bytes, 0, length, b0, b1, start);
+      assertThat(vectorAbsent).as("absent trial %d len %d", trial, length).isEqualTo(swarAbsent);
+
+      // Present check
+      if (length > start) {
+        int pos = start + rnd.nextInt(length - start);
+        bytes[pos] = rnd.nextBoolean() ? b0 : b1;
+
+        int swarHit = ByteSwarScan.indexOfBytePair(bytes, 0, length, b0, b1, start);
+        int vectorHit = ByteVectorScan.indexOfAsciiPair(bytes, 0, length, b0, b1, start);
+        assertThat(vectorHit).as("hit trial %d len %d", trial, length).isEqualTo(swarHit);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 15, 16, 31, 32, 63, 64, 100, 128, 256, 500})
+  void testTripleEquivalenceWithSwar(int length) {
+    assumeTrue(isVectorApiAvailable(), "Vector API not available on module path");
+
+    byte b0 = 'x';
+    byte b1 = 'y';
+    byte b2 = 'z';
+    Random rnd = new Random(2000 + length);
+
+    for (int trial = 0; trial < 50; trial++) {
+      byte[] bytes = new byte[length];
+      for (int i = 0; i < length; i++) {
+        bytes[i] = (byte) ('a' + rnd.nextInt(20)); // 'a'..'t' (no 'x', 'y', 'z')
+      }
+      int start = length == 0 ? 0 : rnd.nextInt(length);
+
+      // Absent check
+      int swarAbsent = ByteSwarScan.indexOfByteTriple(bytes, 0, length, b0, b1, b2, start);
+      int vectorAbsent = ByteVectorScan.indexOfAsciiTriple(bytes, 0, length, b0, b1, b2, start);
+      assertThat(vectorAbsent).as("absent trial %d len %d", trial, length).isEqualTo(swarAbsent);
+
+      // Present check
+      if (length > start) {
+        int pos = start + rnd.nextInt(length - start);
+        int choice = rnd.nextInt(3);
+        bytes[pos] = choice == 0 ? b0 : choice == 1 ? b1 : b2;
+
+        int swarHit = ByteSwarScan.indexOfByteTriple(bytes, 0, length, b0, b1, b2, start);
+        int vectorHit = ByteVectorScan.indexOfAsciiTriple(bytes, 0, length, b0, b1, b2, start);
+        assertThat(vectorHit).as("hit trial %d len %d", trial, length).isEqualTo(swarHit);
+      }
+    }
+  }
+
+  @Test
+  void testScannerPairAndTripleWithLimit() {
+    byte[] bytes = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(UTF_8);
+    Utf8InputScanner scanner = new Utf8InputScanner(bytes);
+
+    // 'a' is at 10, 'A' is at 36
+    assertThat(scanner.indexOfAsciiPair('a', 'A', 0, 10)).isEqualTo(-1);
+    assertThat(scanner.indexOfAsciiPair('a', 'A', 0, 11)).isEqualTo(10);
+    assertThat(scanner.indexOfAsciiPair('a', 'A', 11, 36)).isEqualTo(-1);
+    assertThat(scanner.indexOfAsciiPair('a', 'A', 11, 37)).isEqualTo(36);
+
+    // 'b' at 11, 'm' at 22, 'Z' at 61
+    assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 0, 11)).isEqualTo(-1);
+    assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 0, 12)).isEqualTo(11);
+    assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 12, 22)).isEqualTo(-1);
+    assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 12, 23)).isEqualTo(22);
+    assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 23, 61)).isEqualTo(-1);
+    assertThat(scanner.indexOfAsciiTriple('b', 'm', 'Z', 23, 62)).isEqualTo(61);
+  }
+}

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -17,6 +17,17 @@ import org.junit.jupiter.params.provider.ValueSource;
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class Utf8VectorPairTripleTest {
 
+  @Test
+  void pairAndTripleScansHaveIndependentVectorCutoffs() {
+    if (VectorScanProviders.providerForPairLength(64) != null) {
+      assertThat(VectorScanProviders.providerForLength(64)).isNull();
+      assertThat(VectorScanProviders.providerForTripleLength(64)).isNotNull();
+      assertThat(VectorScanProviders.providerForTripleLength(10_240)).isNotNull();
+      assertThat(VectorScanProviders.providerForTripleLength(10_241)).isNull();
+      assertThat(VectorScanProviders.providerForLength(1024)).isNotNull();
+    }
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
+++ b/safere/src/test/java/org/safere/Utf8VectorPairTripleTest.java
@@ -120,8 +120,7 @@ class Utf8VectorPairTripleTest {
         .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
 
     Pattern pPairAlt = Pattern.compile("Y|Z");
-    assertThat(pPairAlt.utf8StartAccelerator())
-        .isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
+    assertThat(pPairAlt.utf8StartAccelerator()).isInstanceOf(Utf8StartAccelerator.AsciiPair.class);
 
     Pattern pConsecutivePair = Pattern.compile("[ab]");
     assertThat(pConsecutivePair.utf8StartAccelerator())


### PR DESCRIPTION
This adds 256/512-bit SIMD acceleration for 2-character and 3-character searches (`indexOfAsciiPair` and `indexOfAsciiTriple`) on UTF-8 `byte[]` inputs using the JDK Vector API.

`Utf8InputScanner` previously used 64-bit SWAR (`ByteSwarScan`) to scan 8 bytes per iteration for byte pairs (`[ab]`) and triples (`[abc]`). On modern AVX2 and AVX-512 hardware, vector registers can inspect 32 or 64 bytes per cycle.

* Add `indexOfAsciiPair` and `indexOfAsciiTriple` in `ByteVectorScan` using broadcast `ByteVector` comparisons and `.or()` mask reduction.
* Delegate to `scanProvider` in `Utf8InputScanner` when the scan length meets the vector threshold (`>= 64` bytes), with clean fallback to `ByteSwarScan`.
* Provide full unit test coverage for memory alignments (0–63 byte offsets), edge cases, and crosscheck equivalence with SWAR and scalar matching.

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline benchmarks-baseline \
  --vector \
  'SearchScalingBenchmark\.ascii(Pair|Triple).*@safere-utf8'
```

| Benchmark                                         | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------------------------- | ---------------- | --------------- | ------- |
| SearchScalingBenchmark.asciiPairFail.1024         |        86 ± 0.60 |       28 ± 0.15 |   3.11x |
| SearchScalingBenchmark.asciiPairSuccess.1024      |         96 ± 3.8 |        59 ± 2.4 |   1.62x |
| SearchScalingBenchmark.asciiTripleFail.1024       |        96 ± 0.85 |        34 ± 2.0 |   2.83x |
| SearchScalingBenchmark.asciiTripleSuccess.1024    |        101 ± 2.3 |        68 ± 2.8 |   1.48x |
| SearchScalingBenchmark.asciiPairFail.10240        |        217 ± 2.3 |        166 ± 12 |   1.31x |
| SearchScalingBenchmark.asciiPairSuccess.10240     |         229 ± 10 |        194 ± 21 |   1.18x |
| SearchScalingBenchmark.asciiTripleFail.10240      |        303 ± 2.7 |        213 ± 14 |   1.42x |
| SearchScalingBenchmark.asciiTripleSuccess.10240   |        314 ± 5.8 |       234 ± 2.7 |   1.34x |
| SearchScalingBenchmark.asciiPairFail.102400       |        1872 ± 12 |      1669 ± 210 |   1.12x |
| SearchScalingBenchmark.asciiPairSuccess.102400    |        1932 ± 52 |      1887 ± 104 |   1.02x |
| SearchScalingBenchmark.asciiTripleFail.102400     |       2518 ± 140 |       1989 ± 30 |   1.27x |
| SearchScalingBenchmark.asciiTripleSuccess.102400  |       2520 ± 127 |      1965 ± 108 |   1.28x |
| SearchScalingBenchmark.asciiPairFail.1048576      |      19710 ± 591 |     20750 ± 787 |   0.95x |
| SearchScalingBenchmark.asciiPairSuccess.1048576   |      19572 ± 755 |     19960 ± 707 |   0.98x |
| SearchScalingBenchmark.asciiTripleFail.1048576    |     25603 ± 1032 |     21783 ± 927 |   1.18x |
| SearchScalingBenchmark.asciiTripleSuccess.1048576 |     26377 ± 1861 |     21802 ± 779 |   1.21x |