### PR TITLE
Unify StringStartAccelerator structure with Utf8StartAccelerator and use sealed records

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1683,7 +1683,9 @@ public final class Matcher implements MatchResult {
           if (strategy != null) {
             diagnosticParticipation(strategy, StrategyRole.START_ACCELERATION);
           }
-          int idx = accelerator.findCandidate(text, searchFrom, prog.unixLines());
+          int idx =
+              StringStartAccelerator.findNextCandidate(
+                  accelerator, text, searchFrom, prog.unixLines());
           if (idx < 0) {
             if (strategy != null) {
               diagnosticBoundary(strategy);
@@ -4459,7 +4461,9 @@ public final class Matcher implements MatchResult {
     if (options.startAcceleration() && text != null && !prog.anchorStart()) {
       StringStartAccelerator accelerator = parentPattern.stringStartAccelerator();
       if (accelerator != null) {
-        int idx = accelerator.findCandidate(text, fromIndex, prog.unixLines());
+        int idx =
+            StringStartAccelerator.findNextCandidate(
+                accelerator, text, fromIndex, prog.unixLines());
         if (idx < 0) {
           return -1L;
         }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1665,7 +1665,7 @@ public final class Matcher implements MatchResult {
           if (strategy != null) {
             diagnosticParticipation(strategy, StrategyRole.START_ACCELERATION);
           }
-          int idx = accelerator.findCandidate(utf8Scanner, searchFrom);
+          int idx = Utf8StartAccelerator.findNextCandidate(accelerator, utf8Scanner, searchFrom);
           if (idx < 0) {
             if (strategy != null) {
               diagnosticBoundary(strategy);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -667,7 +667,7 @@ public final class Pattern implements Serializable {
     if (enginePathOptions.startAcceleration()
         && utf8StartAccelerator != null
         && !prog.anchorStart()) {
-      searchStart = utf8StartAccelerator.findCandidate(scanner, 0);
+      searchStart = Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, scanner, 0);
       if (searchStart < 0) {
         return false;
       }
@@ -741,7 +741,7 @@ public final class Pattern implements Serializable {
       if (strategy != null) {
         diagnostics.participate(strategy, StrategyRole.START_ACCELERATION);
       }
-      searchStart = utf8StartAccelerator.findCandidate(scanner, 0);
+      searchStart = Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, scanner, 0);
       if (searchStart < 0) {
         if (strategy != null) {
           diagnostics.boundary(strategy);

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -23,13 +23,16 @@ sealed interface StringStartAccelerator {
       return null;
     }
     if (descriptor.prefix() != null) {
-      return new Literal(descriptor.prefix(), descriptor.prefixFoldCase());
+      if (descriptor.prefixFoldCase()) {
+        return CaseInsensitiveLiteral.create(descriptor.prefix());
+      }
+      return Literal.create(descriptor.prefix());
     }
     if (descriptor.fixedOffsetLiteral() != null) {
       return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefixAscii());
     }
     if (descriptor.charClassPrefixAscii() != null && !hasWordBoundary) {
-      return new CharClass(descriptor.charClassPrefixAscii());
+      return CharClass.create(descriptor.charClassPrefixAscii());
     }
     if (descriptor.lineAnchor() != null && !hasWordBoundary) {
       return new LineAnchor(descriptor.lineAnchor());
@@ -56,6 +59,7 @@ sealed interface StringStartAccelerator {
       StringStartAccelerator accelerator, String text, int fromIndex, boolean unixLines) {
     return switch (accelerator) {
       case Literal lit -> lit.findCandidate(text, fromIndex, unixLines);
+      case CaseInsensitiveLiteral cil -> cil.findCandidate(text, fromIndex, unixLines);
       case FixedOffset fo -> fo.findCandidate(text, fromIndex, unixLines);
       case CharClass cc -> cc.findCandidate(text, fromIndex, unixLines);
       case LineAnchor la -> la.findCandidate(text, fromIndex, unixLines);
@@ -67,37 +71,10 @@ sealed interface StringStartAccelerator {
     return AcceleratorPolicy.DEFAULT;
   }
 
-  final class Literal implements StringStartAccelerator {
-    private final String prefix;
-    private final boolean prefixFoldCase;
-    private final int[] failure;
-    private final int anchorOffset;
-    private final char anchorLow;
-    private final char anchorHigh;
+  record Literal(String prefix) implements StringStartAccelerator {
 
-    Literal(String prefix, boolean prefixFoldCase) {
-      this.prefix = prefix;
-      this.prefixFoldCase = prefixFoldCase;
-      if (prefixFoldCase && prefix != null && !prefix.isEmpty()) {
-        this.failure = Ascii.ignoreCaseFailure(prefix);
-        this.anchorOffset = RarityOracle.rarestAsciiOffset(prefix, prefix.length());
-        char anchor = prefix.charAt(anchorOffset);
-        this.anchorLow = Ascii.toLowerCase(anchor);
-        this.anchorHigh = Ascii.toUpperCase(anchor);
-      } else {
-        this.failure = null;
-        this.anchorOffset = 0;
-        this.anchorLow = 0;
-        this.anchorHigh = 0;
-      }
-    }
-
-    public String prefix() {
-      return prefix;
-    }
-
-    public boolean prefixFoldCase() {
-      return prefixFoldCase;
+    static Literal create(String prefix) {
+      return new Literal(prefix);
     }
 
     @Override
@@ -107,10 +84,6 @@ sealed interface StringStartAccelerator {
 
     @Override
     public int findCandidate(String text, int fromIndex, boolean unixLines) {
-      if (prefixFoldCase) {
-        return Matcher.indexOfIgnoreCase(
-            text, prefix, failure, anchorOffset, anchorLow, anchorHigh, fromIndex);
-      }
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record(Math.max(0, text.length() - fromIndex));
       }
@@ -118,22 +91,37 @@ sealed interface StringStartAccelerator {
     }
   }
 
-  final class FixedOffset implements StringStartAccelerator {
-    private final FixedOffsetLiteral fixedOffset;
-    private final AsciiBitmap firstAscii;
+  @SuppressWarnings("ArrayRecordComponent")
+  record CaseInsensitiveLiteral(
+      String prefix, int[] failure, int anchorOffset, char anchorLow, char anchorHigh)
+      implements StringStartAccelerator {
 
-    FixedOffset(FixedOffsetLiteral fixedOffset, AsciiBitmap firstAscii) {
-      this.fixedOffset = fixedOffset;
-      this.firstAscii = firstAscii;
+    static CaseInsensitiveLiteral create(String prefix) {
+      if (prefix == null || prefix.isEmpty()) {
+        return new CaseInsensitiveLiteral(prefix, null, 0, '\0', '\0');
+      }
+      int[] failure = Ascii.ignoreCaseFailure(prefix);
+      int anchorOffset = RarityOracle.rarestAsciiOffset(prefix, prefix.length());
+      char anchor = prefix.charAt(anchorOffset);
+      char anchorLow = Ascii.toLowerCase(anchor);
+      char anchorHigh = Ascii.toUpperCase(anchor);
+      return new CaseInsensitiveLiteral(prefix, failure, anchorOffset, anchorLow, anchorHigh);
     }
 
-    public FixedOffsetLiteral fixedOffset() {
-      return fixedOffset;
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
     }
 
-    public AsciiBitmap firstAscii() {
-      return firstAscii;
+    @Override
+    public int findCandidate(String text, int fromIndex, boolean unixLines) {
+      return Matcher.indexOfIgnoreCase(
+          text, prefix, failure, anchorOffset, anchorLow, anchorHigh, fromIndex);
     }
+  }
+
+  record FixedOffset(FixedOffsetLiteral fixedOffset, AsciiBitmap firstAscii)
+      implements StringStartAccelerator {
 
     @Override
     public AcceleratorPolicy policy() {
@@ -209,17 +197,11 @@ sealed interface StringStartAccelerator {
     }
   }
 
-  final class CharClass implements StringStartAccelerator {
-    private final AsciiBitmap asciiMap;
-    private final boolean[] asciiTable;
+  @SuppressWarnings("ArrayRecordComponent")
+  record CharClass(AsciiBitmap asciiMap, boolean[] asciiTable) implements StringStartAccelerator {
 
-    CharClass(AsciiBitmap asciiMap) {
-      this.asciiMap = asciiMap;
-      this.asciiTable = asciiMap.toBooleanArray();
-    }
-
-    public AsciiBitmap asciiMap() {
-      return asciiMap;
+    static CharClass create(AsciiBitmap asciiMap) {
+      return new CharClass(asciiMap, asciiMap.toBooleanArray());
     }
 
     @Override
@@ -246,16 +228,7 @@ sealed interface StringStartAccelerator {
     }
   }
 
-  final class LineAnchor implements StringStartAccelerator {
-    private final StartAcceleration startAcceleration;
-
-    LineAnchor(StartAcceleration startAcceleration) {
-      this.startAcceleration = startAcceleration;
-    }
-
-    public StartAcceleration startAcceleration() {
-      return startAcceleration;
-    }
+  record LineAnchor(StartAcceleration startAcceleration) implements StringStartAccelerator {
 
     @Override
     public AcceleratorPolicy policy() {

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -41,12 +41,6 @@ sealed interface StringStartAccelerator {
   }
 
   /**
-   * Finds the next candidate match start position at or after {@code fromIndex}. Returns negative
-   * if definitely not found.
-   */
-  int findCandidate(String text, int fromIndex, boolean unixLines);
-
-  /**
    * Finds the next candidate match start position at or after {@code fromIndex} using
    * pattern-matched devirtualization.
    *
@@ -82,8 +76,7 @@ sealed interface StringStartAccelerator {
       return AcceleratorPolicy.LITERAL;
     }
 
-    @Override
-    public int findCandidate(String text, int fromIndex, boolean unixLines) {
+    int findCandidate(String text, int fromIndex, boolean unixLines) {
       if (WorkCounterConfig.ENABLED) {
         WorkCounter.record(Math.max(0, text.length() - fromIndex));
       }
@@ -113,8 +106,7 @@ sealed interface StringStartAccelerator {
       return AcceleratorPolicy.LITERAL;
     }
 
-    @Override
-    public int findCandidate(String text, int fromIndex, boolean unixLines) {
+    int findCandidate(String text, int fromIndex, boolean unixLines) {
       return Matcher.indexOfIgnoreCase(
           text, prefix, failure, anchorOffset, anchorLow, anchorHigh, fromIndex);
     }
@@ -128,8 +120,7 @@ sealed interface StringStartAccelerator {
       return AcceleratorPolicy.LITERAL;
     }
 
-    @Override
-    public int findCandidate(String text, int fromIndex, boolean unixLines) {
+    int findCandidate(String text, int fromIndex, boolean unixLines) {
       return nextFixedOffsetCandidate(text, fixedOffset, firstAscii, fromIndex);
     }
 
@@ -209,8 +200,7 @@ sealed interface StringStartAccelerator {
       return AcceleratorPolicy.CHAR_CLASS;
     }
 
-    @Override
-    public int findCandidate(String text, int fromIndex, boolean unixLines) {
+    int findCandidate(String text, int fromIndex, boolean unixLines) {
       return indexOfCharClass(text, asciiTable, fromIndex);
     }
 
@@ -235,8 +225,7 @@ sealed interface StringStartAccelerator {
       return AcceleratorPolicy.LINE_ANCHOR;
     }
 
-    @Override
-    public int findCandidate(String text, int fromIndex, boolean unixLines) {
+    int findCandidate(String text, int fromIndex, boolean unixLines) {
       return nextAcceleratedStart(text, startAcceleration, fromIndex, unixLines);
     }
 

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -84,6 +84,7 @@ sealed interface StringStartAccelerator {
     }
   }
 
+  // The failure table is immutable pattern metadata; array identity and value semantics are unused.
   @SuppressWarnings("ArrayRecordComponent")
   record CaseInsensitiveLiteral(
       String prefix, int[] failure, int anchorOffset, char anchorLow, char anchorHigh)
@@ -188,6 +189,7 @@ sealed interface StringStartAccelerator {
     }
   }
 
+  // The lookup table is immutable pattern metadata; array identity and value semantics are unused.
   @SuppressWarnings("ArrayRecordComponent")
   record CharClass(AsciiBitmap asciiMap, boolean[] asciiTable) implements StringStartAccelerator {
 

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -48,12 +48,6 @@ sealed interface Utf8StartAccelerator {
   }
 
   /**
-   * Finds the next candidate match start position at or after {@code fromIndex}. Returns negative
-   * if definitely not found.
-   */
-  int findCandidate(Utf8InputScanner scanner, int fromIndex);
-
-  /**
    * Finds the next candidate match start position at or after {@code pos} using pattern-matched
    * devirtualization.
    *
@@ -92,8 +86,7 @@ sealed interface Utf8StartAccelerator {
       return AcceleratorPolicy.LITERAL;
     }
 
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+    int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       if (prefixUtf8 != null) {
         return scanner.indexOf(prefixUtf8, prefixUtf8Failure, prefixUtf8Shifts, fromIndex);
       }
@@ -125,8 +118,7 @@ sealed interface Utf8StartAccelerator {
       return AcceleratorPolicy.LITERAL;
     }
 
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+    int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       return scanner.indexOfIgnoreCase(
           prefix, failure, anchorOffset, anchorLow, anchorHigh, fromIndex);
     }
@@ -140,8 +132,7 @@ sealed interface Utf8StartAccelerator {
       return AcceleratorPolicy.LITERAL;
     }
 
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+    int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       return nextFixedOffsetCandidate(scanner, fixedOffset, charClassPrefixAscii, fromIndex);
     }
 
@@ -196,8 +187,7 @@ sealed interface Utf8StartAccelerator {
       return AcceleratorPolicy.CHAR_CLASS;
     }
 
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+    int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       if (scanInfo != null) {
         return scanner.indexOfCodePointClass(
             scanInfo.ranges, scanInfo.bitmap0, scanInfo.bitmap1, fromIndex, scanner.length());
@@ -212,8 +202,7 @@ sealed interface Utf8StartAccelerator {
       return AcceleratorPolicy.VECTOR_MULTI_LITERAL;
     }
 
-    @Override
-    public int findCandidate(Utf8InputScanner scanner, int fromIndex) {
+    int findCandidate(Utf8InputScanner scanner, int fromIndex) {
       VectorScanProvider provider = VectorScanProviders.providerForTeddyLength(scanner.length());
       if (provider == null) {
         return fromIndex;

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -31,14 +31,25 @@ class StartAcceleratorTest {
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.Literal.class);
     assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
-    assertThat(strAcc.findCandidate("haystack with needle here", 0, false)).isEqualTo(14);
-    assertThat(strAcc.findCandidate("haystack with needle here", 15, false)).isEqualTo(-1);
+    assertThat(
+            StringStartAccelerator.findNextCandidate(strAcc, "haystack with needle here", 0, false))
+        .isEqualTo(14);
+    assertThat(
+            StringStartAccelerator.findNextCandidate(
+                strAcc, "haystack with needle here", 15, false))
+        .isEqualTo(-1);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.Literal.class);
     assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 0)).isEqualTo(14);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 15)).isEqualTo(-1);
+    assertThat(
+            Utf8StartAccelerator.findNextCandidate(
+                utf8Acc, utf8Scanner("haystack with needle here"), 0))
+        .isEqualTo(14);
+    assertThat(
+            Utf8StartAccelerator.findNextCandidate(
+                utf8Acc, utf8Scanner("haystack with needle here"), 15))
+        .isEqualTo(-1);
   }
 
   @Test
@@ -48,22 +59,35 @@ class StartAcceleratorTest {
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CaseInsensitiveLiteral.class);
-    assertThat(strAcc.findCandidate("haystack with NEEDLE here", 0, false)).isEqualTo(14);
+    assertThat(
+            StringStartAccelerator.findNextCandidate(strAcc, "haystack with NEEDLE here", 0, false))
+        .isEqualTo(14);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CaseInsensitiveLiteral.class);
     assertThat(utf8Acc.policy().strategy()).isEqualTo(MatchStrategy.LITERAL);
     assertThat(utf8Acc.policy().isExactMatchCandidate()).isTrue();
-    assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with NEEDLE here"), 0)).isEqualTo(14);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with nEeDlE here"), 0)).isEqualTo(14);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("haystack with needle here"), 15)).isEqualTo(-1);
+    assertThat(
+            Utf8StartAccelerator.findNextCandidate(
+                utf8Acc, utf8Scanner("haystack with NEEDLE here"), 0))
+        .isEqualTo(14);
+    assertThat(
+            Utf8StartAccelerator.findNextCandidate(
+                utf8Acc, utf8Scanner("haystack with nEeDlE here"), 0))
+        .isEqualTo(14);
+    assertThat(
+            Utf8StartAccelerator.findNextCandidate(
+                utf8Acc, utf8Scanner("haystack with needle here"), 15))
+        .isEqualTo(-1);
 
     // Single character case-insensitive prefix
     StartDescriptor singleDesc = descriptor("a", true, null, null);
     Utf8StartAccelerator singleUtf8 = Utf8StartAccelerator.create(singleDesc, false);
     assertThat(singleUtf8).isInstanceOf(Utf8StartAccelerator.CaseInsensitiveLiteral.class);
-    assertThat(singleUtf8.findCandidate(utf8Scanner("xxxA"), 0)).isEqualTo(3);
-    assertThat(singleUtf8.findCandidate(utf8Scanner("xxxa"), 0)).isEqualTo(3);
+    assertThat(Utf8StartAccelerator.findNextCandidate(singleUtf8, utf8Scanner("xxxA"), 0))
+        .isEqualTo(3);
+    assertThat(Utf8StartAccelerator.findNextCandidate(singleUtf8, utf8Scanner("xxxa"), 0))
+        .isEqualTo(3);
 
     // Non-ASCII case-insensitive prefix falls back (null)
     StartDescriptor nonAsciiDesc = descriptor("café", true, null, null);
@@ -78,12 +102,14 @@ class StartAcceleratorTest {
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.FixedOffset.class);
     assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
-    assertThat(strAcc.findCandidate("abtoken cd", 0, false)).isEqualTo(0);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, "abtoken cd", 0, false))
+        .isEqualTo(0);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.FixedOffset.class);
     assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.LITERAL);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("abtoken cd"), 0)).isEqualTo(0);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner("abtoken cd"), 0))
+        .isEqualTo(0);
   }
 
   @Test
@@ -94,12 +120,13 @@ class StartAcceleratorTest {
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
     assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
-    assertThat(strAcc.findCandidate("xxxa", 0, false)).isEqualTo(3);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, "xxxa", 0, false)).isEqualTo(3);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);
     assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
     assertThat(utf8Acc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
-    assertThat(utf8Acc.findCandidate(utf8Scanner("xxxb"), 0)).isEqualTo(3);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner("xxxb"), 0))
+        .isEqualTo(3);
   }
 
   private static StartDescriptor descriptor(
@@ -144,8 +171,9 @@ class StartAcceleratorTest {
             .isEqualTo(strAcc.policy().strategy());
 
         for (String input : testInputs) {
-          int strCandidate = strAcc.findCandidate(input, 0, false);
-          int utf8Candidate = utf8Acc.findCandidate(utf8Scanner(input), 0);
+          int strCandidate = StringStartAccelerator.findNextCandidate(strAcc, input, 0, false);
+          int utf8Candidate =
+              Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 0);
           assertThat(utf8Candidate)
               .as("Candidate indices should match for pattern '%s' on input '%s'", patStr, input)
               .isEqualTo(strCandidate);

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -47,7 +47,7 @@ class StartAcceleratorTest {
     assertThat(desc.hasStartAcceleration()).isTrue();
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(desc, false);
-    assertThat(strAcc).isInstanceOf(StringStartAccelerator.Literal.class);
+    assertThat(strAcc).isInstanceOf(StringStartAccelerator.CaseInsensitiveLiteral.class);
     assertThat(strAcc.findCandidate("haystack with NEEDLE here", 0, false)).isEqualTo(14);
 
     Utf8StartAccelerator utf8Acc = Utf8StartAccelerator.create(desc, false);


### PR DESCRIPTION
This makes StringStartAccelerator and Utf8StartAccelerator more consistent.

Matching loops now route through `StringStartAccelerator.findNextCandidate` instead of doing virtual dispatch.

