### PR TITLE
Make benchmark plan count assertions resilient

### DIFF
--- a/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/BenchmarkInputMaterializerTest.java
@@ -16,12 +16,19 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class BenchmarkInputMaterializerTest {
+  // Historical floors guard against accidental corpus loss. Additions do not raise them.
+  private static final int MINIMUM_MATERIALIZED_INPUTS = 419;
+  private static final int MINIMUM_DECLARED_WORKLOADS = 354;
+  private static final int MINIMUM_EXPANDED_WORKLOADS = 683;
+
   @TempDir Path tempDirectory;
 
   @Test
@@ -32,7 +39,11 @@ class BenchmarkInputMaterializerTest {
     Map<String, byte[]> first = BenchmarkInputMaterializer.materialize(benchmarkData);
     Map<String, byte[]> second = BenchmarkInputMaterializer.materialize(benchmarkData);
 
-    assertThat(first).hasSize(419);
+    Set<String> declaredInputIds =
+        DeclarativeBenchmarkPlan.parseInputDeclarations(benchmarkData.getAsJsonArray("inputs"))
+            .keySet();
+    assertThat(first).hasSizeGreaterThanOrEqualTo(MINIMUM_MATERIALIZED_INPUTS);
+    assertThat(first.keySet()).containsExactlyElementsOf(declaredInputIds);
     assertThat(second.keySet()).containsExactlyElementsOf(first.keySet());
     first.forEach((id, bytes) -> assertThat(second.get(id)).as(id).containsExactly(bytes));
     assertThat(text(first, "crossEngine.RegexBenchmark.literalMatch.input")).isEqualTo("hello");
@@ -127,6 +138,8 @@ class BenchmarkInputMaterializerTest {
 
   @Test
   void manifestAttributesInputsAndRecordsExactEncodingMetadata() throws Exception {
+    JsonObject declaredData =
+        JsonParser.parseString(Files.readString(Path.of("benchmark-data.json"))).getAsJsonObject();
     BenchmarkInputMaterializer.main(
         new String[] {
           Path.of(".").toAbsolutePath().normalize().toString(), tempDirectory.toString()
@@ -149,22 +162,47 @@ class BenchmarkInputMaterializerTest {
     assertThat(entry.get("sha256").getAsString())
         .isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
     JsonObject resolvedData = manifest.getAsJsonObject("benchmarkData");
-    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2")).hasSize(8);
+    // These are historical floors: adding syntax alternates must not require a test update.
+    assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("re2"))
+        .hasSizeGreaterThanOrEqualTo(8);
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("rust-regex"))
-        .hasSize(28);
+        .hasSizeGreaterThanOrEqualTo(28);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("go-regexp"))
-        .hasSize(1);
+        .hasSizeGreaterThanOrEqualTo(1);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("re2-cpp"))
-        .hasSize(8);
+        .hasSizeGreaterThanOrEqualTo(8);
     assertThat(resolvedData.getAsJsonObject("replacementProfiles").getAsJsonArray("rust-regex"))
-        .hasSize(1);
+        .hasSizeGreaterThanOrEqualTo(1);
     assertThat(resolvedData.getAsJsonObject("patternProfiles").getAsJsonArray("dotnet"))
-        .hasSize(40);
+        .hasSizeGreaterThanOrEqualTo(40);
+    assertThat(declarationIds(resolvedData.getAsJsonArray("inputs")))
+        .containsExactlyElementsOf(declarationIds(declaredData.getAsJsonArray("inputs")));
+    assertThat(manifest.getAsJsonObject("inputs").keySet())
+        .containsExactlyElementsOf(
+            DeclarativeBenchmarkPlan.parseInputDeclarations(declaredData.getAsJsonArray("inputs"))
+                .keySet());
+    Set<String> declaredWorkloadIds = declarationIds(declaredData.getAsJsonArray("workloads"));
+    assertThat(declaredWorkloadIds).hasSizeGreaterThanOrEqualTo(MINIMUM_DECLARED_WORKLOADS);
+    assertThat(declarationIds(resolvedData.getAsJsonArray("workloads")))
+        .containsExactlyElementsOf(declaredWorkloadIds);
     JsonObject executionPlan = manifest.getAsJsonObject("executionPlan");
     assertThat(executionPlan.get("version").getAsInt()).isEqualTo(1);
-    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(683);
-    assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(10);
-    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(6_830);
+    Set<String> workloadIds = executionPlanIds(executionPlan, "workloadId");
+    Set<String> expectedWorkloadIds = expandedWorkloadIds(resolvedData);
+    assertThat(expectedWorkloadIds).hasSizeGreaterThanOrEqualTo(MINIMUM_EXPANDED_WORKLOADS);
+    assertThat(workloadIds).containsExactlyInAnyOrderElementsOf(expectedWorkloadIds);
+    Set<String> engineIds = declarationIds(executionPlan.getAsJsonArray("engines"));
+    Set<String> expectedExecutionIds = new LinkedHashSet<>();
+    for (String workloadId : workloadIds) {
+      for (String engineId : engineIds) {
+        expectedExecutionIds.add(workloadId + "@" + engineId);
+      }
+    }
+    assertThat(executionPlan.get("workloadCount").getAsInt()).isEqualTo(expectedWorkloadIds.size());
+    assertThat(executionPlan.get("engineCount").getAsInt()).isEqualTo(engineIds.size());
+    assertThat(executionPlan.getAsJsonArray("entries")).hasSize(expectedExecutionIds.size());
+    assertThat(executionPlanIds(executionPlan, "id"))
+        .containsExactlyInAnyOrderElementsOf(expectedExecutionIds);
     assertThat(
             executionEntry(
                     executionPlan, "UnicodeCompileBenchmark.compile.word.0@dotnet_nonbacktracking")
@@ -236,7 +274,6 @@ class BenchmarkInputMaterializerTest {
                   .getAsString())
           .isEqualTo("[\\u4E00-\\u9FFF]+[0-9]+");
     }
-    assertThat(resolvedData.getAsJsonArray("workloads")).hasSize(354);
     for (JsonElement engineElement : executionPlan.getAsJsonArray("engines")) {
       String engineId = engineElement.getAsJsonObject().get("id").getAsString();
       assertThat(
@@ -248,7 +285,8 @@ class BenchmarkInputMaterializerTest {
                           Set.of("runnable", "excluded")
                               .contains(planEntry.get("status").getAsString())))
           .as(engineId)
-          .hasSize(683);
+          .extracting(planEntry -> planEntry.get("workloadId").getAsString())
+          .containsExactlyInAnyOrderElementsOf(workloadIds);
     }
     assertThat(
             executionPlan.getAsJsonArray("entries").asList().stream()
@@ -309,5 +347,29 @@ class BenchmarkInputMaterializerTest {
         .filter(entry -> entry.get("id").getAsString().equals(id))
         .findFirst()
         .orElseThrow();
+  }
+
+  private static Set<String> declarationIds(JsonArray declarations) {
+    return declarations.asList().stream()
+        .map(JsonElement::getAsJsonObject)
+        .map(declaration -> declaration.get("id").getAsString())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static Set<String> executionPlanIds(JsonObject plan, String property) {
+    return plan.getAsJsonArray("entries").asList().stream()
+        .map(JsonElement::getAsJsonObject)
+        .map(entry -> entry.get(property).getAsString())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static Set<String> expandedWorkloadIds(JsonObject data) {
+    JsonObject planData = new JsonObject();
+    planData.add("schemaVersion", data.get("schemaVersion").deepCopy());
+    planData.add("inputs", data.getAsJsonArray("inputs").deepCopy());
+    planData.add("workloads", data.getAsJsonArray("workloads").deepCopy());
+    return DeclarativeBenchmarkPlan.parse(planData).expandedWorkloads().stream()
+        .map(DeclarativeBenchmarkPlan.ExpandedWorkload::id)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 }

--- a/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
+++ b/safere-benchmarks/src/test/java/org/safere/benchmark/CrossEngineBenchmarkPlanTest.java
@@ -23,6 +23,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.openjdk.jmh.infra.Blackhole;
 
 class CrossEngineBenchmarkPlanTest {
+  // This is a historical floor, not a snapshot. Additions do not raise it.
+  private static final int MINIMUM_CROSS_ENGINE_WORKLOADS = 606;
+  private static final int MINIMUM_RUNNABLE_CROSS_ENGINE_TRIALS = 2_448;
+  private static final int MINIMUM_SPECIALIZED_AVERAGE_TIME_TRIALS = 63;
+  private static final int MINIMUM_SPECIALIZED_RETAINED_MEMORY_TRIALS = 34;
+  private static final int MINIMUM_COLLECTION_RUNNER_TRIALS = 2_487;
 
   @TempDir static Path temporaryDirectory;
 
@@ -49,7 +55,7 @@ class CrossEngineBenchmarkPlanTest {
             "HttpBenchmark.httpFull",
             "SearchScalingBenchmark.searchEasyFail.1024",
             "FanoutBenchmark.fanoutUnicode.1024");
-    assertThat(ids).hasSize(606);
+    assertThat(ids).hasSizeGreaterThanOrEqualTo(MINIMUM_CROSS_ENGINE_WORKLOADS);
   }
 
   @Test
@@ -78,9 +84,14 @@ class CrossEngineBenchmarkPlanTest {
                   .map(CrossEngineBenchmarkPlan.Trial::variant))
           .containsAnyOf(RegexEngineVariant.SAFERE_STRING, RegexEngineVariant.SAFERE_UTF8);
     }
-    assertThat(allTrials).hasSize(2448);
-    assertThat(plan.exclusions()).hasSize(582);
-    assertThat(accounted).hasSize(606 * RegexEngineVariant.values().length);
+    assertThat(allTrials).hasSizeGreaterThanOrEqualTo(MINIMUM_RUNNABLE_CROSS_ENGINE_TRIALS);
+    Set<String> expected = new HashSet<>();
+    for (CrossEngineWorkload workload : plan.workloads()) {
+      for (RegexEngineVariant variant : RegexEngineVariant.values()) {
+        expected.add(workload.id() + "@" + variant.id());
+      }
+    }
+    assertThat(accounted).containsExactlyInAnyOrderElementsOf(expected);
   }
 
   @Test
@@ -118,27 +129,18 @@ class CrossEngineBenchmarkPlanTest {
     CrossEngineBenchmarkPlan first = CrossEngineBenchmarkPlan.load();
     CrossEngineBenchmarkPlan second = CrossEngineBenchmarkPlan.load();
 
-    assertThat(first.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS))
-        .extracting(CrossEngineBenchmarkPlan.Trial::id)
-        .containsExactlyElementsOf(
-            second.trials(CrossEngineWorkload.TimingGroup.NANOSECONDS).stream()
-                .map(CrossEngineBenchmarkPlan.Trial::id)
-                .toList())
-        .hasSize(1787);
-    assertThat(first.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS))
-        .extracting(CrossEngineBenchmarkPlan.Trial::id)
-        .containsExactlyElementsOf(
-            second.trials(CrossEngineWorkload.TimingGroup.MICROSECONDS).stream()
-                .map(CrossEngineBenchmarkPlan.Trial::id)
-                .toList())
-        .hasSize(589);
-    assertThat(first.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS))
-        .extracting(CrossEngineBenchmarkPlan.Trial::id)
-        .containsExactlyElementsOf(
-            second.trials(CrossEngineWorkload.TimingGroup.MILLISECONDS).stream()
-                .map(CrossEngineBenchmarkPlan.Trial::id)
-                .toList())
-        .hasSize(72);
+    Set<String> trialIds = new HashSet<>();
+    for (CrossEngineWorkload.TimingGroup timingGroup : CrossEngineWorkload.TimingGroup.values()) {
+      List<CrossEngineBenchmarkPlan.Trial> firstTrials = first.trials(timingGroup);
+      assertThat(firstTrials)
+          .as(timingGroup.name())
+          .isNotEmpty()
+          .allMatch(trial -> trial.workload().timingGroup() == timingGroup)
+          .extracting(CrossEngineBenchmarkPlan.Trial::id)
+          .containsExactlyElementsOf(
+              second.trials(timingGroup).stream().map(CrossEngineBenchmarkPlan.Trial::id).toList());
+      firstTrials.forEach(trial -> assertThat(trialIds.add(trial.id())).as(trial.id()).isTrue());
+    }
   }
 
   @Test
@@ -472,15 +474,25 @@ class CrossEngineBenchmarkPlanTest {
     SpecializedBenchmarkPlan second = SpecializedBenchmarkPlan.load();
 
     assertThat(first.averageTimeTrials())
+        .hasSizeGreaterThanOrEqualTo(MINIMUM_SPECIALIZED_AVERAGE_TIME_TRIALS)
+        .allMatch(
+            trial ->
+                trial.workload().measurement().mode()
+                    == DeclarativeBenchmarkPlan.MeasurementMode.AVERAGE_TIME)
         .extracting(SpecializedBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
-            second.averageTimeTrials().stream().map(SpecializedBenchmarkPlan.Trial::id).toList())
-        .hasSize(63);
+            second.averageTimeTrials().stream().map(SpecializedBenchmarkPlan.Trial::id).toList());
     assertThat(first.retainedMemoryTrials())
+        .hasSizeGreaterThanOrEqualTo(MINIMUM_SPECIALIZED_RETAINED_MEMORY_TRIALS)
+        .allMatch(
+            trial ->
+                trial.workload().measurement().mode()
+                    == DeclarativeBenchmarkPlan.MeasurementMode.RETAINED_MEMORY)
         .extracting(SpecializedBenchmarkPlan.Trial::id)
         .containsExactlyElementsOf(
-            second.retainedMemoryTrials().stream().map(SpecializedBenchmarkPlan.Trial::id).toList())
-        .hasSize(34);
+            second.retainedMemoryTrials().stream()
+                .map(SpecializedBenchmarkPlan.Trial::id)
+                .toList());
   }
 
   @Test
@@ -495,18 +507,27 @@ class CrossEngineBenchmarkPlanTest {
             "org.safere.benchmark.CrossEngineNoForkBenchmark.run",
             "org.safere.benchmark.CrossEngineColdStartBenchmark.run",
             "org.safere.benchmark.SpecializedBenchmark.run");
-    assertThat(plan.runners())
-        .allMatch(runner -> !runner.trialIds().isEmpty())
-        .flatExtracting(BenchmarkCollectionPlan.Runner::trialIds)
-        .doesNotHaveDuplicates()
-        .hasSize(2487);
-    assertThat(plan.reportPlan().trials()).hasSize(2487);
+    List<String> runnerTrialIds =
+        plan.runners().stream().flatMap(runner -> runner.trialIds().stream()).toList();
+    assertThat(plan.runners()).allMatch(runner -> !runner.trialIds().isEmpty());
+    assertThat(runnerTrialIds)
+        .hasSizeGreaterThanOrEqualTo(MINIMUM_COLLECTION_RUNNER_TRIALS)
+        .doesNotHaveDuplicates();
+    assertThat(plan.reportPlan().trials())
+        .extracting(BenchmarkCollectionPlan.CollectionTrial::id)
+        .containsExactlyInAnyOrderElementsOf(runnerTrialIds);
     assertThat(plan.reportPlan().exclusions()).isNotEmpty().doesNotHaveDuplicates();
-    assertThat(
-            plan.reportPlan(true).trials().stream()
-                .map(BenchmarkCollectionPlan.CollectionTrial::workloadId)
-                .distinct())
-        .hasSize(5);
+    Set<String> expectedSmokeTrialIds = new HashSet<>();
+    for (BenchmarkCollectionPlan.Runner runner : plan.runners()) {
+      String firstTrial = runner.trialIds().getFirst();
+      String firstWorkload = firstTrial.substring(0, firstTrial.lastIndexOf('@'));
+      runner.trialIds().stream()
+          .filter(trialId -> trialId.startsWith(firstWorkload + "@"))
+          .forEach(expectedSmokeTrialIds::add);
+    }
+    assertThat(plan.reportPlan(true).trials())
+        .extracting(BenchmarkCollectionPlan.CollectionTrial::id)
+        .containsExactlyInAnyOrderElementsOf(expectedSmokeTrialIds);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- replace exact production-corpus snapshot counts with historical minimum floors that do not need to change when benchmarks are added
- verify materialized inputs and expanded workloads against their declarations
- verify the complete workload/engine join, runnable-or-excluded coverage, timing-group partitions, and runner/report membership
- retain exact assertions for small fixed behavioral cases and semantic sentinels

## Context

The exact counts were originally useful migration-completeness tripwires. When benchmark inputs and execution plans moved to recipe-driven and declarative data, the expected totals provided an independent check that the migration had not silently dropped inputs, expanded workloads, engine trials, specialized measurements, or report rows.

Those totals later became snapshots of a deliberately evolving corpus. Adding a valid workload changed several unrelated assertions in `BenchmarkInputMaterializerTest` and `CrossEngineBenchmarkPlanTest`, forcing routine count updates and making concurrent benchmark changes conflict on the same lines.

This change preserves the original loss-detection value in two ways:

1. The former totals become historical minimum floors. Accidental corpus shrinkage still fails, while additions do not require raising the floors.
2. Structural checks validate exact derived membership: concrete input IDs match expanded declarations, execution workloads match declared expansion, execution entries form the complete workload-by-engine product, each Java pair is runnable or explicitly excluded, trials remain in the correct timing group, and runner/report/smoke selections agree.

Together these checks detect both broad coverage loss and internally inconsistent plan generation without coupling normal benchmark additions to a set of exact current totals.

Fixes #759
Fixes #699

## Verification

Ran:

- `mvn -pl safere-benchmarks test -q`
- `mvn -pl safere-benchmarks spotless:check -q`
- Codex review/fix loop against `main`; the final pass reported no actionable correctness findings

Not run:

- full SafeRE test suite
- public API crosscheck suite
- benchmarks (test-only change)
