### PR TITLE
Hoist WorkLimit checks out of Boyer-Moore Horspool inner loops

### DIFF
--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -532,7 +532,7 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
    * @return the index of the first match, {@code -1} if the literal is absent, or {@code -2} if the
    *     work budget was exhausted before either could be established
    */
-  private int boundedBoyerMooreHorspool(byte[] literal, int[] shifts, int start) {
+  int boundedBoyerMooreHorspool(byte[] literal, int[] shifts, int start) {
     int last = literal.length - 1;
     int position = start + last;
     long work = 0;

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -545,21 +545,17 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
         int literalPosition = last;
         int inputPosition = position;
         while (literalPosition >= 0 && bytes[offset + inputPosition] == literal[literalPosition]) {
-          if (WorkLimit.isExhausted(work, workLimit)) {
-            return -2;
-          }
-          work++;
           literalPosition--;
           inputPosition--;
         }
         if (literalPosition < 0) {
           return inputPosition + 1;
         }
+        work += (last - literalPosition + 1);
         if (WorkLimit.isExhausted(work, workLimit)) {
           return -2;
         }
         position += shifts[bytes[offset + position] & 0xFF];
-        work++;
       }
     }
     return -1;

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -623,6 +623,46 @@ class Utf8InputScannerTest {
     }
   }
 
+  @Test
+  void boyerMooreHorspoolReturnsExhaustionSentinelOnAdversarialInput() {
+    byte[] needle = "baaaaa".getBytes(UTF_8);
+    int[] shifts = literalShifts(needle);
+    // 100 "a"s is below the filter threshold so Horspool is selected
+    byte[] haystack = "a".repeat(100).getBytes(UTF_8);
+    Utf8InputScanner scanner = new Utf8InputScanner(haystack);
+
+    // Tests that boundedBoyerMooreHorspool hits the WorkLimit on repetitive mismatches and returns
+    // -2
+    assertThat(scanner.boundedBoyerMooreHorspool(needle, shifts, 0)).isEqualTo(-2);
+
+    // Tests that the public indexOf catches -2, falls back to linear KMP, and correctly completes
+    int[] failure = literalFailure(needle);
+    assertThat(scanner.indexOf(needle, failure, shifts, 0)).isEqualTo(-1);
+  }
+
+  @Test
+  void boyerMooreHorspoolFindsMatchWithinBudgetWithoutExhaustion() {
+    byte[] needle = "xyz".getBytes(UTF_8);
+    int[] shifts = literalShifts(needle);
+    byte[] haystack = "abcdefghijklmnopqrstuvwxyz".getBytes(UTF_8);
+    Utf8InputScanner scanner = new Utf8InputScanner(haystack);
+
+    assertThat(scanner.boundedBoyerMooreHorspool(needle, shifts, 0)).isEqualTo(23);
+  }
+
+  @Test
+  void boyerMooreHorspoolCompletesMatchWithoutExhaustionWhenWinningCandidateMatches() {
+    byte[] needle = "abcde".getBytes(UTF_8);
+    int[] shifts = literalShifts(needle);
+    // Haystack has prefix noise followed by match:
+    // With hoisted work checking, the inner loop verifies all 5 characters of the true match
+    // without aborting.
+    byte[] haystack = ("noise " + "abcde").getBytes(UTF_8);
+    Utf8InputScanner scanner = new Utf8InputScanner(haystack);
+
+    assertThat(scanner.boundedBoyerMooreHorspool(needle, shifts, 0)).isEqualTo(6);
+  }
+
   private static List<Integer> traceForward(Utf8InputScanner scanner) {
     ArrayList<Integer> result = new ArrayList<>();
     int position = 0;

--- a/safere/src/test/java/org/safere/Utf8InputScannerTest.java
+++ b/safere/src/test/java/org/safere/Utf8InputScannerTest.java
@@ -652,15 +652,14 @@ class Utf8InputScannerTest {
 
   @Test
   void boyerMooreHorspoolCompletesMatchWithoutExhaustionWhenWinningCandidateMatches() {
-    byte[] needle = "abcde".getBytes(UTF_8);
+    byte[] needle = "baa".getBytes(UTF_8);
     int[] shifts = literalShifts(needle);
-    // Haystack has prefix noise followed by match:
-    // With hoisted work checking, the inner loop verifies all 5 characters of the true match
-    // without aborting.
-    byte[] haystack = ("noise " + "abcde").getBytes(UTF_8);
+    // The failed candidates consume the work budget before the final candidate. With hoisted work
+    // checking, the inner loop completes the true match without aborting partway through it.
+    byte[] haystack = "aaaaaaaaabaa".getBytes(UTF_8);
     Utf8InputScanner scanner = new Utf8InputScanner(haystack);
 
-    assertThat(scanner.boundedBoyerMooreHorspool(needle, shifts, 0)).isEqualTo(6);
+    assertThat(scanner.boundedBoyerMooreHorspool(needle, shifts, 0)).isEqualTo(9);
   }
 
   private static List<Integer> traceForward(Utf8InputScanner scanner) {


### PR DESCRIPTION
This fixes a performance bug in Boyer-Moore Horspool by hoisting `WorkLimit` checks out of the inner loops.

#751 replaces BMP with HashChain, so that makes this fix obsolete. If #751 runs into any issues then this is definitely worth fixing as long as BMP is still used.

```
./safere-benchmarks/scripts/compare-branch.sh --baseline origin/main 'captureFreeBytes'
```

| Benchmark                                               | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------------------------------- | ---------------- | --------------- | ------- |
| Utf8MatchingBenchmark.captureFreeBytes.asciiEarly       |         20 ± 2.9 |       16 ± 0.28 |   1.21x |
| Utf8MatchingBenchmark.captureFreeBytes.asciiLate        |        48 ± 0.65 |        46 ± 3.0 |   1.04x |
| Utf8MatchingBenchmark.captureFreeBytes.asciiNoMatch     |        19 ± 0.33 |       19 ± 0.49 |   0.96x |
| Utf8MatchingBenchmark.captureFreeBytes.multibyteEarly   |         20 ± 2.9 |       17 ± 0.06 |   1.15x |
| Utf8MatchingBenchmark.captureFreeBytes.multibyteLate    |        37 ± 0.50 |       34 ± 0.30 |   1.09x |
| Utf8MatchingBenchmark.captureFreeBytes.multibyteNoMatch |        15 ± 0.03 |       15 ± 0.34 |   0.98x |