### PR TITLE
Benchmark SafeRE UTF-8 replacement in the generic matrix

### DIFF
--- a/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
+++ b/safere-benchmarks/CROSS_ENGINE_EXECUTION.md
@@ -25,8 +25,8 @@ The Java comparison matrix is declared in one engine registry:
 | `re2-ffm-string-conversion` | `re2_ffm` | Java `String`; UTF-8 conversion at the FFM API boundary is timed |
 
 Materialization, UTF-8 validation, Java decoding, `Utf8Input` construction,
-pattern compilation, operation binding, and expected-result validation happen
-in JMH setup, outside the timed operation.
+pattern compilation, replacement-template encoding, operation binding, and expected-result
+validation happen in JMH setup, outside the timed operation.
 
 Each variant declares native capabilities and one input representation. The
 planner joins those declarations with each workload's engine-neutral
@@ -34,9 +34,18 @@ requirements and accepted representations. It emits a trial or a specific
 exclusion for every workload/variant pair, so an unsupported feature or
 representation is different from a missing adapter or operation
 implementation. In particular, SafeRE UTF-8 participates in direct `find` and
-repeated-`find`, whole-input `matches`, `lookingAt`, capture-participation, and
-matcher reset/region operations. Group-text, String replacement, and split
-workloads remain excluded rather than being emulated across representations.
+repeated-`find`, whole-input `matches`, `lookingAt`, capture-participation,
+replacement, and matcher reset/region operations. Group-text and split workloads remain excluded
+rather than being emulated across representations.
+
+Generic replacement workloads use each variant's native output representation. String variants
+produce and consume a Java `String`. The `safere-utf8` variant supplies a pre-encoded `Utf8Input`
+replacement to `Utf8Matcher.appendReplacement(Utf8Sink, Utf8Input)` and `appendTail`, and consumes
+the resulting bytes and byte length without decoding them during measurement. Setup-time validation
+decodes that byte result only after replaying the operation outside measurement. Literal, numbered,
+and named group templates therefore exercise SafeRE's byte-native replacement path. Direct capture
+text, split, duplicate UTF-8 compilation, PatternSet, retained-heap, and String-specific diagnostics
+remain explicitly excluded where their operation or comparison boundary is not available.
 
 ## JMH trials and result names
 

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -5846,11 +5846,6 @@
       "inputs": [
         "replace.anchoredReplace.input"
       ],
-      "inputRepresentations": [
-        "javaString",
-        "javaStringWithTimedUtf8Conversion"
-      ],
-      "inputRepresentationReason": "The Matcher replacement fast path operates on Java strings; preexisting UTF-8 replacement uses a separate API.",
       "resultConsumption": "string",
       "measurement": {
         "mode": "averageTime",

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkOperation.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/BenchmarkOperation.java
@@ -84,7 +84,7 @@ enum BenchmarkOperation {
       List<RegexEngineVariant.CompiledRegex> patterns,
       List<RegexEngineVariant.RegexInput> inputs,
       int[] groups,
-      String replacement,
+      RegexEngineVariant.PreparedReplacement replacement,
       int limit,
       DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
       String flagSet,
@@ -123,12 +123,12 @@ enum BenchmarkOperation {
       case CAPTURE_GROUPS ->
           blackhole -> blackhole.consume(captureGroups(pattern.matcher(input), groups));
       case REPLACE_FIRST ->
-          blackhole -> blackhole.consume(pattern.replaceFirst(input, replacement));
-      case REPLACE_ALL -> blackhole -> blackhole.consume(pattern.replaceAll(input, replacement));
+          blackhole -> pattern.replaceFirst(input, replacement).consume(blackhole);
+      case REPLACE_ALL -> blackhole -> pattern.replaceAll(input, replacement).consume(blackhole);
       case REPLACE_ALL_LENGTH_SUM ->
           blackhole -> blackhole.consume(replaceAllLengthSum(patterns, input, replacement));
       case MANUAL_REPLACE_ALL ->
-          blackhole -> blackhole.consume(manualReplaceAll(pattern.matcher(input), replacement));
+          blackhole -> pattern.manualReplaceAll(input, replacement).consume(blackhole);
       case SPLIT_LENGTH_SUM ->
           blackhole -> blackhole.consume(splitLengthSum(pattern.split(input, limit)));
       case COMPILE_AND_FIND ->
@@ -168,7 +168,7 @@ enum BenchmarkOperation {
       List<RegexEngineVariant.CompiledRegex> patterns,
       List<RegexEngineVariant.RegexInput> inputs,
       int[] groups,
-      String replacement,
+      RegexEngineVariant.PreparedReplacement replacement,
       int limit,
       DeclarativeBenchmarkPlan.MatcherLifecycle lifecycle,
       String flagSet,
@@ -201,10 +201,10 @@ enum BenchmarkOperation {
       case FIND_ALL_LENGTH_SUM -> findAllLengthSum(pattern.matcher(input));
       case FIND_ALL_GROUP_LENGTH_SUM -> findAllGroupLengthSum(pattern.matcher(input), groups);
       case CAPTURE_GROUPS -> captureGroups(pattern.matcher(input), groups);
-      case REPLACE_FIRST -> pattern.replaceFirst(input, replacement);
-      case REPLACE_ALL -> pattern.replaceAll(input, replacement);
+      case REPLACE_FIRST -> pattern.replaceFirst(input, replacement).validationValue();
+      case REPLACE_ALL -> pattern.replaceAll(input, replacement).validationValue();
       case REPLACE_ALL_LENGTH_SUM -> replaceAllLengthSum(patterns, input, replacement);
-      case MANUAL_REPLACE_ALL -> manualReplaceAll(pattern.matcher(input), replacement);
+      case MANUAL_REPLACE_ALL -> pattern.manualReplaceAll(input, replacement).validationValue();
       case SPLIT_LENGTH_SUM -> splitLengthSum(pattern.split(input, limit));
       case COMPILE_AND_FIND -> {
         try (RegexEngineVariant.CompiledRegex compiled =
@@ -354,22 +354,12 @@ enum BenchmarkOperation {
   private static int replaceAllLengthSum(
       List<RegexEngineVariant.CompiledRegex> patterns,
       RegexEngineVariant.RegexInput input,
-      String replacement) {
+      RegexEngineVariant.PreparedReplacement replacement) {
     int sum = 0;
     for (RegexEngineVariant.CompiledRegex pattern : patterns) {
-      sum += pattern.replaceAll(input, replacement).length();
+      sum += pattern.replaceAll(input, replacement).nativeLength();
     }
     return sum;
-  }
-
-  private static String manualReplaceAll(
-      RegexEngineVariant.MatchCursor matcher, String replacement) {
-    StringBuilder result = new StringBuilder();
-    while (matcher.find()) {
-      matcher.appendReplacement(result, replacement);
-    }
-    matcher.appendTail(result);
-    return result.toString();
   }
 
   private static int splitLengthSum(String[] parts) {

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/CrossEngineTrialRunner.java
@@ -60,6 +60,8 @@ final class CrossEngineTrialRunner implements AutoCloseable {
 
     List<RegexEngineVariant.RegexInput> inputs =
         trial.variant().prepareInputs(data, workload.inputKeys());
+    RegexEngineVariant.PreparedReplacement replacement =
+        trial.variant().prepareReplacement(workload.replacement());
     List<String> patternSources = workload.patterns();
     List<RegexEngineVariant.CompiledRegex> patterns = new ArrayList<>();
     try {
@@ -78,7 +80,7 @@ final class CrossEngineTrialRunner implements AutoCloseable {
                     patterns,
                     inputs,
                     workload.groups(),
-                    workload.replacement(),
+                    replacement,
                     workload.limit(),
                     workload.lifecycle(),
                     workload.flagSet(),
@@ -95,7 +97,7 @@ final class CrossEngineTrialRunner implements AutoCloseable {
                   patterns,
                   inputs,
                   workload.groups(),
-                  workload.replacement(),
+                  replacement,
                   workload.limit(),
                   workload.lifecycle(),
                   workload.flagSet(),

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/RegexEngineVariant.java
@@ -7,9 +7,13 @@
 
 package org.safere.benchmark;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import org.openjdk.jmh.infra.Blackhole;
+import org.safere.Utf8Sink;
 
 /** Java-side regex execution variants and their representation/timing boundaries. */
 enum RegexEngineVariant {
@@ -81,13 +85,15 @@ enum RegexEngineVariant {
         }
 
         @Override
-        public String replaceFirst(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceFirst(replacement);
+        public ReplacementOutput replaceFirst(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceFirst(string(replacement)));
         }
 
         @Override
-        public String replaceAll(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceAll(replacement);
+        public ReplacementOutput replaceAll(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceAll(string(replacement)));
         }
 
         @Override
@@ -107,6 +113,8 @@ enum RegexEngineVariant {
           EngineCapability.MATCHES,
           EngineCapability.LOOKING_AT,
           EngineCapability.GROUP_PARTICIPATION,
+          EngineCapability.REPLACE,
+          EngineCapability.APPEND_REPLACEMENT,
           EngineCapability.MATCHER_RESET,
           EngineCapability.REGIONS)) {
     @Override
@@ -157,6 +165,22 @@ enum RegexEngineVariant {
               matcher.region(start, end);
             }
           };
+        }
+
+        @Override
+        public ReplacementOutput replaceFirst(RegexInput input, PreparedReplacement replacement) {
+          return replaceUtf8(pattern.matcher(utf8(input)), utf8(replacement), true);
+        }
+
+        @Override
+        public ReplacementOutput replaceAll(RegexInput input, PreparedReplacement replacement) {
+          return replaceUtf8(pattern.matcher(utf8(input)), utf8(replacement), false);
+        }
+
+        @Override
+        public ReplacementOutput manualReplaceAll(
+            RegexInput input, PreparedReplacement replacement) {
+          return replaceUtf8(pattern.matcher(utf8(input)), utf8(replacement), false);
         }
       };
     }
@@ -228,13 +252,15 @@ enum RegexEngineVariant {
         }
 
         @Override
-        public String replaceFirst(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceFirst(replacement);
+        public ReplacementOutput replaceFirst(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceFirst(string(replacement)));
         }
 
         @Override
-        public String replaceAll(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceAll(replacement);
+        public ReplacementOutput replaceAll(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceAll(string(replacement)));
         }
 
         @Override
@@ -306,13 +332,15 @@ enum RegexEngineVariant {
         }
 
         @Override
-        public String replaceFirst(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceFirst(replacement);
+        public ReplacementOutput replaceFirst(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceFirst(string(replacement)));
         }
 
         @Override
-        public String replaceAll(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceAll(replacement);
+        public ReplacementOutput replaceAll(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceAll(string(replacement)));
         }
 
         @Override
@@ -374,13 +402,15 @@ enum RegexEngineVariant {
         }
 
         @Override
-        public String replaceFirst(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceFirst(replacement);
+        public ReplacementOutput replaceFirst(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceFirst(string(replacement)));
         }
 
         @Override
-        public String replaceAll(RegexInput input, String replacement) {
-          return pattern.matcher(string(input)).replaceAll(replacement);
+        public ReplacementOutput replaceAll(RegexInput input, PreparedReplacement replacement) {
+          return new StringReplacementOutput(
+              pattern.matcher(string(input)).replaceAll(string(replacement)));
         }
 
         @Override
@@ -519,6 +549,17 @@ enum RegexEngineVariant {
     return List.copyOf(inputs);
   }
 
+  PreparedReplacement prepareReplacement(String replacement) {
+    if (replacement == null) {
+      return null;
+    }
+    if (inputRepresentation == InputRepresentation.PREEXISTING_UTF8) {
+      return new Utf8Replacement(
+          org.safere.Utf8Input.trusted(replacement.getBytes(StandardCharsets.UTF_8)));
+    }
+    return new StringReplacement(replacement);
+  }
+
   abstract CompiledRegex compile(String regex);
 
   Object compileForBenchmark(String regex, String flagSet) {
@@ -580,11 +621,89 @@ enum RegexEngineVariant {
     return ((Utf8RegexInput) input).value();
   }
 
+  private static String string(PreparedReplacement replacement) {
+    return ((StringReplacement) replacement).value();
+  }
+
+  private static org.safere.Utf8Input utf8(PreparedReplacement replacement) {
+    return ((Utf8Replacement) replacement).value();
+  }
+
+  private static ReplacementOutput replaceUtf8(
+      org.safere.Utf8Matcher matcher, org.safere.Utf8Input replacement, boolean firstOnly) {
+    ByteArraySink sink = new ByteArraySink();
+    while (matcher.find()) {
+      matcher.appendReplacement(sink, replacement);
+      if (firstOnly) {
+        break;
+      }
+    }
+    matcher.appendTail(sink);
+    return sink.output();
+  }
+
   sealed interface RegexInput permits StringRegexInput, Utf8RegexInput {}
 
   record StringRegexInput(String value) implements RegexInput {}
 
   record Utf8RegexInput(org.safere.Utf8Input value) implements RegexInput {}
+
+  sealed interface PreparedReplacement permits StringReplacement, Utf8Replacement {}
+
+  record StringReplacement(String value) implements PreparedReplacement {}
+
+  record Utf8Replacement(org.safere.Utf8Input value) implements PreparedReplacement {}
+
+  sealed interface ReplacementOutput permits StringReplacementOutput, Utf8ReplacementOutput {
+    int nativeLength();
+
+    String validationValue();
+
+    void consume(Blackhole blackhole);
+  }
+
+  record StringReplacementOutput(String value) implements ReplacementOutput {
+    @Override
+    public int nativeLength() {
+      return value.length();
+    }
+
+    @Override
+    public String validationValue() {
+      return value;
+    }
+
+    @Override
+    public void consume(Blackhole blackhole) {
+      blackhole.consume(value);
+    }
+  }
+
+  private static final class Utf8ReplacementOutput implements ReplacementOutput {
+    private final byte[] bytes;
+    private final int length;
+
+    Utf8ReplacementOutput(byte[] bytes, int length) {
+      this.bytes = bytes;
+      this.length = length;
+    }
+
+    @Override
+    public int nativeLength() {
+      return length;
+    }
+
+    @Override
+    public String validationValue() {
+      return new String(bytes, 0, length, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void consume(Blackhole blackhole) {
+      blackhole.consume(bytes);
+      blackhole.consume(length);
+    }
+  }
 
   interface MatchCursor {
     default boolean find() {
@@ -641,12 +760,22 @@ enum RegexEngineVariant {
       throw new UnsupportedOperationException();
     }
 
-    default String replaceAll(RegexInput input, String replacement) {
+    default ReplacementOutput replaceAll(RegexInput input, PreparedReplacement replacement) {
       throw new UnsupportedOperationException();
     }
 
-    default String replaceFirst(RegexInput input, String replacement) {
+    default ReplacementOutput replaceFirst(RegexInput input, PreparedReplacement replacement) {
       throw new UnsupportedOperationException();
+    }
+
+    default ReplacementOutput manualReplaceAll(RegexInput input, PreparedReplacement replacement) {
+      MatchCursor matcher = matcher(input);
+      StringBuilder result = new StringBuilder();
+      while (matcher.find()) {
+        matcher.appendReplacement(result, string(replacement));
+      }
+      matcher.appendTail(result);
+      return new StringReplacementOutput(result.toString());
     }
 
     default String[] split(RegexInput input, int limit) {
@@ -661,5 +790,24 @@ enum RegexEngineVariant {
     JAVA_STRING,
     PREEXISTING_UTF8,
     JAVA_STRING_WITH_TIMED_UTF8_CONVERSION
+  }
+
+  private static final class ByteArraySink implements Utf8Sink {
+    private byte[] bytes = new byte[256];
+    private int length;
+
+    @Override
+    public void append(byte[] source, int offset, int rangeLength) {
+      int requiredLength = length + rangeLength;
+      if (requiredLength > bytes.length) {
+        bytes = Arrays.copyOf(bytes, Math.max(requiredLength, bytes.length * 2));
+      }
+      System.arraycopy(source, offset, bytes, length, rangeLength);
+      length = requiredLength;
+    }
+
+    ReplacementOutput output() {
+      return new Utf8ReplacementOutput(bytes, length);
+    }
   }
 }

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -8,6 +8,7 @@ package org.safere.benchmark;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -77,8 +78,8 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2190);
-    assertThat(plan.exclusions()).hasSize(735);
+    assertThat(allTrials).hasSize(2352);
+    assertThat(plan.exclusions()).hasSize(573);
     assertThat(accounted).hasSize(585 * RegexEngineVariant.values().length);
   }
 
@@ -123,14 +124,14 @@ class CrossEngineBenchmarkPlanTest {
             second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(1540);
+        .hasSize(1691);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
             second.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
                 .map(CrossEngineBenchmarkPlan.Trial::id)
                 .toList())
-        .hasSize(578);
+        .hasSize(589);
     assertThat(first.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS))
         .extracting(CrossEngineBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
@@ -163,12 +164,36 @@ class CrossEngineBenchmarkPlanTest {
             BenchmarkOperation.LOOKING_AT,
             BenchmarkOperation.MATCHER_RESET_FIND,
             BenchmarkOperation.MATCHER_REGION_FIND,
-            BenchmarkOperation.FIND_GROUP_PRESENT)
+            BenchmarkOperation.FIND_GROUP_PRESENT,
+            BenchmarkOperation.REPLACE_FIRST,
+            BenchmarkOperation.REPLACE_ALL,
+            BenchmarkOperation.REPLACE_ALL_LENGTH_SUM,
+            BenchmarkOperation.MANUAL_REPLACE_ALL)
         .doesNotContain(
             BenchmarkOperation.CAPTURE_GROUPS,
             BenchmarkOperation.FIND_GROUP,
-            BenchmarkOperation.REPLACE_ALL,
             BenchmarkOperation.SPLIT_LENGTH_SUM);
+  }
+
+  @Test
+  void utf8ReplacementTrialsCoverGenericBenchmarkFamilies() {
+    CrossEngineBenchmarkPlan plan = CrossEngineBenchmarkPlan.load();
+
+    assertThat(
+            List.of(
+                    plan.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS),
+                    plan.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
+                .stream()
+                .flatMap(List::stream)
+                .filter(trial -> trial.variant() == RegexEngineVariant.SAFERE_UTF8)
+                .map(CrossEngineBenchmarkPlan.Trial::id))
+        .contains(
+            "ApplicationBenchmark.secretRedaction@safere-utf8",
+            "RealWorldRegexBenchmark.runBenchmark.markupImageLink.match.1000@safere-utf8",
+            "ReplaceBenchmark.literalReplaceFirst@safere-utf8",
+            "ReplaceBenchmark.pigLatinReplaceAll@safere-utf8",
+            "ReplaceBenchmark.anchoredReplace@safere-utf8",
+            "ReplaceBenchmark.manualReplaceAll@safere-utf8");
   }
 
   @Test
@@ -289,6 +314,51 @@ class CrossEngineBenchmarkPlanTest {
     }
     assertThat(plan.resolve("MatcherApiBenchmark.resetAndFind@re2-ffm-string-conversion"))
         .isNotNull();
+  }
+
+  @Test
+  void utf8ReplacementOperationsPrepareAndRunThroughTheGenericAdapter() {
+    CrossEngineBenchmarkPlan plan = CrossEngineBenchmarkPlan.load();
+    Blackhole blackhole =
+        new Blackhole(
+            "Today's password is swordfish. I understand instantiating Blackholes directly is"
+                + " dangerous.");
+    for (String id :
+        List.of(
+            "ReplaceBenchmark.literalReplaceFirst@safere-utf8",
+            "ReplaceBenchmark.pigLatinReplaceAll@safere-utf8",
+            "ReplaceBenchmark.manualReplaceAll@safere-utf8",
+            "ApplicationBenchmark.secretRedaction@safere-utf8",
+            "RealWorldRegexBenchmark.runBenchmark.markupImageLink.match.1000@safere-utf8")) {
+      CrossEngineBenchmarkPlan.Trial trial = plan.resolve(id);
+      try (CrossEngineTrialRunner runner =
+          CrossEngineTrialRunner.prepare(id, trial.workload().timingGroup())) {
+        runner.run(blackhole);
+      }
+    }
+  }
+
+  @Test
+  void utf8ReplacementAdapterExpandsLiteralNumberedAndNamedTemplates() {
+    RegexEngineVariant variant = RegexEngineVariant.SAFERE_UTF8;
+    RegexEngineVariant.RegexInput input =
+        new RegexEngineVariant.Utf8RegexInput(
+            org.safere.Utf8Input.trusted("alpha=one&beta=two".getBytes(StandardCharsets.UTF_8)));
+
+    try (RegexEngineVariant.CompiledRegex literal = variant.compile("&");
+        RegexEngineVariant.CompiledRegex numbered = variant.compile("([a-z]+)=([a-z]+)");
+        RegexEngineVariant.CompiledRegex named =
+            variant.compile("(?<key>[a-z]+)=(?<value>[a-z]+)")) {
+      assertThat(literal.replaceFirst(input, variant.prepareReplacement(";")).validationValue())
+          .isEqualTo("alpha=one;beta=two");
+      assertThat(numbered.replaceAll(input, variant.prepareReplacement("$2:$1")).validationValue())
+          .isEqualTo("one:alpha&two:beta");
+      assertThat(
+              named
+                  .replaceAll(input, variant.prepareReplacement("${key}=[${value}]"))
+                  .validationValue())
+          .isEqualTo("alpha=[one]&beta=[two]");
+    }
   }
 
   @Test
@@ -429,8 +499,8 @@ class CrossEngineBenchmarkPlanTest {
         .allMatch(runner -> !runner.trialIds().isEmpty())
         .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
         .doesNotHaveDuplicates()
-        .hasSize(2229);
-    assertThat(plan.reportPlan().trials()).hasSize(2229);
+        .hasSize(2391);
+    assertThat(plan.reportPlan().trials()).hasSize(2391);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
     assertThat(
             plan.reportPlan(true).trials().stream()


### PR DESCRIPTION
## Summary

- add generic SafeRE UTF-8 support for replace-first, replace-all, and manual append-replacement workloads
- prepare replacement bytes during setup and keep UTF-8 output decoding outside the timed operation
- include applicable Application, Real-world, and replacement-suite trials while preserving explicit exclusions for unsupported operations
- document the byte-native replacement measurement boundary

Fixes #676

## Verification

- `mvn -pl safere-benchmarks verify -q`
- `mvn -pl safere-benchmarks spotless:check -q`
- focused `run-java-benchmarks.sh --smoke --fastbuild` trials for literal replace-first, numbered replacement, and manual append-replacement on `safere-utf8`
- generated declarative report plan inspection: 162 runnable generic `safere-utf8` replacement trials and zero replacement exclusions
- Codex review-fix loop against `main`: no P0-P2 findings

Not run: full SafeRE test suite and public API crosscheck validation; this change is confined to the benchmark adapter, plan, tests, workload declaration, and benchmark execution documentation.
