### PR TITLE
Retain required infix literals in RejectPrefilter and wire into replace and split operations

### DIFF
--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2820,12 +2820,14 @@ public final class Matcher implements MatchResult {
   private String replaceImpl(String replacement, int limit) {
     Objects.requireNonNull(replacement, "replacement");
     reset();
-    RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
-    if (rejectPrefilter != null && text != null) {
-      if (rejectPrefilter.canReject(activeScanner(), text, searchFrom, enginePathOptions())) {
-        diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
-        diagnosticBoundary(rejectPrefilter.strategy());
-        return text;
+    if (!parentPattern.prog().anchorStart()) {
+      RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
+      if (rejectPrefilter != null && text != null) {
+        if (rejectPrefilter.canReject(activeScanner(), text, searchFrom, enginePathOptions())) {
+          diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
+          diagnosticBoundary(rejectPrefilter.strategy());
+          return text;
+        }
       }
     }
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
@@ -4357,10 +4359,12 @@ public final class Matcher implements MatchResult {
   }
 
   int findSplitPositions(int limit, SplitBuffer buffer) {
-    RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
-    if (rejectPrefilter != null && text != null) {
-      if (rejectPrefilter.canReject(activeScanner(), text, 0, enginePathOptions())) {
-        return 0;
+    if (!parentPattern.prog().anchorStart()) {
+      RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
+      if (rejectPrefilter != null && text != null) {
+        if (rejectPrefilter.canReject(activeScanner(), text, 0, enginePathOptions())) {
+          return 0;
+        }
       }
     }
     int last = 0;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2823,9 +2823,17 @@ public final class Matcher implements MatchResult {
     if (!parentPattern.prog().anchorStart()) {
       RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
       if (rejectPrefilter != null && text != null) {
-        if (rejectPrefilter.canReject(activeScanner(), text, searchFrom, enginePathOptions())) {
-          diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
-          diagnosticBoundary(rejectPrefilter.strategy());
+        InputScanner scanner = activeScanner();
+        EnginePathOptions options = enginePathOptions();
+        MatchStrategy rejectionStrategy =
+            rejectPrefilter instanceof RejectPrefilter.Composite composite
+                ? composite.rejectionStrategy(scanner, text, searchFrom, options)
+                : rejectPrefilter.canReject(scanner, text, searchFrom, options)
+                    ? rejectPrefilter.strategy()
+                    : null;
+        if (rejectionStrategy != null) {
+          diagnosticParticipation(rejectionStrategy, StrategyRole.REJECT_PREFILTER);
+          diagnosticBoundary(rejectionStrategy);
           return text;
         }
       }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -2820,6 +2820,14 @@ public final class Matcher implements MatchResult {
   private String replaceImpl(String replacement, int limit) {
     Objects.requireNonNull(replacement, "replacement");
     reset();
+    RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
+    if (rejectPrefilter != null && text != null) {
+      if (rejectPrefilter.canReject(activeScanner(), text, searchFrom, enginePathOptions())) {
+        diagnosticParticipation(rejectPrefilter.strategy(), StrategyRole.REJECT_PREFILTER);
+        diagnosticBoundary(rejectPrefilter.strategy());
+        return text;
+      }
+    }
     LazyTemplate template = new LazyTemplate(replacement, groupCount());
     String literalResult = literalReplaceFastPath(template, limit);
     if (literalResult != null) {
@@ -4349,6 +4357,12 @@ public final class Matcher implements MatchResult {
   }
 
   int findSplitPositions(int limit, SplitBuffer buffer) {
+    RejectPrefilter rejectPrefilter = parentPattern.rejectPrefilter();
+    if (rejectPrefilter != null && text != null) {
+      if (rejectPrefilter.canReject(activeScanner(), text, 0, enginePathOptions())) {
+        return 0;
+      }
+    }
     int last = 0;
     int searchFrom = 0;
     int textLen = text.length();

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -3179,9 +3179,10 @@ public final class Pattern implements Serializable {
     String prefix = startDescriptor != null ? startDescriptor.prefix() : null;
     CharClassScanInfo ccPrefix = startDescriptor != null ? startDescriptor.charClassPrefix() : null;
     String suffixStr = endAnchoredSuffix != null ? endAnchoredSuffix.suffix() : null;
-    String requiredLiteral = extractRequiredLiteral(metadataAst, prefix, suffixStr);
+    String requiredLiteral =
+        !anchorStart ? extractRequiredLiteral(metadataAst, prefix, suffixStr) : null;
     CharClassScanInfo requiredMatchClass = null;
-    if (prefix == null && endAnchoredCharClass == null) {
+    if (!anchorStart && prefix == null && endAnchoredCharClass == null) {
       if (ccPrefix == null) {
         requiredMatchClass = extractRequiredMatchClass(metadataAst, true);
       } else {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -3178,7 +3178,8 @@ public final class Pattern implements Serializable {
         endAnchoredSuffix == null ? extractEndAnchoredCharClass(metadataAst, flags) : null;
     String prefix = startDescriptor != null ? startDescriptor.prefix() : null;
     CharClassScanInfo ccPrefix = startDescriptor != null ? startDescriptor.charClassPrefix() : null;
-    String requiredLiteral = prefix == null ? extractRequiredLiteral(metadataAst) : null;
+    String suffixStr = endAnchoredSuffix != null ? endAnchoredSuffix.suffix() : null;
+    String requiredLiteral = extractRequiredLiteral(metadataAst, prefix, suffixStr);
     CharClassScanInfo requiredMatchClass = null;
     if (prefix == null && endAnchoredCharClass == null) {
       if (ccPrefix == null) {
@@ -3435,8 +3436,13 @@ public final class Pattern implements Serializable {
    * alternation and optional repetition, so the result can only reject inputs that cannot match.
    */
   private static String extractRequiredLiteral(Regexp re) {
-    String longest = null;
-    int longestScore = 0;
+    return extractRequiredLiteral(re, null, null);
+  }
+
+  private static String extractRequiredLiteral(
+      Regexp re, String excludePrefix, String excludeSuffix) {
+    String best = null;
+    int bestScore = 0;
     Deque<Regexp> pending = new ArrayDeque<>();
     pending.addLast(re);
     while (!pending.isEmpty()) {
@@ -3460,17 +3466,20 @@ public final class Pattern implements Serializable {
               && node.runes != null
               && node.runes.length >= 2) {
             String candidate = new String(node.runes, 0, node.runes.length);
-            int candidateScore = RarityOracle.literalSelectivityScore(candidate);
-            if (longest == null || candidateScore > longestScore) {
-              longest = candidate;
-              longestScore = candidateScore;
+            if ((excludePrefix == null || !candidate.equals(excludePrefix))
+                && (excludeSuffix == null || !candidate.equals(excludeSuffix))) {
+              int candidateScore = RarityOracle.literalSelectivityScore(candidate);
+              if (best == null || candidateScore > bestScore) {
+                best = candidate;
+                bestScore = candidateScore;
+              }
             }
           }
         }
         default -> {}
       }
     }
-    return longest;
+    return best;
   }
 
   /**

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -199,6 +199,35 @@ class DiagnosticsTest {
   }
 
   @Test
+  void compositeRejectPrefilterReplacementReportsTheChildThatRejected() {
+    Pattern.setDiagnostics(diagnostics);
+
+    for (MatchOperation operation :
+        List.of(MatchOperation.REPLACE_FIRST, MatchOperation.REPLACE_ALL)) {
+      Pattern pattern = Pattern.compile("foo.*bar.*[0-9]$");
+      Matcher matcher = pattern.matcher("foo---7");
+
+      String result =
+          operation == MatchOperation.REPLACE_FIRST
+              ? matcher.replaceFirst("replacement")
+              : matcher.replaceAll("replacement");
+
+      assertThat(result).isEqualTo("foo---7");
+      assertThat(operationsFor(pattern))
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.operation()).isEqualTo(operation);
+                assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.LITERAL);
+                assertThat(event.auxiliaryStrategies())
+                    .containsExactly(
+                        new StrategyParticipation(
+                            MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER));
+              });
+    }
+  }
+
+  @Test
   void ordinaryReplacementLoopSuppressesNestedFindEvents() {
     Pattern.setDiagnostics(diagnostics);
     EnginePathOptions exactOnly =

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -312,4 +312,50 @@ class RejectPrefilterTest {
     byte[] bytes = text.getBytes(UTF_8);
     return new Utf8InputScanner(bytes, 0, bytes.length);
   }
+
+  @Test
+  void requiredInfixLiteralRetainedWhenPrefixPresent() {
+    Pattern p = Pattern.compile("(\\{Link:[^}]*?)<<!nav>>([^}]*?\\})");
+    assertThat(p.prefix()).isEqualTo("{Link:");
+    assertThat(p.rejectDescriptor().requiredLiteral()).isEqualTo("<<!nav>>");
+    assertThat(p.rejectPrefilter()).isNotNull();
+
+    // Negative text with {Link:...} but missing <<!nav>> should reject in Tier 0
+    String textNoNav = "{Link: home_page}{Link: about_page}{Link: contact_page}";
+    assertThat(p.rejectPrefilter().canReject(null, textNoNav, 0, EnginePathOptions.allEnabled()))
+        .isTrue();
+    assertThat(p.find(Utf8Input.validated(textNoNav.getBytes(UTF_8)))).isFalse();
+
+    // Positive text with <<!nav>> should match and capture properly
+    String textWithNav = "{Link: home_page}{Link: section<<!nav>>item}";
+    assertThat(p.rejectPrefilter().canReject(null, textWithNav, 0, EnginePathOptions.allEnabled()))
+        .isFalse();
+    Matcher m = p.matcher(textWithNav);
+    assertThat(m.find()).isTrue();
+    assertThat(m.group(1)).isEqualTo("{Link: section");
+    assertThat(m.group(2)).isEqualTo("item}");
+  }
+
+  @Test
+  void requiredLiteralPrefersDistinctCandidateOverPrefix() {
+    Pattern p = Pattern.compile("(?s)<meta_start>.*?<meta_end>");
+    assertThat(p.prefix()).isEqualTo("<meta_start>");
+    // Even though "<meta_start>" is longer than "<meta_end>", extractRequiredLiteral
+    // should skip the prefix and select "<meta_end>".
+    assertThat(p.rejectDescriptor().requiredLiteral()).isEqualTo("<meta_end>");
+    assertThat(p.rejectPrefilter()).isNotNull();
+
+    String inputNoEnd = "<meta_start>Thinking process: analyzing query...\n".repeat(1_000);
+    assertThat(p.rejectPrefilter().canReject(null, inputNoEnd, 0, EnginePathOptions.allEnabled()))
+        .isTrue();
+    assertThat(p.matcher(inputNoEnd).replaceAll("")).isEqualTo(inputNoEnd);
+  }
+
+  @Test
+  void identicalPrefixAndRequiredLiteralDeduplicated() {
+    Pattern p = Pattern.compile("abc[0-9]+");
+    assertThat(p.prefix()).isEqualTo("abc");
+    // "abc" is already the start prefix, so requiredLiteral should not duplicate "abc"
+    assertThat(p.rejectDescriptor().requiredLiteral()).isNull();
+  }
 }

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -347,6 +347,36 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void requiredInfixLiteralRejectsDensePrefixNoiseWithSinglePassWork() {
+    // Prefix "{Link:" is common (appears 1,000 times).
+    // Infix "<<!nav>>" is rare and absent.
+    Pattern pattern = Pattern.compile("(\\{Link:[^}]*?)<<!nav>>([^}]*?\\})");
+    String input = "{Link: target=home_page, category=general, priority=high}\n".repeat(1_000);
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input).find()).isFalse());
+
+    assertThat(work)
+        .as(
+            "Infix literal prefilter must reject dense-prefix noise in a single pass without DFA"
+                + " churn")
+        .isLessThanOrEqualTo(input.length() + 100);
+  }
+
+  @Test
+  void requiredInfixLiteralRejectsDensePrefixNoiseInSplitWithSinglePassWork() {
+    Pattern pattern = Pattern.compile("(\\{Link:[^}]*?)<<!nav>>([^}]*?\\})");
+    String input = "{Link: target=home_page, category=general, priority=high}\n".repeat(1_000);
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.split(input)).containsExactly(input));
+
+    assertThat(work)
+        .as("Split must reject dense-prefix noise in a single pass without DFA churn")
+        .isLessThanOrEqualTo(input.length() + 100);
+  }
+
+  @Test
   void literalSelectivityScoringIsLinearInPatternSize() {
     long smallerWork = WorkCounter.countForTesting(() -> Pattern.compile(selectivityPattern(100)));
     long largerWork = WorkCounter.countForTesting(() -> Pattern.compile(selectivityPattern(400)));


### PR DESCRIPTION
Previously, `extractRequiredLiteral` was suppressed whenever a start prefix was present. When extracting required literals, the AST search only tracked a single longest literal, which could end up being the same as the start prefix.

Additionally, `Matcher.replaceImpl()` and `Matcher.findSplitPositions()` were not evaluating RejectPrefilter at their entry points.

This change allows both prefix and required literal extraction to occur, and `extractRequiredLiteral` excludes candidates identical to the start prefix or end suffix to find distinct required literals. It also wires RejectPrefilter into replacement and split operations.

```
./safere-benchmarks/scripts/compare-branch.sh --baseline main 'RealWorldRegexBenchmark\.runBenchmark\.metadataBlock\.noMatch.*@safere-string'
```

| Benchmark                    | baseline (ns/op) | current (ns/op) | Speedup |
| ---------------------------- | ---------------- | --------------- | ------- |
| metadataBlock.noMatch.1000   |         952 ± 16 |       128 ± 5.7 |   7.43x |
| metadataBlock.noMatch.10000  |        8157 ± 31 |      1039 ± 9.3 |   7.85x |
| metadataBlock.noMatch.100000 |    124751 ± 2608 |     10137 ± 157 |   12.3x |