### PR TITLE
Gate character class acceleration on selectivity and restore primitive DFA loop

### DIFF
--- a/safere/src/main/java/org/safere/CharClassScanInfo.java
+++ b/safere/src/main/java/org/safere/CharClassScanInfo.java
@@ -24,11 +24,8 @@ sealed interface CharClassScanInfo {
   int[] ranges();
 
   default boolean isSelective() {
-    if (!isAscii()) {
-      return true; // Unicode classes have wide gaps in ASCII text
-    }
     int count = Long.bitCount(bitmap0()) + Long.bitCount(bitmap1());
-    return count > 0 && count <= 3;
+    return count <= 3;
   }
 
   /** Matches 1, 2, or 3 exact ASCII characters via single-instruction SIMD equality. */

--- a/safere/src/main/java/org/safere/CharClassScanInfo.java
+++ b/safere/src/main/java/org/safere/CharClassScanInfo.java
@@ -23,6 +23,14 @@ sealed interface CharClassScanInfo {
 
   int[] ranges();
 
+  default boolean isSelective() {
+    if (!isAscii()) {
+      return true; // Unicode classes have wide gaps in ASCII text
+    }
+    int count = Long.bitCount(bitmap0()) + Long.bitCount(bitmap1());
+    return count > 0 && count <= 3;
+  }
+
   /** Matches 1, 2, or 3 exact ASCII characters via single-instruction SIMD equality. */
   // Arrays are immutable, privately owned scanner metadata; array identity is never observed.
   @SuppressWarnings("ArrayRecordComponent")

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -727,8 +727,7 @@ final class Dfa {
     }
 
     int escapeCount = 0;
-    int[] escapes = new int[4];
-    AsciiBitmap.Builder escapeBitmap = null;
+    int[] escapes = new int[3];
     int[] seeds = new int[insts.length];
 
     for (int ch = 0; ch < 128; ch++) {
@@ -740,18 +739,13 @@ final class Dfa {
         }
       }
       if (seedCount == 0 || !Arrays.equals(expand(seeds, seedCount, 0), insts)) {
-        if (escapeCount < 4) {
+        if (escapeCount < 3) {
           escapes[escapeCount] = ch;
-        } else if (escapeBitmap == null) {
-          escapeBitmap = new AsciiBitmap.Builder();
-          for (int i = 0; i < 4; i++) {
-            escapeBitmap.add(escapes[i]);
-          }
-        }
-        if (escapeBitmap != null) {
-          escapeBitmap.add(ch);
         }
         escapeCount++;
+        if (escapeCount > 3) {
+          return null;
+        }
       }
     }
 
@@ -775,23 +769,12 @@ final class Dfa {
       }
     }
 
-    if (escapeCount >= 1 && escapeCount <= 3) {
-      if (escapeCount == 1) {
-        return new StateAccelerator.SingleAsciiEscape(escapes[0]);
-      } else if (escapeCount == 2) {
-        return new StateAccelerator.AsciiPairEscape(escapes[0], escapes[1]);
-      } else {
-        return new StateAccelerator.AsciiTripleEscape(escapes[0], escapes[1], escapes[2]);
-      }
-    }
-    if (escapeBitmap != null && escapeCount < 128) {
-      AsciiBitmap bitmap = escapeBitmap.build();
-      int[] ranges = bitmap.toRanges();
-      if (ranges.length <= 8) {
-        return new StateAccelerator.CharClassEscape(ranges, bitmap.bitmap0(), bitmap.bitmap1());
-      }
-    }
-    return null;
+    return switch (escapeCount) {
+      case 1 -> new StateAccelerator.SingleAsciiEscape(escapes[0]);
+      case 2 -> new StateAccelerator.AsciiPairEscape(escapes[0], escapes[1]);
+      case 3 -> new StateAccelerator.AsciiTripleEscape(escapes[0], escapes[1], escapes[2]);
+      default -> null;
+    };
   }
 
   /** Returns whether this DFA was constructed with start-position acceleration enabled. */
@@ -1494,23 +1477,23 @@ final class Dfa {
           }
         }
       }
+      if (s.accelerator != null && !s.isStartState && (textLen - pos >= 16)) {
+        int nextPos = StateAccelerator.findNextEscape(s.accelerator, text, pos, textLen);
+        if (nextPos == -1) {
+          pos = textLen;
+          break;
+        }
+        if (nextPos > pos) {
+          pos = nextPos;
+          if (pos >= textLen) {
+            break;
+          }
+        }
+      }
       int limit =
           hasPositionDependentTransitions ? Math.min(textLen, posDepThreshold - 1) : textLen;
       int sId = s.id * numClasses;
       while (pos < limit) {
-        if (s.accelerator != null && !s.isStartState && (limit - pos >= 16)) {
-          int nextPos = StateAccelerator.findNextEscape(s.accelerator, text, pos, limit);
-          if (nextPos == -1) {
-            pos = limit;
-            break;
-          }
-          if (nextPos > pos) {
-            pos = nextPos;
-            if (pos >= limit) {
-              break;
-            }
-          }
-        }
         int ch = text.asciiAt(pos);
         if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
           break;
@@ -1535,7 +1518,6 @@ final class Dfa {
           }
         }
         sId = nsId;
-        s = offsetToState[sId];
         pos++;
       }
       s = offsetToState[sId];

--- a/safere/src/main/java/org/safere/StateAccelerator.java
+++ b/safere/src/main/java/org/safere/StateAccelerator.java
@@ -43,8 +43,6 @@ sealed interface StateAccelerator {
       case AsciiPairEscape pair -> text.indexOfAsciiPair(pair.c1(), pair.c2(), fromIndex, limit);
       case AsciiTripleEscape triple ->
           text.indexOfAsciiTriple(triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
-      case CharClassEscape cc ->
-          text.indexOfCodePointClass(cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
     };
   }
 
@@ -64,8 +62,6 @@ sealed interface StateAccelerator {
       case AsciiTripleEscape triple ->
           text.indexOfAsciiTripleOrNonAscii(
               triple.c1(), triple.c2(), triple.c3(), fromIndex, limit);
-      case CharClassEscape cc ->
-          text.indexOfCodePointClass(cc.ranges(), cc.bitmap0(), cc.bitmap1(), fromIndex, limit);
     };
   }
 
@@ -100,20 +96,6 @@ sealed interface StateAccelerator {
     @Override
     public int findEscape(InputScanner text, int fromIndex, int limit) {
       return text.indexOfAsciiTriple(c1, c2, c3, fromIndex, limit);
-    }
-
-    @Override
-    public AcceleratorPolicy policy() {
-      return AcceleratorPolicy.CHAR_CLASS;
-    }
-  }
-
-  /** Accelerator for a character-class escape (e.g. delimiters or character ranges). */
-  @SuppressWarnings("ArrayRecordComponent")
-  record CharClassEscape(int[] ranges, long bitmap0, long bitmap1) implements StateAccelerator {
-    @Override
-    public int findEscape(InputScanner text, int fromIndex, int limit) {
-      return text.indexOfCodePointClass(ranges, bitmap0, bitmap1, fromIndex, limit);
     }
 
     @Override

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -31,7 +31,9 @@ sealed interface StringStartAccelerator {
     if (descriptor.fixedOffsetLiteral() != null) {
       return new FixedOffset(descriptor.fixedOffsetLiteral(), descriptor.charClassPrefix());
     }
-    if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
+    if (descriptor.charClassPrefix() != null
+        && !hasWordBoundary
+        && descriptor.charClassPrefix().isSelective()) {
       return CharClass.create(descriptor.charClassPrefix());
     }
     if (descriptor.lineAnchor() != null && !hasWordBoundary) {

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -41,7 +41,9 @@ sealed interface Utf8StartAccelerator {
         && VectorScanProviders.teddyProviderAvailable()) {
       return new Teddy(descriptor.teddyModel());
     }
-    if (descriptor.charClassPrefix() != null && !hasWordBoundary) {
+    if (descriptor.charClassPrefix() != null
+        && !hasWordBoundary
+        && descriptor.charClassPrefix().isSelective()) {
       return new CharClass(descriptor.charClassPrefix());
     }
     if (descriptor.leadingExpansion() != null) {

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -8,6 +8,7 @@ package org.safere;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Random;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -742,5 +743,21 @@ class DfaTest {
     Pattern pattern = Pattern.compile(regex);
     assertThat(pattern.matcher(input).find()).isTrue();
     assertThat(pattern.find(Utf8Input.validated(input.getBytes(UTF_8)))).isTrue();
+  }
+
+  @Test
+  void matchDenseNumericFindAllDoesNotUseStartAcceleration() {
+    Pattern pattern = Pattern.compile("\\d{3}/\\d{3}/\\d{4}");
+    byte[] text = new byte[32768];
+    Random random = new Random(42);
+    for (int i = 0; i < text.length; i++) {
+      text[i] = (byte) (47 + random.nextInt(11)); // '/', '0'-'9'
+    }
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.trusted(text, 0, text.length));
+    int matches = 0;
+    while (matcher.find()) {
+      matches++;
+    }
+    assertThat(matches).isEqualTo(112);
   }
 }

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -143,6 +143,21 @@ class StartAcceleratorTest {
     StartDescriptor descMulti = descriptor(null, false, null, multiScanInfo);
     assertThat(Utf8StartAccelerator.create(descMulti, false)).isNull();
     assertThat(StringStartAccelerator.create(descMulti, false)).isNull();
+
+    CharClassScanInfo denseUnicodeScanInfo = Pattern.compile("[0-9é]").charClassPrefix();
+    StartDescriptor denseUnicode = descriptor(null, false, null, denseUnicodeScanInfo);
+    assertThat(Utf8StartAccelerator.create(denseUnicode, false)).isNull();
+    assertThat(StringStartAccelerator.create(denseUnicode, false)).isNull();
+
+    CharClassScanInfo sparseUnicodeScanInfo = Pattern.compile("[aé]").charClassPrefix();
+    StartDescriptor sparseUnicode = descriptor(null, false, null, sparseUnicodeScanInfo);
+    assertThat(Utf8StartAccelerator.create(sparseUnicode, false)).isNotNull();
+    assertThat(StringStartAccelerator.create(sparseUnicode, false)).isNotNull();
+
+    CharClassScanInfo nonAsciiScanInfo = Pattern.compile("[éê]").charClassPrefix();
+    StartDescriptor nonAscii = descriptor(null, false, null, nonAsciiScanInfo);
+    assertThat(Utf8StartAccelerator.create(nonAscii, false)).isNotNull();
+    assertThat(StringStartAccelerator.create(nonAscii, false)).isNotNull();
   }
 
   private static StartDescriptor descriptor(
@@ -165,7 +180,7 @@ class StartAcceleratorTest {
 
   @Test
   void unicodeCharClassPrefixAcceleratesStringAndUtf8() {
-    Pattern pattern = Pattern.compile("[\\p{IsAlphabetic}]+");
+    Pattern pattern = Pattern.compile("[aéĀ]+");
     StringStartAccelerator strAcc = pattern.stringStartAccelerator();
     assertThat(strAcc).isInstanceOf(StringStartAccelerator.CharClass.class);
     assertThat(strAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
@@ -197,8 +212,7 @@ class StartAcceleratorTest {
 
   @Test
   void unicodeCharClassPrefixResumesAsciiScanningAfterNonAsciiCodePoints() {
-    StringStartAccelerator accelerator =
-        Pattern.compile("[\\p{IsAlphabetic}]+").stringStartAccelerator();
+    StringStartAccelerator accelerator = Pattern.compile("[aéĀ]+").stringStartAccelerator();
 
     assertThat(StringStartAccelerator.findNextCandidate(accelerator, "000©000", 0, false))
         .isEqualTo(-1);

--- a/safere/src/test/java/org/safere/StartAcceleratorTest.java
+++ b/safere/src/test/java/org/safere/StartAcceleratorTest.java
@@ -131,13 +131,18 @@ class StartAcceleratorTest {
     assertThat(Utf8StartAccelerator.findNextCandidate(utf8PairAcc, utf8Scanner("xxxb"), 0))
         .isEqualTo(3);
 
+    CharClassScanInfo tripleScanInfo = Pattern.compile("[abc]").charClassPrefix();
+    StartDescriptor descTriple = descriptor(null, false, null, tripleScanInfo);
+    Utf8StartAccelerator utf8TripleAcc = Utf8StartAccelerator.create(descTriple, false);
+    assertThat(utf8TripleAcc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
+    assertThat(utf8TripleAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+    assertThat(Utf8StartAccelerator.findNextCandidate(utf8TripleAcc, utf8Scanner("xxxc"), 0))
+        .isEqualTo(3);
+
     CharClassScanInfo multiScanInfo = Pattern.compile("[abcd]").charClassPrefix();
     StartDescriptor descMulti = descriptor(null, false, null, multiScanInfo);
-    Utf8StartAccelerator utf8MultiAcc = Utf8StartAccelerator.create(descMulti, false);
-    assertThat(utf8MultiAcc).isInstanceOf(Utf8StartAccelerator.CharClass.class);
-    assertThat(utf8MultiAcc.policy()).isEqualTo(AcceleratorPolicy.CHAR_CLASS);
-    assertThat(Utf8StartAccelerator.findNextCandidate(utf8MultiAcc, utf8Scanner("xxxd"), 0))
-        .isEqualTo(3);
+    assertThat(Utf8StartAccelerator.create(descMulti, false)).isNull();
+    assertThat(StringStartAccelerator.create(descMulti, false)).isNull();
   }
 
   private static StartDescriptor descriptor(
@@ -263,13 +268,17 @@ class StartAcceleratorTest {
     assertThat(caseInsensitivePat.utf8StartAccelerator().policy().strategy())
         .isEqualTo(MatchStrategy.LITERAL);
 
-    Pattern charClassPat = Pattern.compile("[0-9][a-z]+");
+    Pattern charClassPat = Pattern.compile("[0-2][a-z]+");
     assertThat(charClassPat.stringStartAccelerator()).isNotNull();
     assertThat(charClassPat.utf8StartAccelerator()).isNotNull();
     assertThat(charClassPat.stringStartAccelerator().policy())
         .isEqualTo(AcceleratorPolicy.CHAR_CLASS);
     assertThat(charClassPat.utf8StartAccelerator().policy())
         .isEqualTo(AcceleratorPolicy.CHAR_CLASS);
+
+    Pattern broadCharClassPat = Pattern.compile("[0-9][a-z]+");
+    assertThat(broadCharClassPat.stringStartAccelerator()).isNull();
+    assertThat(broadCharClassPat.utf8StartAccelerator()).isNull();
 
     Pattern fixedOffsetPat = Pattern.compile("..needle");
     assertThat(fixedOffsetPat.stringStartAccelerator()).isNotNull();


### PR DESCRIPTION
This partially reverts #720 (keeping some of the refactoring on other cleanups from that PR). That change added character class acceleration for broad character classes  (e.g. `\d`, `\w`, `[0-9]`), which can have high match density and regress performance for some inputs.

Restricting start acceleration to selective classes ($\le 3$ ASCII characters, such as delimiters `[,;:]` or quotes `['"]`) ensures broad classes execute directly in the scalar DFA without prefilter overhead.

This improves the benchmarks that regressed in #763, using the JMH version in the gist from https://github.com/eaftan/safere/issues/764#issuecomment-5417263093 shows `issue763_matchDense_digitsFindAll32k` runs in ~23% less time after this change:

| version | time | 
| ---     | --- | 
| 906d4c317ccd2f91015344d509dc00081ef70d5a | 102746.775 ± 549.625  ns/op |
| this change  | 79105.647 ± 643.503  ns/op |  |

---

* Restrict `Dfa.analyzeStateAcceleration` to $\le 3$ exact ASCII escape characters (`SingleAsciiEscape`, `AsciiPairEscape`, `AsciiTripleEscape`) and remove `CharClassEscape`.
* Restore the pure primitive `int` inner transition loop in `Dfa.doSearch()`, removing per-byte `offsetToState` reference array lookups and branch checks inside `while (pos < limit)`.
