### PR TITLE
Add SafeRE quality gates for vector species, repeated find scaling, and accelerator policy introspection

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -147,6 +147,7 @@
                         <exclude name="Utf8InputTest.java"/>
                         <exclude name="Utf8LinearTimeTest.java"/>
                         <exclude name="UtilsTest.java"/>
+                        <exclude name="VectorSpeciesSimulationTest.java"/>
                         <exclude name="WalkerTest.java"/>
                         <exclude name="WorkCounterTest.java"/>
                         <exclude name="WorkLimitTest.java"/>

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -20,13 +20,18 @@ final class ByteVectorScan {
   private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
 
   static int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
+    return indexOfAsciiClass(SPECIES, bytes, offset, length, ranges, start);
+  }
+
+  static int indexOfAsciiClass(
+      VectorSpecies<Byte> species, byte[] bytes, int offset, int length, int[] ranges, int start) {
     if (!Swar.supportsAsciiRanges(ranges, 4)) {
       return VectorScanProvider.UNSUPPORTED;
     }
     int position = Math.max(0, start);
-    int limit = position + SPECIES.loopBound(length - position);
-    for (; position < limit; position += SPECIES.length()) {
-      ByteVector values = ByteVector.fromArray(SPECIES, bytes, offset + position);
+    int limit = position + species.loopBound(length - position);
+    for (; position < limit; position += species.length()) {
+      ByteVector values = ByteVector.fromArray(species, bytes, offset + position);
       VectorMask<Byte> matches = matches(values, ranges);
       if (matches.anyTrue()) {
         return position + matches.firstTrue();
@@ -85,6 +90,21 @@ final class ByteVectorScan {
       byte low,
       byte high,
       int start) {
+    return indexOfIgnoreCase(
+        SPECIES, bytes, offset, length, prefix, prefixLen, anchorOffset, low, high, start);
+  }
+
+  public static int indexOfIgnoreCase(
+      VectorSpecies<Byte> species,
+      byte[] bytes,
+      int offset,
+      int length,
+      String prefix,
+      int prefixLen,
+      int anchorOffset,
+      byte low,
+      byte high,
+      int start) {
     if (prefixLen == 0) {
       return Math.min(Math.max(0, start), length);
     }
@@ -108,7 +128,7 @@ final class ByteVectorScan {
       }
     }
 
-    int vectorLen = SPECIES.length();
+    int vectorLen = species.length();
     int limit = length - vectorLen;
     if (pos > limit) {
       int limitScalar = length - prefixLen;
@@ -128,11 +148,11 @@ final class ByteVectorScan {
       return -1;
     }
 
-    ByteVector lowVec = ByteVector.broadcast(SPECIES, low);
-    ByteVector highVec = ByteVector.broadcast(SPECIES, high);
+    ByteVector lowVec = ByteVector.broadcast(species, low);
+    ByteVector highVec = ByteVector.broadcast(species, high);
 
     for (; pos <= limit; pos += vectorLen) {
-      ByteVector inputVec = ByteVector.fromArray(SPECIES, bytes, offset + pos);
+      ByteVector inputVec = ByteVector.fromArray(species, bytes, offset + pos);
       VectorMask<Byte> matchMask = inputVec.compare(EQ, lowVec).or(inputVec.compare(EQ, highVec));
 
       if (matchMask.anyTrue()) {

--- a/safere/src/main/java/org/safere/ShortVectorScan.java
+++ b/safere/src/main/java/org/safere/ShortVectorScan.java
@@ -25,18 +25,22 @@ import jdk.incubator.vector.VectorSpecies;
  */
 final class ShortVectorScan {
   private static final VectorSpecies<Short> SPECIES = ShortVector.SPECIES_PREFERRED;
-  private static final VectorSpecies<Byte> BYTE_SPECIES = SPECIES.withLanes(byte.class);
 
   static int indexOfCharClass(char[] chars, int offset, int length, int[] ranges, int start) {
+    return indexOfCharClass(SPECIES, chars, offset, length, ranges, start);
+  }
+
+  static int indexOfCharClass(
+      VectorSpecies<Short> species, char[] chars, int offset, int length, int[] ranges, int start) {
     if (!Swar.supportsBmpCodeUnitRanges(ranges, 4)) {
       return VectorScanProvider.UNSUPPORTED;
     }
     int position = Math.max(0, start);
-    int vectorLen = SPECIES.length();
+    int vectorLen = species.length();
     int limit = length - vectorLen;
 
     for (; position <= limit; position += vectorLen) {
-      ShortVector values = ShortVector.fromCharArray(SPECIES, chars, offset + position);
+      ShortVector values = ShortVector.fromCharArray(species, chars, offset + position);
       VectorMask<Short> matches = matches(values, ranges);
       if (matches.anyTrue()) {
         return position + matches.firstTrue();
@@ -53,16 +57,22 @@ final class ShortVectorScan {
   }
 
   static int indexOfCharClassUtf16(byte[] bytes, int offset, int length, int[] ranges, int start) {
+    return indexOfCharClassUtf16(SPECIES, bytes, offset, length, ranges, start);
+  }
+
+  static int indexOfCharClassUtf16(
+      VectorSpecies<Short> species, byte[] bytes, int offset, int length, int[] ranges, int start) {
     if (!Swar.supportsBmpCodeUnitRanges(ranges, 4) || nativeOrder() == BIG_ENDIAN) {
       return VectorScanProvider.UNSUPPORTED;
     }
     int position = Math.max(0, start);
-    int vectorLen = SPECIES.length();
+    int vectorLen = species.length();
     int limit = length - vectorLen;
+    VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
 
     for (; position <= limit; position += vectorLen) {
       ShortVector values =
-          ByteVector.fromArray(BYTE_SPECIES, bytes, offset + (position << 1)).reinterpretAsShorts();
+          ByteVector.fromArray(byteSpecies, bytes, offset + (position << 1)).reinterpretAsShorts();
       VectorMask<Short> matches = matches(values, ranges);
       if (matches.anyTrue()) {
         return position + matches.firstTrue();
@@ -82,6 +92,16 @@ final class ShortVectorScan {
   }
 
   static int indexOfIgnoreCase(char[] chars, int offset, int length, String prefix, int start) {
+    return indexOfIgnoreCase(SPECIES, chars, offset, length, prefix, start);
+  }
+
+  static int indexOfIgnoreCase(
+      VectorSpecies<Short> species,
+      char[] chars,
+      int offset,
+      int length,
+      String prefix,
+      int start) {
     int prefixLen = prefix.length();
     if (prefixLen == 0) {
       return Math.min(Math.max(0, start), length);
@@ -96,17 +116,17 @@ final class ShortVectorScan {
     }
 
     int pos = Math.max(0, start);
-    int vectorLen = SPECIES.length();
+    int vectorLen = species.length();
     int limit = length - vectorLen;
 
     char first = prefix.charAt(0);
     short low = (short) toLowerCase(first);
     short high = (short) toUpperCase(first);
-    ShortVector lowVec = ShortVector.broadcast(SPECIES, low);
-    ShortVector highVec = ShortVector.broadcast(SPECIES, high);
+    ShortVector lowVec = ShortVector.broadcast(species, low);
+    ShortVector highVec = ShortVector.broadcast(species, high);
 
     for (; pos <= limit; pos += vectorLen) {
-      ShortVector inputVec = ShortVector.fromCharArray(SPECIES, chars, offset + pos);
+      ShortVector inputVec = ShortVector.fromCharArray(species, chars, offset + pos);
       VectorMask<Short> matchMask =
           inputVec
               .compare(VectorOperators.EQ, lowVec)
@@ -137,6 +157,16 @@ final class ShortVectorScan {
 
   static int indexOfIgnoreCaseUtf16(
       byte[] bytes, int offset, int length, String prefix, int start) {
+    return indexOfIgnoreCaseUtf16(SPECIES, bytes, offset, length, prefix, start);
+  }
+
+  static int indexOfIgnoreCaseUtf16(
+      VectorSpecies<Short> species,
+      byte[] bytes,
+      int offset,
+      int length,
+      String prefix,
+      int start) {
     int prefixLen = prefix.length();
     if (prefixLen == 0) {
       return Math.min(Math.max(0, start), length);
@@ -154,18 +184,19 @@ final class ShortVectorScan {
     }
 
     int pos = Math.max(0, start);
-    int vectorLen = SPECIES.length();
+    int vectorLen = species.length();
     int limit = length - vectorLen;
+    VectorSpecies<Byte> byteSpecies = species.withLanes(byte.class);
 
     char first = prefix.charAt(0);
     short low = (short) toLowerCase(first);
     short high = (short) toUpperCase(first);
-    ShortVector lowVec = ShortVector.broadcast(SPECIES, low);
-    ShortVector highVec = ShortVector.broadcast(SPECIES, high);
+    ShortVector lowVec = ShortVector.broadcast(species, low);
+    ShortVector highVec = ShortVector.broadcast(species, high);
 
     for (; pos <= limit; pos += vectorLen) {
       ShortVector inputVec =
-          ByteVector.fromArray(BYTE_SPECIES, bytes, offset + (pos << 1)).reinterpretAsShorts();
+          ByteVector.fromArray(byteSpecies, bytes, offset + (pos << 1)).reinterpretAsShorts();
       VectorMask<Short> matchMask =
           inputVec
               .compare(VectorOperators.EQ, lowVec)

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -641,6 +641,85 @@ class SearchScalingRegressionTest {
     }
   }
 
+  @Test
+  void startAnchoredLiteralRejectsDisplacedCandidateWithConstantWorkForString() {
+    Pattern pattern = Pattern.compile("^abc");
+    String displaced = "x".repeat(10_000) + "abc";
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(displaced).find()).isFalse());
+    assertThat(work)
+        .as("Start-anchored pattern with displaced candidate must reject in constant work")
+        .isLessThan(20);
+  }
+
+  @Test
+  void startAnchoredLiteralRejectsDisplacedCandidateWithConstantWorkForUtf8() {
+    Pattern pattern = Pattern.compile("^abc");
+    byte[] displaced = ("x".repeat(10_000) + "abc").getBytes(UTF_8);
+    long work =
+        WorkCounter.countForTesting(
+            () -> assertThat(pattern.matcher(Utf8Input.trusted(displaced)).find()).isFalse());
+    assertThat(work)
+        .as("Start-anchored UTF-8 pattern with displaced candidate must reject in constant work")
+        .isLessThan(20);
+  }
+
+  @Test
+  void startAnchoredCharClassRejectsDisplacedCandidateWithConstantWork() {
+    Pattern pattern = Pattern.compile("^[0-9]");
+    String displaced = "a".repeat(10_000) + "5";
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(displaced).find()).isFalse());
+    assertThat(work)
+        .as("Start-anchored char-class with displaced match must reject in constant work")
+        .isLessThan(20);
+  }
+
+  @Test
+  void repeatedFindWithAlternatingCaseIsLinearForString() {
+    Pattern pattern = Pattern.compile("(?i)needle");
+    assertRepeatedFindWorkIsLinear(
+        size -> {
+          StringBuilder sb = new StringBuilder();
+          String[] variants = {"Needle ", "needle ", "NEEDLE ", "nEeDlE "};
+          for (int i = 0; i < size; i++) {
+            sb.append(variants[i % variants.length]);
+          }
+          return pattern.matcher(sb.toString())::find;
+        },
+        "String");
+  }
+
+  @Test
+  void repeatedFindWithAlternatingCaseIsLinearForUtf8() {
+    Pattern pattern = Pattern.compile("(?i)needle");
+    assertRepeatedFindWorkIsLinear(
+        size -> {
+          StringBuilder sb = new StringBuilder();
+          String[] variants = {"Needle ", "needle ", "NEEDLE ", "nEeDlE "};
+          for (int i = 0; i < size; i++) {
+            sb.append(variants[i % variants.length]);
+          }
+          return pattern.matcher(Utf8Input.trusted(sb.toString().getBytes(UTF_8)))::find;
+        },
+        "UTF-8");
+  }
+
+  @Test
+  void repeatedFindWithMultiBranchAlternationIsLinear() {
+    Pattern pattern = Pattern.compile("(?:apple|banana|cherry|date)");
+    assertRepeatedFindWorkIsLinear(
+        size -> {
+          StringBuilder sb = new StringBuilder();
+          String[] variants = {"apple ", "banana ", "cherry ", "date "};
+          for (int i = 0; i < size; i++) {
+            sb.append(variants[i % variants.length]);
+          }
+          return pattern.matcher(sb.toString())::find;
+        },
+        "String");
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -145,6 +145,40 @@ class StartAcceleratorTest {
     }
   }
 
+  @Test
+  void compiledPatternPoliciesMatchExpectedAccelerators() {
+    Pattern literalPat = Pattern.compile("abc");
+    assertThat(literalPat.stringStartAccelerator()).isNotNull();
+    assertThat(literalPat.utf8StartAccelerator()).isNotNull();
+    assertThat(literalPat.stringStartAccelerator().policy()).isEqualTo(AcceleratorPolicy.LITERAL);
+    assertThat(literalPat.utf8StartAccelerator().policy()).isEqualTo(AcceleratorPolicy.LITERAL);
+
+    Pattern caseInsensitivePat = Pattern.compile("(?i)abc");
+    assertThat(caseInsensitivePat.stringStartAccelerator()).isNotNull();
+    assertThat(caseInsensitivePat.utf8StartAccelerator()).isNotNull();
+    assertThat(caseInsensitivePat.utf8StartAccelerator().policy().strategy())
+        .isEqualTo(MatchStrategy.LITERAL);
+
+    Pattern charClassPat = Pattern.compile("[0-9][a-z]+");
+    assertThat(charClassPat.stringStartAccelerator()).isNotNull();
+    assertThat(charClassPat.utf8StartAccelerator()).isNotNull();
+    assertThat(charClassPat.stringStartAccelerator().policy())
+        .isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(charClassPat.utf8StartAccelerator().policy())
+        .isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+
+    Pattern fixedOffsetPat = Pattern.compile("..needle");
+    assertThat(fixedOffsetPat.stringStartAccelerator()).isNotNull();
+    assertThat(fixedOffsetPat.utf8StartAccelerator()).isNotNull();
+    assertThat(fixedOffsetPat.stringStartAccelerator().policy())
+        .isEqualTo(AcceleratorPolicy.LITERAL);
+    assertThat(fixedOffsetPat.utf8StartAccelerator().policy()).isEqualTo(AcceleratorPolicy.LITERAL);
+
+    Pattern unacceleratedPat = Pattern.compile(".*");
+    assertThat(unacceleratedPat.stringStartAccelerator()).isNull();
+    assertThat(unacceleratedPat.utf8StartAccelerator()).isNull();
+  }
+
   private static Utf8InputScanner utf8Scanner(String text) {
     byte[] bytes = text.getBytes(UTF_8);
     return new Utf8InputScanner(bytes, 0, bytes.length);

--- a/safere/src/test/java/org/safere/VectorSpeciesSimulationTest.java
+++ b/safere/src/test/java/org/safere/VectorSpeciesSimulationTest.java
@@ -1,0 +1,256 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+@DisabledForCrosscheck("implementation test uses package-private Vector API internals")
+class VectorSpeciesSimulationTest {
+
+  private static final Object[] BYTE_SPECIES = getSpeciesList("jdk.incubator.vector.ByteVector");
+  private static final Object[] SHORT_SPECIES = getSpeciesList("jdk.incubator.vector.ShortVector");
+  private static final Method BYTE_INDEX_OF_ASCII_CLASS = resolveByteIndexOfAsciiClass();
+  private static final Method BYTE_INDEX_OF_IGNORE_CASE = resolveByteIndexOfIgnoreCase();
+  private static final Method SHORT_INDEX_OF_CHAR_CLASS = resolveShortIndexOfCharClass();
+
+  private static Object[] getSpeciesList(String vectorClassName) {
+    try {
+      Class<?> vectorClass = Class.forName(vectorClassName);
+      return new Object[] {
+        vectorClass.getField("SPECIES_64").get(null),
+        vectorClass.getField("SPECIES_128").get(null),
+        vectorClass.getField("SPECIES_256").get(null),
+        vectorClass.getField("SPECIES_512").get(null)
+      };
+    } catch (Throwable t) {
+      return new Object[0];
+    }
+  }
+
+  private static Method resolveByteIndexOfAsciiClass() {
+    try {
+      Class<?> speciesClass = Class.forName("jdk.incubator.vector.VectorSpecies");
+      Method m =
+          ByteVectorScan.class.getDeclaredMethod(
+              "indexOfAsciiClass",
+              speciesClass,
+              byte[].class,
+              int.class,
+              int.class,
+              int[].class,
+              int.class);
+      m.setAccessible(true);
+      return m;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private static Method resolveByteIndexOfIgnoreCase() {
+    try {
+      Class<?> speciesClass = Class.forName("jdk.incubator.vector.VectorSpecies");
+      Method m =
+          ByteVectorScan.class.getDeclaredMethod(
+              "indexOfIgnoreCase",
+              speciesClass,
+              byte[].class,
+              int.class,
+              int.class,
+              String.class,
+              int.class,
+              int.class,
+              byte.class,
+              byte.class,
+              int.class);
+      m.setAccessible(true);
+      return m;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private static Method resolveShortIndexOfCharClass() {
+    try {
+      Class<?> speciesClass = Class.forName("jdk.incubator.vector.VectorSpecies");
+      Method m =
+          ShortVectorScan.class.getDeclaredMethod(
+              "indexOfCharClass",
+              speciesClass,
+              char[].class,
+              int.class,
+              int.class,
+              int[].class,
+              int.class);
+      m.setAccessible(true);
+      return m;
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private static int invokeByteIndexOfAsciiClass(
+      Object species, byte[] bytes, int offset, int length, int[] ranges, int start) {
+    try {
+      return (int)
+          BYTE_INDEX_OF_ASCII_CLASS.invoke(null, species, bytes, offset, length, ranges, start);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static int invokeByteIndexOfIgnoreCase(
+      Object species,
+      byte[] bytes,
+      int offset,
+      int length,
+      String prefix,
+      int prefixLen,
+      int anchorOffset,
+      byte low,
+      byte high,
+      int start) {
+    try {
+      return (int)
+          BYTE_INDEX_OF_IGNORE_CASE.invoke(
+              null,
+              species,
+              bytes,
+              offset,
+              length,
+              prefix,
+              prefixLen,
+              anchorOffset,
+              low,
+              high,
+              start);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static int invokeShortIndexOfCharClass(
+      Object species, char[] chars, int offset, int length, int[] ranges, int start) {
+    try {
+      return (int)
+          SHORT_INDEX_OF_CHAR_CLASS.invoke(null, species, chars, offset, length, ranges, start);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void asciiClassMatchingAcrossAllByteVectorSpecies() {
+    if (BYTE_SPECIES.length == 0 || BYTE_INDEX_OF_ASCII_CLASS == null) {
+      return;
+    }
+    int[] ranges = {'0', '9', 'a', 'z'};
+    for (Object species : BYTE_SPECIES) {
+      for (int len = 0; len <= 256; len++) {
+        byte[] absent = "A".repeat(len).getBytes(UTF_8);
+        for (int start = 0; start <= len; start++) {
+          assertThat(invokeByteIndexOfAsciiClass(species, absent, 0, len, ranges, start))
+              .as("Absent for species %s, len %d, start %d", species, len, start)
+              .isEqualTo(-1);
+        }
+
+        if (len > 0) {
+          // Match at start
+          byte[] matchStart = absent.clone();
+          matchStart[0] = '5';
+          assertThat(invokeByteIndexOfAsciiClass(species, matchStart, 0, len, ranges, 0))
+              .as("Match start for species %s, len %d", species, len)
+              .isEqualTo(0);
+
+          // Match in middle
+          int mid = len / 2;
+          byte[] matchMid = absent.clone();
+          matchMid[mid] = 'b';
+          assertThat(invokeByteIndexOfAsciiClass(species, matchMid, 0, len, ranges, 0))
+              .as("Match mid for species %s, len %d, mid %d", species, len, mid)
+              .isEqualTo(mid);
+
+          // Match at end
+          byte[] matchEnd = absent.clone();
+          matchEnd[len - 1] = 'z';
+          assertThat(invokeByteIndexOfAsciiClass(species, matchEnd, 0, len, ranges, 0))
+              .as("Match end for species %s, len %d", species, len)
+              .isEqualTo(len - 1);
+        }
+      }
+    }
+  }
+
+  @Test
+  void ignoreCaseMatchingAcrossAllByteVectorSpecies() {
+    if (BYTE_SPECIES.length == 0 || BYTE_INDEX_OF_IGNORE_CASE == null) {
+      return;
+    }
+    String prefix = "needle";
+    int prefixLen = prefix.length();
+    int anchorOffset = 0;
+    byte low = 'n';
+    byte high = 'N';
+
+    for (Object species : BYTE_SPECIES) {
+      for (int pad = 0; pad <= 128; pad++) {
+        String base = "x".repeat(pad) + "NeEdLe" + "y".repeat(64);
+        byte[] bytes = base.getBytes(UTF_8);
+
+        assertThat(
+                invokeByteIndexOfIgnoreCase(
+                    species, bytes, 0, bytes.length, prefix, prefixLen, anchorOffset, low, high, 0))
+            .as("IgnoreCase match for species %s, pad %d", species, pad)
+            .isEqualTo(pad);
+
+        byte[] absent = "x".repeat(pad + 64).getBytes(UTF_8);
+        assertThat(
+                invokeByteIndexOfIgnoreCase(
+                    species,
+                    absent,
+                    0,
+                    absent.length,
+                    prefix,
+                    prefixLen,
+                    anchorOffset,
+                    low,
+                    high,
+                    0))
+            .as("IgnoreCase absent for species %s, pad %d", species, pad)
+            .isEqualTo(-1);
+      }
+    }
+  }
+
+  @Test
+  void charClassMatchingAcrossAllShortVectorSpecies() {
+    if (SHORT_SPECIES.length == 0 || SHORT_INDEX_OF_CHAR_CLASS == null) {
+      return;
+    }
+    int[] ranges = {'0', '9', 'A', 'Z'};
+    for (Object species : SHORT_SPECIES) {
+      for (int len = 0; len <= 128; len++) {
+        char[] chars = "a".repeat(len).toCharArray();
+        for (int start = 0; start <= len; start++) {
+          assertThat(invokeShortIndexOfCharClass(species, chars, 0, len, ranges, start))
+              .as("Short absent for species %s, len %d, start %d", species, len, start)
+              .isEqualTo(-1);
+        }
+
+        if (len > 0) {
+          char[] matchEnd = chars.clone();
+          matchEnd[len - 1] = '9';
+          assertThat(invokeShortIndexOfCharClass(species, matchEnd, 0, len, ranges, 0))
+              .as("Short end match for species %s, len %d", species, len)
+              .isEqualTo(len - 1);
+        }
+      }
+    }
+  }
+}

--- a/safere/src/test/java/org/safere/VectorSpeciesSimulationTest.java
+++ b/safere/src/test/java/org/safere/VectorSpeciesSimulationTest.java
@@ -7,30 +7,48 @@ package org.safere;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 @DisabledForCrosscheck("implementation test uses package-private Vector API internals")
 class VectorSpeciesSimulationTest {
 
-  private static final Object[] BYTE_SPECIES = getSpeciesList("jdk.incubator.vector.ByteVector");
-  private static final Object[] SHORT_SPECIES = getSpeciesList("jdk.incubator.vector.ShortVector");
-  private static final Method BYTE_INDEX_OF_ASCII_CLASS = resolveByteIndexOfAsciiClass();
-  private static final Method BYTE_INDEX_OF_IGNORE_CASE = resolveByteIndexOfIgnoreCase();
-  private static final Method SHORT_INDEX_OF_CHAR_CLASS = resolveShortIndexOfCharClass();
+  private static final boolean VECTOR_AVAILABLE = isVectorApiAvailable();
+  private static final List<SpeciesHandle> BYTE_SPECIES =
+      VECTOR_AVAILABLE ? getSpeciesList("jdk.incubator.vector.ByteVector") : List.of();
+  private static final List<SpeciesHandle> SHORT_SPECIES =
+      VECTOR_AVAILABLE ? getSpeciesList("jdk.incubator.vector.ShortVector") : List.of();
+  private static final Method BYTE_INDEX_OF_ASCII_CLASS =
+      VECTOR_AVAILABLE ? resolveByteIndexOfAsciiClass() : null;
+  private static final Method BYTE_INDEX_OF_IGNORE_CASE =
+      VECTOR_AVAILABLE ? resolveByteIndexOfIgnoreCase() : null;
+  private static final Method SHORT_INDEX_OF_CHAR_CLASS =
+      VECTOR_AVAILABLE ? resolveShortIndexOfCharClass() : null;
 
-  private static Object[] getSpeciesList(String vectorClassName) {
+  private record SpeciesHandle(Object value) {}
+
+  private static boolean isVectorApiAvailable() {
+    try {
+      Class.forName("jdk.incubator.vector.ByteVector");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  private static List<SpeciesHandle> getSpeciesList(String vectorClassName) {
     try {
       Class<?> vectorClass = Class.forName(vectorClassName);
-      return new Object[] {
-        vectorClass.getField("SPECIES_64").get(null),
-        vectorClass.getField("SPECIES_128").get(null),
-        vectorClass.getField("SPECIES_256").get(null),
-        vectorClass.getField("SPECIES_512").get(null)
-      };
-    } catch (Throwable t) {
-      return new Object[0];
+      return List.of(
+          new SpeciesHandle(vectorClass.getField("SPECIES_64").get(null)),
+          new SpeciesHandle(vectorClass.getField("SPECIES_128").get(null)),
+          new SpeciesHandle(vectorClass.getField("SPECIES_256").get(null)),
+          new SpeciesHandle(vectorClass.getField("SPECIES_512").get(null)));
+    } catch (ReflectiveOperationException | LinkageError e) {
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -48,8 +66,8 @@ class VectorSpeciesSimulationTest {
               int.class);
       m.setAccessible(true);
       return m;
-    } catch (Throwable t) {
-      return null;
+    } catch (ReflectiveOperationException | LinkageError e) {
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -71,8 +89,8 @@ class VectorSpeciesSimulationTest {
               int.class);
       m.setAccessible(true);
       return m;
-    } catch (Throwable t) {
-      return null;
+    } catch (ReflectiveOperationException | LinkageError e) {
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -90,23 +108,24 @@ class VectorSpeciesSimulationTest {
               int.class);
       m.setAccessible(true);
       return m;
-    } catch (Throwable t) {
-      return null;
+    } catch (ReflectiveOperationException | LinkageError e) {
+      throw new ExceptionInInitializerError(e);
     }
   }
 
   private static int invokeByteIndexOfAsciiClass(
-      Object species, byte[] bytes, int offset, int length, int[] ranges, int start) {
+      SpeciesHandle species, byte[] bytes, int offset, int length, int[] ranges, int start) {
     try {
       return (int)
-          BYTE_INDEX_OF_ASCII_CLASS.invoke(null, species, bytes, offset, length, ranges, start);
+          BYTE_INDEX_OF_ASCII_CLASS.invoke(
+              null, species.value(), bytes, offset, length, ranges, start);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
   private static int invokeByteIndexOfIgnoreCase(
-      Object species,
+      SpeciesHandle species,
       byte[] bytes,
       int offset,
       int length,
@@ -120,7 +139,7 @@ class VectorSpeciesSimulationTest {
       return (int)
           BYTE_INDEX_OF_IGNORE_CASE.invoke(
               null,
-              species,
+              species.value(),
               bytes,
               offset,
               length,
@@ -136,10 +155,11 @@ class VectorSpeciesSimulationTest {
   }
 
   private static int invokeShortIndexOfCharClass(
-      Object species, char[] chars, int offset, int length, int[] ranges, int start) {
+      SpeciesHandle species, char[] chars, int offset, int length, int[] ranges, int start) {
     try {
       return (int)
-          SHORT_INDEX_OF_CHAR_CLASS.invoke(null, species, chars, offset, length, ranges, start);
+          SHORT_INDEX_OF_CHAR_CLASS.invoke(
+              null, species.value(), chars, offset, length, ranges, start);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -147,11 +167,9 @@ class VectorSpeciesSimulationTest {
 
   @Test
   void asciiClassMatchingAcrossAllByteVectorSpecies() {
-    if (BYTE_SPECIES.length == 0 || BYTE_INDEX_OF_ASCII_CLASS == null) {
-      return;
-    }
+    assumeTrue(VECTOR_AVAILABLE, "Vector API not available on module path");
     int[] ranges = {'0', '9', 'a', 'z'};
-    for (Object species : BYTE_SPECIES) {
+    for (SpeciesHandle species : BYTE_SPECIES) {
       for (int len = 0; len <= 256; len++) {
         byte[] absent = "A".repeat(len).getBytes(UTF_8);
         for (int start = 0; start <= len; start++) {
@@ -189,16 +207,14 @@ class VectorSpeciesSimulationTest {
 
   @Test
   void ignoreCaseMatchingAcrossAllByteVectorSpecies() {
-    if (BYTE_SPECIES.length == 0 || BYTE_INDEX_OF_IGNORE_CASE == null) {
-      return;
-    }
+    assumeTrue(VECTOR_AVAILABLE, "Vector API not available on module path");
     String prefix = "needle";
     int prefixLen = prefix.length();
     int anchorOffset = 0;
     byte low = 'n';
     byte high = 'N';
 
-    for (Object species : BYTE_SPECIES) {
+    for (SpeciesHandle species : BYTE_SPECIES) {
       for (int pad = 0; pad <= 128; pad++) {
         String base = "x".repeat(pad) + "NeEdLe" + "y".repeat(64);
         byte[] bytes = base.getBytes(UTF_8);
@@ -230,11 +246,9 @@ class VectorSpeciesSimulationTest {
 
   @Test
   void charClassMatchingAcrossAllShortVectorSpecies() {
-    if (SHORT_SPECIES.length == 0 || SHORT_INDEX_OF_CHAR_CLASS == null) {
-      return;
-    }
+    assumeTrue(VECTOR_AVAILABLE, "Vector API not available on module path");
     int[] ranges = {'0', '9', 'A', 'Z'};
-    for (Object species : SHORT_SPECIES) {
+    for (SpeciesHandle species : SHORT_SPECIES) {
       for (int len = 0; len <= 128; len++) {
         char[] chars = "a".repeat(len).toCharArray();
         for (int start = 0; start <= len; start++) {


### PR DESCRIPTION
This is another round of additional test coverage inspired by bugs caught in recent PR reviews, similar to https://github.com/eaftan/safere/commit/6f165b3514a404a4c17b32f758a647fa333e8acd

* displaced start-anchored constant work assertions for String and UTF-8
* repeated `find()` scaling linearity assertions across alternating case and multi-branch alternations
* explicit start accelerator and policy assertions on compiled `Pattern`s
* exercise `ByteVectorScan` and `ShortVectorScan` across all vector shapes