### PR TITLE
Improve DFA start state acceleration

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -452,7 +452,7 @@
       "id": "vectorScan.multi.nonascii.32768",
       "recipe": {
         "kind": "repeatToLength",
-        "unit": "é",
+        "unit": "\u00e9",
         "length": 32768
       },
       "shared": true
@@ -730,6 +730,27 @@
         "kind": "appendInput",
         "input": "searchScaling.random.{size}",
         "suffix": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      },
+      "shared": true
+    },
+    {
+      "id": "searchScaling.wildcardBody.{size}",
+      "axes": {
+        "size": [
+          64,
+          256,
+          1024,
+          10240,
+          102400,
+          1048576
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "HEADER ",
+        "unit": "abcdefghijklmnopqrstuvwxyz ",
+        "suffix": " FOOTER",
+        "length": "{size}"
       },
       "shared": true
     },
@@ -1727,7 +1748,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
+        "value": "\u3044\u304f\u3064\u3082\u306e\u3000\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u3000\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u3000\u305d\u3057\u3066\u3000\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u3000\u304c\u3042\u308a\u307e\u3059",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1745,7 +1766,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
+        "value": "\u3044\u304f\u3064\u3082\u306e\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u305d\u3057\u3066\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u304c\u3042\u308a\u307e\u3059",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1763,7 +1784,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "这是一个中文测试句子",
+        "value": "\u8fd9\u662f\u4e00\u4e2a\u4e2d\u6587\u6d4b\u8bd5\u53e5\u5b50",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1799,7 +1820,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "Today is a beautiful day 😇 with warm sunshine.",
+        "value": "Today is a beautiful day \ud83d\ude07 with warm sunshine.",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -2111,21 +2132,21 @@
       "id": "utf8.captureFree.multibyteEarly",
       "recipe": {
         "kind": "literal",
-        "text": "错误：请求失败"
+        "text": "\u9519\u8bef\uff1a\u8bf7\u6c42\u5931\u8d25"
       }
     },
     {
       "id": "utf8.captureFree.multibyteLate",
       "recipe": {
         "kind": "literal",
-        "text": "请求处理结束：错误"
+        "text": "\u8bf7\u6c42\u5904\u7406\u7ed3\u675f\uff1a\u9519\u8bef"
       }
     },
     {
       "id": "utf8.captureFree.multibyteNoMatch",
       "recipe": {
         "kind": "literal",
-        "text": "请求处理成功"
+        "text": "\u8bf7\u6c42\u5904\u7406\u6210\u529f"
       }
     },
     {
@@ -2139,7 +2160,7 @@
       "id": "utf8.repeatedFind.multibyte",
       "recipe": {
         "kind": "literal",
-        "text": "one café 東京 naïve"
+        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
       }
     },
     {
@@ -2153,7 +2174,7 @@
       "id": "utf8.captureBounds.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
@@ -2167,42 +2188,42 @@
       "id": "utf8.emptyMatch",
       "recipe": {
         "kind": "literal",
-        "text": "a💰有"
+        "text": "a\ud83d\udcb0\u6709"
       }
     },
     {
       "id": "utf8.window",
       "recipe": {
         "kind": "literal",
-        "text": "sentinel-before-city=東京&name=Renée-sentinel-after"
+        "text": "sentinel-before-city=\u6771\u4eac&name=Ren\u00e9e-sentinel-after"
       }
     },
     {
       "id": "utf8.construction",
       "recipe": {
         "kind": "literal",
-        "text": "one café 東京 naïve"
+        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
       }
     },
     {
       "id": "utf8.replacement.literal",
       "recipe": {
         "kind": "literal",
-        "text": "错误 then 错误"
+        "text": "\u9519\u8bef then \u9519\u8bef"
       }
     },
     {
       "id": "utf8.replacement.numbered",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
       "id": "utf8.replacement.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=東京&name=Renée"
+        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
       }
     },
     {
@@ -2410,7 +2431,7 @@
       "recipe": {
         "kind": "suffixToLength",
         "prefixUnit": "0123456789 9876543210 1357924680 ",
-        "suffix": "é123",
+        "suffix": "\u00e9123",
         "length": "{size}"
       },
       "shared": true
@@ -2443,7 +2464,7 @@
       "recipe": {
         "kind": "suffixToLength",
         "prefixUnit": "The quick brown fox jumps over the lazy dog. Standard English prose without CJK characters. ",
-        "suffix": "你好123",
+        "suffix": "\u4f60\u597d123",
         "length": "{size}"
       },
       "shared": true
@@ -2901,14 +2922,14 @@
       "operation": "replaceAll",
       "patterns": [
         {
-          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
+          "java": " ?[\\[\uff3b](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]\uff3d]",
           "alternates": {
             "rust-regex": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
               "reason": "Rust regex gives \\d Unicode semantics"
             },
             "dotnet": {
-              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
+              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
               "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
             }
           }
@@ -3773,7 +3794,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "realWorldRegex.cjkSearch.{matchLabel}.{size}"
@@ -3803,7 +3824,7 @@
       "operation": "find",
       "patterns": [
         {
-          "java": "[😀-😇]",
+          "java": "[\ud83d\ude00-\ud83d\ude07]",
           "alternates": {
             "dotnet": {
               "pattern": "\\uD83D[\\uDE00-\\uDE07]",
@@ -3839,7 +3860,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "\\s*[\\[［]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,、]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]］]"
+        "\\s*[\\[\uff3b]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,\u3001]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\uff3d]"
       ],
       "inputs": [
         "realWorldRegex.recitation.{matchLabel}.{size}"
@@ -4035,6 +4056,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.wildcardBodyFind.64",
+      "operation": "find",
+      "patterns": [
+        "(?s)HEADER.*?FOOTER"
+      ],
+      "inputs": [
+        "searchScaling.wildcardBody.64"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.alternationScaled.64",
       "operation": "find",
       "patterns": [
@@ -4053,31 +4092,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.64",
+      "id": "SearchScalingBenchmark.wildcardBodyFind.256",
       "operation": "find",
       "patterns": [
-        "apple+?|banana+?|cherry+?"
+        "(?s)HEADER.*?FOOTER"
       ],
       "inputs": [
-        "searchScaling.prose.64"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.currencyPriceScaled.64",
-      "operation": "find",
-      "patterns": [
-        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
-      ],
-      "inputs": [
-        "searchScaling.prose.64"
+        "searchScaling.wildcardBody.256"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4107,31 +4128,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.256",
+      "id": "SearchScalingBenchmark.wildcardBodyFind.1024",
       "operation": "find",
       "patterns": [
-        "apple+?|banana+?|cherry+?"
+        "(?s)HEADER.*?FOOTER"
       ],
       "inputs": [
-        "searchScaling.prose.256"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.currencyPriceScaled.256",
-      "operation": "find",
-      "patterns": [
-        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
-      ],
-      "inputs": [
-        "searchScaling.prose.256"
+        "searchScaling.wildcardBody.1024"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4147,42 +4150,6 @@
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
-      ],
-      "inputs": [
-        "searchScaling.prose.1024"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.1024",
-      "operation": "find",
-      "patterns": [
-        "apple+?|banana+?|cherry+?"
-      ],
-      "inputs": [
-        "searchScaling.prose.1024"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.currencyPriceScaled.1024",
-      "operation": "find",
-      "patterns": [
-        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
       ],
       "inputs": [
         "searchScaling.prose.1024"
@@ -4359,46 +4326,28 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.wildcardBodyFind.10240",
+      "operation": "find",
+      "patterns": [
+        "(?s)HEADER.*?FOOTER"
+      ],
+      "inputs": [
+        "searchScaling.wildcardBody.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.alternationScaled.10240",
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
-      ],
-      "inputs": [
-        "searchScaling.prose.10240"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.10240",
-      "operation": "find",
-      "patterns": [
-        "apple+?|banana+?|cherry+?"
-      ],
-      "inputs": [
-        "searchScaling.prose.10240"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.currencyPriceScaled.10240",
-      "operation": "find",
-      "patterns": [
-        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
       ],
       "inputs": [
         "searchScaling.prose.10240"
@@ -4575,46 +4524,28 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.wildcardBodyFind.102400",
+      "operation": "find",
+      "patterns": [
+        "(?s)HEADER.*?FOOTER"
+      ],
+      "inputs": [
+        "searchScaling.wildcardBody.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.alternationScaled.102400",
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
-      ],
-      "inputs": [
-        "searchScaling.prose.102400"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.102400",
-      "operation": "find",
-      "patterns": [
-        "apple+?|banana+?|cherry+?"
-      ],
-      "inputs": [
-        "searchScaling.prose.102400"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.currencyPriceScaled.102400",
-      "operation": "find",
-      "patterns": [
-        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
       ],
       "inputs": [
         "searchScaling.prose.102400"
@@ -4791,46 +4722,28 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.wildcardBodyFind.1048576",
+      "operation": "find",
+      "patterns": [
+        "(?s)HEADER.*?FOOTER"
+      ],
+      "inputs": [
+        "searchScaling.wildcardBody.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.alternationScaled.1048576",
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
-      ],
-      "inputs": [
-        "searchScaling.prose.1048576"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.1048576",
-      "operation": "find",
-      "patterns": [
-        "apple+?|banana+?|cherry+?"
-      ],
-      "inputs": [
-        "searchScaling.prose.1048576"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      }
-    },
-    {
-      "id": "SearchScalingBenchmark.currencyPriceScaled.1048576",
-      "operation": "find",
-      "patterns": [
-        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
       ],
       "inputs": [
         "searchScaling.prose.1048576"
@@ -8353,7 +8266,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteEarly",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8372,7 +8285,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteLate",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8391,7 +8304,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteNoMatch",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8479,7 +8392,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8502,7 +8415,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteLate",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8525,7 +8438,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8617,7 +8530,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8640,7 +8553,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteLate",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8663,7 +8576,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8831,7 +8744,7 @@
       "id": "Utf8MatchingBenchmark.window",
       "operation": "findInWindow",
       "patterns": [
-        "東京"
+        "\u6771\u4eac"
       ],
       "inputs": [
         "utf8.window"
@@ -8914,7 +8827,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchBytes",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9418,7 +9331,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchMatcher",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9444,7 +9357,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchString",
       "operation": "find",
       "patterns": [
-        "[一-龥]{3,}"
+        "[\u4e00-\u9fa5]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9628,7 +9541,7 @@
       "id": "ByteReplacementBenchmark.literal",
       "operation": "utf8Replacement",
       "patterns": [
-        "错误"
+        "\u9519\u8bef"
       ],
       "inputs": [
         "utf8.replacement.literal"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4038,7 +4038,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.64",
       "operation": "find",
       "patterns": [
-        "\\d*\\[\\[.*?\\]\\]"
+        "(?:a*x|b*y|c*z)"
       ],
       "inputs": [
         "searchScaling.prose.64"
@@ -4074,7 +4074,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.256",
       "operation": "find",
       "patterns": [
-        "\\d*\\[\\[.*?\\]\\]"
+        "(?:a*x|b*y|c*z)"
       ],
       "inputs": [
         "searchScaling.prose.256"
@@ -4110,7 +4110,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1024",
       "operation": "find",
       "patterns": [
-        "\\d*\\[\\[.*?\\]\\]"
+        "(?:a*x|b*y|c*z)"
       ],
       "inputs": [
         "searchScaling.prose.1024"
@@ -4308,7 +4308,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.10240",
       "operation": "find",
       "patterns": [
-        "\\d*\\[\\[.*?\\]\\]"
+        "(?:a*x|b*y|c*z)"
       ],
       "inputs": [
         "searchScaling.prose.10240"
@@ -4506,7 +4506,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.102400",
       "operation": "find",
       "patterns": [
-        "\\d*\\[\\[.*?\\]\\]"
+        "(?:a*x|b*y|c*z)"
       ],
       "inputs": [
         "searchScaling.prose.102400"
@@ -4704,7 +4704,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1048576",
       "operation": "find",
       "patterns": [
-        "\\d*\\[\\[.*?\\]\\]"
+        "(?:a*x|b*y|c*z)"
       ],
       "inputs": [
         "searchScaling.prose.1048576"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4053,6 +4053,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.64",
+      "operation": "find",
+      "patterns": [
+        "apple+?|banana+?|cherry+?"
+      ],
+      "inputs": [
+        "searchScaling.prose.64"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.currencyPriceScaled.64",
       "operation": "find",
       "patterns": [
@@ -4089,6 +4107,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.256",
+      "operation": "find",
+      "patterns": [
+        "apple+?|banana+?|cherry+?"
+      ],
+      "inputs": [
+        "searchScaling.prose.256"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.currencyPriceScaled.256",
       "operation": "find",
       "patterns": [
@@ -4111,6 +4147,24 @@
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.1024",
+      "operation": "find",
+      "patterns": [
+        "apple+?|banana+?|cherry+?"
       ],
       "inputs": [
         "searchScaling.prose.1024"
@@ -4323,6 +4377,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.10240",
+      "operation": "find",
+      "patterns": [
+        "apple+?|banana+?|cherry+?"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.currencyPriceScaled.10240",
       "operation": "find",
       "patterns": [
@@ -4521,6 +4593,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.102400",
+      "operation": "find",
+      "patterns": [
+        "apple+?|banana+?|cherry+?"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.currencyPriceScaled.102400",
       "operation": "find",
       "patterns": [
@@ -4705,6 +4795,24 @@
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.nonGreedyAlternationScaled.1048576",
+      "operation": "find",
+      "patterns": [
+        "apple+?|banana+?|cherry+?"
       ],
       "inputs": [
         "searchScaling.prose.1048576"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4075,7 +4075,7 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.64",
+      "id": "SearchScalingBenchmark.starredAlternationScaled.64",
       "operation": "find",
       "patterns": [
         "(?:a*x|b*y|c*z)"
@@ -4111,7 +4111,7 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.256",
+      "id": "SearchScalingBenchmark.starredAlternationScaled.256",
       "operation": "find",
       "patterns": [
         "(?:a*x|b*y|c*z)"
@@ -4147,7 +4147,7 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1024",
+      "id": "SearchScalingBenchmark.starredAlternationScaled.1024",
       "operation": "find",
       "patterns": [
         "(?:a*x|b*y|c*z)"
@@ -4345,7 +4345,7 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.10240",
+      "id": "SearchScalingBenchmark.starredAlternationScaled.10240",
       "operation": "find",
       "patterns": [
         "(?:a*x|b*y|c*z)"
@@ -4543,7 +4543,7 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.102400",
+      "id": "SearchScalingBenchmark.starredAlternationScaled.102400",
       "operation": "find",
       "patterns": [
         "(?:a*x|b*y|c*z)"
@@ -4741,7 +4741,7 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1048576",
+      "id": "SearchScalingBenchmark.starredAlternationScaled.1048576",
       "operation": "find",
       "patterns": [
         "(?:a*x|b*y|c*z)"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -734,27 +734,6 @@
       "shared": true
     },
     {
-      "id": "searchScaling.wildcardBody.{size}",
-      "axes": {
-        "size": [
-          64,
-          256,
-          1024,
-          10240,
-          102400,
-          1048576
-        ]
-      },
-      "recipe": {
-        "kind": "surroundToLength",
-        "prefix": "HEADER ",
-        "unit": "abcdefghijklmnopqrstuvwxyz ",
-        "suffix": " FOOTER",
-        "length": "{size}"
-      },
-      "shared": true
-    },
-    {
       "id": "searchScaling.prose.{size}",
       "axes": {
         "size": [
@@ -4056,13 +4035,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.wildcardBodyFind.64",
+      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.64",
       "operation": "find",
       "patterns": [
-        "(?s)HEADER.*?FOOTER"
+        "[ \\t]*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
-        "searchScaling.wildcardBody.64"
+        "searchScaling.prose.64"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4092,13 +4071,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.wildcardBodyFind.256",
+      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.256",
       "operation": "find",
       "patterns": [
-        "(?s)HEADER.*?FOOTER"
+        "[ \\t]*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
-        "searchScaling.wildcardBody.256"
+        "searchScaling.prose.256"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4128,13 +4107,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.wildcardBodyFind.1024",
+      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1024",
       "operation": "find",
       "patterns": [
-        "(?s)HEADER.*?FOOTER"
+        "[ \\t]*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
-        "searchScaling.wildcardBody.1024"
+        "searchScaling.prose.1024"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4326,13 +4305,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.wildcardBodyFind.10240",
+      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.10240",
       "operation": "find",
       "patterns": [
-        "(?s)HEADER.*?FOOTER"
+        "[ \\t]*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
-        "searchScaling.wildcardBody.10240"
+        "searchScaling.prose.10240"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4524,13 +4503,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.wildcardBodyFind.102400",
+      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.102400",
       "operation": "find",
       "patterns": [
-        "(?s)HEADER.*?FOOTER"
+        "[ \\t]*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
-        "searchScaling.wildcardBody.102400"
+        "searchScaling.prose.102400"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -4722,13 +4701,13 @@
       }
     },
     {
-      "id": "SearchScalingBenchmark.wildcardBodyFind.1048576",
+      "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1048576",
       "operation": "find",
       "patterns": [
-        "(?s)HEADER.*?FOOTER"
+        "[ \\t]*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
-        "searchScaling.wildcardBody.1048576"
+        "searchScaling.prose.1048576"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -4038,7 +4038,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.64",
       "operation": "find",
       "patterns": [
-        "[ \\t]*\\[\\[.*?\\]\\]"
+        "\\d*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
         "searchScaling.prose.64"
@@ -4074,7 +4074,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.256",
       "operation": "find",
       "patterns": [
-        "[ \\t]*\\[\\[.*?\\]\\]"
+        "\\d*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
         "searchScaling.prose.256"
@@ -4110,7 +4110,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1024",
       "operation": "find",
       "patterns": [
-        "[ \\t]*\\[\\[.*?\\]\\]"
+        "\\d*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
         "searchScaling.prose.1024"
@@ -4308,7 +4308,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.10240",
       "operation": "find",
       "patterns": [
-        "[ \\t]*\\[\\[.*?\\]\\]"
+        "\\d*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
         "searchScaling.prose.10240"
@@ -4506,7 +4506,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.102400",
       "operation": "find",
       "patterns": [
-        "[ \\t]*\\[\\[.*?\\]\\]"
+        "\\d*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
         "searchScaling.prose.102400"
@@ -4704,7 +4704,7 @@
       "id": "SearchScalingBenchmark.optionalIndentBracketScaled.1048576",
       "operation": "find",
       "patterns": [
-        "[ \\t]*\\[\\[.*?\\]\\]"
+        "\\d*\\[\\[.*?\\]\\]"
       ],
       "inputs": [
         "searchScaling.prose.1048576"

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -452,7 +452,7 @@
       "id": "vectorScan.multi.nonascii.32768",
       "recipe": {
         "kind": "repeatToLength",
-        "unit": "\u00e9",
+        "unit": "é",
         "length": 32768
       },
       "shared": true
@@ -1727,7 +1727,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "\u3044\u304f\u3064\u3082\u306e\u3000\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u3000\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u3000\u305d\u3057\u3066\u3000\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u3000\u304c\u3042\u308a\u307e\u3059",
+        "value": "いくつもの　中国語と日本語の文字　がここにあります　そして　いくつかのスペース　があります",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1745,7 +1745,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "\u3044\u304f\u3064\u3082\u306e\u4e2d\u56fd\u8a9e\u3068\u65e5\u672c\u8a9e\u306e\u6587\u5b57\u304c\u3053\u3053\u306b\u3042\u308a\u307e\u3059\u305d\u3057\u3066\u3044\u304f\u3064\u304b\u306e\u30b9\u30da\u30fc\u30b9\u304c\u3042\u308a\u307e\u3059",
+        "value": "いくつもの中国語と日本語の文字がここにありますそしていくつかのスペースがあります",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1763,7 +1763,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "\u8fd9\u662f\u4e00\u4e2a\u4e2d\u6587\u6d4b\u8bd5\u53e5\u5b50",
+        "value": "这是一个中文测试句子",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -1799,7 +1799,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "Today is a beautiful day \ud83d\ude07 with warm sunshine.",
+        "value": "Today is a beautiful day 😇 with warm sunshine.",
         "delimiterAlphabet": " ",
         "seed": 42,
         "length": "{size}"
@@ -2111,21 +2111,21 @@
       "id": "utf8.captureFree.multibyteEarly",
       "recipe": {
         "kind": "literal",
-        "text": "\u9519\u8bef\uff1a\u8bf7\u6c42\u5931\u8d25"
+        "text": "错误：请求失败"
       }
     },
     {
       "id": "utf8.captureFree.multibyteLate",
       "recipe": {
         "kind": "literal",
-        "text": "\u8bf7\u6c42\u5904\u7406\u7ed3\u675f\uff1a\u9519\u8bef"
+        "text": "请求处理结束：错误"
       }
     },
     {
       "id": "utf8.captureFree.multibyteNoMatch",
       "recipe": {
         "kind": "literal",
-        "text": "\u8bf7\u6c42\u5904\u7406\u6210\u529f"
+        "text": "请求处理成功"
       }
     },
     {
@@ -2139,7 +2139,7 @@
       "id": "utf8.repeatedFind.multibyte",
       "recipe": {
         "kind": "literal",
-        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
+        "text": "one café 東京 naïve"
       }
     },
     {
@@ -2153,7 +2153,7 @@
       "id": "utf8.captureBounds.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
+        "text": "city=東京&name=Renée"
       }
     },
     {
@@ -2167,42 +2167,42 @@
       "id": "utf8.emptyMatch",
       "recipe": {
         "kind": "literal",
-        "text": "a\ud83d\udcb0\u6709"
+        "text": "a💰有"
       }
     },
     {
       "id": "utf8.window",
       "recipe": {
         "kind": "literal",
-        "text": "sentinel-before-city=\u6771\u4eac&name=Ren\u00e9e-sentinel-after"
+        "text": "sentinel-before-city=東京&name=Renée-sentinel-after"
       }
     },
     {
       "id": "utf8.construction",
       "recipe": {
         "kind": "literal",
-        "text": "one caf\u00e9 \u6771\u4eac na\u00efve"
+        "text": "one café 東京 naïve"
       }
     },
     {
       "id": "utf8.replacement.literal",
       "recipe": {
         "kind": "literal",
-        "text": "\u9519\u8bef then \u9519\u8bef"
+        "text": "错误 then 错误"
       }
     },
     {
       "id": "utf8.replacement.numbered",
       "recipe": {
         "kind": "literal",
-        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
+        "text": "city=東京&name=Renée"
       }
     },
     {
       "id": "utf8.replacement.named",
       "recipe": {
         "kind": "literal",
-        "text": "city=\u6771\u4eac&name=Ren\u00e9e"
+        "text": "city=東京&name=Renée"
       }
     },
     {
@@ -2410,7 +2410,7 @@
       "recipe": {
         "kind": "suffixToLength",
         "prefixUnit": "0123456789 9876543210 1357924680 ",
-        "suffix": "\u00e9123",
+        "suffix": "é123",
         "length": "{size}"
       },
       "shared": true
@@ -2443,7 +2443,7 @@
       "recipe": {
         "kind": "suffixToLength",
         "prefixUnit": "The quick brown fox jumps over the lazy dog. Standard English prose without CJK characters. ",
-        "suffix": "\u4f60\u597d123",
+        "suffix": "你好123",
         "length": "{size}"
       },
       "shared": true
@@ -2901,14 +2901,14 @@
       "operation": "replaceAll",
       "patterns": [
         {
-          "java": " ?[\\[\uff3b](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]\uff3d]",
+          "java": " ?[\\[［](?:(?:\\d+\\.){2,}\\d+(?:, )?)+[\\]］]",
           "alternates": {
             "rust-regex": {
-              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
               "reason": "Rust regex gives \\d Unicode semantics"
             },
             "dotnet": {
-              "pattern": " ?[\\[\uff3b](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]\uff3d]",
+              "pattern": " ?[\\[［](?:(?:[0-9]+\\.){2,}[0-9]+(?:, )?)+[\\]］]",
               "reason": ".NET gives \\d Unicode semantics while Java defaults to ASCII"
             }
           }
@@ -3773,7 +3773,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.cjkSearch.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "realWorldRegex.cjkSearch.{matchLabel}.{size}"
@@ -3803,7 +3803,7 @@
       "operation": "find",
       "patterns": [
         {
-          "java": "[\ud83d\ude00-\ud83d\ude07]",
+          "java": "[😀-😇]",
           "alternates": {
             "dotnet": {
               "pattern": "\\uD83D[\\uDE00-\\uDE07]",
@@ -3839,7 +3839,7 @@
       "id": "RealWorldRegexBenchmark.runBenchmark.recitation.{matchLabel}.{size}",
       "operation": "replaceAll",
       "patterns": [
-        "\\s*[\\[\uff3b]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,\u3001]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]\uff3d]"
+        "\\s*[\\[［]\\s*(?:(?:[0-9]+\\.?){3,4}(?:\\s*[,、]\\s*(?:[0-9]+\\.?){3,4})*)\\s*[\\]］]"
       ],
       "inputs": [
         "realWorldRegex.recitation.{matchLabel}.{size}"
@@ -4053,6 +4053,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.currencyPriceScaled.64",
+      "operation": "find",
+      "patterns": [
+        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
+      ],
+      "inputs": [
+        "searchScaling.prose.64"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.alternationScaled.256",
       "operation": "find",
       "patterns": [
@@ -4071,10 +4089,46 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.currencyPriceScaled.256",
+      "operation": "find",
+      "patterns": [
+        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
+      ],
+      "inputs": [
+        "searchScaling.prose.256"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.alternationScaled.1024",
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.1024"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.currencyPriceScaled.1024",
+      "operation": "find",
+      "patterns": [
+        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
       ],
       "inputs": [
         "searchScaling.prose.1024"
@@ -4269,6 +4323,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.currencyPriceScaled.10240",
+      "operation": "find",
+      "patterns": [
+        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
+      ],
+      "inputs": [
+        "searchScaling.prose.10240"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.startAnchoredLiteralFail.10240",
       "operation": "find",
       "patterns": [
@@ -4449,6 +4521,24 @@
       }
     },
     {
+      "id": "SearchScalingBenchmark.currencyPriceScaled.102400",
+      "operation": "find",
+      "patterns": [
+        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
+      ],
+      "inputs": [
+        "searchScaling.prose.102400"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "SearchScalingBenchmark.startAnchoredLiteralFail.102400",
       "operation": "find",
       "patterns": [
@@ -4615,6 +4705,24 @@
       "operation": "find",
       "patterns": [
         "foo|bar|baz|qux|quux|corge|grault|garply"
+      ],
+      "inputs": [
+        "searchScaling.prose.1048576"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "SearchScalingBenchmark.currencyPriceScaled.1048576",
+      "operation": "find",
+      "patterns": [
+        "[$€£¥]\\s*\\d+(?:\\.\\d+)?|\\d+(?:\\.\\d+)?\\s*[$€£¥]"
       ],
       "inputs": [
         "searchScaling.prose.1048576"
@@ -8137,7 +8245,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteEarly",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8156,7 +8264,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteLate",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8175,7 +8283,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeDecode.multibyteNoMatch",
       "operation": "utf8DecodeFind",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8263,7 +8371,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8286,7 +8394,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteLate",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8309,7 +8417,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8401,7 +8509,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteEarly",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteEarly"
@@ -8424,7 +8532,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteLate",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteLate"
@@ -8447,7 +8555,7 @@
       "id": "Utf8MatchingBenchmark.captureFreeString.multibyteNoMatch",
       "operation": "find",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.captureFree.multibyteNoMatch"
@@ -8615,7 +8723,7 @@
       "id": "Utf8MatchingBenchmark.window",
       "operation": "findInWindow",
       "patterns": [
-        "\u6771\u4eac"
+        "東京"
       ],
       "inputs": [
         "utf8.window"
@@ -8698,7 +8806,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchBytes",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9202,7 +9310,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchMatcher",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9228,7 +9336,7 @@
       "id": "Utf8MatchingBenchmark.requiredClassNonmatchString",
       "operation": "find",
       "patterns": [
-        "[\u4e00-\u9fa5]{3,}"
+        "[一-龥]{3,}"
       ],
       "inputs": [
         "utf8Matching.requiredClassNonmatch.text"
@@ -9412,7 +9520,7 @@
       "id": "ByteReplacementBenchmark.literal",
       "operation": "utf8Replacement",
       "patterns": [
-        "\u9519\u8bef"
+        "错误"
       ],
       "inputs": [
         "utf8.replacement.literal"

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(406);
+    assertThat(first).hasSize(400);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(40);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(657);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(663);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_570);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_630);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -243,7 +243,7 @@ class BenchmarkInputMaterializerTest {
                   .getAsString())
           .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(338);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(344);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -255,7 +255,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(657);
+          .hasSize(663);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(40);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(663);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(669);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_630);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_690);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -243,7 +243,7 @@ class BenchmarkInputMaterializerTest {
                   .getAsString())
           .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(344);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(350);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -255,7 +255,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(663);
+          .hasSize(669);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(400);
+    assertThat(first).hasSize(406);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(40);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(669);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(663);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_690);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_630);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -243,7 +243,7 @@ class BenchmarkInputMaterializerTest {
                   .getAsString())
           .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(350);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(344);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -255,7 +255,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(669);
+          .hasSize(663);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(580);
+    assertThat(ids).hasSize(586);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2166);
+    assertThat(allTrials).hasSize(2196);
     assertThat(plan.exclusions()).hasSize(734);
-    assertThat(accounted).hasSize(580 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(586 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1516);
+        .hasSize(1546);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2205);
-    assertThat(plan.reportPlan().trials()).hasSize(2205);
+        .hasSize(2235);
+    assertThat(plan.reportPlan().trials()).hasSize(2235);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(592);
+    assertThat(ids).hasSize(586);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2226);
+    assertThat(allTrials).hasSize(2196);
     assertThat(plan.exclusions()).hasSize(734);
-    assertThat(accounted).hasSize(592 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(586 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1576);
+        .hasSize(1546);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2265);
-    assertThat(plan.reportPlan().trials()).hasSize(2265);
+        .hasSize(2235);
+    assertThat(plan.reportPlan().trials()).hasSize(2235);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(586);
+    assertThat(ids).hasSize(592);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2196);
+    assertThat(allTrials).hasSize(2226);
     assertThat(plan.exclusions()).hasSize(734);
-    assertThat(accounted).hasSize(586 * RegexEngineVariant.values().length);
+    assertThat(accounted).hasSize(592 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1546);
+        .hasSize(1576);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2235);
-    assertThat(plan.reportPlan().trials()).hasSize(2235);
+        .hasSize(2265);
+    assertThat(plan.reportPlan().trials()).hasSize(2265);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -45,6 +45,30 @@ final class ByteVectorScan {
     return -1;
   }
 
+  static int indexOfByte(byte[] bytes, int offset, int length, byte target, int start) {
+    return indexOfByte(SPECIES, bytes, offset, length, target, start);
+  }
+
+  static int indexOfByte(
+      VectorSpecies<Byte> species, byte[] bytes, int offset, int length, byte target, int start) {
+    int position = Math.max(0, start);
+    int limit = position + species.loopBound(length - position);
+    ByteVector targetVec = ByteVector.broadcast(species, target);
+    for (; position < limit; position += species.length()) {
+      ByteVector values = ByteVector.fromArray(species, bytes, offset + position);
+      VectorMask<Byte> matches = values.compare(EQ, targetVec);
+      if (matches.anyTrue()) {
+        return position + matches.firstTrue();
+      }
+    }
+    for (; position < length; position++) {
+      if (bytes[offset + position] == target) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
   static int indexOfAsciiPair(byte[] bytes, int offset, int length, byte b0, byte b1, int start) {
     int position = Math.max(0, start);
     int limit = position + SPECIES.loopBound(length - position);

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -801,16 +801,24 @@ final class Dfa {
 
   /** Returns whether this DFA can accelerate start positions for the supplied input substrate. */
   boolean hasStartAcceleration(InputScanner text) {
-    return startAccelerationPolicy(text) != null;
+    return startAccelerationPolicy(text, null) != null;
   }
 
-  private AcceleratorPolicy startAccelerationPolicy(InputScanner text) {
-    return switch (text) {
-      case Utf8InputScanner unusedUtf8 ->
-          utf8StartAccelerator != null ? utf8StartAccelerator.policy() : null;
-      case StringInputScanner unusedString ->
-          stringStartAccelerator != null ? stringStartAccelerator.policy() : null;
-    };
+  private AcceleratorPolicy startAccelerationPolicy(InputScanner text, State startState) {
+    AcceleratorPolicy policy =
+        switch (text) {
+          case Utf8InputScanner unusedUtf8 ->
+              utf8StartAccelerator != null ? utf8StartAccelerator.policy() : null;
+          case StringInputScanner unusedString ->
+              stringStartAccelerator != null ? stringStartAccelerator.policy() : null;
+        };
+    if (policy != null) {
+      return policy;
+    }
+    if (startState != null && startState.accelerator != null) {
+      return startState.accelerator.policy();
+    }
+    return null;
   }
 
   private static boolean instMatches(Inst ip, int ch) {
@@ -1316,26 +1324,43 @@ final class Dfa {
    * Fast-forwards the start position of unanchored search matching when returning to the start
    * state.
    */
-  private int fastForward(InputScanner text, int pos, int posDepThreshold) {
-    return switch (text) {
-      case Utf8InputScanner utf8Scanner -> {
-        if (utf8StartAccelerator != null) {
-          int idx = Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, utf8Scanner, pos);
-          if (idx >= 0) {
-            yield Math.min(idx, posDepThreshold - 1);
+  private int fastForward(InputScanner text, int pos, int posDepThreshold, State startState) {
+    int next =
+        switch (text) {
+          case Utf8InputScanner utf8Scanner -> {
+            if (utf8StartAccelerator != null) {
+              int idx =
+                  Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, utf8Scanner, pos);
+              if (idx >= 0) {
+                yield Math.min(idx, posDepThreshold - 1);
+              }
+              yield -1;
+            }
+            yield -2;
           }
-          yield -1;
-        }
-        yield pos;
+          case StringInputScanner stringScanner -> {
+            if (stringStartAccelerator != null) {
+              yield StringStartAccelerator.findNextCandidate(
+                  stringStartAccelerator, stringScanner.text(), pos, prog.unixLines());
+            }
+            yield -2;
+          }
+        };
+    if (next != -2) {
+      return next;
+    }
+    if (startState != null && startState.accelerator != null) {
+      int limit =
+          hasPositionDependentTransitions
+              ? Math.min(text.length(), posDepThreshold - 1)
+              : text.length();
+      int idx = StateAccelerator.findNextEscape(startState.accelerator, text, pos, limit);
+      if (idx >= 0) {
+        return idx;
       }
-      case StringInputScanner stringScanner -> {
-        if (stringStartAccelerator != null) {
-          yield StringStartAccelerator.findNextCandidate(
-              stringStartAccelerator, stringScanner.text(), pos, prog.unixLines());
-        }
-        yield pos;
-      }
-    };
+      return -1;
+    }
+    return pos;
   }
 
   /**
@@ -1392,7 +1417,7 @@ final class Dfa {
       return new SearchResult(matched, matchEnd);
     }
 
-    AcceleratorPolicy activePolicy = startAccelerationPolicy(text);
+    AcceleratorPolicy activePolicy = startAccelerationPolicy(text, s);
     boolean canAccelerate = activePolicy != null && !anchored;
     int minSkip = AcceleratorPolicy.DEFAULT.minProfitableSkip();
     int maxStrikes = AcceleratorPolicy.DEFAULT.strikeBudget();
@@ -1415,7 +1440,7 @@ final class Dfa {
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
       if (canAccelerate && !accelerationDisabled && s.isStartState && (textLen - pos >= minSkip)) {
-        int nextPos = fastForward(text, pos, posDepThreshold);
+        int nextPos = fastForward(text, pos, posDepThreshold, s);
         if (nextPos == -1) {
           return new SearchResult(matched, matchEnd);
         }
@@ -1538,7 +1563,7 @@ final class Dfa {
     // General loop handles non-ASCII, position-dependent checks, and trailing end-of-text sentinel
     while (pos <= textLen) {
       if (canAccelerate && !accelerationDisabled && s.isStartState && (textLen - pos >= minSkip)) {
-        int nextPos = fastForward(text, pos, posDepThreshold);
+        int nextPos = fastForward(text, pos, posDepThreshold, s);
         if (nextPos == -1) {
           return new SearchResult(matched, matchEnd);
         }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1358,6 +1358,9 @@ final class Dfa {
       if (idx >= 0) {
         return idx;
       }
+      if (hasPositionDependentTransitions && limit < text.length()) {
+        return limit;
+      }
       return -1;
     }
     return pos;

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1325,30 +1325,19 @@ final class Dfa {
    * state.
    */
   private int fastForward(InputScanner text, int pos, int posDepThreshold, State startState) {
-    int next =
-        switch (text) {
-          case Utf8InputScanner utf8Scanner -> {
-            if (utf8StartAccelerator != null) {
-              int idx =
-                  Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, utf8Scanner, pos);
-              if (idx >= 0) {
-                yield Math.min(idx, posDepThreshold - 1);
-              }
-              yield -1;
-            }
-            yield -2;
-          }
-          case StringInputScanner stringScanner -> {
-            if (stringStartAccelerator != null) {
-              yield StringStartAccelerator.findNextCandidate(
-                  stringStartAccelerator, stringScanner.text(), pos, prog.unixLines());
-            }
-            yield -2;
-          }
-        };
-    if (next != -2) {
-      return next;
+    if (text instanceof Utf8InputScanner utf8Scanner && utf8StartAccelerator != null) {
+      int idx = Utf8StartAccelerator.findNextCandidate(utf8StartAccelerator, utf8Scanner, pos);
+      return idx >= 0 ? Math.min(idx, posDepThreshold - 1) : -1;
     }
+    if (text instanceof StringInputScanner stringScanner && stringStartAccelerator != null) {
+      return StringStartAccelerator.findNextCandidate(
+          stringStartAccelerator, stringScanner.text(), pos, prog.unixLines());
+    }
+    return fastForwardStartState(text, pos, posDepThreshold, startState);
+  }
+
+  private int fastForwardStartState(
+      InputScanner text, int pos, int posDepThreshold, State startState) {
     if (startState != null && startState.accelerator != null) {
       int limit =
           hasPositionDependentTransitions

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -83,7 +83,7 @@ final class Dfa {
    * plus position-dependent flags. States are cached and shared across transitions to avoid
    * recomputation.
    */
-  private static final class State {
+  static final class State {
     final int id;
     final int[] insts; // sorted NFA instruction IDs (CHAR_RANGE, EMPTY_WIDTH, and MATCH only)
     final int flags;
@@ -822,7 +822,7 @@ final class Dfa {
   }
 
   private static boolean instMatches(Inst ip, int ch) {
-    if (ip.opCode == InstOp.OP_CHAR_RANGE) {
+    if (ip.opCode == InstOp.OP_CHAR_RANGE || ip.opCode == InstOp.OP_ALT_MATCH) {
       return ip.matchesChar(ch);
     }
     if (ip.opCode == InstOp.OP_CHAR_CLASS) {
@@ -838,7 +838,7 @@ final class Dfa {
    * prefix loop that the compiler generates. This keeps all start positions alive within the DFA
    * state without needing to restart at each position (unlike the NFA).
    */
-  private State startState(InputScanner text, int pos, boolean anchored) {
+  State startState(InputScanner text, int pos, boolean anchored) {
     return startState(text, pos, anchored, false);
   }
 
@@ -886,7 +886,7 @@ final class Dfa {
    * @param reverseContext if true, FLAG_LAST_WORD is set based on the character AT pos (the char to
    *     the right of where a reverse scan begins), rather than the character BEFORE pos
    */
-  private State startState(InputScanner text, int pos, boolean anchored, boolean reverseContext) {
+  State startState(InputScanner text, int pos, boolean anchored, boolean reverseContext) {
     int startInst = anchored ? prog.start() : prog.startUnanchored();
     if (startInst == 0) {
       return deadState;

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -39,6 +39,11 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   }
 
   @Override
+  public int indexOfByte(byte[] bytes, int offset, int length, byte target, int start) {
+    return ByteVectorScan.indexOfByte(bytes, offset, length, target, start);
+  }
+
+  @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
     return ByteVectorScan.indexOfAsciiClass(bytes, offset, length, ranges, start);
   }

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -24,14 +24,7 @@ sealed interface StateAccelerator {
   int findEscape(InputScanner text, int fromIndex, int limit);
 
   /** Returns the accelerator policy for this state accelerator. */
-  default AcceleratorPolicy policy() {
-    return switch (this) {
-      case SingleAsciiEscape single -> AcceleratorPolicy.LITERAL;
-      case AsciiPairEscape pair -> AcceleratorPolicy.CHAR_CLASS;
-      case AsciiTripleEscape triple -> AcceleratorPolicy.CHAR_CLASS;
-      case CharClassEscape cc -> AcceleratorPolicy.CHAR_CLASS;
-    };
-  }
+  AcceleratorPolicy policy();
 
   /**
    * Fast-forwards to the next escape character in a self-loop state using pattern-matched
@@ -61,6 +54,11 @@ sealed interface StateAccelerator {
     public int findEscape(InputScanner text, int fromIndex, int limit) {
       return text.indexOfAscii(escape, fromIndex, limit);
     }
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.LITERAL;
+    }
   }
 
   /** Accelerator for two escape characters (e.g. quote {@code '"'} and backslash {@code '\\'}). */
@@ -68,6 +66,11 @@ sealed interface StateAccelerator {
     @Override
     public int findEscape(InputScanner text, int fromIndex, int limit) {
       return text.indexOfAsciiPair(c1, c2, fromIndex, limit);
+    }
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
     }
   }
 
@@ -77,6 +80,11 @@ sealed interface StateAccelerator {
     public int findEscape(InputScanner text, int fromIndex, int limit) {
       return text.indexOfAsciiTriple(c1, c2, c3, fromIndex, limit);
     }
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
+    }
   }
 
   /** Accelerator for a character-class escape (e.g. delimiters or character ranges). */
@@ -85,6 +93,11 @@ sealed interface StateAccelerator {
     @Override
     public int findEscape(InputScanner text, int fromIndex, int limit) {
       return text.indexOfCodePointClass(ranges, bitmap0, bitmap1, fromIndex, limit);
+    }
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return AcceleratorPolicy.CHAR_CLASS;
     }
   }
 }

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -23,6 +23,16 @@ sealed interface StateAccelerator {
    */
   int findEscape(InputScanner text, int fromIndex, int limit);
 
+  /** Returns the accelerator policy for this state accelerator. */
+  default AcceleratorPolicy policy() {
+    return switch (this) {
+      case SingleAsciiEscape single -> AcceleratorPolicy.LITERAL;
+      case AsciiPairEscape pair -> AcceleratorPolicy.CHAR_CLASS;
+      case AsciiTripleEscape triple -> AcceleratorPolicy.CHAR_CLASS;
+      case CharClassEscape cc -> AcceleratorPolicy.CHAR_CLASS;
+    };
+  }
+
   /**
    * Fast-forwards to the next escape character in a self-loop state using pattern-matched
    * devirtualization.

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -68,8 +68,19 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
       }
       return -1;
     }
-    int res = indexOfByte((byte) ascii, start);
+    int res = scanByte(scanLen, (byte) ascii, start);
     return (res >= 0 && res < limit) ? res : -1;
+  }
+
+  private int scanByte(int scanLen, byte b0, int start) {
+    VectorScanProvider byteProvider = VectorScanProviders.providerForByteLength(scanLen - start);
+    if (byteProvider != null) {
+      int idx = byteProvider.indexOfByte(bytes, offset, scanLen, b0, start);
+      if (idx != VectorScanProvider.UNSUPPORTED) {
+        return idx;
+      }
+    }
+    return ByteSwarScan.indexOfByte(bytes, offset, scanLen, b0, start);
   }
 
   @Override

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -20,6 +20,11 @@ interface VectorScanProvider {
   int maximumTripleInputLength();
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
+  default int indexOfByte(byte[] bytes, int offset, int length, byte target, int start) {
+    return UNSUPPORTED;
+  }
+
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */

--- a/safere/src/main/java/org/safere/VectorScanProviders.java
+++ b/safere/src/main/java/org/safere/VectorScanProviders.java
@@ -24,6 +24,10 @@ final class VectorScanProviders {
     return SELECTED != null;
   }
 
+  static VectorScanProvider providerForByteLength(int length) {
+    return SELECTED != null && length >= SELECTED.minimumPairInputLength() ? SELECTED : null;
+  }
+
   static VectorScanProvider providerForPairLength(int length) {
     return SELECTED != null && length >= SELECTED.minimumPairInputLength() ? SELECTED : null;
   }

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -683,6 +683,15 @@ class DfaTest {
     assertThat(accelerated.find(Utf8Input.validated(input.getBytes(UTF_8)))).isTrue();
   }
 
+
+  @Test
+  void automataDerivedStartStateAcceleratesOptionalWhitespaceBracket() {
+    Pattern pattern = Pattern.compile("[ \\t]*\\[\\[.*?\\]\\]");
+    String text = "x".repeat(1000) + "[[test]]" + "y".repeat(1000);
+    assertThat(pattern.matcher(text).find()).isTrue();
+    assertThat(pattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
+  }
+
   @Test
   void automataDerivedStartStateAcceleratesAlternations() {
     Regexp re = Parser.parse("apple|banana|cherry", FLAGS);

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -684,6 +684,42 @@ class DfaTest {
   }
 
   @Test
+  void automataDerivedStartStateAcceleratesAlternations() {
+    Pattern pattern = Pattern.compile("apple|banana|cherry");
+    String text = "x".repeat(500) + "banana" + "y".repeat(500);
+    assertThat(pattern.matcher(text).find()).isTrue();
+    assertThat(pattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
+
+    String noMatch = "x".repeat(1000);
+    assertThat(pattern.matcher(noMatch).find()).isFalse();
+    assertThat(pattern.find(Utf8Input.validated(noMatch.getBytes(UTF_8)))).isFalse();
+  }
+
+  @Test
+  void automataDerivedStartStateAcceleratesMultiTokenAlternation() {
+    Pattern pattern = Pattern.compile("(?:image-tokens|video-tokens|pdf-tokens)");
+    String text = "x".repeat(500) + "video-tokens" + "y".repeat(500);
+    assertThat(pattern.matcher(text).find()).isTrue();
+    assertThat(pattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
+
+    String noMatch = "x".repeat(1000);
+    assertThat(pattern.matcher(noMatch).find()).isFalse();
+    assertThat(pattern.find(Utf8Input.validated(noMatch.getBytes(UTF_8)))).isFalse();
+  }
+
+  @Test
+  void automataDerivedStartStateAcceleratesDisjointRangeAlternation() {
+    Pattern pattern = Pattern.compile("[0-9]{3}|[a-z]{3}");
+    String text = "---".repeat(100) + "123" + "---".repeat(100);
+    assertThat(pattern.matcher(text).find()).isTrue();
+    assertThat(pattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
+
+    String noMatch = "---".repeat(200);
+    assertThat(pattern.matcher(noMatch).find()).isFalse();
+    assertThat(pattern.find(Utf8Input.validated(noMatch.getBytes(UTF_8)))).isFalse();
+  }
+
+  @Test
   void wordBoundaryLongText() {
     String regex = "(?:\\w(?:\\b))";
     String input = "#".repeat(260) + "a";

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -691,7 +691,6 @@ class DfaTest {
     assertThat(pattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
   }
 
-
   @Test
   void automataDerivedStartStateAcceleratesAlternations() {
     Regexp re = Parser.parse("apple|banana|cherry", FLAGS);

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -685,6 +685,14 @@ class DfaTest {
 
   @Test
   void automataDerivedStartStateAcceleratesAlternations() {
+    Regexp re = Parser.parse("apple|banana|cherry", FLAGS);
+    Prog prog = Compiler.compile(re);
+    Dfa dfa = new Dfa(prog, 1000, Dfa.buildSetup(prog), false);
+    InputScanner scanner = new StringInputScanner("x".repeat(100));
+    Dfa.State s = dfa.startState(scanner, 0, false);
+    assertThat(s.accelerator).isNotNull();
+    assertThat(s.accelerator).isInstanceOf(StateAccelerator.AsciiTripleEscape.class);
+
     Pattern pattern = Pattern.compile("apple|banana|cherry");
     String text = "x".repeat(500) + "banana" + "y".repeat(500);
     assertThat(pattern.matcher(text).find()).isTrue();

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -691,6 +691,7 @@ class DfaTest {
     assertThat(pattern.find(Utf8Input.validated(text.getBytes(UTF_8)))).isTrue();
   }
 
+
   @Test
   void automataDerivedStartStateAcceleratesAlternations() {
     Regexp re = Parser.parse("apple|banana|cherry", FLAGS);

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -683,7 +683,6 @@ class DfaTest {
     assertThat(accelerated.find(Utf8Input.validated(input.getBytes(UTF_8)))).isTrue();
   }
 
-
   @Test
   void automataDerivedStartStateAcceleratesOptionalWhitespaceBracket() {
     Pattern pattern = Pattern.compile("[ \\t]*\\[\\[.*?\\]\\]");

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -736,6 +736,41 @@ class SearchScalingRegressionTest {
         "String");
   }
 
+  @Test
+  void directDfaStartStateAcceleratesUnanchoredAlternationOnString() {
+    Prog prog = Compiler.compile(Parser.parse("apple|banana|cherry", ParseFlags.MATCH_NL));
+    Dfa dfa = new Dfa(prog, 1000, Dfa.buildSetup(prog), false);
+    String input = "x".repeat(10_000) + "cherry";
+    long work =
+        WorkCounter.countForTesting(
+            () -> {
+              Dfa.SearchResult res = dfa.doSearch(input, false, false);
+              assertThat(res).isNotNull();
+              assertThat(res.matched()).isTrue();
+            });
+    assertThat(work)
+        .as("Direct DFA start state acceleration must scan input linearly")
+        .isLessThanOrEqualTo(input.length() + 20);
+  }
+
+  @Test
+  void directDfaStartStateAcceleratesUnanchoredAlternationOnUtf8() {
+    Prog prog = Compiler.compile(Parser.parse("apple|banana|cherry", ParseFlags.MATCH_NL));
+    Dfa dfa = new Dfa(prog, 1000, Dfa.buildSetup(prog), false);
+    byte[] input = ("x".repeat(10_000) + "cherry").getBytes(UTF_8);
+    long work =
+        WorkCounter.countForTesting(
+            () -> {
+              Dfa.SearchResult res =
+                  dfa.doSearch(new Utf8InputScanner(input, 0, input.length), 0, false, false);
+              assertThat(res).isNotNull();
+              assertThat(res.matched()).isTrue();
+            });
+    assertThat(work)
+        .as("Direct DFA start state acceleration on UTF-8 must scan input linearly")
+        .isLessThanOrEqualTo(input.length + 20);
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");


### PR DESCRIPTION
The DFA inner loop acceleration in #655 optimized cases where the DFA returned to the start state by re-using start accelerators to fast forward, and states where almost all transitions looped back to the same state by searching for 1-3 escape characters.

This change fixes a gap where if the DFA returned to the start state, and a start accelerator wasn't available, the DFA wouldn't check if it could use the escape character fast path. This PR ensures that if the DFA returns to the start state it will use a start accelerator if one is available, and then check if the escape character fast path is available.

Additionally this fixes a missing implementation of `ByteVectorScan.indexOfByte`, previously there was only a SWAR implementation.

```
./safere-benchmarks/scripts/compare-branch.sh --baseline benchmark-wildcard-baseline --vector 'optionalIndentBracketScaled.*@safere-utf8'
```

| Benchmark                                                  | baseline (ns/op) | current (ns/op) | Speedup |
| ---------------------------------------------------------- | ---------------- | --------------- | ------- |
| SearchScalingBenchmark.optionalIndentBracketScaled.64      |        101 ± 1.3 |         87 ± 11 |   1.16x |
| SearchScalingBenchmark.optionalIndentBracketScaled.256     |        102 ± 3.2 |        81 ± 1.1 |   1.26x |
| SearchScalingBenchmark.optionalIndentBracketScaled.1024    |        105 ± 3.7 |        71 ± 1.2 |   1.48x |
| SearchScalingBenchmark.optionalIndentBracketScaled.10240   |        101 ± 1.3 |       71 ± 0.59 |   1.43x |
| SearchScalingBenchmark.optionalIndentBracketScaled.102400  |        104 ± 9.6 |        71 ± 1.9 |   1.46x |
| SearchScalingBenchmark.optionalIndentBracketScaled.1048576 |        105 ± 5.8 |        71 ± 1.1 |   1.48x |
