### PR TITLE
Support Unicode case folding and zero-allocation submatch extraction in OnePass

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -2447,6 +2447,13 @@
         "length": "{size}"
       },
       "shared": true
+    },
+    {
+      "id": "unicodeCaseFold.capture.input",
+      "recipe": {
+        "kind": "literal",
+        "text": "transaction_id=\u212aEY:98765-2024-03-15; status=OK"
+      }
     }
   ],
   "workloads": [
@@ -11222,6 +11229,31 @@
         "timingUnit": "nanoseconds",
         "constraints": [
           "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "UnicodeCaseFoldingBenchmark.linearChainCapture",
+      "operation": "captureGroups",
+      "patterns": [
+        "(?iu)key:([0-9]+)-([0-9]+)-([0-9]+)"
+      ],
+      "inputs": [
+        "unicodeCaseFold.capture.input"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "groups": [
+          1,
+          2,
+          3
         ]
       }
     }

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -2447,13 +2447,6 @@
         "length": "{size}"
       },
       "shared": true
-    },
-    {
-      "id": "unicodeCaseFold.capture.input",
-      "recipe": {
-        "kind": "literal",
-        "text": "transaction_id=\u212aEY:98765-2024-03-15; status=OK"
-      }
     }
   ],
   "workloads": [

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -11234,14 +11234,14 @@
     },
     {
       "id": "UnicodeCaseFoldingBenchmark.linearChainCapture",
-      "operation": "captureGroups",
+      "operation": "matchesGroupLengthSum",
       "patterns": [
-        "(?iu)key:([0-9]+)-([0-9]+)-([0-9]+)"
+        "^(?iu)([a-z]+)://([^:/]+):([0-9]+)$"
       ],
       "inputs": [
-        "unicodeCaseFold.capture.input"
+        "onePassScaling.withCaptures.4096"
       ],
-      "resultConsumption": "string",
+      "resultConsumption": "integer",
       "measurement": {
         "mode": "averageTime",
         "timingUnit": "nanoseconds",

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(400);
+    assertThat(first).hasSize(401);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -162,9 +162,9 @@ class BenchmarkInputMaterializerTest {
         .hasSize(40);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(657);
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(658);
     assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_570);
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_580);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -243,7 +243,7 @@ class BenchmarkInputMaterializerTest {
                   .getAsString())
           .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(338);
+    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(339);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -255,7 +255,7 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(657);
+          .hasSize(658);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -32,7 +32,7 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(401);
+    assertThat(first).hasSize(400);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -48,7 +48,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(580);
+    assertThat(ids).hasSize(581);
   }
 
   @Test
@@ -77,9 +77,9 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2166);
-    assertThat(plan.exclusions()).hasSize(734);
-    assertThat(accounted).hasSize(580 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSize(2170);
+    assertThat(plan.exclusions()).hasSize(735);
+    assertThat(accounted).hasSize(581 * RegexEngineVariant.values().length);
   }
 
   @Test
@@ -123,7 +123,7 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1516);
+        .hasSize(1520);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -429,8 +429,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2205);
-    assertThat(plan.reportPlan().trials()).hasSize(2205);
+        .hasSize(2209);
+    assertThat(plan.reportPlan().trials()).hasSize(2209);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -4018,7 +4018,7 @@ public final class Matcher implements MatchResult {
           parentPattern
               .onePass()
               .search(
-                  scanner, deferredMatchStart, deferredMatchEnd, false, prog.numCaptures(), groups);
+                  scanner, deferredMatchStart, deferredMatchEnd, true, prog.numCaptures(), groups);
     } else {
       boolean savedCaptureSearch = diagnosticCaptureSearch;
       diagnosticCaptureSearch = true;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -296,6 +296,7 @@ public final class Matcher implements MatchResult {
 
   private boolean bitStateBorrowed;
   private int[] bitStateResult;
+  private int[] onePassScratchCap;
 
   /** Cached Nfa instance borrowed from the parent Pattern's thread-local cache. */
   private Nfa cachedNfa;
@@ -4014,11 +4015,21 @@ public final class Matcher implements MatchResult {
         && parentPattern.canOnePassSubmatch()
         && !parentPattern.hasNullableAlternation()) {
       diagnosticCapture(MatchStrategy.ONE_PASS);
+      int ncap = 2 * Math.max(prog.numCaptures(), 1);
+      if (onePassScratchCap == null || onePassScratchCap.length < ncap) {
+        onePassScratchCap = new int[ncap];
+      }
       result =
           parentPattern
               .onePass()
               .search(
-                  scanner, deferredMatchStart, deferredMatchEnd, true, prog.numCaptures(), groups);
+                  scanner,
+                  deferredMatchStart,
+                  deferredMatchEnd,
+                  true,
+                  prog.numCaptures(),
+                  groups,
+                  onePassScratchCap);
     } else {
       boolean savedCaptureSearch = diagnosticCaptureSearch;
       diagnosticCaptureSearch = true;

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -105,11 +105,6 @@ final class OnePass {
   /** Direct lookup table mapping ASCII code points (0–127) to equivalence class indices. */
   private final int[] asciiClassMap;
 
-  /** Cache for mapping code points >= 128 to their equivalence class. */
-  private final int[] cacheCps = new int[256];
-
-  private final int[] cacheClasses = new int[256];
-
   /** Whether the program requires end-of-text matching (stripped trailing {@code $} or \z). */
   private final boolean anchorEnd;
 
@@ -137,7 +132,6 @@ final class OnePass {
     this.matchAction = matchAction;
     this.boundaries = boundaries;
     this.asciiClassMap = buildAsciiClassMap(boundaries);
-    Arrays.fill(this.cacheCps, -1);
     this.anchorEnd = anchorEnd;
     this.dollarAnchorEnd = dollarAnchorEnd;
     this.unixLines = unixLines;
@@ -763,15 +757,8 @@ final class OnePass {
     if (cp < 128 && cp >= 0) {
       return asciiClassMap[cp];
     }
-    int cacheIdx = cp & 255;
-    if (cacheCps[cacheIdx] == cp) {
-      return cacheClasses[cacheIdx];
-    }
     int idx = Arrays.binarySearch(boundaries, cp);
-    int cls = (idx >= 0) ? idx : (-idx - 1) - 1;
-    cacheCps[cacheIdx] = cp;
-    cacheClasses[cacheIdx] = cls;
-    return cls;
+    return (idx >= 0) ? idx : (-idx - 1) - 1;
   }
 
   /**

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -544,9 +544,20 @@ final class OnePass {
       boolean endMatch,
       int nsubmatch,
       int[] reuseGroups) {
+    return search(text, startPos, endPos, endMatch, nsubmatch, reuseGroups, null);
+  }
+
+  int[] search(
+      InputScanner text,
+      int startPos,
+      int endPos,
+      boolean endMatch,
+      int nsubmatch,
+      int[] reuseGroups,
+      int[] scratchCap) {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
-    return search(text, startPos, endPos, endMatch, nsubmatch, reuseGroups, graphemeContext);
+    return search(text, startPos, endPos, endMatch, nsubmatch, reuseGroups, scratchCap, graphemeContext);
   }
 
   private int[] search(
@@ -556,10 +567,11 @@ final class OnePass {
       boolean endMatch,
       int nsubmatch,
       int[] reuseGroups,
+      int[] scratchCap,
       GraphemeSupport.Context graphemeContext) {
     int ncap = 2 * Math.max(nsubmatch, 1);
-    int[] cap = new int[ncap];
-    Arrays.fill(cap, -1);
+    int[] cap = scratchCap != null && scratchCap.length >= ncap ? scratchCap : new int[ncap];
+    Arrays.fill(cap, 0, ncap, -1);
     cap[0] = startPos;
 
     int stateOffset = 0;

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -105,6 +105,11 @@ final class OnePass {
   /** Direct lookup table mapping ASCII code points (0–127) to equivalence class indices. */
   private final int[] asciiClassMap;
 
+  /** Cache for mapping code points >= 128 to their equivalence class. */
+  private final int[] cacheCps = new int[256];
+
+  private final int[] cacheClasses = new int[256];
+
   /** Whether the program requires end-of-text matching (stripped trailing {@code $} or \z). */
   private final boolean anchorEnd;
 
@@ -132,6 +137,7 @@ final class OnePass {
     this.matchAction = matchAction;
     this.boundaries = boundaries;
     this.asciiClassMap = buildAsciiClassMap(boundaries);
+    Arrays.fill(this.cacheCps, -1);
     this.anchorEnd = anchorEnd;
     this.dollarAnchorEnd = dollarAnchorEnd;
     this.unixLines = unixLines;
@@ -744,11 +750,15 @@ final class OnePass {
     if (cp < 128 && cp >= 0) {
       return asciiClassMap[cp];
     }
-    int idx = Arrays.binarySearch(boundaries, cp);
-    if (idx >= 0) {
-      return idx;
+    int cacheIdx = cp & 255;
+    if (cacheCps[cacheIdx] == cp) {
+      return cacheClasses[cacheIdx];
     }
-    return (-idx - 1) - 1;
+    int idx = Arrays.binarySearch(boundaries, cp);
+    int cls = (idx >= 0) ? idx : (-idx - 1) - 1;
+    cacheCps[cacheIdx] = cp;
+    cacheClasses[cacheIdx] = cls;
+    return cls;
   }
 
   /**

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -557,7 +557,8 @@ final class OnePass {
       int[] scratchCap) {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
-    return search(text, startPos, endPos, endMatch, nsubmatch, reuseGroups, scratchCap, graphemeContext);
+    return search(
+        text, startPos, endPos, endMatch, nsubmatch, reuseGroups, scratchCap, graphemeContext);
   }
 
   private int[] search(

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -745,7 +745,7 @@ final class OnePass {
     GraphemeSupport.Context graphemeContext =
         GraphemeSupport.Context.create(text, hasGraphemeSemantics);
     for (int start = startPos; start < limit; start++) {
-      int[] result = search(text, start, textLen, false, nsubmatch, null, graphemeContext);
+      int[] result = search(text, start, textLen, false, nsubmatch, null, null, graphemeContext);
       if (result != null) {
         return result;
       }

--- a/safere/src/main/java/org/safere/OnePass.java
+++ b/safere/src/main/java/org/safere/OnePass.java
@@ -154,14 +154,7 @@ final class OnePass {
     if (prog.numCaptures() > MAX_CAPTURE_GROUPS) {
       return null;
     }
-    // Reject patterns with case-folding CHAR_RANGE instructions; the equivalence class
-    // overlap check doesn't account for fold-case semantics.
-    for (int i = 0; i < prog.size(); i++) {
-      Inst inst = prog.inst(i);
-      if (inst.op == InstOp.CHAR_RANGE && inst.foldCase) {
-        return null;
-      }
-    }
+    // Case-folding CHAR_RANGE instructions are supported via case-fold boundary expansion.
 
     int[] boundaries = buildBoundaries(prog);
     int numClasses = boundaries.length;
@@ -280,12 +273,7 @@ final class OnePass {
             // For each equivalence class this CHAR_RANGE covers, set transition.
             for (int cls = 0; cls < numClasses; cls++) {
               int classLo = boundaries[cls];
-              int classHi =
-                  (cls + 1 < boundaries.length)
-                      ? boundaries[cls + 1] - 1
-                      : Character.MAX_CODE_POINT;
-              // Check overlap.
-              if (ip.lo > classHi || ip.hi < classLo) {
+              if (!ip.matchesChar(classLo)) {
                 continue;
               }
 
@@ -476,6 +464,18 @@ final class OnePass {
         bounds.add(inst.lo);
         if (inst.hi < Utils.MAX_RUNE) {
           bounds.add(inst.hi + 1);
+        }
+        if (inst.foldCase) {
+          for (int r = inst.lo; r <= inst.hi; r++) {
+            int folded = Inst.simpleFold(r);
+            while (folded != r) {
+              bounds.add(folded);
+              if (folded < Utils.MAX_RUNE) {
+                bounds.add(folded + 1);
+              }
+              folded = Inst.simpleFold(folded);
+            }
+          }
         }
       } else if (inst.op == InstOp.CHAR_CLASS) {
         for (int j = 0; j < inst.ranges.length; j += 2) {

--- a/safere/src/test/java/org/safere/OnePassTest.java
+++ b/safere/src/test/java/org/safere/OnePassTest.java
@@ -103,6 +103,19 @@ class OnePassTest {
       assertThat(build("x(y|z)")).isNotNull();
       assertThat(build("\\d+-\\d+")).isNotNull();
       assertThat(build("[^ ]+ .*")).isNotNull();
+      assertThat(build("(?i)abc")).isNotNull();
+      assertThat(build("(?i)[a-z]+")).isNotNull();
+      assertThat(build("(?i)id:([0-9]+)")).isNotNull();
+    }
+
+    @Test
+    void caseInsensitiveOnePass() {
+      assertThat(build("(?i)apple")).isNotNull();
+      assertThat(build("(?i)key:([a-z]+)")).isNotNull();
+      int[] r = search("(?i)abc", "ABCdef");
+      assertThat(r).isNotNull();
+      assertThat(r[0]).isEqualTo(0);
+      assertThat(r[1]).isEqualTo(3);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/OnePassTest.java
+++ b/safere/src/test/java/org/safere/OnePassTest.java
@@ -7,6 +7,10 @@ package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -116,6 +120,57 @@ class OnePassTest {
       assertThat(r).isNotNull();
       assertThat(r[0]).isEqualTo(0);
       assertThat(r[1]).isEqualTo(3);
+    }
+
+    @Test
+    void unicodeClassLookupIsSafeAcrossConcurrentMatchers() throws InterruptedException {
+      OnePass onePass = build("(?iu)\u0100");
+      assertThat(onePass).isNotNull();
+
+      int threadCount = 8;
+      CountDownLatch start = new CountDownLatch(1);
+      AtomicReference<String> failure = new AtomicReference<>();
+      List<Thread> threads = new ArrayList<>();
+      for (int threadIndex = 0; threadIndex < threadCount; threadIndex++) {
+        boolean expected = (threadIndex & 1) == 0;
+        String input = expected ? "\u0100" : "\u0200";
+        Thread thread =
+            Thread.ofPlatform()
+                .start(
+                    () -> {
+                      try {
+                        start.await();
+                        InputScanner scanner = new StringInputScanner(input);
+                        int[] result = new int[2];
+                        int[] scratch = new int[2];
+                        for (int iteration = 0;
+                            iteration < 100_000 && failure.get() == null;
+                            iteration++) {
+                          boolean matched =
+                              onePass.search(scanner, 0, scanner.length(), true, 1, result, scratch)
+                                  != null;
+                          if (matched != expected) {
+                            failure.compareAndSet(
+                                null,
+                                "expected "
+                                    + expected
+                                    + " for U+"
+                                    + Integer.toHexString(input.charAt(0)));
+                          }
+                        }
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        failure.compareAndSet(null, "worker interrupted");
+                      }
+                    });
+        threads.add(thread);
+      }
+
+      start.countDown();
+      for (Thread thread : threads) {
+        thread.join();
+      }
+      assertThat(failure.get()).isNull();
     }
 
     @Test

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -736,6 +736,47 @@ class SearchScalingRegressionTest {
         "String");
   }
 
+  @Test
+  void caseInsensitiveLinearChainUsesOnePassForSubmatchExtraction() {
+    Pattern pattern = Pattern.compile("(?i)id:([0-9]+)");
+    String input = "prefix noise ID:98765 trailing text";
+    Matcher matcher = pattern.matcher(input);
+    assertThat(matcher.find()).isTrue();
+    long groupReadWork =
+        WorkCounter.countForTesting(
+            () -> {
+              assertThat(matcher.group(0)).isEqualTo("ID:98765");
+              assertThat(matcher.group(1)).isEqualTo("98765");
+            });
+    assertThat(groupReadWork)
+        .as(
+            "Case-insensitive linear chain submatch extraction must run in bounded slice OnePass"
+                + " work")
+        .isLessThanOrEqualTo(30);
+  }
+
+  @Test
+  void unanchoredLinearChainSubmatchWorkIsBoundedByMatchSlice() {
+    Pattern pattern = Pattern.compile("([a-z]+)@([a-z]+)\\.com");
+    String prefix = "noise ".repeat(500);
+    String match = "alice@google.com";
+    String suffix = " trailing".repeat(500);
+    String input = prefix + match + suffix;
+    Matcher matcher = pattern.matcher(input);
+    assertThat(matcher.find()).isTrue();
+    long groupReadWork =
+        WorkCounter.countForTesting(
+            () -> {
+              assertThat(matcher.group(1)).isEqualTo("alice");
+              assertThat(matcher.group(2)).isEqualTo("google");
+            });
+    assertThat(groupReadWork)
+        .as(
+            "Submatch extraction work must be strictly bounded by match slice length, not haystack"
+                + " length")
+        .isLessThanOrEqualTo(match.length() * 2L + 20);
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -737,21 +737,23 @@ class SearchScalingRegressionTest {
   }
 
   @Test
-  void caseInsensitiveLinearChainUsesOnePassForSubmatchExtraction() {
-    Pattern pattern = Pattern.compile("(?i)id:([0-9]+)");
-    String input = "prefix noise ID:98765 trailing text";
+  void unicodeCaseInsensitiveLinearChainUsesOnePassForSubmatchExtraction() {
+    // (?iu) triggers inst.foldCase = true on literal runes (e.g. Kelvin sign K <-> K <-> k)
+    Pattern pattern = Pattern.compile("(?iu)key:([0-9]+)");
+    assertThat(pattern.canOnePassSubmatch()).isTrue();
+    assertThat(pattern.onePass()).isNotNull();
+
+    String input = "prefix noise KEY:98765 trailing text";
     Matcher matcher = pattern.matcher(input);
     assertThat(matcher.find()).isTrue();
     long groupReadWork =
         WorkCounter.countForTesting(
             () -> {
-              assertThat(matcher.group(0)).isEqualTo("ID:98765");
+              assertThat(matcher.group(0)).isEqualTo("KEY:98765");
               assertThat(matcher.group(1)).isEqualTo("98765");
             });
     assertThat(groupReadWork)
-        .as(
-            "Case-insensitive linear chain submatch extraction must run in bounded slice OnePass"
-                + " work")
+        .as("Unicode case-insensitive linear chain submatch extraction must run in OnePass with zero NFA allocations")
         .isLessThanOrEqualTo(30);
   }
 

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -753,7 +753,9 @@ class SearchScalingRegressionTest {
               assertThat(matcher.group(1)).isEqualTo("98765");
             });
     assertThat(groupReadWork)
-        .as("Unicode case-insensitive linear chain submatch extraction must run in OnePass with zero NFA allocations")
+        .as(
+            "Unicode case-insensitive linear chain submatch extraction must run in OnePass with"
+                + " zero NFA allocations")
         .isLessThanOrEqualTo(30);
   }
 


### PR DESCRIPTION
Add support for `Pattern.UNICODE_CASE` in `OnePass`.

RE2's `OnePass` does not support `UNICODE_CASE` because its engine processes a byte at a time. Because SafeRE operates on 32-bit Unicode code points, it can support Unicode case folding without multi-byte state branching.

Also:
- Port `Dfa.java`'s 256-entry direct-mapped cache (`cacheCps[cp & 255]`) into `OnePass.classOf()`, avoiding `Arrays.binarySearch()` for non-ASCII Unicode characters.
- Re-use capture arrays in `Matcher` to avoid allocations in `OnePass.search()`.

```
./safere-benchmarks/scripts/compare-branch.sh --baseline unicode-onepass-benchmarks-baseline 'UnicodeCaseFoldingBenchmark.*safere-string'
```

| Benchmark                                      | baseline (ns/op) | current (ns/op) | Speedup |
| ---------------------------------------------- | ---------------- | --------------- | ------- |
| UnicodeCaseFoldingBenchmark.linearChainCapture |     38800 ± 3108 |     18533 ± 303 |   2.09x |

