### PR TITLE
Specialize matches and lookingAt with forward DFA lazy capture deferral

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -2447,6 +2447,46 @@
         "length": "{size}"
       },
       "shared": true
+    },
+    {
+      "id": "crossEngine.ValidationBenchmark.emailValid.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "user.name+service@subdomain.example.com"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ValidationBenchmark.emailInvalid.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "invalid-email-address-missing-domain-and-at-symbol-noise"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ValidationBenchmark.dateValid.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "2026-08-22"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ValidationBenchmark.dateInvalid.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "not-a-valid-date-string-value-with-no-matching-format"
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.ValidationBenchmark.tokenLookingAt.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "AUTH: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 (extra trailing text that is not consumed)"
+      },
+      "shared": true
     }
   ],
   "workloads": [
@@ -11223,6 +11263,119 @@
         "constraints": [
           "prematerializedInput"
         ]
+      }
+    },
+    {
+      "id": "ValidationBenchmark.emailMatches.match",
+      "operation": "matches",
+      "patterns": [
+        "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+)$"
+      ],
+      "inputs": [
+        "crossEngine.ValidationBenchmark.emailValid.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "boolean",
+        "value": true
+      }
+    },
+    {
+      "id": "ValidationBenchmark.emailMatches.noMatch",
+      "operation": "matches",
+      "patterns": [
+        "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+)$"
+      ],
+      "inputs": [
+        "crossEngine.ValidationBenchmark.emailInvalid.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "boolean",
+        "value": false
+      }
+    },
+    {
+      "id": "ValidationBenchmark.dateMatches.match",
+      "operation": "matches",
+      "patterns": [
+        "^(\\d{4})-(\\d{2})-(\\d{2})$"
+      ],
+      "inputs": [
+        "crossEngine.ValidationBenchmark.dateValid.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "boolean",
+        "value": true
+      }
+    },
+    {
+      "id": "ValidationBenchmark.dateMatches.noMatch",
+      "operation": "matches",
+      "patterns": [
+        "^(\\d{4})-(\\d{2})-(\\d{2})$"
+      ],
+      "inputs": [
+        "crossEngine.ValidationBenchmark.dateInvalid.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "boolean",
+        "value": false
+      }
+    },
+    {
+      "id": "ValidationBenchmark.tokenLookingAt",
+      "operation": "lookingAt",
+      "patterns": [
+        "^AUTH:\\s+([A-Za-z]+)\\s+([A-Za-z0-9_.-]+)"
+      ],
+      "inputs": [
+        "crossEngine.ValidationBenchmark.tokenLookingAt.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "expected": {
+        "type": "boolean",
+        "value": true
+      },
+      "lifecycle": {
+        "matcher": "newPerInvocation"
       }
     }
   ]

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -2449,42 +2449,42 @@
       "shared": true
     },
     {
-      "id": "crossEngine.ValidationBenchmark.emailValid.input",
+      "id": "crossEngine.ValidationBenchmark.ambiguousValid.input",
       "recipe": {
         "kind": "literal",
-        "text": "user.name+service@subdomain.example.com"
+        "text": "helloworldbwelcome"
       },
       "shared": true
     },
     {
-      "id": "crossEngine.ValidationBenchmark.emailInvalid.input",
+      "id": "crossEngine.ValidationBenchmark.ambiguousInvalid.input",
       "recipe": {
         "kind": "literal",
-        "text": "invalid-email-address-missing-domain-and-at-symbol-noise"
+        "text": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
       },
       "shared": true
     },
     {
-      "id": "crossEngine.ValidationBenchmark.dateValid.input",
+      "id": "crossEngine.ValidationBenchmark.overlapValid.input",
       "recipe": {
         "kind": "literal",
-        "text": "2026-08-22"
+        "text": "application:12345"
       },
       "shared": true
     },
     {
-      "id": "crossEngine.ValidationBenchmark.dateInvalid.input",
+      "id": "crossEngine.ValidationBenchmark.overlapInvalid.input",
       "recipe": {
         "kind": "literal",
-        "text": "not-a-valid-date-string-value-with-no-matching-format"
+        "text": "applenotvalid:12345"
       },
       "shared": true
     },
     {
-      "id": "crossEngine.ValidationBenchmark.tokenLookingAt.input",
+      "id": "crossEngine.ValidationBenchmark.overlapLookingAt.input",
       "recipe": {
         "kind": "literal",
-        "text": "AUTH: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 (extra trailing text that is not consumed)"
+        "text": "application:12345 (and trailing data that is not matched)"
       },
       "shared": true
     }
@@ -11266,13 +11266,13 @@
       }
     },
     {
-      "id": "ValidationBenchmark.emailMatches.match",
+      "id": "ValidationBenchmark.ambiguousLoopMatches.match",
       "operation": "matches",
       "patterns": [
-        "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+)$"
+        "^([a-z]+)b([a-z]+)$"
       ],
       "inputs": [
-        "crossEngine.ValidationBenchmark.emailValid.input"
+        "crossEngine.ValidationBenchmark.ambiguousValid.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -11288,13 +11288,13 @@
       }
     },
     {
-      "id": "ValidationBenchmark.emailMatches.noMatch",
+      "id": "ValidationBenchmark.ambiguousLoopMatches.noMatch",
       "operation": "matches",
       "patterns": [
-        "^([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+)$"
+        "^([a-z]+)b([a-z]+)$"
       ],
       "inputs": [
-        "crossEngine.ValidationBenchmark.emailInvalid.input"
+        "crossEngine.ValidationBenchmark.ambiguousInvalid.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -11310,13 +11310,13 @@
       }
     },
     {
-      "id": "ValidationBenchmark.dateMatches.match",
+      "id": "ValidationBenchmark.overlappingAlternationMatches.match",
       "operation": "matches",
       "patterns": [
-        "^(\\d{4})-(\\d{2})-(\\d{2})$"
+        "^(?:apple|application|apply):([0-9]+)$"
       ],
       "inputs": [
-        "crossEngine.ValidationBenchmark.dateValid.input"
+        "crossEngine.ValidationBenchmark.overlapValid.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -11332,13 +11332,13 @@
       }
     },
     {
-      "id": "ValidationBenchmark.dateMatches.noMatch",
+      "id": "ValidationBenchmark.overlappingAlternationMatches.noMatch",
       "operation": "matches",
       "patterns": [
-        "^(\\d{4})-(\\d{2})-(\\d{2})$"
+        "^(?:apple|application|apply):([0-9]+)$"
       ],
       "inputs": [
-        "crossEngine.ValidationBenchmark.dateInvalid.input"
+        "crossEngine.ValidationBenchmark.overlapInvalid.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {
@@ -11354,13 +11354,13 @@
       }
     },
     {
-      "id": "ValidationBenchmark.tokenLookingAt",
+      "id": "ValidationBenchmark.overlappingLookingAt",
       "operation": "lookingAt",
       "patterns": [
-        "^AUTH:\\s+([A-Za-z]+)\\s+([A-Za-z0-9_.-]+)"
+        "^(?:apple|application|apply):([0-9]+)"
       ],
       "inputs": [
-        "crossEngine.ValidationBenchmark.tokenLookingAt.input"
+        "crossEngine.ValidationBenchmark.overlapLookingAt.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(400);
+    assertThat(first).hasSize(405);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(40);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(657);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(662);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_570);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_620);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -243,7 +243,7 @@ class BenchmarkInputMaterializerTest {
                   .getAsString())
           .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(338);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(343);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -255,7 +255,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(657);
+          .hasSize(662);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(580);
+    assertThat(ids).hasSize(585);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2166);
-    assertThat(plan.exclusions()).hasSize(734);
-    assertThat(accounted).hasSize(580 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(2190);
+    assertThat(plan.exclusions()).hasSize(735);
+    assertThat(accounted).hasSize(585 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1516);
+        .hasSize(1540);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2205);
-    assertThat(plan.reportPlan().trials()).hasSize(2205);
+        .hasSize(2229);
+    assertThat(plan.reportPlan().trials()).hasSize(2229);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1203,13 +1203,20 @@ public final class Matcher implements MatchResult {
 
     Prog prog = parentPattern.prog();
     InputScanner scanner = activeScanner();
+    boolean preferCaptureEngine = shouldPreferCaptureEngine(prog, scanner);
     // Medium path: use DFA to check if an anchored match exists.
-    if (enginePathOptions().dfa() && dfaSupportsProgram(parentPattern.flatDfaProg())) {
+    if (!preferCaptureEngine
+        && enginePathOptions().dfa()
+        && dfaSupportsProgram(parentPattern.flatDfaProg())) {
       diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
       Dfa.SearchResult dfaResult = searchForwardDfa(dfa(false), scanner, true, false);
       if (dfaResult != null && !dfaResult.matched()) {
         diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
+      }
+      if (dfaResult != null && prog.numLoopRegs() == 0) {
+        diagnosticBoundary(MatchStrategy.DFA);
+        return applyDeferredMatchResult(0, dfaResult.pos(), prog.numCaptures(), true, false);
       }
       if (dfaResult == null) {
         diagnosticDecision(

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -738,28 +738,29 @@ class SearchScalingRegressionTest {
 
   @Test
   void matchesWithCapturesDefersNfaWorkUntilGroupIsRead() {
-    Pattern pattern = Pattern.compile("([a-z]+)@([a-z]+)\\.com");
-    String input = "alice@google.com";
+    // Non-OnePass pattern due to ambiguous repetition where b is part of [a-z]
+    Pattern pattern = Pattern.compile("([a-z]+)b([a-z]+)");
+    String input = "helloworldbwelcome";
     Matcher matcher = pattern.matcher(input);
     long matchWork = WorkCounter.countForTesting(() -> assertThat(matcher.matches()).isTrue());
     assertThat(matcher.group(0)).isEqualTo(input);
     long groupReadWork =
         WorkCounter.countForTesting(
             () -> {
-              assertThat(matcher.group(1)).isEqualTo("alice");
-              assertThat(matcher.group(2)).isEqualTo("google");
+              assertThat(matcher.group(1)).isEqualTo("helloworld");
+              assertThat(matcher.group(2)).isEqualTo("welcome");
             });
     assertThat(matchWork)
         .as("matches() must only run forward DFA work without eager NFA state building")
         .isLessThanOrEqualTo(input.length() * 2L + 20);
     assertThat(groupReadWork)
         .as("Submatch extraction happens on-demand when group(k) is read")
-        .isLessThanOrEqualTo(input.length() * 2L + 20);
+        .isLessThanOrEqualTo(input.length() * 5L + 20);
   }
 
   @Test
   void matchesWithCapturesRejectsNonMatchingInputInLinearWork() {
-    Pattern pattern = Pattern.compile("([a-z]+)@([a-z]+)\\.com");
+    Pattern pattern = Pattern.compile("([a-z]+)b([a-z]+)");
     String input = "x".repeat(10_000);
     Matcher matcher = pattern.matcher(input);
     long work = WorkCounter.countForTesting(() -> assertThat(matcher.matches()).isFalse());
@@ -770,17 +771,17 @@ class SearchScalingRegressionTest {
 
   @Test
   void lookingAtWithCapturesDefersNfaWorkUntilGroupIsRead() {
-    Pattern pattern = Pattern.compile("([a-z]+):\\s+(\\d+)");
-    String input = "count: 42 (and extra trailing text that should not prevent lookingAt)";
+    // Non-OnePass pattern due to overlapping alternation branches
+    Pattern pattern = Pattern.compile("(?:apple|application|apply):([0-9]+)");
+    String input = "application:12345 " + "x".repeat(10_000);
     Matcher matcher = pattern.matcher(input);
     long lookingAtWork =
         WorkCounter.countForTesting(() -> assertThat(matcher.lookingAt()).isTrue());
-    assertThat(matcher.group(0)).isEqualTo("count: 42");
-    assertThat(matcher.group(1)).isEqualTo("count");
-    assertThat(matcher.group(2)).isEqualTo("42");
     assertThat(lookingAtWork)
-        .as("lookingAt() must only execute DFA prefix scan")
-        .isLessThanOrEqualTo(input.length() + 20);
+        .as("lookingAt() must only execute DFA prefix scan bounded by matched prefix, not trailing 10k chars")
+        .isLessThanOrEqualTo(50);
+    assertThat(matcher.group(0)).isEqualTo("application:12345");
+    assertThat(matcher.group(1)).isEqualTo("12345");
   }
 
   private static boolean isVectorApiAvailable() {

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -736,6 +736,53 @@ class SearchScalingRegressionTest {
         "String");
   }
 
+  @Test
+  void matchesWithCapturesDefersNfaWorkUntilGroupIsRead() {
+    Pattern pattern = Pattern.compile("([a-z]+)@([a-z]+)\\.com");
+    String input = "alice@google.com";
+    Matcher matcher = pattern.matcher(input);
+    long matchWork = WorkCounter.countForTesting(() -> assertThat(matcher.matches()).isTrue());
+    assertThat(matcher.group(0)).isEqualTo(input);
+    long groupReadWork =
+        WorkCounter.countForTesting(
+            () -> {
+              assertThat(matcher.group(1)).isEqualTo("alice");
+              assertThat(matcher.group(2)).isEqualTo("google");
+            });
+    assertThat(matchWork)
+        .as("matches() must only run forward DFA work without eager NFA state building")
+        .isLessThanOrEqualTo(input.length() * 2L + 20);
+    assertThat(groupReadWork)
+        .as("Submatch extraction happens on-demand when group(k) is read")
+        .isLessThanOrEqualTo(input.length() * 2L + 20);
+  }
+
+  @Test
+  void matchesWithCapturesRejectsNonMatchingInputInLinearWork() {
+    Pattern pattern = Pattern.compile("([a-z]+)@([a-z]+)\\.com");
+    String input = "x".repeat(10_000);
+    Matcher matcher = pattern.matcher(input);
+    long work = WorkCounter.countForTesting(() -> assertThat(matcher.matches()).isFalse());
+    assertThat(work)
+        .as("Non-matching input in matches() must reject in linear DFA steps without NFA work")
+        .isLessThanOrEqualTo(input.length() + 20);
+  }
+
+  @Test
+  void lookingAtWithCapturesDefersNfaWorkUntilGroupIsRead() {
+    Pattern pattern = Pattern.compile("([a-z]+):\\s+(\\d+)");
+    String input = "count: 42 (and extra trailing text that should not prevent lookingAt)";
+    Matcher matcher = pattern.matcher(input);
+    long lookingAtWork =
+        WorkCounter.countForTesting(() -> assertThat(matcher.lookingAt()).isTrue());
+    assertThat(matcher.group(0)).isEqualTo("count: 42");
+    assertThat(matcher.group(1)).isEqualTo("count");
+    assertThat(matcher.group(2)).isEqualTo("42");
+    assertThat(lookingAtWork)
+        .as("lookingAt() must only execute DFA prefix scan")
+        .isLessThanOrEqualTo(input.length() + 20);
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -778,7 +778,9 @@ class SearchScalingRegressionTest {
     long lookingAtWork =
         WorkCounter.countForTesting(() -> assertThat(matcher.lookingAt()).isTrue());
     assertThat(lookingAtWork)
-        .as("lookingAt() must only execute DFA prefix scan bounded by matched prefix, not trailing 10k chars")
+        .as(
+            "lookingAt() must only execute DFA prefix scan bounded by matched prefix, not trailing"
+                + " 10k chars")
         .isLessThanOrEqualTo(50);
     assertThat(matcher.group(0)).isEqualTo("application:12345");
     assertThat(matcher.group(1)).isEqualTo("12345");


### PR DESCRIPTION
Improves `Matcher.lookingAt()` and `Matcher.matches()` performance by routing anchored execution through the forward DFA and deferring inner capture extraction until `Matcher.group(k)` is explicitly accessed.

```
./safere-benchmarks/scripts/compare-branch.sh --baseline validation-benchmarks-baseline 'ValidationBenchmark.*safere-string'
```

| Benchmark                                                 | baseline (ns/op) | current (ns/op) | Speedup |
| --------------------------------------------------------- | ---------------- | --------------- | ------- |
| ValidationBenchmark.ambiguousLoopMatches.match            |         235 ± 11 |        240 ± 12 |   0.98x |
| ValidationBenchmark.ambiguousLoopMatches.noMatch          |        348 ± 7.5 |       328 ± 6.2 |   1.06x |
| ValidationBenchmark.overlappingAlternationMatches.match   |         199 ± 19 |       210 ± 9.3 |   0.95x |
| ValidationBenchmark.overlappingAlternationMatches.noMatch |         71 ± 8.0 |       69 ± 0.44 |   1.03x |
| ValidationBenchmark.overlappingLookingAt                  |        313 ± 9.9 |       100 ± 3.1 |   3.13x |
