### PR TITLE
Avoid duplicate DFA start acceleration

### DIFF
--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1321,6 +1321,23 @@ final class Dfa {
   }
 
   /**
+   * Searches from a position that the caller may already have selected with this DFA's start
+   * accelerator.
+   *
+   * <p>A preselected position must still be matched normally because it is only a candidate. The
+   * flag suppresses the redundant accelerator call at exactly {@code startPos}; acceleration
+   * remains available after the DFA consumes input and returns to its start state.
+   */
+  SearchResult doSearch(
+      InputScanner text,
+      int startPos,
+      boolean anchored,
+      boolean longest,
+      boolean startPositionPreselected) {
+    return doSearchInternal(text, startPos, anchored, longest, startPositionPreselected);
+  }
+
+  /**
    * Fast-forwards the start position of unanchored search matching when returning to the start
    * state.
    */
@@ -1370,6 +1387,15 @@ final class Dfa {
    *     exceeded its state budget
    */
   SearchResult doSearch(InputScanner text, int startPos, boolean anchored, boolean longest) {
+    return doSearchInternal(text, startPos, anchored, longest, false);
+  }
+
+  private SearchResult doSearchInternal(
+      InputScanner text,
+      int startPos,
+      boolean anchored,
+      boolean longest,
+      boolean startPositionPreselected) {
     graphemeContext = GraphemeSupport.Context.create(text, hasGraphemeSemantics);
     int textLen = text.length();
     // If the compiled program requires end-of-text matching (stripped $ or \z), enforce it.
@@ -1431,7 +1457,11 @@ final class Dfa {
     int pos = startPos;
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
-      if (canAccelerate && !accelerationDisabled && s.isStartState && (textLen - pos >= minSkip)) {
+      if (canAccelerate
+          && !accelerationDisabled
+          && s.isStartState
+          && (!startPositionPreselected || pos != startPos)
+          && (textLen - pos >= minSkip)) {
         int nextPos = fastForward(text, pos, posDepThreshold, s);
         if (nextPos == -1) {
           return new SearchResult(matched, matchEnd);
@@ -1554,7 +1584,11 @@ final class Dfa {
 
     // General loop handles non-ASCII, position-dependent checks, and trailing end-of-text sentinel
     while (pos <= textLen) {
-      if (canAccelerate && !accelerationDisabled && s.isStartState && (textLen - pos >= minSkip)) {
+      if (canAccelerate
+          && !accelerationDisabled
+          && s.isStartState
+          && (!startPositionPreselected || pos != startPos)
+          && (textLen - pos >= minSkip)) {
         int nextPos = fastForward(text, pos, posDepThreshold, s);
         if (nextPos == -1) {
           return new SearchResult(matched, matchEnd);

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -243,7 +243,18 @@ public final class Matcher implements MatchResult {
 
   private Dfa.SearchResult searchForwardDfa(
       Dfa dfa, InputScanner scanner, int startPos, boolean anchored, boolean longest) {
-    Dfa.SearchResult result = dfa.doSearch(scanner, startPos, anchored, longest);
+    return searchForwardDfa(dfa, scanner, startPos, anchored, longest, false);
+  }
+
+  private Dfa.SearchResult searchForwardDfa(
+      Dfa dfa,
+      InputScanner scanner,
+      int startPos,
+      boolean anchored,
+      boolean longest,
+      boolean startPositionPreselected) {
+    Dfa.SearchResult result =
+        dfa.doSearch(scanner, startPos, anchored, longest, startPositionPreselected);
     DiagnosticOperation activeDiagnostics = diagnosticOperation;
     if (activeDiagnostics != null) {
       activeDiagnostics.accumulator().incrementForwardDfaSearchCount();
@@ -1664,6 +1675,7 @@ public final class Matcher implements MatchResult {
     // character-class, or line-anchor), skip ahead to candidate match positions.
     int effectiveStart = searchFrom;
     boolean literalPrefixCandidateStart = false;
+    boolean startPositionPreselected = false;
     if (options.startAcceleration() && !prog.anchorStart()) {
       if (scanner instanceof Utf8InputScanner utf8Scanner) {
         Utf8StartAccelerator accelerator = parentPattern.utf8StartAccelerator();
@@ -1682,6 +1694,7 @@ public final class Matcher implements MatchResult {
           }
           effectiveStart = idx;
           literalPrefixCandidateStart = policy.isExactMatchCandidate();
+          startPositionPreselected = true;
         }
       } else if (text != null) {
         StringStartAccelerator accelerator = parentPattern.stringStartAccelerator();
@@ -1702,6 +1715,7 @@ public final class Matcher implements MatchResult {
           }
           effectiveStart = idx;
           literalPrefixCandidateStart = policy.isExactMatchCandidate();
+          startPositionPreselected = true;
         }
       }
     }
@@ -1856,7 +1870,14 @@ public final class Matcher implements MatchResult {
       fwdResult = null;
     } else {
       diagnosticParticipation(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
-      fwdResult = searchForwardDfa(dfa(false), scanner, effectiveStart, prog.anchorStart(), false);
+      fwdResult =
+          searchForwardDfa(
+              dfa(false),
+              scanner,
+              effectiveStart,
+              prog.anchorStart(),
+              false,
+              startPositionPreselected);
       if (fwdResult != null && !fwdResult.matched()) {
         diagnosticBoundary(MatchStrategy.DFA);
         return applyFailedMatchResult();
@@ -3214,7 +3235,8 @@ public final class Matcher implements MatchResult {
         pos = idx;
       }
 
-      Dfa.SearchResult fwdResult = searchForwardDfa(fwdDfa, scanner, pos, isStartAnchored, false);
+      Dfa.SearchResult fwdResult =
+          searchForwardDfa(fwdDfa, scanner, pos, isStartAnchored, false, hasStartAcceleration);
       if (fwdResult == null || !fwdResult.matched()) {
         break;
       }
@@ -4556,6 +4578,7 @@ public final class Matcher implements MatchResult {
     }
 
     int effectiveStart = fromIndex;
+    boolean startPositionPreselected = false;
     if (options.startAcceleration() && text != null && !prog.anchorStart()) {
       StringStartAccelerator accelerator = parentPattern.stringStartAccelerator();
       if (accelerator != null) {
@@ -4566,12 +4589,16 @@ public final class Matcher implements MatchResult {
           return -1L;
         }
         effectiveStart = idx;
+        startPositionPreselected = true;
       }
     }
 
     Dfa.SearchResult fwdResult = null;
     if (canUseForwardDfa()) {
-      fwdResult = dfa(false).doSearch(scanner, effectiveStart, prog.anchorStart(), false);
+      fwdResult =
+          dfa(false)
+              .doSearch(
+                  scanner, effectiveStart, prog.anchorStart(), false, startPositionPreselected);
       if (fwdResult != null && !fwdResult.matched()) {
         return -1L;
       }

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -782,6 +782,7 @@ public final class Pattern implements Serializable {
       return false;
     }
     int searchStart = 0;
+    boolean startPositionPreselected = false;
     if (enginePathOptions.startAcceleration()
         && utf8StartAccelerator != null
         && !prog.anchorStart()) {
@@ -789,9 +790,12 @@ public final class Pattern implements Serializable {
       if (searchStart < 0) {
         return false;
       }
+      startPositionPreselected = true;
     }
     if (!prog.anchorEnd() && !prog.hasGraphemeSemantics() && prog.numLoopRegs() == 0) {
-      Dfa.SearchResult result = forwardFirstMatchDfa().doSearch(scanner, searchStart, false, false);
+      Dfa.SearchResult result =
+          forwardFirstMatchDfa()
+              .doSearch(scanner, searchStart, false, false, startPositionPreselected);
       if (result != null) {
         return result.matched();
       }
@@ -852,6 +856,7 @@ public final class Pattern implements Serializable {
       return false;
     }
     int searchStart = 0;
+    boolean startPositionPreselected = false;
     if (enginePathOptions.startAcceleration()
         && utf8StartAccelerator != null
         && !prog.anchorStart()) {
@@ -866,11 +871,14 @@ public final class Pattern implements Serializable {
         }
         return false;
       }
+      startPositionPreselected = true;
     }
     if (!prog.anchorEnd() && !prog.hasGraphemeSemantics() && prog.numLoopRegs() == 0) {
       diagnostics.participate(MatchStrategy.DFA, StrategyRole.REJECT_PREFILTER);
       diagnostics.incrementForwardDfaSearchCount();
-      Dfa.SearchResult result = forwardFirstMatchDfa().doSearch(scanner, searchStart, false, false);
+      Dfa.SearchResult result =
+          forwardFirstMatchDfa()
+              .doSearch(scanner, searchStart, false, false, startPositionPreselected);
       if (result != null) {
         diagnostics.boundary(MatchStrategy.DFA);
         return result.matched();

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -462,6 +462,33 @@ class SearchScalingRegressionTest {
         "Case-insensitive literal find");
   }
 
+  @Test
+  void preselectedUtf8DfaCandidateSkipsRedundantStartScan() {
+    Pattern pattern = Pattern.compile("\\d{3}/\\d{3}/\\d{4}");
+    byte[] bytes = ("123/456/7890" + "x".repeat(100)).getBytes(UTF_8);
+    Utf8InputScanner scanner = new Utf8InputScanner(bytes, 0, bytes.length);
+    int candidate =
+        Utf8StartAccelerator.findNextCandidate(pattern.utf8StartAccelerator(), scanner, 0);
+    Dfa dfa = pattern.forwardFirstMatchDfa();
+
+    assertThat(candidate).isZero();
+    dfa.doSearch(scanner, candidate, false, false, false);
+    long ordinaryWork =
+        WorkCounter.countForTesting(
+            () ->
+                assertThat(dfa.doSearch(scanner, candidate, false, false, false).matched())
+                    .isTrue());
+    long preselectedWork =
+        WorkCounter.countForTesting(
+            () ->
+                assertThat(dfa.doSearch(scanner, candidate, false, false, true).matched())
+                    .isTrue());
+
+    assertThat(preselectedWork)
+        .as("DFA must trust a candidate already selected by the caller")
+        .isLessThan(ordinaryWork);
+  }
+
   private static void assertRepeatedFindWorkIsLinear(
       IntFunction<FindIterator> matcherFactory, String description) {
     long smallerWork = countAllMatches(matcherFactory.apply(500), 500);


### PR DESCRIPTION
## Summary

- avoid running the same start-position accelerator twice when a caller has already selected the DFA's initial candidate
- preserve normal DFA matching at that candidate and preserve start acceleration after the DFA consumes input and returns to its start state
- cover the invariant with a work-counter regression test

Fixes #763.

## Root cause

The higher-level `Matcher` and direct UTF-8 `Pattern.find` paths already run the compiled start accelerator and pass its candidate to the forward DFA. Since #655, `Dfa.doSearch` also runs start acceleration whenever it is in the start state, including immediately at the candidate passed by the caller. A match-dense `find()` loop therefore pays for the same candidate search twice at every restart.

This change carries an explicit `startPositionPreselected` bit into the DFA. It suppresses acceleration only at the original `startPos`. The DFA still evaluates that position normally because an accelerator yields a candidate rather than a proven match. If matching consumes input and later returns to the start state, acceleration remains enabled.

The bit is propagated through ordinary `Matcher.find`, direct UTF-8 `Pattern.find`, DFA-optimized replacement, and optimized split.

## Relation to the issue analysis

The issue correctly localized the regression to #655 and to time spent in `Dfa.doSearch`, but its proposed mechanism was not present in the relevant code. Neither the #655 implementation nor current main uses a 64-character chunked inner loop or a 512-character penalty window. #655 already has adaptive defeat detection for consecutive unprofitable skips.

Profiling the checked-in reproduction put 87.6% of samples in `Dfa.doSearch`. As a diagnostic experiment, disabling DFA start acceleration reduced the dense UTF-8 workload from approximately 98.4 us/op to 61.3 us/op. Tracing the caller/DFA handoff then exposed the duplicate accelerator invocation described above. The fix removes that duplicated work rather than changing chunk sizes, density estimation, or the adaptive policy.

## Benchmarks

All measurements below were collected sequentially on the same machine with the standard Java benchmark configuration: 2 forks, 2 x 500 ms warmup, and 5 x 500 ms measurement. Long mode was not used.

The historical point uses production code from `82e84f5c48eba9958fade6f62144768e13390874` with the current benchmark-only declarations and harness, because the checked-in reproduction did not exist at that commit. The other points are unchanged current main (`f6b557891abac125122f7fab36f8d1da0e1b7ce6`) and this change (`54b8a84237c3ccc7d653c4a7053aa3113930fe00`).

### Reported dense find-all regression

| Input | `82e84f5` | Current main | This PR | PR vs main | PR vs `82e84f5` |
|---|---:|---:|---:|---:|---:|
| Pre-existing UTF-8 | 50.722 +/- 2.085 us/op | 98.368 +/- 2.418 us/op | 57.078 +/- 2.313 us/op | 42.0% faster | 12.5% slower |
| Java String | 49.816 +/- 1.339 us/op | 57.251 +/- 2.931 us/op | 55.414 +/- 6.047 us/op | 3.2% faster | 11.2% slower |

For the issue's UTF-8 workload, the PR is 1.72x faster than current main and removes approximately 87% of the added time since the historical commit. The remaining difference from `82e84f5` spans all changes since that historical point; this PR specifically removes the duplicated work introduced by the caller/DFA handoff.

### Regression controls

| Control group | Rows | Result for this PR vs current main |
|---|---:|---|
| Sparse repeated phone-pattern find, String and UTF-8 | 8 | Six improved; the other two were +1.5% and +3.7% with overlapping intervals |
| One-shot fixed-offset find: absent, slash noise, sparse/early | 8 | Unchanged to 12.2% faster |
| UTF-8 pair/range prefix, absent and late | 4 | Within -0.5% to +0.3% |
| UTF-8 pair/range repeated find, sparse and dense | 4 | 1.9% to 13.9% faster |
| DFA sparse `replaceAll` | 1 | 646.3 +/- 4.6 to 651.4 +/- 9.6 ns/op; intervals overlap |
| `split` at 1 KiB | 1 | 11.638 +/- 0.160 to 11.569 +/- 0.111 us/op; 0.6% faster |
| `split` at 100 KiB, reverse-order confirmation | 1 | 1211.9 +/- 23.0 to 1218.3 +/- 9.2 us/op; +0.5%, intervals overlap |

The initial 100 KiB split matrix showed a 3.4% increase, so it was repeated in isolation and then with PR/main order reversed. The reverse-order result above was effectively even, so the increase did not reproduce as a material regression.

## Verification

Passed:

- `mvn -pl safere -Dtest=DfaTest,MatcherTest,Utf8MatcherStateMachineTest test -q`
- `mvn -pl safere -Pwork-counters -Dtest=SearchScalingRegressionTest test -q`
- `mvn -pl safere test -q`
- standard-mode three-point benchmark matrix covering 29 search, replacement, and split rows
- noninteractive review against `main`: no P0-P2 findings and no correctness or linear-time regression identified
- `git diff --check`

Not run:

- long benchmark mode
- external OpenJDK-derived benchmark suite
- cross-language benchmark collection
- generated public API crosscheck suite
