### PR TITLE
Reverse suffix acceleration

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -195,6 +195,26 @@
       "shared": true
     },
     {
+      "id": "crossEngine.RegexBenchmark.emailFindDoc.input",
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "The quick brown fox jumps over the lazy dog. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. ",
+        "suffix": "Contact support directly at service_alerts123@support.internal.org for any system assistance.",
+        "length": 4096
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.tokenSuffixFind.input",
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "timestamp=2026-08-24T12:00:00Z level=INFO module=engine message=\"processing request packet chunk 0x4f2a\"\n",
+        "suffix": "target_service_node=node987-staging status=READY",
+        "length": 4096
+      },
+      "shared": true
+    },
+    {
       "id": "crossEngine.ApplicationBenchmark.uuidValidation.input.0",
       "recipe": {
         "kind": "literal",
@@ -2656,6 +2676,42 @@
       ],
       "inputs": [
         "crossEngine.RegexBenchmark.emailFind.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.emailFindDoc",
+      "operation": "find",
+      "patterns": [
+        "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.emailFindDoc.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.tokenSuffixFind",
+      "operation": "find",
+      "patterns": [
+        "[a-z]+[0-9]+-(?:prod|staging|canary)"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.tokenSuffixFind.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -209,7 +209,7 @@
       "recipe": {
         "kind": "suffixToLength",
         "prefixUnit": "The quick brown fox jumps over the lazy dog. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. ",
-        "suffix": "Contact support directly at department/alert99@support.internal.org for any system assistance.",
+        "suffix": "Contact support directly at department/99@support.internal.org for any system assistance.",
         "length": 4096
       },
       "shared": true

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -205,7 +205,27 @@
       "shared": true
     },
     {
+      "id": "crossEngine.RegexBenchmark.emailPathFind.input",
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "The quick brown fox jumps over the lazy dog. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. ",
+        "suffix": "Contact support directly at department/alert99@support.internal.org for any system assistance.",
+        "length": 4096
+      },
+      "shared": true
+    },
+    {
       "id": "crossEngine.RegexBenchmark.tokenSuffixFind.input",
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "timestamp=2026-08-24T12:00:00Z level=INFO module=engine message=\"processing request packet chunk 0x4f2a\"\n",
+        "suffix": "target_service_node=node987-staging status=READY",
+        "length": 4096
+      },
+      "shared": true
+    },
+    {
+      "id": "crossEngine.RegexBenchmark.serviceNodeFind.input",
       "recipe": {
         "kind": "suffixToLength",
         "prefixUnit": "timestamp=2026-08-24T12:00:00Z level=INFO module=engine message=\"processing request packet chunk 0x4f2a\"\n",
@@ -2705,6 +2725,24 @@
       }
     },
     {
+      "id": "RegexBenchmark.emailPathFind",
+      "operation": "find",
+      "patterns": [
+        "[a-z]+/[0-9]+@support\\.internal\\.org"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.emailPathFind.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "RegexBenchmark.tokenSuffixFind",
       "operation": "find",
       "patterns": [
@@ -2712,6 +2750,24 @@
       ],
       "inputs": [
         "crossEngine.RegexBenchmark.tokenSuffixFind.input"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
+      "id": "RegexBenchmark.serviceNodeFind",
+      "operation": "find",
+      "patterns": [
+        "[a-z]+[0-9]+-staging"
+      ],
+      "inputs": [
+        "crossEngine.RegexBenchmark.serviceNodeFind.input"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -266,6 +266,13 @@ final class Dfa {
     return new Setup(boundaries, numClasses, asciiClassMap);
   }
 
+  static Dfa createReverse(Prog reverseProg) {
+    if (reverseProg == null) {
+      return null;
+    }
+    return new Dfa(reverseProg, DEFAULT_MAX_STATES, buildSetup(reverseProg), true);
+  }
+
   Dfa(Prog prog, int maxStates, Setup setup, boolean longest) {
     this(prog, maxStates, setup, longest, null, null);
   }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -665,7 +665,10 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean literalRegionMatches(String literal, int offset, int length) {
-    if (parentPattern.literalFoldCase() || parentPattern.prefixFoldCase()) {
+    boolean prefixFold =
+        parentPattern.startDescriptor() instanceof StartDescriptor.Literal lit
+            && lit.prefixFoldCase();
+    if (parentPattern.literalFoldCase() || prefixFold) {
       return Ascii.regionMatchesIgnoreCase(text, offset, literal, length);
     }
     return text.regionMatches(false, offset, literal, 0, length);
@@ -940,21 +943,22 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean prefixOrCharClassCannotMatch(int searchFrom) {
-    if (parentPattern.prefix() != null && !parentPattern.prefixFoldCase()) {
+    StartDescriptor desc = parentPattern.startDescriptor();
+    if (desc instanceof StartDescriptor.Literal lit && !lit.prefixFoldCase() && lit.prefix() != null) {
       if (text != null) {
-        if (!text.startsWith(parentPattern.prefix(), searchFrom)) {
+        if (!text.startsWith(lit.prefix(), searchFrom)) {
           if (WorkCounterConfig.ENABLED) {
-            WorkCounter.record(parentPattern.prefix().length());
+            WorkCounter.record(lit.prefix().length());
           }
           return true;
         }
       } else if (textScanner instanceof Utf8InputScanner utf8Scanner) {
-        if (!utf8Scanner.startsWith(parentPattern.prefixUtf8(), searchFrom)) {
+        if (!utf8Scanner.startsWith(lit.prefixUtf8(), searchFrom)) {
           return true;
         }
       }
-    } else if (parentPattern.charClassPrefix() != null) {
-      CharClassScanInfo cc = parentPattern.charClassPrefix();
+    } else if (desc instanceof StartDescriptor.HasCharClassPrefix hcc && hcc.charClassPrefix() != null) {
+      CharClassScanInfo cc = hcc.charClassPrefix();
       if (text != null) {
         if (searchFrom >= text.length()) {
           return true;
@@ -980,27 +984,28 @@ public final class Matcher implements MatchResult {
   }
 
   private boolean anchoredPrefixOrCharClassCannotMatch(int searchFrom) {
-    if (parentPattern.anchoredPrefix() != null) {
+    StartDescriptor desc = parentPattern.startDescriptor();
+    if (desc instanceof StartDescriptor.Literal lit && lit.anchoredPrefix() != null) {
       if (text != null) {
-        if (!text.startsWith(parentPattern.anchoredPrefix(), searchFrom)) {
+        if (!text.startsWith(lit.anchoredPrefix(), searchFrom)) {
           if (WorkCounterConfig.ENABLED) {
-            WorkCounter.record(parentPattern.anchoredPrefix().length());
+            WorkCounter.record(lit.anchoredPrefix().length());
           }
           return true;
         }
       } else if (textScanner instanceof Utf8InputScanner utf8Scanner) {
-        if (!utf8Scanner.startsWith(parentPattern.anchoredPrefixUtf8(), searchFrom)) {
+        if (!utf8Scanner.startsWith(lit.anchoredPrefixUtf8(), searchFrom)) {
           return true;
         }
       }
-    } else if (parentPattern.anchoredCharClassPrefix() != null) {
-      CharClassScanInfo cc = parentPattern.anchoredCharClassPrefix();
+    } else if (desc instanceof StartDescriptor.CharClass cc && cc.anchoredCharClassPrefix() != null) {
+      CharClassScanInfo ccScan = cc.anchoredCharClassPrefix();
       if (text != null) {
         if (searchFrom >= text.length()) {
           return true;
         }
         int cp = text.codePointAt(searchFrom);
-        if (!cc.contains(cp)) {
+        if (!ccScan.contains(cp)) {
           if (WorkCounterConfig.ENABLED) {
             WorkCounter.record(1);
           }
@@ -1011,7 +1016,7 @@ public final class Matcher implements MatchResult {
           return true;
         }
         int cp = utf8Scanner.codePointAt(searchFrom);
-        if (!cc.contains(cp)) {
+        if (!ccScan.contains(cp)) {
           return true;
         }
       }
@@ -1025,7 +1030,7 @@ public final class Matcher implements MatchResult {
 
     if (prefixOrCharClassCannotMatch(0) || anchoredPrefixOrCharClassCannotMatch(0)) {
       MatchStrategy strat =
-          parentPattern.prefix() != null || parentPattern.anchoredPrefix() != null
+          parentPattern.startDescriptor() instanceof StartDescriptor.Literal
               ? MatchStrategy.LITERAL
               : MatchStrategy.CHARACTER_CLASS;
       diagnosticParticipation(strat, StrategyRole.REJECT_PREFILTER);
@@ -1194,7 +1199,7 @@ public final class Matcher implements MatchResult {
 
     if (prefixOrCharClassCannotMatch(0) || anchoredPrefixOrCharClassCannotMatch(0)) {
       MatchStrategy strat =
-          parentPattern.prefix() != null || parentPattern.anchoredPrefix() != null
+          parentPattern.startDescriptor() instanceof StartDescriptor.Literal
               ? MatchStrategy.LITERAL
               : MatchStrategy.CHARACTER_CLASS;
       diagnosticParticipation(strat, StrategyRole.REJECT_PREFILTER);
@@ -1427,7 +1432,7 @@ public final class Matcher implements MatchResult {
       }
       if (anchoredPrefixOrCharClassCannotMatch(0)) {
         MatchStrategy strategy =
-            parentPattern.anchoredPrefix() != null
+            parentPattern.startDescriptor() instanceof StartDescriptor.Literal
                 ? MatchStrategy.LITERAL
                 : MatchStrategy.CHARACTER_CLASS;
         diagnosticParticipation(strategy, StrategyRole.REJECT_PREFILTER);
@@ -1636,7 +1641,7 @@ public final class Matcher implements MatchResult {
       }
       if (anchoredPrefixOrCharClassCannotMatch(searchFrom)) {
         MatchStrategy strat =
-            parentPattern.anchoredPrefix() != null
+            parentPattern.startDescriptor() instanceof StartDescriptor.Literal
                 ? MatchStrategy.LITERAL
                 : MatchStrategy.CHARACTER_CLASS;
         diagnosticParticipation(strat, StrategyRole.REJECT_PREFILTER);
@@ -2982,8 +2987,13 @@ public final class Matcher implements MatchResult {
     diagnosticParticipation(MatchStrategy.DFA, StrategyRole.CANDIDATE_VERIFICATION);
 
     boolean isStartAnchored = parentPattern.prog().anchorStart();
-    String prefix = parentPattern.prefix();
-    boolean foldCase = parentPattern.prefixFoldCase();
+    String prefix =
+        parentPattern.startDescriptor() instanceof StartDescriptor.Literal lit
+            ? lit.prefix()
+            : null;
+    boolean foldCase =
+        parentPattern.startDescriptor() instanceof StartDescriptor.Literal lit
+            && lit.prefixFoldCase();
     boolean hasStartAcceleration =
         enginePathOptions().startAcceleration() && prefix != null && !isStartAnchored;
     int startPos = searchFrom;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -944,7 +944,9 @@ public final class Matcher implements MatchResult {
 
   private boolean prefixOrCharClassCannotMatch(int searchFrom) {
     StartDescriptor desc = parentPattern.startDescriptor();
-    if (desc instanceof StartDescriptor.Literal lit && !lit.prefixFoldCase() && lit.prefix() != null) {
+    if (desc instanceof StartDescriptor.Literal lit
+        && !lit.prefixFoldCase()
+        && lit.prefix() != null) {
       if (text != null) {
         if (!text.startsWith(lit.prefix(), searchFrom)) {
           if (WorkCounterConfig.ENABLED) {
@@ -957,7 +959,8 @@ public final class Matcher implements MatchResult {
           return true;
         }
       }
-    } else if (desc instanceof StartDescriptor.HasCharClassPrefix hcc && hcc.charClassPrefix() != null) {
+    } else if (desc instanceof StartDescriptor.HasCharClassPrefix hcc
+        && hcc.charClassPrefix() != null) {
       CharClassScanInfo cc = hcc.charClassPrefix();
       if (text != null) {
         if (searchFrom >= text.length()) {
@@ -998,7 +1001,8 @@ public final class Matcher implements MatchResult {
           return true;
         }
       }
-    } else if (desc instanceof StartDescriptor.CharClass cc && cc.anchoredCharClassPrefix() != null) {
+    } else if (desc instanceof StartDescriptor.CharClass cc
+        && cc.anchoredCharClassPrefix() != null) {
       CharClassScanInfo ccScan = cc.anchoredCharClassPrefix();
       if (text != null) {
         if (searchFrom >= text.length()) {

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -482,11 +482,11 @@ public final class Pattern implements Serializable {
   }
 
   private static StartDescriptor extractStartDescriptor(Regexp metadataAst) {
-    return extractStartDescriptor(metadataAst, true);
+    return extractStartDescriptor(metadataAst, true, true);
   }
 
   private static StartDescriptor extractStartDescriptor(
-      Regexp metadataAst, boolean allowLeadingExpansion) {
+      Regexp metadataAst, boolean allowLeadingExpansion, boolean allowReverseAnchor) {
     PrefixResult prefixResult = extractPrefix(metadataAst);
     String prefix = prefixResult.prefix();
     boolean prefixFoldCase = prefixResult.foldCase();
@@ -534,6 +534,21 @@ public final class Pattern implements Serializable {
       ccPrefix = null;
       startAcceleration = null;
     }
+    StartDescriptor.ReverseAnchor reverseAnchor =
+        (allowReverseAnchor
+                && prefix == null
+                && fixedOffsetLiteral == null
+                && multiLiteral == null
+                && teddyModel == null
+                && leadingExpansion == null
+                && startAcceleration == null
+                && anchoredPrefix == null
+                && anchoredCharClassPrefix == null)
+            ? extractReverseAnchor(metadataAst)
+            : null;
+    if (reverseAnchor != null) {
+      ccPrefix = null;
+    }
     if (prefix == null
         && fixedOffsetLiteral == null
         && ccPrefix == null
@@ -542,7 +557,8 @@ public final class Pattern implements Serializable {
         && anchoredPrefix == null
         && anchoredCharClassPrefix == null
         && teddyModel == null
-        && leadingExpansion == null) {
+        && leadingExpansion == null
+        && reverseAnchor == null) {
       return StartDescriptor.NONE;
     }
     return new StartDescriptor(
@@ -555,7 +571,8 @@ public final class Pattern implements Serializable {
         anchoredCharClassPrefix,
         multiLiteral,
         teddyModel,
-        leadingExpansion);
+        leadingExpansion,
+        reverseAnchor);
   }
 
   private static StartDescriptor.LeadingExpansion extractLeadingExpansion(Regexp re) {
@@ -633,12 +650,150 @@ public final class Pattern implements Serializable {
     List<Regexp> tailSubs = re.subs.subList(idx + 1, re.nsub());
     Regexp tail = tailSubs.size() == 1 ? tailSubs.getFirst() : Regexp.concat(tailSubs, 0);
 
-    StartDescriptor inner = extractStartDescriptor(tail, false);
-    if (inner == null || !inner.hasStartAcceleration() || inner.leadingExpansion() != null) {
+    StartDescriptor inner = extractStartDescriptor(tail, false, false);
+    if (inner == null
+        || !inner.hasStartAcceleration()
+        || inner.leadingExpansion() != null
+        || !isSelectiveLeadingExpansionAnchor(inner)) {
       return null;
     }
 
     return new StartDescriptor.LeadingExpansion(leadingClass, minRepetition, maxRepetition, inner);
+  }
+
+  private static StartDescriptor.ReverseAnchor extractReverseAnchor(Regexp re) {
+    if (re == null) {
+      return null;
+    }
+    re = unwrapCaptures(re);
+    if (re == null || re.op != RegexpOp.CONCAT || re.nsub() < 2) {
+      return null;
+    }
+
+    int startIdx = 0;
+    while (startIdx < re.nsub() && isLeadingZeroWidth(re.subs.get(startIdx))) {
+      startIdx++;
+    }
+    if (startIdx >= re.nsub() - 1) {
+      return null;
+    }
+
+    for (int anchorIdx = re.nsub() - 1; anchorIdx > startIdx; anchorIdx--) {
+      List<Regexp> tailSubs = re.subs.subList(anchorIdx, re.nsub());
+      Regexp tail = tailSubs.size() == 1 ? tailSubs.getFirst() : Regexp.concat(tailSubs, 0);
+
+      StartDescriptor anchorDesc = extractStartDescriptor(tail, false, false);
+      if (anchorDesc == null
+          || !anchorDesc.hasStartAcceleration()
+          || anchorDesc.leadingExpansion() != null
+          || anchorDesc.reverseAnchor() != null) {
+        continue;
+      }
+
+      if (!isSelectiveReverseAnchor(anchorDesc)) {
+        continue;
+      }
+
+      List<Regexp> prefixSubs = re.subs.subList(startIdx, anchorIdx);
+      Regexp prefix = prefixSubs.size() == 1 ? prefixSubs.getFirst() : Regexp.concat(prefixSubs, 0);
+
+      int minPrefixLen = extractMinMatchLength(prefix);
+      if (minPrefixLen < 1) {
+        continue;
+      }
+
+      if (containsWildcardOrZeroWidth(prefix)) {
+        continue;
+      }
+
+      Prog reverseProg = Compiler.compileForDfa(prefix, true);
+      if (reverseProg == null) {
+        continue;
+      }
+
+      int minTailLen = extractMinMatchLength(tail);
+      int minLength = minPrefixLen + minTailLen;
+
+      return new StartDescriptor.ReverseAnchor(anchorDesc, reverseProg, minLength);
+    }
+
+    return null;
+  }
+
+  private static boolean isSelectiveReverseAnchor(StartDescriptor desc) {
+    if (desc == null) {
+      return false;
+    }
+    if (desc.prefix() != null) {
+      String prefix = desc.prefix();
+      if (prefix.length() >= 2) {
+        return true;
+      }
+      if (!prefix.isEmpty()) {
+        char c = prefix.charAt(0);
+        return RarityOracle.byteRarity(c) >= 40;
+      }
+    }
+    if (desc.multiLiteral() != null || desc.teddyModel() != null) {
+      return true;
+    }
+    if (desc.fixedOffsetLiteral() != null) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean isSelectiveLeadingExpansionAnchor(StartDescriptor desc) {
+    if (isSelectiveReverseAnchor(desc)) {
+      return true;
+    }
+    if (desc.charClassPrefix() != null) {
+      int numRunes = 0;
+      int[] ranges = desc.charClassPrefix().ranges();
+      if (ranges != null) {
+        for (int i = 0; i < ranges.length; i += 2) {
+          numRunes += (ranges[i + 1] - ranges[i] + 1);
+        }
+      }
+      return numRunes > 0 && numRunes <= 8;
+    }
+    return false;
+  }
+
+  private static boolean containsWildcardOrZeroWidth(Regexp re) {
+    if (re == null) {
+      return false;
+    }
+    re = unwrapCaptures(re);
+    if (re == null) {
+      return false;
+    }
+    return switch (re.op) {
+      case ANY_CHAR,
+          ANY_BYTE,
+          BEGIN_LINE,
+          END_LINE,
+          BEGIN_TEXT,
+          END_TEXT,
+          WORD_BOUNDARY,
+          NO_WORD_BOUNDARY,
+          GRAPHEME_CLUSTER_BOUNDARY,
+          GRAPHEME_CLUSTER ->
+          true;
+      case STAR, PLUS, QUEST, REPEAT, CAPTURE, NON_CAPTURE ->
+          containsWildcardOrZeroWidth(re.sub());
+      case CONCAT, ALTERNATE -> {
+        if (re.subs != null) {
+          for (Regexp sub : re.subs) {
+            if (containsWildcardOrZeroWidth(sub)) {
+              yield true;
+            }
+          }
+        }
+        yield false;
+      }
+      default -> false;
+    };
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -3399,19 +3399,16 @@ public final class Pattern implements Serializable {
     SuffixInfo endAnchoredSuffix = extractEndAnchoredSuffix(metadataAst, flags);
     EndAnchoredCharClassInfo endAnchoredCharClass =
         endAnchoredSuffix == null ? extractEndAnchoredCharClass(metadataAst, flags) : null;
-    String prefix = startDescriptor instanceof StartDescriptor.Literal lit ? lit.prefix() : null;
+    String startAnchorNeedle = extractStartAnchorNeedle(startDescriptor);
     CharClassScanInfo ccPrefix =
         startDescriptor instanceof StartDescriptor.HasCharClassPrefix hcc
             ? hcc.charClassPrefix()
             : null;
-    boolean hasLeadingExpansion = startDescriptor instanceof StartDescriptor.LeadingExpansion;
     String suffixStr = endAnchoredSuffix != null ? endAnchoredSuffix.suffix() : null;
     String requiredLiteral =
-        !anchorStart && !hasLeadingExpansion
-            ? extractRequiredLiteral(metadataAst, prefix, suffixStr)
-            : null;
+        !anchorStart ? extractRequiredLiteral(metadataAst, startAnchorNeedle, suffixStr) : null;
     CharClassScanInfo requiredMatchClass = null;
-    if (!anchorStart && prefix == null && endAnchoredCharClass == null) {
+    if (!anchorStart && startAnchorNeedle == null && endAnchoredCharClass == null) {
       if (ccPrefix == null) {
         requiredMatchClass = extractRequiredMatchClass(metadataAst, true);
       } else {
@@ -3432,7 +3429,7 @@ public final class Pattern implements Serializable {
       }
     }
     DisjointRequiredLiterals disjointRequiredLiterals =
-        (!anchorStart && prefix == null && requiredLiteral == null)
+        (!anchorStart && startAnchorNeedle == null && requiredLiteral == null)
             ? DisjointRequiredLiterals.create(extractDisjointRequiredLiterals(metadataAst))
             : null;
     if (requiredLiteral == null
@@ -3696,8 +3693,13 @@ public final class Pattern implements Serializable {
               && node.runes != null
               && node.runes.length >= 2) {
             String candidate = new String(node.runes, 0, node.runes.length);
-            if ((excludePrefix == null || !candidate.equals(excludePrefix))
-                && (excludeSuffix == null || !candidate.equals(excludeSuffix))) {
+            boolean isSubsumedByPrefix =
+                excludePrefix != null
+                    && (excludePrefix.contains(candidate) || candidate.contains(excludePrefix));
+            boolean isSubsumedBySuffix =
+                excludeSuffix != null
+                    && (excludeSuffix.contains(candidate) || candidate.contains(excludeSuffix));
+            if (!isSubsumedByPrefix && !isSubsumedBySuffix) {
               int candidateScore = RarityOracle.literalSelectivityScore(candidate);
               if (best == null || candidateScore > bestScore) {
                 best = candidate;
@@ -3710,6 +3712,38 @@ public final class Pattern implements Serializable {
       }
     }
     return best;
+  }
+
+  private static String extractStartAnchorNeedle(StartDescriptor desc) {
+    if (desc == null) {
+      return null;
+    }
+    return switch (desc) {
+      case StartDescriptor.Literal lit -> lit.prefix();
+      case StartDescriptor.ReverseAnchor ra -> {
+        if (ra.anchorDescriptor() instanceof StartDescriptor.Literal lit) {
+          yield lit.prefix();
+        }
+        if (ra.anchorDescriptor() instanceof StartDescriptor.FixedOffset fo
+            && fo.fixedOffsetLiteral() != null) {
+          yield fo.fixedOffsetLiteral().literal();
+        }
+        yield null;
+      }
+      case StartDescriptor.LeadingExpansion le -> {
+        if (le.innerDescriptor() instanceof StartDescriptor.Literal lit) {
+          yield lit.prefix();
+        }
+        if (le.innerDescriptor() instanceof StartDescriptor.FixedOffset fo
+            && fo.fixedOffsetLiteral() != null) {
+          yield fo.fixedOffsetLiteral().literal();
+        }
+        yield null;
+      }
+      case StartDescriptor.FixedOffset fo when fo.fixedOffsetLiteral() != null ->
+          fo.fixedOffsetLiteral().literal();
+      default -> null;
+    };
   }
 
   /**

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -122,25 +122,16 @@ public final class Pattern implements Serializable {
   private final transient Regexp ast;
 
   private final transient Map<String, Integer> namedGroups;
-  private final transient String prefix;
-  private final transient boolean prefixFoldCase;
   private final transient MatchDescriptor matchDescriptor;
   private final transient byte[] literalMatchUtf8;
   private final transient int[] literalMatchFailure;
   private final transient int[] literalMatchShifts;
-  private final transient byte[] prefixUtf8;
-  private final transient String anchoredPrefix;
-  private final transient byte[] anchoredPrefixUtf8;
   private final transient boolean hasLazy;
   private final transient boolean hasAlternation;
   private final transient boolean hasNullableAlternation;
   private final transient boolean canMatchEmpty;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
-  private final transient CharClassScanInfo charClassPrefix;
-  private final transient CharClassScanInfo anchoredCharClassPrefix;
-  private final transient FixedOffsetLiteral fixedOffsetLiteral;
-  private final transient MultiLiteralInfo multiLiteral;
   private final transient Utf8StartAccelerator utf8StartAccelerator;
   private final transient StartDescriptor startDescriptor;
   private final transient StringStartAccelerator stringStartAccelerator;
@@ -263,7 +254,6 @@ public final class Pattern implements Serializable {
       boolean hasInternalGraphemeClusterBoundary,
       RejectDescriptor rejectDescriptor,
       EnginePathOptions enginePathOptions) {
-    this.patternId = nextPatternId();
     this.pattern = pattern;
     this.flags = flags;
     this.prog = prog;
@@ -287,20 +277,10 @@ public final class Pattern implements Serializable {
       this.flatProg = null;
       this.flatDfaProg = null;
     }
-
     this.ast = ast;
     this.namedGroups = namedGroups;
-    this.prefix = startDescriptor.prefix();
-    this.prefixFoldCase = startDescriptor.prefixFoldCase();
-    this.prefixUtf8 =
-        startDescriptor.prefix() == null || startDescriptor.prefix().isEmpty()
-            ? null
-            : startDescriptor.prefix().getBytes(StandardCharsets.UTF_8);
-    this.anchoredPrefix = startDescriptor.anchoredPrefix();
-    this.anchoredPrefixUtf8 =
-        anchoredPrefix == null || anchoredPrefix.isEmpty()
-            ? null
-            : anchoredPrefix.getBytes(StandardCharsets.UTF_8);
+    this.startDescriptor =
+        startDescriptor != null ? startDescriptor : StartDescriptor.None.INSTANCE;
     this.matchDescriptor = matchDescriptor != null ? matchDescriptor : MatchDescriptor.NONE;
     String literalMatch = this.matchDescriptor.literalMatch();
     this.literalMatchUtf8 =
@@ -313,20 +293,16 @@ public final class Pattern implements Serializable {
     this.canMatchEmpty = canMatchEmpty;
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
-    this.charClassPrefix = startDescriptor.charClassPrefix();
-    this.anchoredCharClassPrefix = startDescriptor.anchoredCharClassPrefix();
-    this.fixedOffsetLiteral = startDescriptor.fixedOffsetLiteral();
-    this.multiLiteral = startDescriptor.multiLiteral();
-    this.startDescriptor = startDescriptor != null ? startDescriptor : StartDescriptor.NONE;
     this.utf8StartAccelerator =
-        Utf8StartAccelerator.create(startDescriptor, prog.hasWordBoundary());
+        Utf8StartAccelerator.create(this.startDescriptor, prog.hasWordBoundary());
     this.stringStartAccelerator =
-        StringStartAccelerator.create(startDescriptor, prog.hasWordBoundary());
+        StringStartAccelerator.create(this.startDescriptor, prog.hasWordBoundary());
     this.enginePathOptions = enginePathOptions;
     this.rejectDescriptor = rejectDescriptor != null ? rejectDescriptor : RejectDescriptor.NONE;
     this.rejectPrefilter = RejectPrefilter.create(this.rejectDescriptor);
     this.defaultPreparedMatchRunner = createPreparedRunner(false);
     this.regionPreparedMatchRunner = createPreparedRunner(true);
+    this.patternId = nextPatternId();
 
     // Eagerly compute analysis and setup to avoid latency spikes on first use.
     if (shouldEagerlyBuildOnePass()) {
@@ -487,13 +463,33 @@ public final class Pattern implements Serializable {
 
   private static StartDescriptor extractStartDescriptor(
       Regexp metadataAst, boolean allowLeadingExpansion, boolean allowReverseAnchor) {
+    if (metadataAst == null) {
+      return StartDescriptor.None.INSTANCE;
+    }
+
+    // Literal prefix (exact match or unanchored text search)
     PrefixResult prefixResult = extractPrefix(metadataAst);
     String prefix = prefixResult.prefix();
     boolean prefixFoldCase = prefixResult.foldCase();
-    FixedOffsetLiteral fixedOffsetLiteral =
-        prefix == null ? extractFixedOffsetLiteral(metadataAst) : null;
-    CharClassScanInfo ccPrefix = (prefix == null) ? extractCharClassPrefix(metadataAst) : null;
-    String[] altLiterals = prefix == null ? extractLiteralAlternation(metadataAst) : null;
+    Regexp anchoredCandidate = firstPrefixCandidateAfterTextAnchor(metadataAst);
+    PrefixResult anchoredPrefixResult = extractPrefixFromCandidate(anchoredCandidate);
+    String anchoredPrefix =
+        anchoredPrefixResult.prefix() != null && !anchoredPrefixResult.foldCase()
+            ? anchoredPrefixResult.prefix()
+            : null;
+    if (prefix != null || anchoredPrefix != null) {
+      return new StartDescriptor.Literal(prefix, prefixFoldCase, anchoredPrefix);
+    }
+
+    // Fixed offset literal
+    FixedOffsetLiteral fixedOffsetLiteral = extractFixedOffsetLiteral(metadataAst);
+    if (fixedOffsetLiteral != null) {
+      CharClassScanInfo ccPrefix = extractCharClassPrefix(metadataAst);
+      return new StartDescriptor.FixedOffset(fixedOffsetLiteral, ccPrefix);
+    }
+
+    // Multi-literal and Teddy alternation models
+    String[] altLiterals = extractLiteralAlternation(metadataAst);
     MultiLiteralInfo multiLiteral =
         VectorScanProviders.multiLiteralProviderAvailable()
                 && altLiterals != null
@@ -501,78 +497,48 @@ public final class Pattern implements Serializable {
                 && altLiterals.length <= 4
             ? MultiLiteralInfo.create(altLiterals)
             : null;
-    TeddyModel teddyModel = null;
-    if (altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 32) {
-      teddyModel = TeddyModel.compileForSelectedProvider(altLiterals);
+    TeddyModel teddyModel =
+        altLiterals != null && altLiterals.length >= 2 && altLiterals.length <= 32
+            ? TeddyModel.compileForSelectedProvider(altLiterals)
+            : null;
+    if (multiLiteral != null) {
+      return new StartDescriptor.MultiLiteral(multiLiteral, teddyModel);
     }
-    StartAcceleration startAcceleration =
-        (prefix == null
-                && ccPrefix == null
-                && fixedOffsetLiteral == null
-                && multiLiteral == null
-                && teddyModel == null)
-            ? extractStartAcceleration(metadataAst)
-            : null;
-    Regexp anchoredCandidate = firstPrefixCandidateAfterTextAnchor(metadataAst);
-    PrefixResult anchoredPrefixResult = extractPrefixFromCandidate(anchoredCandidate);
-    String anchoredPrefix =
-        anchoredPrefixResult.prefix() != null && !anchoredPrefixResult.foldCase()
-            ? anchoredPrefixResult.prefix()
-            : null;
+    if (teddyModel != null) {
+      return new StartDescriptor.Teddy(teddyModel);
+    }
+
+    // Leading nullable or bounded character class repetition
+    if (allowLeadingExpansion) {
+      StartDescriptor.LeadingExpansion leadingExpansion = extractLeadingExpansion(metadataAst);
+      if (leadingExpansion != null) {
+        return leadingExpansion;
+      }
+    }
+
+    // Reverse suffix or inner anchor
+    if (allowReverseAnchor) {
+      StartDescriptor.ReverseAnchor reverseAnchor = extractReverseAnchor(metadataAst);
+      if (reverseAnchor != null) {
+        return reverseAnchor;
+      }
+    }
+
+    // Character class prefix
+    CharClassScanInfo ccPrefix = extractCharClassPrefix(metadataAst);
     CharClassScanInfo anchoredCharClassPrefix =
-        anchoredPrefix == null && anchoredCandidate != null
-            ? extractCharClassPrefix(anchoredCandidate)
-            : null;
-    StartDescriptor.LeadingExpansion leadingExpansion =
-        (allowLeadingExpansion
-                && prefix == null
-                && fixedOffsetLiteral == null
-                && teddyModel == null)
-            ? extractLeadingExpansion(metadataAst)
-            : null;
-    if (leadingExpansion != null) {
-      ccPrefix = null;
-      startAcceleration = null;
+        anchoredCandidate != null ? extractCharClassPrefix(anchoredCandidate) : null;
+    if (ccPrefix != null || anchoredCharClassPrefix != null) {
+      return new StartDescriptor.CharClass(ccPrefix, anchoredCharClassPrefix);
     }
-    StartDescriptor.ReverseAnchor reverseAnchor =
-        (allowReverseAnchor
-                && prefix == null
-                && fixedOffsetLiteral == null
-                && multiLiteral == null
-                && teddyModel == null
-                && leadingExpansion == null
-                && startAcceleration == null
-                && anchoredPrefix == null
-                && anchoredCharClassPrefix == null)
-            ? extractReverseAnchor(metadataAst)
-            : null;
-    if (reverseAnchor != null) {
-      ccPrefix = null;
+
+    // Line start anchor
+    StartAcceleration startAcceleration = extractStartAcceleration(metadataAst);
+    if (startAcceleration != null) {
+      return new StartDescriptor.LineAnchor(startAcceleration);
     }
-    if (prefix == null
-        && fixedOffsetLiteral == null
-        && ccPrefix == null
-        && multiLiteral == null
-        && startAcceleration == null
-        && anchoredPrefix == null
-        && anchoredCharClassPrefix == null
-        && teddyModel == null
-        && leadingExpansion == null
-        && reverseAnchor == null) {
-      return StartDescriptor.NONE;
-    }
-    return new StartDescriptor(
-        prefix,
-        prefixFoldCase,
-        fixedOffsetLiteral,
-        ccPrefix,
-        startAcceleration,
-        anchoredPrefix,
-        anchoredCharClassPrefix,
-        multiLiteral,
-        teddyModel,
-        leadingExpansion,
-        reverseAnchor);
+
+    return StartDescriptor.None.INSTANCE;
   }
 
   private static StartDescriptor.LeadingExpansion extractLeadingExpansion(Regexp re) {
@@ -653,7 +619,7 @@ public final class Pattern implements Serializable {
     StartDescriptor inner = extractStartDescriptor(tail, false, false);
     if (inner == null
         || !inner.hasStartAcceleration()
-        || inner.leadingExpansion() != null
+        || inner instanceof StartDescriptor.LeadingExpansion
         || !isSelectiveLeadingExpansionAnchor(inner)) {
       return null;
     }
@@ -685,8 +651,8 @@ public final class Pattern implements Serializable {
       StartDescriptor anchorDesc = extractStartDescriptor(tail, false, false);
       if (anchorDesc == null
           || !anchorDesc.hasStartAcceleration()
-          || anchorDesc.leadingExpansion() != null
-          || anchorDesc.reverseAnchor() != null) {
+          || anchorDesc instanceof StartDescriptor.LeadingExpansion
+          || anchorDesc instanceof StartDescriptor.ReverseAnchor) {
         continue;
       }
 
@@ -724,32 +690,31 @@ public final class Pattern implements Serializable {
     if (desc == null) {
       return false;
     }
-    if (desc.prefix() != null) {
-      String prefix = desc.prefix();
-      if (prefix.length() >= 2) {
-        return true;
-      }
-      if (!prefix.isEmpty()) {
+    return switch (desc) {
+      case StartDescriptor.Literal lit -> {
+        String prefix = lit.prefix();
+        if (prefix == null || prefix.isEmpty()) {
+          yield false;
+        }
+        if (prefix.length() >= 2) {
+          yield true;
+        }
         char c = prefix.charAt(0);
-        return RarityOracle.byteRarity(c) >= 40;
+        yield RarityOracle.byteRarity(c) >= 40;
       }
-    }
-    if (desc.multiLiteral() != null || desc.teddyModel() != null) {
-      return true;
-    }
-    if (desc.fixedOffsetLiteral() != null) {
-      return true;
-    }
-    return false;
+      case StartDescriptor.HasTeddyModel htm -> true;
+      case StartDescriptor.FixedOffset fo -> true;
+      default -> false;
+    };
   }
 
   private static boolean isSelectiveLeadingExpansionAnchor(StartDescriptor desc) {
     if (isSelectiveReverseAnchor(desc)) {
       return true;
     }
-    if (desc.charClassPrefix() != null) {
+    if (desc instanceof StartDescriptor.HasCharClassPrefix hcc && hcc.charClassPrefix() != null) {
       int numRunes = 0;
-      int[] ranges = desc.charClassPrefix().ranges();
+      int[] ranges = hcc.charClassPrefix().ranges();
       if (ranges != null) {
         for (int i = 0; i < ranges.length; i += 2) {
           numRunes += (ranges[i + 1] - ranges[i] + 1);
@@ -780,8 +745,7 @@ public final class Pattern implements Serializable {
           GRAPHEME_CLUSTER_BOUNDARY,
           GRAPHEME_CLUSTER ->
           true;
-      case STAR, PLUS, QUEST, REPEAT, CAPTURE, NON_CAPTURE ->
-          containsWildcardOrZeroWidth(re.sub());
+      case STAR, PLUS, QUEST, REPEAT, CAPTURE, NON_CAPTURE -> containsWildcardOrZeroWidth(re.sub());
       case CONCAT, ALTERNATE -> {
         if (re.subs != null) {
           for (Regexp sub : re.subs) {
@@ -916,16 +880,16 @@ public final class Pattern implements Serializable {
       return matchDescriptor.keywordAlternation().find(scanner, 0) >= 0;
     }
     if (prog.anchorStart()) {
-      if (anchoredPrefixUtf8 != null) {
-        if (!scanner.startsWith(anchoredPrefixUtf8, 0)) {
+      if (startDescriptor instanceof StartDescriptor.Literal lit && lit.anchoredPrefixUtf8() != null) {
+        if (!scanner.startsWith(lit.anchoredPrefixUtf8(), 0)) {
           return false;
         }
-      } else if (anchoredCharClassPrefix != null) {
+      } else if (startDescriptor instanceof StartDescriptor.CharClass cc && cc.anchoredCharClassPrefix() != null) {
         if (scanner.length() == 0) {
           return false;
         }
         int cp = scanner.codePointAt(0);
-        if (!anchoredCharClassPrefix.contains(cp)) {
+        if (!cc.anchoredCharClassPrefix().contains(cp)) {
           return false;
         }
       }
@@ -979,20 +943,20 @@ public final class Pattern implements Serializable {
       return matched;
     }
     if (prog.anchorStart()) {
-      if (anchoredPrefixUtf8 != null) {
-        if (!scanner.startsWith(anchoredPrefixUtf8, 0)) {
+      if (startDescriptor instanceof StartDescriptor.Literal lit && lit.anchoredPrefixUtf8() != null) {
+        if (!scanner.startsWith(lit.anchoredPrefixUtf8(), 0)) {
           diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.LITERAL);
           return false;
         }
-      } else if (anchoredCharClassPrefix != null) {
+      } else if (startDescriptor instanceof StartDescriptor.CharClass cc && cc.anchoredCharClassPrefix() != null) {
         if (scanner.length() == 0) {
           diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
           return false;
         }
         int cp = scanner.codePointAt(0);
-        if (!anchoredCharClassPrefix.contains(cp)) {
+        if (!cc.anchoredCharClassPrefix().contains(cp)) {
           diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);
           return false;
@@ -1584,52 +1548,8 @@ public final class Pattern implements Serializable {
     return !hasLazy && !matchDescriptor.hasFindFastPath();
   }
 
-  /**
-   * Returns the literal prefix for this pattern, or {@code null} if the pattern has no fixed
-   * literal prefix. Used for prefix acceleration in {@link Matcher#doFind()}.
-   */
-  String prefix() {
-    return prefix;
-  }
-
-  /** Returns whether the prefix should be matched case-insensitively. */
-  boolean prefixFoldCase() {
-    return prefixFoldCase;
-  }
-
-  /**
-   * Returns a {@link CharClassScanInfo} of the character-class prefix, or {@code null} if the
-   * pattern has no character-class prefix. Used for prefix acceleration in {@link Matcher#doFind()}
-   * when no literal prefix exists.
-   */
-  CharClassScanInfo charClassPrefix() {
-    return charClassPrefix;
-  }
-
   StartDescriptor startDescriptor() {
     return startDescriptor;
-  }
-
-  String anchoredPrefix() {
-    return anchoredPrefix;
-  }
-
-  byte[] anchoredPrefixUtf8() {
-    return anchoredPrefixUtf8;
-  }
-
-  CharClassScanInfo anchoredCharClassPrefix() {
-    return anchoredCharClassPrefix;
-  }
-
-  /** Returns a mandatory ASCII literal at a fixed offset from the match start, or {@code null}. */
-  FixedOffsetLiteral fixedOffsetLiteral() {
-    return fixedOffsetLiteral;
-  }
-
-  /** Returns metadata for 2-6 keyword literal alternation acceleration, or {@code null}. */
-  MultiLiteralInfo multiLiteral() {
-    return multiLiteral;
   }
 
   /** Returns the compiled UTF-8 start-position accelerator strategy, or {@code null}. */
@@ -1764,10 +1684,6 @@ public final class Pattern implements Serializable {
 
   int[] literalMatchShifts() {
     return literalMatchShifts;
-  }
-
-  byte[] prefixUtf8() {
-    return prefixUtf8;
   }
 
   /** Returns {@code true} if this pattern is a simple literal with no metacharacters. */
@@ -3458,10 +3374,12 @@ public final class Pattern implements Serializable {
     SuffixInfo endAnchoredSuffix = extractEndAnchoredSuffix(metadataAst, flags);
     EndAnchoredCharClassInfo endAnchoredCharClass =
         endAnchoredSuffix == null ? extractEndAnchoredCharClass(metadataAst, flags) : null;
-    String prefix = startDescriptor != null ? startDescriptor.prefix() : null;
-    CharClassScanInfo ccPrefix = startDescriptor != null ? startDescriptor.charClassPrefix() : null;
-    boolean hasLeadingExpansion =
-        startDescriptor != null && startDescriptor.leadingExpansion() != null;
+    String prefix = startDescriptor instanceof StartDescriptor.Literal lit ? lit.prefix() : null;
+    CharClassScanInfo ccPrefix =
+        startDescriptor instanceof StartDescriptor.HasCharClassPrefix hcc
+            ? hcc.charClassPrefix()
+            : null;
+    boolean hasLeadingExpansion = startDescriptor instanceof StartDescriptor.LeadingExpansion;
     String suffixStr = endAnchoredSuffix != null ? endAnchoredSuffix.suffix() : null;
     String requiredLiteral =
         !anchorStart && !hasLeadingExpansion

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -700,10 +700,8 @@ public final class Pattern implements Serializable {
   }
 
   private static int reverseAnchorSelectivityScore(StartDescriptor desc) {
-    if (desc == null) {
-      return 0;
-    }
     return switch (desc) {
+      case null -> 0;
       case StartDescriptor.Literal lit -> {
         String prefix = lit.prefix();
         if (prefix == null || prefix.isEmpty()) {
@@ -3715,33 +3713,13 @@ public final class Pattern implements Serializable {
   }
 
   private static String extractStartAnchorNeedle(StartDescriptor desc) {
-    if (desc == null) {
-      return null;
-    }
     return switch (desc) {
+      case null -> null;
       case StartDescriptor.Literal lit -> lit.prefix();
-      case StartDescriptor.ReverseAnchor ra -> {
-        if (ra.anchorDescriptor() instanceof StartDescriptor.Literal lit) {
-          yield lit.prefix();
-        }
-        if (ra.anchorDescriptor() instanceof StartDescriptor.FixedOffset fo
-            && fo.fixedOffsetLiteral() != null) {
-          yield fo.fixedOffsetLiteral().literal();
-        }
-        yield null;
-      }
-      case StartDescriptor.LeadingExpansion le -> {
-        if (le.innerDescriptor() instanceof StartDescriptor.Literal lit) {
-          yield lit.prefix();
-        }
-        if (le.innerDescriptor() instanceof StartDescriptor.FixedOffset fo
-            && fo.fixedOffsetLiteral() != null) {
-          yield fo.fixedOffsetLiteral().literal();
-        }
-        yield null;
-      }
       case StartDescriptor.FixedOffset fo when fo.fixedOffsetLiteral() != null ->
           fo.fixedOffsetLiteral().literal();
+      case StartDescriptor.ReverseAnchor ra -> extractStartAnchorNeedle(ra.anchorDescriptor());
+      case StartDescriptor.LeadingExpansion le -> extractStartAnchorNeedle(le.innerDescriptor());
       default -> null;
     };
   }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -712,7 +712,7 @@ public final class Pattern implements Serializable {
         }
         yield RarityOracle.literalSelectivityScore(prefix);
       }
-      case StartDescriptor.HasTeddyModel htm -> 80;
+      case StartDescriptor.HasTeddyModel unusedHtm -> 80;
       case StartDescriptor.FixedOffset fo -> {
         if (fo.fixedOffsetLiteral() != null && fo.fixedOffsetLiteral().literal() != null) {
           yield RarityOracle.literalSelectivityScore(fo.fixedOffsetLiteral().literal());

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -644,7 +644,12 @@ public final class Pattern implements Serializable {
       return null;
     }
 
-    for (int anchorIdx = re.nsub() - 1; anchorIdx > startIdx; anchorIdx--) {
+    int bestScore = 0;
+    StartDescriptor bestAnchorDesc = null;
+    Prog bestReverseProg = null;
+    int bestMinLength = 0;
+
+    for (int anchorIdx = startIdx + 1; anchorIdx < re.nsub(); anchorIdx++) {
       List<Regexp> tailSubs = re.subs.subList(anchorIdx, re.nsub());
       Regexp tail = tailSubs.size() == 1 ? tailSubs.getFirst() : Regexp.concat(tailSubs, 0);
 
@@ -656,7 +661,8 @@ public final class Pattern implements Serializable {
         continue;
       }
 
-      if (!isSelectiveReverseAnchor(anchorDesc)) {
+      int score = reverseAnchorSelectivityScore(anchorDesc);
+      if (score <= bestScore) {
         continue;
       }
 
@@ -680,32 +686,47 @@ public final class Pattern implements Serializable {
       int minTailLen = extractMinMatchLength(tail);
       int minLength = minPrefixLen + minTailLen;
 
-      return new StartDescriptor.ReverseAnchor(anchorDesc, reverseProg, minLength);
+      bestScore = score;
+      bestAnchorDesc = anchorDesc;
+      bestReverseProg = reverseProg;
+      bestMinLength = minLength;
+    }
+
+    if (bestAnchorDesc != null && bestReverseProg != null) {
+      return new StartDescriptor.ReverseAnchor(bestAnchorDesc, bestReverseProg, bestMinLength);
     }
 
     return null;
   }
 
-  private static boolean isSelectiveReverseAnchor(StartDescriptor desc) {
+  private static int reverseAnchorSelectivityScore(StartDescriptor desc) {
     if (desc == null) {
-      return false;
+      return 0;
     }
     return switch (desc) {
       case StartDescriptor.Literal lit -> {
         String prefix = lit.prefix();
         if (prefix == null || prefix.isEmpty()) {
-          yield false;
+          yield 0;
         }
-        if (prefix.length() >= 2) {
-          yield true;
+        if (prefix.length() < 2 && RarityOracle.byteRarity(prefix.charAt(0)) < 40) {
+          yield 0;
         }
-        char c = prefix.charAt(0);
-        yield RarityOracle.byteRarity(c) >= 40;
+        yield RarityOracle.literalSelectivityScore(prefix);
       }
-      case StartDescriptor.HasTeddyModel htm -> true;
-      case StartDescriptor.FixedOffset fo -> true;
-      default -> false;
+      case StartDescriptor.HasTeddyModel htm -> 80;
+      case StartDescriptor.FixedOffset fo -> {
+        if (fo.fixedOffsetLiteral() != null && fo.fixedOffsetLiteral().literal() != null) {
+          yield RarityOracle.literalSelectivityScore(fo.fixedOffsetLiteral().literal());
+        }
+        yield 40;
+      }
+      default -> 0;
     };
+  }
+
+  private static boolean isSelectiveReverseAnchor(StartDescriptor desc) {
+    return reverseAnchorSelectivityScore(desc) > 0;
   }
 
   private static boolean isSelectiveLeadingExpansionAnchor(StartDescriptor desc) {
@@ -880,11 +901,13 @@ public final class Pattern implements Serializable {
       return matchDescriptor.keywordAlternation().find(scanner, 0) >= 0;
     }
     if (prog.anchorStart()) {
-      if (startDescriptor instanceof StartDescriptor.Literal lit && lit.anchoredPrefixUtf8() != null) {
+      if (startDescriptor instanceof StartDescriptor.Literal lit
+          && lit.anchoredPrefixUtf8() != null) {
         if (!scanner.startsWith(lit.anchoredPrefixUtf8(), 0)) {
           return false;
         }
-      } else if (startDescriptor instanceof StartDescriptor.CharClass cc && cc.anchoredCharClassPrefix() != null) {
+      } else if (startDescriptor instanceof StartDescriptor.CharClass cc
+          && cc.anchoredCharClassPrefix() != null) {
         if (scanner.length() == 0) {
           return false;
         }
@@ -943,13 +966,15 @@ public final class Pattern implements Serializable {
       return matched;
     }
     if (prog.anchorStart()) {
-      if (startDescriptor instanceof StartDescriptor.Literal lit && lit.anchoredPrefixUtf8() != null) {
+      if (startDescriptor instanceof StartDescriptor.Literal lit
+          && lit.anchoredPrefixUtf8() != null) {
         if (!scanner.startsWith(lit.anchoredPrefixUtf8(), 0)) {
           diagnostics.participate(MatchStrategy.LITERAL, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.LITERAL);
           return false;
         }
-      } else if (startDescriptor instanceof StartDescriptor.CharClass cc && cc.anchoredCharClassPrefix() != null) {
+      } else if (startDescriptor instanceof StartDescriptor.CharClass cc
+          && cc.anchoredCharClassPrefix() != null) {
         if (scanner.length() == 0) {
           diagnostics.participate(MatchStrategy.CHARACTER_CLASS, StrategyRole.REJECT_PREFILTER);
           diagnostics.boundary(MatchStrategy.CHARACTER_CLASS);

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -22,7 +22,8 @@ record StartDescriptor(
     CharClassScanInfo anchoredCharClassPrefix,
     MultiLiteralInfo multiLiteral,
     TeddyModel teddyModel,
-    LeadingExpansion leadingExpansion) {
+    LeadingExpansion leadingExpansion,
+    ReverseAnchor reverseAnchor) {
 
   record LeadingExpansion(
       CharClassScanInfo leadingClass,
@@ -30,27 +31,10 @@ record StartDescriptor(
       int maxRepetition,
       StartDescriptor innerDescriptor) {}
 
-  static final StartDescriptor NONE =
-      new StartDescriptor(null, false, null, null, null, null, null, null, null, null);
+  record ReverseAnchor(StartDescriptor anchorDescriptor, Prog reversePrefixProg, int minLength) {}
 
-  StartDescriptor(
-      String prefix,
-      boolean prefixFoldCase,
-      FixedOffsetLiteral fixedOffsetLiteral,
-      CharClassScanInfo charClassPrefix,
-      StartAcceleration lineAnchor) {
-    this(
-        prefix,
-        prefixFoldCase,
-        fixedOffsetLiteral,
-        charClassPrefix,
-        lineAnchor,
-        null,
-        null,
-        null,
-        null,
-        null);
-  }
+  static final StartDescriptor NONE =
+      new StartDescriptor(null, false, null, null, null, null, null, null, null, null, null);
 
   boolean hasStartAcceleration() {
     return prefix != null
@@ -59,6 +43,7 @@ record StartDescriptor(
         || lineAnchor != null
         || multiLiteral != null
         || teddyModel != null
-        || leadingExpansion != null;
+        || leadingExpansion != null
+        || reverseAnchor != null;
   }
 }

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -72,8 +72,7 @@ sealed interface StartDescriptor
       StartDescriptor innerDescriptor)
       implements StartDescriptor {}
 
-  record ReverseAnchor(
-      StartDescriptor anchorDescriptor, Prog reversePrefixProg, int minLength)
+  record ReverseAnchor(StartDescriptor anchorDescriptor, Prog reversePrefixProg, int minLength)
       implements StartDescriptor {}
 
   enum None implements StartDescriptor {

--- a/safere/src/main/java/org/safere/StartDescriptor.java
+++ b/safere/src/main/java/org/safere/StartDescriptor.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import java.nio.charset.StandardCharsets;
 import org.safere.Pattern.FixedOffsetLiteral;
 import org.safere.Pattern.StartAcceleration;
 
@@ -12,38 +13,74 @@ import org.safere.Pattern.StartAcceleration;
  * Immutable descriptor capturing pre-computed start-position metadata extracted from a regular
  * expression AST.
  */
-record StartDescriptor(
-    String prefix,
-    boolean prefixFoldCase,
-    FixedOffsetLiteral fixedOffsetLiteral,
-    CharClassScanInfo charClassPrefix,
-    StartAcceleration lineAnchor,
-    String anchoredPrefix,
-    CharClassScanInfo anchoredCharClassPrefix,
-    MultiLiteralInfo multiLiteral,
-    TeddyModel teddyModel,
-    LeadingExpansion leadingExpansion,
-    ReverseAnchor reverseAnchor) {
+sealed interface StartDescriptor
+    permits StartDescriptor.Literal,
+        StartDescriptor.FixedOffset,
+        StartDescriptor.CharClass,
+        StartDescriptor.LineAnchor,
+        StartDescriptor.MultiLiteral,
+        StartDescriptor.Teddy,
+        StartDescriptor.LeadingExpansion,
+        StartDescriptor.ReverseAnchor,
+        StartDescriptor.None {
+
+  interface HasCharClassPrefix {
+    CharClassScanInfo charClassPrefix();
+  }
+
+  interface HasTeddyModel {
+    TeddyModel teddyModel();
+  }
+
+  @SuppressWarnings("ArrayRecordComponent")
+  record Literal(
+      String prefix,
+      boolean prefixFoldCase,
+      String anchoredPrefix,
+      byte[] prefixUtf8,
+      byte[] anchoredPrefixUtf8)
+      implements StartDescriptor {
+    Literal(String prefix, boolean prefixFoldCase, String anchoredPrefix) {
+      this(
+          prefix,
+          prefixFoldCase,
+          anchoredPrefix,
+          prefix == null || prefix.isEmpty() ? null : prefix.getBytes(StandardCharsets.UTF_8),
+          anchoredPrefix == null || anchoredPrefix.isEmpty()
+              ? null
+              : anchoredPrefix.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  record FixedOffset(FixedOffsetLiteral fixedOffsetLiteral, CharClassScanInfo charClassPrefix)
+      implements StartDescriptor, HasCharClassPrefix {}
+
+  record CharClass(CharClassScanInfo charClassPrefix, CharClassScanInfo anchoredCharClassPrefix)
+      implements StartDescriptor, HasCharClassPrefix {}
+
+  record LineAnchor(StartAcceleration lineAnchor) implements StartDescriptor {}
+
+  record MultiLiteral(MultiLiteralInfo multiLiteral, TeddyModel teddyModel)
+      implements StartDescriptor, HasTeddyModel {}
+
+  record Teddy(TeddyModel teddyModel) implements StartDescriptor, HasTeddyModel {}
 
   record LeadingExpansion(
       CharClassScanInfo leadingClass,
       int minRepetition,
       int maxRepetition,
-      StartDescriptor innerDescriptor) {}
+      StartDescriptor innerDescriptor)
+      implements StartDescriptor {}
 
-  record ReverseAnchor(StartDescriptor anchorDescriptor, Prog reversePrefixProg, int minLength) {}
+  record ReverseAnchor(
+      StartDescriptor anchorDescriptor, Prog reversePrefixProg, int minLength)
+      implements StartDescriptor {}
 
-  static final StartDescriptor NONE =
-      new StartDescriptor(null, false, null, null, null, null, null, null, null, null, null);
+  enum None implements StartDescriptor {
+    INSTANCE
+  }
 
-  boolean hasStartAcceleration() {
-    return prefix != null
-        || fixedOffsetLiteral != null
-        || charClassPrefix != null
-        || lineAnchor != null
-        || multiLiteral != null
-        || teddyModel != null
-        || leadingExpansion != null
-        || reverseAnchor != null;
+  default boolean hasStartAcceleration() {
+    return !(this instanceof None);
   }
 }

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -19,46 +19,45 @@ sealed interface StringStartAccelerator {
    * no acceleration strategy applies.
    */
   static StringStartAccelerator create(StartDescriptor descriptor, boolean hasWordBoundary) {
-    if (descriptor == null || !descriptor.hasStartAcceleration()) {
+    if (descriptor == null) {
       return null;
     }
-    if (descriptor.prefix() != null) {
-      if (descriptor.prefixFoldCase()) {
-        return CaseInsensitiveLiteral.create(descriptor.prefix());
+    return switch (descriptor) {
+      case StartDescriptor.Literal lit ->
+          lit.prefix() == null
+              ? null
+              : (lit.prefixFoldCase()
+                  ? CaseInsensitiveLiteral.create(lit.prefix())
+                  : Literal.create(lit.prefix()));
+      case StartDescriptor.FixedOffset fix ->
+          new FixedOffset(fix.fixedOffsetLiteral(), fix.charClassPrefix());
+      case StartDescriptor.CharClass cc when !hasWordBoundary && cc.charClassPrefix() != null ->
+          CharClass.create(cc.charClassPrefix());
+      case StartDescriptor.LineAnchor la when !hasWordBoundary && la.lineAnchor() != null ->
+          new LineAnchor(la.lineAnchor());
+      case StartDescriptor.LeadingExpansion le -> {
+        StringStartAccelerator inner = create(le.innerDescriptor(), hasWordBoundary);
+        yield inner == null
+            ? null
+            : new LeadingExpansion(
+                le.leadingClass(), le.minRepetition(), le.maxRepetition(), inner);
       }
-      return Literal.create(descriptor.prefix());
-    }
-    if (descriptor.fixedOffsetLiteral() != null) {
-      return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefix());
-    }
-    if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
-      return CharClass.create(descriptor.charClassPrefix());
-    }
-    if (descriptor.lineAnchor() != null && !hasWordBoundary) {
-      return new LineAnchor(descriptor.lineAnchor());
-    }
-    if (descriptor.leadingExpansion() != null) {
-      StringStartAccelerator inner =
-          create(descriptor.leadingExpansion().innerDescriptor(), hasWordBoundary);
-      if (inner != null) {
-        return new LeadingExpansion(
-            descriptor.leadingExpansion().leadingClass(),
-            descriptor.leadingExpansion().minRepetition(),
-            descriptor.leadingExpansion().maxRepetition(),
-            inner);
-      }
-    }
-    if (descriptor.reverseAnchor() != null) {
-      StringStartAccelerator inner =
-          create(descriptor.reverseAnchor().anchorDescriptor(), hasWordBoundary);
-      if (inner != null && descriptor.reverseAnchor().reversePrefixProg() != null) {
-        Dfa revDfa = Dfa.createReverse(descriptor.reverseAnchor().reversePrefixProg());
-        if (revDfa != null) {
-          return new ReverseAnchor(inner, revDfa, descriptor.reverseAnchor().minLength());
+      case StartDescriptor.ReverseAnchor ra -> {
+        StringStartAccelerator inner = create(ra.anchorDescriptor(), hasWordBoundary);
+        if (inner != null && ra.reversePrefixProg() != null) {
+          Dfa revDfa = Dfa.createReverse(ra.reversePrefixProg());
+          if (revDfa != null) {
+            yield new ReverseAnchor(inner, revDfa, ra.minLength());
+          }
         }
+        yield null;
       }
-    }
-    return null;
+      case StartDescriptor.MultiLiteral ml -> null;
+      case StartDescriptor.Teddy td -> null;
+      case StartDescriptor.CharClass cc -> null;
+      case StartDescriptor.LineAnchor la -> null;
+      case StartDescriptor.None none -> null;
+    };
   }
 
   /**

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -52,11 +52,11 @@ sealed interface StringStartAccelerator {
         }
         yield null;
       }
-      case StartDescriptor.MultiLiteral ml -> null;
-      case StartDescriptor.Teddy td -> null;
-      case StartDescriptor.CharClass cc -> null;
-      case StartDescriptor.LineAnchor la -> null;
-      case StartDescriptor.None none -> null;
+      case StartDescriptor.MultiLiteral unusedMl -> null;
+      case StartDescriptor.Teddy unusedTd -> null;
+      case StartDescriptor.CharClass unusedCc -> null;
+      case StartDescriptor.LineAnchor unusedLa -> null;
+      case StartDescriptor.None unusedNone -> null;
     };
   }
 

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -48,6 +48,16 @@ sealed interface StringStartAccelerator {
             inner);
       }
     }
+    if (descriptor.reverseAnchor() != null) {
+      StringStartAccelerator inner =
+          create(descriptor.reverseAnchor().anchorDescriptor(), hasWordBoundary);
+      if (inner != null && descriptor.reverseAnchor().reversePrefixProg() != null) {
+        Dfa revDfa = Dfa.createReverse(descriptor.reverseAnchor().reversePrefixProg());
+        if (revDfa != null) {
+          return new ReverseAnchor(inner, revDfa, descriptor.reverseAnchor().minLength());
+        }
+      }
+    }
     return null;
   }
 
@@ -69,6 +79,7 @@ sealed interface StringStartAccelerator {
       case CharClass cc -> cc.findCandidate(text, fromIndex, unixLines);
       case LineAnchor la -> la.findCandidate(text, fromIndex, unixLines);
       case LeadingExpansion le -> le.findCandidate(text, fromIndex, unixLines);
+      case ReverseAnchor ra -> ra.findCandidate(text, fromIndex, unixLines);
     };
   }
 
@@ -388,6 +399,35 @@ sealed interface StringStartAccelerator {
           return start;
         }
         searchPos = innerMatch + 1;
+      }
+      return -1;
+    }
+  }
+
+  record ReverseAnchor(StringStartAccelerator anchor, Dfa reverseDfa, int minLength)
+      implements StringStartAccelerator {
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return new AcceleratorPolicy(16, 4, false, anchor.policy().strategy());
+    }
+
+    int findCandidate(String text, int fromIndex, boolean unixLines) {
+      int searchPos = Math.max(0, fromIndex);
+      int textLen = text.length();
+      int minBound = Math.max(0, fromIndex);
+      while (searchPos <= textLen - minLength) {
+        int anchorPos =
+            StringStartAccelerator.findNextCandidate(anchor, text, searchPos, unixLines);
+        if (anchorPos < 0) {
+          return -1;
+        }
+        Dfa.SearchResult revResult =
+            reverseDfa.doSearchReverse(text, anchorPos, minBound, true, true);
+        if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
+          return revResult.pos();
+        }
+        searchPos = anchorPos + 1;
       }
       return -1;
     }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -19,53 +19,49 @@ sealed interface Utf8StartAccelerator {
    * acceleration strategy applies.
    */
   static Utf8StartAccelerator create(StartDescriptor descriptor, boolean hasWordBoundary) {
-    if (descriptor == null || !descriptor.hasStartAcceleration()) {
+    if (descriptor == null) {
       return null;
     }
-    if (descriptor.prefix() != null) {
-      if (descriptor.prefixFoldCase()) {
-        return CaseInsensitiveLiteral.create(descriptor.prefix());
+    return switch (descriptor) {
+      case StartDescriptor.Literal lit ->
+          lit.prefix() == null
+              ? null
+              : (lit.prefixFoldCase()
+                  ? CaseInsensitiveLiteral.create(lit.prefix())
+                  : Literal.create(lit.prefix()));
+      case StartDescriptor.FixedOffset fix ->
+          new FixedOffset(fix.fixedOffsetLiteral(), fix.charClassPrefix());
+      case StartDescriptor.MultiLiteral ml
+          when !hasWordBoundary && VectorScanProviders.multiLiteralProviderAvailable() ->
+          new MultiLiteral(ml.multiLiteral(), ml.teddyModel());
+      case StartDescriptor.Teddy td
+          when !hasWordBoundary && VectorScanProviders.teddyProviderAvailable() ->
+          new Teddy(td.teddyModel());
+      case StartDescriptor.CharClass cc when !hasWordBoundary && cc.charClassPrefix() != null ->
+          new CharClass(cc.charClassPrefix());
+      case StartDescriptor.LeadingExpansion le -> {
+        Utf8StartAccelerator inner = create(le.innerDescriptor(), hasWordBoundary);
+        yield inner == null
+            ? null
+            : new LeadingExpansion(
+                le.leadingClass(), le.minRepetition(), le.maxRepetition(), inner);
       }
-      return Literal.create(descriptor.prefix());
-    }
-    if (descriptor.fixedOffsetLiteral() != null) {
-      return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefix());
-    }
-    if (descriptor.multiLiteral() != null
-        && !hasWordBoundary
-        && VectorScanProviders.multiLiteralProviderAvailable()) {
-      return new MultiLiteral(descriptor.multiLiteral(), descriptor.teddyModel());
-    }
-    if (descriptor.teddyModel() != null
-        && !hasWordBoundary
-        && VectorScanProviders.teddyProviderAvailable()) {
-      return new Teddy(descriptor.teddyModel());
-    }
-    if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
-      return new CharClass(descriptor.charClassPrefix());
-    }
-    if (descriptor.leadingExpansion() != null) {
-      Utf8StartAccelerator inner =
-          create(descriptor.leadingExpansion().innerDescriptor(), hasWordBoundary);
-      if (inner != null) {
-        return new LeadingExpansion(
-            descriptor.leadingExpansion().leadingClass(),
-            descriptor.leadingExpansion().minRepetition(),
-            descriptor.leadingExpansion().maxRepetition(),
-            inner);
-      }
-    }
-    if (descriptor.reverseAnchor() != null) {
-      Utf8StartAccelerator inner =
-          create(descriptor.reverseAnchor().anchorDescriptor(), hasWordBoundary);
-      if (inner != null && descriptor.reverseAnchor().reversePrefixProg() != null) {
-        Dfa revDfa = Dfa.createReverse(descriptor.reverseAnchor().reversePrefixProg());
-        if (revDfa != null) {
-          return new ReverseAnchor(inner, revDfa, descriptor.reverseAnchor().minLength());
+      case StartDescriptor.ReverseAnchor ra -> {
+        Utf8StartAccelerator inner = create(ra.anchorDescriptor(), hasWordBoundary);
+        if (inner != null && ra.reversePrefixProg() != null) {
+          Dfa revDfa = Dfa.createReverse(ra.reversePrefixProg());
+          if (revDfa != null) {
+            yield new ReverseAnchor(inner, revDfa, ra.minLength());
+          }
         }
+        yield null;
       }
-    }
-    return null;
+      case StartDescriptor.LineAnchor la -> null;
+      case StartDescriptor.MultiLiteral ml -> null;
+      case StartDescriptor.Teddy td -> null;
+      case StartDescriptor.CharClass cc -> null;
+      case StartDescriptor.None none -> null;
+    };
   }
 
   /**

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -55,6 +55,16 @@ sealed interface Utf8StartAccelerator {
             inner);
       }
     }
+    if (descriptor.reverseAnchor() != null) {
+      Utf8StartAccelerator inner =
+          create(descriptor.reverseAnchor().anchorDescriptor(), hasWordBoundary);
+      if (inner != null && descriptor.reverseAnchor().reversePrefixProg() != null) {
+        Dfa revDfa = Dfa.createReverse(descriptor.reverseAnchor().reversePrefixProg());
+        if (revDfa != null) {
+          return new ReverseAnchor(inner, revDfa, descriptor.reverseAnchor().minLength());
+        }
+      }
+    }
     return null;
   }
 
@@ -77,6 +87,7 @@ sealed interface Utf8StartAccelerator {
       case Teddy t -> t.findCandidate(scanner, pos);
       case MultiLiteral ml -> ml.findCandidate(scanner, pos);
       case LeadingExpansion le -> le.findCandidate(scanner, pos);
+      case ReverseAnchor ra -> ra.findCandidate(scanner, pos);
     };
   }
 
@@ -364,6 +375,34 @@ sealed interface Utf8StartAccelerator {
             }
           }
         }
+      }
+      return -1;
+    }
+  }
+
+  record ReverseAnchor(Utf8StartAccelerator anchor, Dfa reverseDfa, int minLength)
+      implements Utf8StartAccelerator {
+
+    @Override
+    public AcceleratorPolicy policy() {
+      return new AcceleratorPolicy(16, 4, false, anchor.policy().strategy());
+    }
+
+    int findCandidate(Utf8InputScanner scanner, int pos) {
+      int searchPos = Math.max(0, pos);
+      int textLen = scanner.length();
+      int minBound = Math.max(0, pos);
+      while (searchPos <= textLen - minLength) {
+        int anchorPos = Utf8StartAccelerator.findNextCandidate(anchor, scanner, searchPos);
+        if (anchorPos < 0) {
+          return -1;
+        }
+        Dfa.SearchResult revResult =
+            reverseDfa.doSearchReverse(scanner, anchorPos, minBound, true, true);
+        if (revResult != null && revResult.matched() && !revResult.ambiguous()) {
+          return revResult.pos();
+        }
+        searchPos = anchorPos + 1;
       }
       return -1;
     }

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -56,11 +56,11 @@ sealed interface Utf8StartAccelerator {
         }
         yield null;
       }
-      case StartDescriptor.LineAnchor la -> null;
-      case StartDescriptor.MultiLiteral ml -> null;
-      case StartDescriptor.Teddy td -> null;
-      case StartDescriptor.CharClass cc -> null;
-      case StartDescriptor.None none -> null;
+      case StartDescriptor.LineAnchor unusedLa -> null;
+      case StartDescriptor.MultiLiteral unusedMl -> null;
+      case StartDescriptor.Teddy unusedTd -> null;
+      case StartDescriptor.CharClass unusedCc -> null;
+      case StartDescriptor.None unusedNone -> null;
     };
   }
 

--- a/safere/src/test/java/org/safere/MultiLiteralTest.java
+++ b/safere/src/test/java/org/safere/MultiLiteralTest.java
@@ -21,9 +21,9 @@ class MultiLiteralTest {
     Pattern pattern = Pattern.compile("apple|banana|cherry");
 
     if (!VectorScanProviders.multiLiteralProviderAvailable()) {
-      assertThat(pattern.multiLiteral()).isNull();
+      assertThat(pattern.startDescriptor()).isNotInstanceOf(StartDescriptor.MultiLiteral.class);
     } else {
-      assertThat(pattern.multiLiteral()).isNotNull();
+      assertThat(pattern.startDescriptor()).isInstanceOf(StartDescriptor.MultiLiteral.class);
       assertThat(VectorScanProviders.providerForLength(64)).isNull();
       assertThat(VectorScanProviders.providerForMultiLiteralLength(64)).isNotNull();
       assertThat(VectorScanProviders.providerForLength(1024)).isNotNull();
@@ -74,7 +74,7 @@ class MultiLiteralTest {
   @Test
   void testFivePlusLiteralsFallbackToCharClass() {
     Pattern pattern = Pattern.compile("apple|banana|cherry|date|fig");
-    assertThat(pattern.multiLiteral()).isNull();
+    assertThat(pattern.startDescriptor()).isNotInstanceOf(StartDescriptor.MultiLiteral.class);
 
     String haystack = "prefix date suffix";
     Utf8Matcher m = pattern.matcher(Utf8Input.validated(haystack.getBytes(UTF_8)));
@@ -120,7 +120,7 @@ class MultiLiteralTest {
     String regex = String.join("|", keywords);
     Pattern safere = Pattern.compile(regex);
     if (VectorScanProviders.multiLiteralProviderAvailable()) {
-      assertThat(safere.multiLiteral()).isNotNull();
+      assertThat(safere.startDescriptor()).isInstanceOf(StartDescriptor.MultiLiteral.class);
     }
     java.util.regex.Pattern jre = java.util.regex.Pattern.compile(regex);
 

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -51,14 +51,15 @@ class PatternInternalTest {
     Pattern p = Pattern.compile("(?:abcdef)");
 
     assertThat(p.literalMatch()).isEqualTo("abcdef");
-    assertThat(p.prefix()).isEqualTo("abcdef");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("abcdef");
   }
 
   @Test
   void transparentGroupsPreserveCharacterClassAccelerators() {
     Pattern p = Pattern.compile("(?:[A-Z]+)");
 
-    CharClassScanInfo prefix = p.charClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('A')).isTrue();
     assertThat(p.matchDescriptor().charClassMatch()).isNotNull();
@@ -66,10 +67,18 @@ class PatternInternalTest {
 
   @Test
   void textStartAnchorsPreservePrefixAccelerators() {
-    assertThat(Pattern.compile("^https://.*").anchoredPrefix()).isEqualTo("https://");
-    assertThat(Pattern.compile("\\Ahttps://.*").anchoredPrefix()).isEqualTo("https://");
+    assertThat(
+            ((StartDescriptor.Literal) Pattern.compile("^https://.*").startDescriptor())
+                .anchoredPrefix())
+        .isEqualTo("https://");
+    assertThat(
+            ((StartDescriptor.Literal) Pattern.compile("\\Ahttps://.*").startDescriptor())
+                .anchoredPrefix())
+        .isEqualTo("https://");
 
-    CharClassScanInfo prefix = Pattern.compile("^[0-9]+").anchoredCharClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) Pattern.compile("^[0-9]+").startDescriptor())
+            .anchoredCharClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('0')).isTrue();
     assertThat(prefix.contains('9')).isTrue();
@@ -128,8 +137,8 @@ class PatternInternalTest {
     Pattern p = Pattern.compile("(?i)needle");
 
     assertThat(p.literalMatch()).isEqualTo("needle");
-    assertThat(p.prefix()).isEqualTo("needle");
-    assertThat(p.prefixFoldCase()).isTrue();
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("needle");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefixFoldCase()).isTrue();
   }
 
   @Test
@@ -137,8 +146,8 @@ class PatternInternalTest {
     Pattern p = Pattern.compile("(?i)needle\\d+");
 
     assertThat(p.literalMatch()).isNull();
-    assertThat(p.prefix()).isEqualTo("needle");
-    assertThat(p.prefixFoldCase()).isTrue();
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("needle");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefixFoldCase()).isTrue();
   }
 
   @Test
@@ -146,19 +155,23 @@ class PatternInternalTest {
     Pattern p = Pattern.compile("\\bSCRUB:begin_strip\\b(?s:.*?)\\bSCRUB:end_strip\\b");
 
     assertThat(p.literalMatch()).isNull();
-    assertThat(p.prefix()).isEqualTo("SCRUB:begin_strip");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix())
+        .isEqualTo("SCRUB:begin_strip");
   }
 
   @Test
   void leadingTextAnchorsDoNotExposeMovableLiteralPrefixAccelerator() {
-    assertThat(Pattern.compile("^SCRUB").prefix()).isNull();
-    assertThat(Pattern.compile("\\ASCRUB").prefix()).isNull();
+    assertThat(((StartDescriptor.Literal) Pattern.compile("^SCRUB").startDescriptor()).prefix())
+        .isNull();
+    assertThat(((StartDescriptor.Literal) Pattern.compile("\\ASCRUB").startDescriptor()).prefix())
+        .isNull();
   }
 
   @Test
   void alternatePrefixAcceleration() {
     Pattern p = Pattern.compile("(?:cat|dog|bird)s?");
-    CharClassScanInfo prefix = p.charClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('c')).isTrue();
     assertThat(prefix.contains('d')).isTrue();
@@ -169,7 +182,8 @@ class PatternInternalTest {
   @Test
   void alternatePrefixCaseInsensitiveAcceleration() {
     Pattern p = Pattern.compile("(?i)(?:cat|dog|bird)s?");
-    CharClassScanInfo prefix = p.charClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('c')).isTrue();
     assertThat(prefix.contains('C')).isTrue();
@@ -183,7 +197,8 @@ class PatternInternalTest {
   @Test
   void unicodeCharacterClassPrefixAcceleration() {
     Pattern p = Pattern.compile("[\\p{IsAlphabetic}]+");
-    CharClassScanInfo prefix = p.charClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.isAscii()).isFalse();
     assertThat(prefix.contains('a')).isTrue();
@@ -198,7 +213,8 @@ class PatternInternalTest {
   void deeplyNestedRequiredQuantifierPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedRequiredPlusPattern(1_000, "[ab]"));
 
-    CharClassScanInfo prefix = p.charClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('a')).isTrue();
     assertThat(prefix.contains('b')).isTrue();
@@ -209,7 +225,8 @@ class PatternInternalTest {
   void deeplyNestedAlternationPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedAlternationPattern(1_000));
 
-    CharClassScanInfo prefix = p.charClassPrefix();
+    CharClassScanInfo prefix =
+        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('a')).isTrue();
     assertThat(prefix.contains('b')).isTrue();
@@ -220,14 +237,15 @@ class PatternInternalTest {
   void deeplyNestedConcatPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedPrefixConcatPattern(1_000));
 
-    assertThat(p.prefix()).isEqualTo("foo");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("foo");
   }
 
   @Test
   void deeplyNestedFixedOffsetWidthExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedFixedOffsetPattern(2_000));
 
-    assertThat(p.fixedOffsetLiteral()).isNotNull();
+    assertThat(((StartDescriptor.FixedOffset) p.startDescriptor()).fixedOffsetLiteral())
+        .isNotNull();
   }
 
   @Test
@@ -237,7 +255,9 @@ class PatternInternalTest {
       regex.append("(x)");
     }
 
-    Pattern.FixedOffsetLiteral fixed = Pattern.compile(regex.toString()).fixedOffsetLiteral();
+    Pattern.FixedOffsetLiteral fixed =
+        ((StartDescriptor.FixedOffset) Pattern.compile(regex.toString()).startDescriptor())
+            .fixedOffsetLiteral();
 
     assertThat(fixed).isNotNull();
     assertThat(fixed.literal()).hasSize(2_000);
@@ -249,8 +269,8 @@ class PatternInternalTest {
     Pattern p = Pattern.compile("(?i)i");
 
     assertThat(p.literalMatch()).isEqualTo("i");
-    assertThat(p.prefix()).isEqualTo("i");
-    assertThat(p.prefixFoldCase()).isTrue();
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("i");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefixFoldCase()).isTrue();
   }
 
   @Test
@@ -281,7 +301,9 @@ class PatternInternalTest {
     "'[ab][cd]-xyz',          -xyz, 2"
   })
   void fixedOffsetAsciiLiteralsAreRecorded(String regex, String literal, int offset) {
-    Pattern.FixedOffsetLiteral fixedOffsetLiteral = Pattern.compile(regex).fixedOffsetLiteral();
+    Pattern.FixedOffsetLiteral fixedOffsetLiteral =
+        ((StartDescriptor.FixedOffset) Pattern.compile(regex).startDescriptor())
+            .fixedOffsetLiteral();
 
     assertThat(fixedOffsetLiteral).isNotNull();
     assertThat(fixedOffsetLiteral.literal()).isEqualTo(literal);
@@ -291,12 +313,15 @@ class PatternInternalTest {
   @ParameterizedTest
   @ValueSource(strings = {"\\d+/x", "[ab](?i:x)", "literal-prefix"})
   void variableWidthUnicodeAndOrdinaryPrefixesDoNotRecordFixedOffsetLiterals(String regex) {
-    assertThat(Pattern.compile(regex).fixedOffsetLiteral()).isNull();
+    assertThat(Pattern.compile(regex).startDescriptor())
+        .isNotInstanceOf(StartDescriptor.FixedOffset.class);
   }
 
   @Test
   void unicodeClassOffsetsAreRecordedAsNonDiscreteCodePointRanges() {
-    Pattern.FixedOffsetLiteral fixed = Pattern.compile("[αβ]/x").fixedOffsetLiteral();
+    Pattern.FixedOffsetLiteral fixed =
+        ((StartDescriptor.FixedOffset) Pattern.compile("[αβ]/x").startDescriptor())
+            .fixedOffsetLiteral();
 
     assertThat(fixed).isNotNull();
     assertThat(fixed.minOffset()).isEqualTo(1);
@@ -307,7 +332,9 @@ class PatternInternalTest {
   @Test
   void discreteMultiOffsetLiteralsAreRecorded() {
     Pattern.FixedOffsetLiteral fixed =
-        Pattern.compile("(^|[a-z])(#!customTag)").fixedOffsetLiteral();
+        ((StartDescriptor.FixedOffset)
+                Pattern.compile("(^|[a-z])(#!customTag)").startDescriptor())
+            .fixedOffsetLiteral();
     assertThat(fixed).isNotNull();
     assertThat(fixed.literal()).isEqualTo("#!customTag");
     assertThat(fixed.minOffset()).isZero();
@@ -318,7 +345,9 @@ class PatternInternalTest {
   @Test
   void boundedRangeOffsetLiteralsAreRecorded() {
     Pattern.FixedOffsetLiteral fixed =
-        Pattern.compile("\\s{0,8}renderElement\\(").fixedOffsetLiteral();
+        ((StartDescriptor.FixedOffset)
+                Pattern.compile("\\s{0,8}renderElement\\(").startDescriptor())
+            .fixedOffsetLiteral();
     assertThat(fixed).isNotNull();
     assertThat(fixed.literal()).isEqualTo("renderElement(");
     assertThat(fixed.minOffset()).isEqualTo(0);
@@ -469,7 +498,9 @@ class PatternInternalTest {
       })
   void invalidOrNullableAlternationsDoNotRecordDisjointLiterals(String regex) {
     Pattern p = Pattern.compile(regex);
-    if (p.prefix() == null && p.rejectDescriptor().requiredLiteral() == null) {
+    String prefix =
+        p.startDescriptor() instanceof StartDescriptor.Literal lit ? lit.prefix() : null;
+    if (prefix == null && p.rejectDescriptor().requiredLiteral() == null) {
       assertThat(p.requiredDisjointLiterals()).isNull();
     }
   }
@@ -591,14 +622,16 @@ class PatternInternalTest {
   @Test
   void prefixExtractionFromNestedCaptureInConcat() {
     Pattern p1 = Pattern.compile("(foo bar)baz");
-    assertThat(p1.prefix()).isEqualTo("foo bar");
+    assertThat(((StartDescriptor.Literal) p1.startDescriptor()).prefix()).isEqualTo("foo bar");
 
     Pattern p2 = Pattern.compile("(<template name>.*)");
-    assertThat(p2.prefix()).isEqualTo("<template name>");
+    assertThat(((StartDescriptor.Literal) p2.startDescriptor()).prefix())
+        .isEqualTo("<template name>");
 
     // reproducing the actual templateTagMatch pattern structure
     Pattern p3 = Pattern.compile("(<template name>.*)([^>])");
-    assertThat(p3.prefix()).isEqualTo("<template name>");
+    assertThat(((StartDescriptor.Literal) p3.startDescriptor()).prefix())
+        .isEqualTo("<template name>");
   }
 
   @Test
@@ -606,9 +639,10 @@ class PatternInternalTest {
     // "____" has length 4 with common underscores.
     // "zq" has length 2 with rare letters 'z' and 'q'.
     Pattern pattern = Pattern.compile("[0-9]{2}____[a-z]zq[a-z]");
-    assertThat(pattern.fixedOffsetLiteral()).isNotNull();
+    StartDescriptor.FixedOffset start = (StartDescriptor.FixedOffset) pattern.startDescriptor();
+    assertThat(start.fixedOffsetLiteral()).isNotNull();
     // "zq" has higher selectivity than "____"
-    assertThat(pattern.fixedOffsetLiteral().literal()).isEqualTo("zq");
+    assertThat(start.fixedOffsetLiteral().literal()).isEqualTo("zq");
   }
 
   @Test

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -58,8 +58,7 @@ class PatternInternalTest {
   void transparentGroupsPreserveCharacterClassAccelerators() {
     Pattern p = Pattern.compile("(?:[A-Z]+)");
 
-    CharClassScanInfo prefix =
-        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
+    CharClassScanInfo prefix = ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('A')).isTrue();
     assertThat(p.matchDescriptor().charClassMatch()).isNotNull();
@@ -170,8 +169,7 @@ class PatternInternalTest {
   @Test
   void alternatePrefixAcceleration() {
     Pattern p = Pattern.compile("(?:cat|dog|bird)s?");
-    CharClassScanInfo prefix =
-        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
+    CharClassScanInfo prefix = ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('c')).isTrue();
     assertThat(prefix.contains('d')).isTrue();
@@ -182,8 +180,7 @@ class PatternInternalTest {
   @Test
   void alternatePrefixCaseInsensitiveAcceleration() {
     Pattern p = Pattern.compile("(?i)(?:cat|dog|bird)s?");
-    CharClassScanInfo prefix =
-        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
+    CharClassScanInfo prefix = ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('c')).isTrue();
     assertThat(prefix.contains('C')).isTrue();
@@ -197,8 +194,7 @@ class PatternInternalTest {
   @Test
   void unicodeCharacterClassPrefixAcceleration() {
     Pattern p = Pattern.compile("[\\p{IsAlphabetic}]+");
-    CharClassScanInfo prefix =
-        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
+    CharClassScanInfo prefix = ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.isAscii()).isFalse();
     assertThat(prefix.contains('a')).isTrue();
@@ -213,8 +209,7 @@ class PatternInternalTest {
   void deeplyNestedRequiredQuantifierPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedRequiredPlusPattern(1_000, "[ab]"));
 
-    CharClassScanInfo prefix =
-        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
+    CharClassScanInfo prefix = ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('a')).isTrue();
     assertThat(prefix.contains('b')).isTrue();
@@ -225,8 +220,7 @@ class PatternInternalTest {
   void deeplyNestedAlternationPrefixExtractionIsStackSafe() {
     Pattern p = Pattern.compile(nestedAlternationPattern(1_000));
 
-    CharClassScanInfo prefix =
-        ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
+    CharClassScanInfo prefix = ((StartDescriptor.CharClass) p.startDescriptor()).charClassPrefix();
     assertThat(prefix).isNotNull();
     assertThat(prefix.contains('a')).isTrue();
     assertThat(prefix.contains('b')).isTrue();
@@ -332,8 +326,7 @@ class PatternInternalTest {
   @Test
   void discreteMultiOffsetLiteralsAreRecorded() {
     Pattern.FixedOffsetLiteral fixed =
-        ((StartDescriptor.FixedOffset)
-                Pattern.compile("(^|[a-z])(#!customTag)").startDescriptor())
+        ((StartDescriptor.FixedOffset) Pattern.compile("(^|[a-z])(#!customTag)").startDescriptor())
             .fixedOffsetLiteral();
     assertThat(fixed).isNotNull();
     assertThat(fixed.literal()).isEqualTo("#!customTag");

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -358,4 +358,32 @@ class RejectPrefilterTest {
     // "abc" is already the start prefix, so requiredLiteral should not duplicate "abc"
     assertThat(p.rejectDescriptor().requiredLiteral()).isNull();
   }
+
+  @Test
+  void rejectPrefilterSubsumedByMatchingReverseAnchor() {
+    Pattern p = Pattern.compile("[a-z]+/[0-9]+@support\\.internal\\.org");
+    assertThat(p.startDescriptor()).isInstanceOf(StartDescriptor.ReverseAnchor.class);
+    assertThat(p.rejectPrefilter()).isNull();
+    assertThat(p.rejectDescriptor().requiredLiteral()).isNull();
+  }
+
+  @Test
+  void rejectPrefilterSubsumedByMatchingLeadingExpansion() {
+    Pattern p = Pattern.compile("\\w+@gmail\\.com");
+    assertThat(p.startDescriptor()).isInstanceOf(StartDescriptor.LeadingExpansion.class);
+    assertThat(p.rejectPrefilter()).isNull();
+    assertThat(p.rejectDescriptor().requiredLiteral()).isNull();
+  }
+
+  @Test
+  void rejectPrefilterRetainedWhenInfixIsDisjointAndRarer() {
+    Pattern p = Pattern.compile("GET\\s+[a-z0-9/]+/[a-f0-9]{32}/rare_admin_token");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("GET");
+    assertThat(p.rejectDescriptor().requiredLiteral()).isEqualTo("/rare_admin_token");
+    assertThat(p.rejectPrefilter()).isNotNull();
+
+    String noise = "GET /index.html HTTP/1.1\n".repeat(100);
+    assertThat(p.rejectPrefilter().canReject(null, noise, 0, EnginePathOptions.allEnabled()))
+        .isTrue();
+  }
 }

--- a/safere/src/test/java/org/safere/RejectPrefilterTest.java
+++ b/safere/src/test/java/org/safere/RejectPrefilterTest.java
@@ -316,7 +316,7 @@ class RejectPrefilterTest {
   @Test
   void requiredInfixLiteralRetainedWhenPrefixPresent() {
     Pattern p = Pattern.compile("(\\{Link:[^}]*?)<<!nav>>([^}]*?\\})");
-    assertThat(p.prefix()).isEqualTo("{Link:");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("{Link:");
     assertThat(p.rejectDescriptor().requiredLiteral()).isEqualTo("<<!nav>>");
     assertThat(p.rejectPrefilter()).isNotNull();
 
@@ -339,7 +339,7 @@ class RejectPrefilterTest {
   @Test
   void requiredLiteralPrefersDistinctCandidateOverPrefix() {
     Pattern p = Pattern.compile("(?s)<meta_start>.*?<meta_end>");
-    assertThat(p.prefix()).isEqualTo("<meta_start>");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("<meta_start>");
     // Even though "<meta_start>" is longer than "<meta_end>", extractRequiredLiteral
     // should skip the prefix and select "<meta_end>".
     assertThat(p.rejectDescriptor().requiredLiteral()).isEqualTo("<meta_end>");
@@ -354,7 +354,7 @@ class RejectPrefilterTest {
   @Test
   void identicalPrefixAndRequiredLiteralDeduplicated() {
     Pattern p = Pattern.compile("abc[0-9]+");
-    assertThat(p.prefix()).isEqualTo("abc");
+    assertThat(((StartDescriptor.Literal) p.startDescriptor()).prefix()).isEqualTo("abc");
     // "abc" is already the start prefix, so requiredLiteral should not duplicate "abc"
     assertThat(p.rejectDescriptor().requiredLiteral()).isNull();
   }

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -1035,4 +1035,32 @@ class SearchScalingRegressionTest {
                 ::find,
         "UTF-8");
   }
+
+  @Test
+  void reverseAnchorFindOnSparseMatchHasSublinearWork() {
+    Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
+    String noise = "the quick brown fox jumps over the lazy dog. ".repeat(200);
+    String input = noise + "contactuser123@gmail.com" + noise;
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input).find()).isTrue());
+
+    assertThat(work)
+        .as("Reverse anchor find on sparse match must avoid scanning prefix noise")
+        .isLessThan(500);
+  }
+
+  @Test
+  void reverseAnchorIsLinearAcrossFindIteration() {
+    Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
+    assertRepeatedFindWorkIsLinear(
+        size -> pattern.matcher("user1@gmail.com user2@gmail.com ".repeat(size))::find, "String");
+    assertRepeatedFindWorkIsLinear(
+        size ->
+            pattern.matcher(
+                    Utf8Input.trusted(
+                        "user1@gmail.com user2@gmail.com ".repeat(size).getBytes(UTF_8)))
+                ::find,
+        "UTF-8");
+  }
 }

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -1066,6 +1066,19 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void disjointRareInfixRejectsWithoutScanningPrefixNoise() {
+    Pattern pattern = Pattern.compile("GET\\s+[a-z0-9/]+/[a-f0-9]{32}/rare_admin_token");
+    String noise = "GET /index.html HTTP/1.1\nGET /static/style.css HTTP/1.1\n".repeat(500);
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(noise).find()).isFalse());
+
+    assertThat(work)
+        .as("Disjoint rare infix prefilter must reject without entering DFA on GET prefixes")
+        .isLessThan(200);
+  }
+
+  @Test
   void reverseAnchorIsLinearAcrossFindIteration() {
     Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
     assertRepeatedFindWorkIsLinear(

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -1051,6 +1051,21 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void reverseAnchorSelectivityAvoidsIntermediateNoiseStalls() {
+    Pattern pattern = Pattern.compile("[a-z]+/[0-9]+@support\\.internal\\.org");
+    String noise =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. ".repeat(100);
+    String input = noise + "department/99@support.internal.org" + noise;
+
+    long work =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input).find()).isTrue());
+
+    assertThat(work)
+        .as("Selective reverse anchor must avoid scanning intermediate noise words")
+        .isLessThan(500);
+  }
+
+  @Test
   void reverseAnchorIsLinearAcrossFindIteration() {
     Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
     assertRepeatedFindWorkIsLinear(

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -551,6 +551,51 @@ class StartAcceleratorTest {
         .isEqualTo(34);
   }
 
+  @Test
+  void reverseAnchorSelectsMostSelectiveSuffixAnchor() {
+    Pattern pattern = Pattern.compile("[a-z]+/[0-9]+@support\\.internal\\.org");
+    StartDescriptor desc = pattern.startDescriptor();
+    assertThat(desc).isInstanceOf(StartDescriptor.ReverseAnchor.class);
+    StartDescriptor.ReverseAnchor ra = (StartDescriptor.ReverseAnchor) desc;
+    assertThat(ra.anchorDescriptor()).isInstanceOf(StartDescriptor.Literal.class);
+    assertThat(((StartDescriptor.Literal) ra.anchorDescriptor()).prefix())
+        .isEqualTo("@support.internal.org");
+
+    String input = "noise prefix before department/99@support.internal.org trailing noise";
+    StringStartAccelerator strAcc = pattern.stringStartAccelerator();
+    assertThat(strAcc).isInstanceOf(StringStartAccelerator.ReverseAnchor.class);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, input, 0, false)).isEqualTo(20);
+
+    Utf8StartAccelerator utf8Acc = pattern.utf8StartAccelerator();
+    assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.ReverseAnchor.class);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 0))
+        .isEqualTo(20);
+  }
+
+  @Test
+  void reverseAnchorSelectsRarestInfixOverShortTail() {
+    Pattern pattern = Pattern.compile("[a-z]+/[0-9]+_SPECIAL_AUTH_TOKEN_[a-z]{1,3}");
+    StartDescriptor desc = pattern.startDescriptor();
+    assertThat(desc).isInstanceOf(StartDescriptor.ReverseAnchor.class);
+    StartDescriptor.ReverseAnchor ra = (StartDescriptor.ReverseAnchor) desc;
+    assertThat(ra.anchorDescriptor()).isInstanceOf(StartDescriptor.Literal.class);
+    assertThat(((StartDescriptor.Literal) ra.anchorDescriptor()).prefix())
+        .isEqualTo("_SPECIAL_AUTH_TOKEN_");
+  }
+
+  @Test
+  void reverseAnchorPreservesLeftmostFirstWithFalsePositives() {
+    Pattern pattern = Pattern.compile("[a-z]+/[0-9]+@support\\.internal\\.org");
+    String input = "noise invalid/notdigit@support.internal.org valid/123@support.internal.org";
+    Matcher safereMatcher = pattern.matcher(input);
+    assertThat(safereMatcher.find()).isTrue();
+    java.util.regex.Matcher jdkMatcher =
+        java.util.regex.Pattern.compile("[a-z]+/[0-9]+@support\\.internal\\.org").matcher(input);
+    assertThat(jdkMatcher.find()).isTrue();
+    assertThat(safereMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safereMatcher.end()).isEqualTo(jdkMatcher.end());
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -155,6 +155,7 @@ class StartAcceleratorTest {
         null,
         null,
         null,
+        null,
         null);
   }
 

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -514,6 +514,45 @@ class StartAcceleratorTest {
     assertThatCode(() -> Pattern.compile(regex.toString())).doesNotThrowAnyException();
   }
 
+  @Test
+  void reverseAnchorAcceleratesStringAndUtf8ForSuffixLiterals() {
+    Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
+    StartDescriptor desc = pattern.startDescriptor();
+    assertThat(desc.hasStartAcceleration()).isTrue();
+    assertThat(desc.reverseAnchor()).isNotNull();
+
+    String input = "noise prefix before user123@gmail.com trailing noise";
+    StringStartAccelerator strAcc = pattern.stringStartAccelerator();
+    assertThat(strAcc).isInstanceOf(StringStartAccelerator.ReverseAnchor.class);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, input, 0, false)).isEqualTo(20);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, input, 21, false)).isEqualTo(21);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, input, 25, false)).isEqualTo(-1);
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, input, 38, false)).isEqualTo(-1);
+
+    Utf8StartAccelerator utf8Acc = pattern.utf8StartAccelerator();
+    assertThat(utf8Acc).isInstanceOf(Utf8StartAccelerator.ReverseAnchor.class);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 0))
+        .isEqualTo(20);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 21))
+        .isEqualTo(21);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 25))
+        .isEqualTo(-1);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 38))
+        .isEqualTo(-1);
+  }
+
+  @Test
+  void reverseAnchorRejectsInvalidPrefixBeforeAnchor() {
+    Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
+    String input = "noise prefix before !!!@gmail.com user123@gmail.com";
+    StringStartAccelerator strAcc = pattern.stringStartAccelerator();
+    assertThat(StringStartAccelerator.findNextCandidate(strAcc, input, 0, false)).isEqualTo(34);
+
+    Utf8StartAccelerator utf8Acc = pattern.utf8StartAccelerator();
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8Acc, utf8Scanner(input), 0))
+        .isEqualTo(34);
+  }
+
   private static boolean isVectorApiAvailable() {
     try {
       Class.forName("jdk.incubator.vector.ByteVector");

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -18,10 +18,10 @@ class StartAcceleratorTest {
   @Test
   void nullAndNoneDescriptorsProduceNullAccelerators() {
     assertThat(StringStartAccelerator.create(null, false)).isNull();
-    assertThat(StringStartAccelerator.create(StartDescriptor.NONE, false)).isNull();
+    assertThat(StringStartAccelerator.create(StartDescriptor.None.INSTANCE, false)).isNull();
     assertThat(Utf8StartAccelerator.create(null, false)).isNull();
-    assertThat(Utf8StartAccelerator.create(StartDescriptor.NONE, false)).isNull();
-    assertThat(StartDescriptor.NONE.hasStartAcceleration()).isFalse();
+    assertThat(Utf8StartAccelerator.create(StartDescriptor.None.INSTANCE, false)).isNull();
+    assertThat(StartDescriptor.None.INSTANCE.hasStartAcceleration()).isFalse();
   }
 
   @Test
@@ -115,8 +115,7 @@ class StartAcceleratorTest {
 
   @Test
   void charClassPrefixAcceleratesStringAndUtf8() {
-    CharClassScanInfo pairScanInfo = Pattern.compile("[ab]").charClassPrefix();
-    StartDescriptor descPair = descriptor(null, false, null, pairScanInfo);
+    StartDescriptor descPair = Pattern.compile("[ab]").startDescriptor();
 
     StringStartAccelerator strAcc = StringStartAccelerator.create(descPair, false);
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
@@ -131,8 +130,7 @@ class StartAcceleratorTest {
     assertThat(Utf8StartAccelerator.findNextCandidate(utf8PairAcc, utf8Scanner("xxxb"), 0))
         .isEqualTo(3);
 
-    CharClassScanInfo multiScanInfo = Pattern.compile("[abcd]").charClassPrefix();
-    StartDescriptor descMulti = descriptor(null, false, null, multiScanInfo);
+    StartDescriptor descMulti = Pattern.compile("[abcd]").startDescriptor();
     Utf8StartAccelerator utf8MultiAcc = Utf8StartAccelerator.create(descMulti, false);
     assertThat(utf8MultiAcc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
     assertThat(utf8MultiAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
@@ -145,18 +143,16 @@ class StartAcceleratorTest {
       boolean prefixFoldCase,
       FixedOffsetLiteral fixedOffsetLiteral,
       CharClassScanInfo charClassPrefix) {
-    return new StartDescriptor(
-        prefix,
-        prefixFoldCase,
-        fixedOffsetLiteral,
-        charClassPrefix,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null);
+    if (prefix != null) {
+      return new StartDescriptor.Literal(prefix, prefixFoldCase, null);
+    }
+    if (fixedOffsetLiteral != null) {
+      return new StartDescriptor.FixedOffset(fixedOffsetLiteral, charClassPrefix);
+    }
+    if (charClassPrefix != null) {
+      return new StartDescriptor.CharClass(charClassPrefix, null);
+    }
+    return StartDescriptor.None.INSTANCE;
   }
 
   @Test
@@ -371,7 +367,7 @@ class StartAcceleratorTest {
     Pattern pattern = Pattern.compile("\\s*[\\[\\uff3b]\\d+[\\]\\uff3d]");
     StartDescriptor desc = pattern.startDescriptor();
     assertThat(desc.hasStartAcceleration()).isTrue();
-    assertThat(desc.leadingExpansion()).isNotNull();
+    assertThat(desc).isInstanceOf(StartDescriptor.LeadingExpansion.class);
 
     StringStartAccelerator strAcc = pattern.stringStartAccelerator();
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.LeadingExpansion.class);
@@ -405,7 +401,7 @@ class StartAcceleratorTest {
     Pattern pattern = Pattern.compile("\\s+https?://\\w+");
     StartDescriptor desc = pattern.startDescriptor();
     assertThat(desc.hasStartAcceleration()).isTrue();
-    assertThat(desc.leadingExpansion()).isNotNull();
+    assertThat(desc).isInstanceOf(StartDescriptor.LeadingExpansion.class);
 
     StringStartAccelerator strAcc = pattern.stringStartAccelerator();
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.LeadingExpansion.class);
@@ -434,9 +430,10 @@ class StartAcceleratorTest {
     Pattern pattern = Pattern.compile("[\\u00e9\\u00e8]+:target");
     StartDescriptor desc = pattern.startDescriptor();
     assertThat(desc.hasStartAcceleration()).isTrue();
-    assertThat(desc.leadingExpansion()).isNotNull();
-    assertThat(desc.leadingExpansion().minRepetition()).isEqualTo(1);
-    assertThat(desc.leadingExpansion().maxRepetition()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(desc).isInstanceOf(StartDescriptor.LeadingExpansion.class);
+    StartDescriptor.LeadingExpansion expansion = (StartDescriptor.LeadingExpansion) desc;
+    assertThat(expansion.minRepetition()).isEqualTo(1);
+    assertThat(expansion.maxRepetition()).isEqualTo(Integer.MAX_VALUE);
 
     StringStartAccelerator strAcc = pattern.stringStartAccelerator();
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.LeadingExpansion.class);
@@ -476,7 +473,7 @@ class StartAcceleratorTest {
     Pattern pattern = Pattern.compile("[\\x{1F600}\\x{1F601}]+:target");
     StartDescriptor desc = pattern.startDescriptor();
     assertThat(desc.hasStartAcceleration()).isTrue();
-    assertThat(desc.leadingExpansion()).isNotNull();
+    assertThat(desc).isInstanceOf(StartDescriptor.LeadingExpansion.class);
 
     String emoji4 =
         new StringBuilder("abc")
@@ -520,7 +517,7 @@ class StartAcceleratorTest {
     Pattern pattern = Pattern.compile("[a-z]+[0-9]+@gmail\\.com");
     StartDescriptor desc = pattern.startDescriptor();
     assertThat(desc.hasStartAcceleration()).isTrue();
-    assertThat(desc.reverseAnchor()).isNotNull();
+    assertThat(desc).isInstanceOf(StartDescriptor.ReverseAnchor.class);
 
     String input = "noise prefix before user123@gmail.com trailing noise";
     StringStartAccelerator strAcc = pattern.stringStartAccelerator();


### PR DESCRIPTION
Implements reverse suffix and inner search acceleration for unanchored regular expressions containing a complex prefix followed by a selective literal or multi-literal anchor.

See also 'reverse suffix' discussion in https://burntsushi.net/regex-internals/

When searching large haystacks for unanchored patterns without a simple literal prefix, SafeRE previously had to evaluate prefix character classes or fallback to forward DFA byte-by-byte stepping. This PR introduces bidirectional acceleration:

1. Use existing start accelerators to search forward for the selective suffix/inner anchor
2. Run a reverse DFA backwards from the anchor position to locate the leftmost match start position for the preceding prefix
3. Pass the confirmed match start directly to the linear execution pipeline

Implementation:

* `StartDescriptor.ReverseAnchor` encapsulates the inner anchor's `StartDescriptor`, the compiled reverse prefix `Prog`, and the minimum required match length
* `StringStartAccelerator.ReverseAnchor` and `Utf8StartAccelerator.ReverseAnchor` implement bidirectional search, scanning forward to candidate anchors and executing a bounded reverse DFA search backwards.
- Analysis and gating in `Pattern.java`:
  - `extractReverseAnchor` decomposes `metadataAst` concatenations into prefix + anchor pairs
  - `isSelectiveReverseAnchor` requires high-selectivity anchors (literals of length $\ge 2$, high-rarity single characters, Teddy models, or multi-literals; rejects generic character classes)
  - `containsWildcardOrZeroWidth` recursively ensures the prefix contains no wildcards (`.`, `\C`) or zero-width assertions (`^`, `$`, `\b`, `\B`)
  - non-nullable prefix invariant (`minPrefixLen >= 1`) ensures reverse scan determines exact JDK leftmost-match start boundaries
* When the start accelerator anchor already covers the required literal, `RejectPrefilter` is suppressed to avoid redundant double-scanning on matching inputs, while retaining `RejectPrefilter` when infix literals are disjoint and rarer than the start prefix.

```
 ./safere-benchmarks/scripts/compare-branch.sh --baseline reverse-suffix-benchmark-baseline '(emailPathFind|serviceNodeFind).*@safere-string'
```

| Benchmark                      | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------ | ---------------- | --------------- | ------- |
| RegexBenchmark.emailPathFind   |        3052 ± 39 |        776 ± 23 |   3.93x |
| RegexBenchmark.serviceNodeFind |        7922 ± 58 |        700 ± 11 |  11.30x |