### PR TITLE
Consolidate redundant AST walks into a unified single-pass AstAnalysis walker

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -104,6 +104,7 @@
                         <exclude name="AnchoredDfaCachingTest.java"/>
                         <exclude name="AsciiBitmapTest.java"/>
                         <exclude name="AsciiTest.java"/>
+                        <exclude name="AstAnalysisTest.java"/>
                         <exclude name="BitStateTest.java"/>
                         <exclude name="CharClassTest.java"/>
                         <exclude name="CompilerTest.java"/>

--- a/safere/src/main/java/org/safere/AstAnalysis.java
+++ b/safere/src/main/java/org/safere/AstAnalysis.java
@@ -1,0 +1,186 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encapsulates structural analysis of a regular expression AST in a single bottom-up pass using the
+ * stack-safe {@link Walker}.
+ */
+record AstAnalysis(
+    boolean hasLazy,
+    boolean hasAlt,
+    boolean hasNullableAlt,
+    boolean canMatchEmpty,
+    boolean hasUserCaptures,
+    int minMatchLength,
+    Map<String, Integer> namedGroups) {
+
+  static AstAnalysis analyze(Regexp re) {
+    if (re == null) {
+      return new AstAnalysis(false, false, false, true, false, 0, Map.of());
+    }
+    Map<String, Integer> named = new HashMap<>();
+    AnalysisNode root =
+        new AstAnalysisWalker(named)
+            .walk(re, new AnalysisNode(false, false, false, true, false, 0));
+    return new AstAnalysis(
+        root.hasLazy,
+        root.hasAlt,
+        root.hasNullableAlt,
+        root.canMatchEmpty,
+        root.hasUserCaptures,
+        root.minMatchLength,
+        named.isEmpty() ? Map.of() : Collections.unmodifiableMap(named));
+  }
+
+  private record AnalysisNode(
+      boolean hasLazy,
+      boolean hasAlt,
+      boolean hasNullableAlt,
+      boolean canMatchEmpty,
+      boolean hasUserCaptures,
+      int minMatchLength) {}
+
+  private static final class AstAnalysisWalker extends Walker<AnalysisNode> {
+    private final Map<String, Integer> named;
+
+    AstAnalysisWalker(Map<String, Integer> named) {
+      this.named = named;
+    }
+
+    @Override
+    protected AnalysisNode shortVisit(Regexp re, AnalysisNode parentArg) {
+      return new AnalysisNode(false, false, false, true, false, 0);
+    }
+
+    @Override
+    protected AnalysisNode postVisit(
+        Regexp re, AnalysisNode parentArg, AnalysisNode preArg, List<AnalysisNode> childArgs) {
+      if (re.op == RegexpOp.CAPTURE && re.name != null && !re.name.isEmpty()) {
+        named.put(re.name, re.cap);
+      }
+
+      boolean anyLazy = re.nonGreedy();
+      boolean anyAlt = re.op == RegexpOp.ALTERNATE;
+      boolean anyNullableAlt = false;
+      boolean anyUserCaptures = re.op == RegexpOp.CAPTURE && re.cap > 0;
+
+      for (AnalysisNode child : childArgs) {
+        if (child.hasLazy) {
+          anyLazy = true;
+        }
+        if (child.hasAlt) {
+          anyAlt = true;
+        }
+        if (child.hasNullableAlt) {
+          anyNullableAlt = true;
+        }
+        if (child.hasUserCaptures) {
+          anyUserCaptures = true;
+        }
+      }
+
+      boolean canMatchEmpty;
+      int minMatchLength;
+
+      switch (re.op) {
+        case NO_MATCH -> {
+          canMatchEmpty = false;
+          minMatchLength = Integer.MAX_VALUE / 2;
+        }
+        case EMPTY_MATCH,
+            BEGIN_LINE,
+            END_LINE,
+            BEGIN_TEXT,
+            END_TEXT,
+            WORD_BOUNDARY,
+            NO_WORD_BOUNDARY,
+            GRAPHEME_CLUSTER_BOUNDARY,
+            HAVE_MATCH -> {
+          canMatchEmpty = true;
+          minMatchLength = 0;
+        }
+        case LITERAL -> {
+          int count = re.rune != 0 ? Character.charCount(re.rune) : 0;
+          canMatchEmpty = count == 0;
+          minMatchLength = count;
+        }
+        case LITERAL_STRING -> {
+          int count = 0;
+          if (re.runes != null) {
+            for (int r : re.runes) {
+              count += Character.charCount(r);
+            }
+          }
+          canMatchEmpty = count == 0;
+          minMatchLength = count;
+        }
+        case CHAR_CLASS, ANY_CHAR, ANY_BYTE, GRAPHEME_CLUSTER -> {
+          canMatchEmpty = false;
+          minMatchLength = 1;
+        }
+        case STAR, QUEST -> {
+          canMatchEmpty = true;
+          minMatchLength = 0;
+        }
+        case PLUS -> {
+          canMatchEmpty = !childArgs.isEmpty() && childArgs.getFirst().canMatchEmpty;
+          minMatchLength = !childArgs.isEmpty() ? childArgs.getFirst().minMatchLength : 0;
+        }
+        case REPEAT -> {
+          int subMin = !childArgs.isEmpty() ? childArgs.getFirst().minMatchLength : 0;
+          minMatchLength =
+              (int) Math.min((long) subMin * Math.max(0, re.min), Integer.MAX_VALUE / 2);
+          canMatchEmpty =
+              re.min == 0 || (!childArgs.isEmpty() && childArgs.getFirst().canMatchEmpty);
+        }
+        case CAPTURE, NON_CAPTURE -> {
+          canMatchEmpty = !childArgs.isEmpty() && childArgs.getFirst().canMatchEmpty;
+          minMatchLength = !childArgs.isEmpty() ? childArgs.getFirst().minMatchLength : 0;
+        }
+        case CONCAT -> {
+          boolean allEmpty = true;
+          long sum = 0;
+          for (AnalysisNode child : childArgs) {
+            if (!child.canMatchEmpty) {
+              allEmpty = false;
+            }
+            sum += child.minMatchLength;
+          }
+          canMatchEmpty = allEmpty;
+          minMatchLength = (int) Math.min(sum, Integer.MAX_VALUE / 2);
+        }
+        case ALTERNATE -> {
+          boolean anyChildEmpty = false;
+          int min = Integer.MAX_VALUE / 2;
+          for (AnalysisNode child : childArgs) {
+            if (child.canMatchEmpty) {
+              anyChildEmpty = true;
+            }
+            min = Math.min(min, child.minMatchLength);
+          }
+          canMatchEmpty = anyChildEmpty || childArgs.isEmpty();
+          minMatchLength = min == Integer.MAX_VALUE / 2 ? 0 : min;
+          if (anyChildEmpty) {
+            anyNullableAlt = true;
+          }
+        }
+        default -> {
+          canMatchEmpty = false;
+          minMatchLength = 0;
+        }
+      }
+
+      return new AnalysisNode(
+          anyLazy, anyAlt, anyNullableAlt, canMatchEmpty, anyUserCaptures, minMatchLength);
+    }
+  }
+}

--- a/safere/src/main/java/org/safere/AstAnalysis.java
+++ b/safere/src/main/java/org/safere/AstAnalysis.java
@@ -109,9 +109,8 @@ record AstAnalysis(
           minMatchLength = 0;
         }
         case LITERAL -> {
-          int count = re.rune != 0 ? Character.charCount(re.rune) : 0;
-          canMatchEmpty = count == 0;
-          minMatchLength = count;
+          canMatchEmpty = false;
+          minMatchLength = Character.charCount(re.rune);
         }
         case LITERAL_STRING -> {
           int count = 0;

--- a/safere/src/main/java/org/safere/Compiler.java
+++ b/safere/src/main/java/org/safere/Compiler.java
@@ -508,7 +508,7 @@ final class Compiler extends Walker<Compiler.Frag> {
       Regexp node = stack.pop();
       if (isCaptureRetainingQuantifier(node)
           && hasCapture(node.sub())
-          && Pattern.canMatchEmpty(node.sub())) {
+          && AstAnalysis.analyze(node.sub()).canMatchEmpty()) {
         return true;
       }
       if (node.subs != null) {

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -3051,7 +3051,7 @@ public final class Matcher implements MatchResult {
         // dollarAnchorEnd is safe if start-anchored because we skip the reverse DFA scan.
         || (parentPattern.prog().dollarAnchorEnd() && !parentPattern.prog().anchorStart())
         || parentPattern.literalMatch() != null
-        || parentPattern.hasNullableAlternation()
+        || parentPattern.astAnalysis().hasNullableAlt()
         || regionActive) {
       return null;
     }
@@ -3109,7 +3109,7 @@ public final class Matcher implements MatchResult {
         needsCaptures
             && enginePathOptions().onePass()
             && parentPattern.canOnePassSubmatch()
-            && !parentPattern.hasNullableAlternation();
+            && !parentPattern.astAnalysis().hasNullableAlt();
 
     int textLen = text.length();
     StringBuilder sb = new StringBuilder(textLen);
@@ -3622,7 +3622,7 @@ public final class Matcher implements MatchResult {
     Pattern.CharClassMatchInfo ccMatch = parentPattern.matchDescriptor().charClassMatch();
     if (!enginePathOptions().charClassReplacementFastPath()
         || ccMatch == null
-        || parentPattern.hasLazyQuantifiers()) {
+        || parentPattern.astAnalysis().hasLazy()) {
       return null;
     }
     DiagnosticOperation activeDiagnostics = diagnosticOperation;
@@ -4116,7 +4116,7 @@ public final class Matcher implements MatchResult {
     int[] result;
     if (enginePathOptions().onePass()
         && parentPattern.canOnePassSubmatch()
-        && !parentPattern.hasNullableAlternation()) {
+        && !parentPattern.astAnalysis().hasNullableAlt()) {
       diagnosticCapture(MatchStrategy.ONE_PASS);
       int ncap = 2 * Math.max(prog.numCaptures(), 1);
       if (onePassScratchCap == null || onePassScratchCap.length < ncap) {
@@ -5077,7 +5077,9 @@ public final class Matcher implements MatchResult {
       Pattern pattern = matcher.parentPattern;
       Prog prog = pattern.prog();
       OnePass onePass = pattern.onePass();
-      if (onePass != null && !prog.hasGraphemeSemantics() && !pattern.hasNullableAlternation()) {
+      if (onePass != null
+          && !prog.hasGraphemeSemantics()
+          && !pattern.astAnalysis().hasNullableAlt()) {
         matcher.diagnosticBoundary(MatchStrategy.ONE_PASS);
         if (pattern.numGroups() > 0) {
           matcher.diagnosticCapture(MatchStrategy.ONE_PASS);

--- a/safere/src/main/java/org/safere/Pattern.java
+++ b/safere/src/main/java/org/safere/Pattern.java
@@ -16,10 +16,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -120,8 +118,7 @@ public final class Pattern implements Serializable {
   private final transient Prog flatProg;
   private final transient Prog flatDfaProg;
   private final transient Regexp ast;
-
-  private final transient Map<String, Integer> namedGroups;
+  private final transient AstAnalysis astAnalysis;
   private final transient String prefix;
   private final transient boolean prefixFoldCase;
   private final transient MatchDescriptor matchDescriptor;
@@ -131,10 +128,6 @@ public final class Pattern implements Serializable {
   private final transient byte[] prefixUtf8;
   private final transient String anchoredPrefix;
   private final transient byte[] anchoredPrefixUtf8;
-  private final transient boolean hasLazy;
-  private final transient boolean hasAlternation;
-  private final transient boolean hasNullableAlternation;
-  private final transient boolean canMatchEmpty;
   private final transient boolean startsWithGraphemeClusterBoundary;
   private final transient boolean hasInternalGraphemeClusterBoundary;
   private final transient CharClassScanInfo charClassPrefix;
@@ -252,13 +245,9 @@ public final class Pattern implements Serializable {
       int flags,
       Prog prog,
       Regexp ast,
-      Map<String, Integer> namedGroups,
+      AstAnalysis astAnalysis,
       StartDescriptor startDescriptor,
       MatchDescriptor matchDescriptor,
-      boolean hasLazy,
-      boolean hasAlternation,
-      boolean hasNullableAlternation,
-      boolean canMatchEmpty,
       boolean startsWithGraphemeClusterBoundary,
       boolean hasInternalGraphemeClusterBoundary,
       RejectDescriptor rejectDescriptor,
@@ -289,7 +278,7 @@ public final class Pattern implements Serializable {
     }
 
     this.ast = ast;
-    this.namedGroups = namedGroups;
+    this.astAnalysis = astAnalysis;
     this.prefix = startDescriptor.prefix();
     this.prefixFoldCase = startDescriptor.prefixFoldCase();
     this.prefixUtf8 =
@@ -307,10 +296,6 @@ public final class Pattern implements Serializable {
         literalMatch == null ? null : literalMatch.getBytes(StandardCharsets.UTF_8);
     this.literalMatchFailure = literalMatchUtf8 == null ? null : literalFailure(literalMatchUtf8);
     this.literalMatchShifts = literalMatchUtf8 == null ? null : literalShifts(literalMatchUtf8);
-    this.hasLazy = hasLazy;
-    this.hasAlternation = hasAlternation;
-    this.hasNullableAlternation = hasNullableAlternation;
-    this.canMatchEmpty = canMatchEmpty;
     this.startsWithGraphemeClusterBoundary = startsWithGraphemeClusterBoundary;
     this.hasInternalGraphemeClusterBoundary = hasInternalGraphemeClusterBoundary;
     this.charClassPrefix = startDescriptor.charClassPrefix();
@@ -453,13 +438,9 @@ public final class Pattern implements Serializable {
     if (metadataAst == null) {
       throw new PatternSyntaxException("pattern too large to simplify", regex, -1);
     }
-    Map<String, Integer> named = extractNamedGroups(re);
+    AstAnalysis astAnalysis = AstAnalysis.analyze(re);
     StartDescriptor startDescriptor = extractStartDescriptor(metadataAst);
     MatchDescriptor matchDescriptor = extractMatchDescriptor(metadataAst, re, flags, compiled);
-    boolean hasLazy = hasLazyQuantifiers(re);
-    boolean hasAlt = hasAlternation(re);
-    boolean canMatchEmpty = canMatchEmpty(re);
-    boolean hasNullableAlt = hasAlt && hasNullableAlternation(re);
     boolean startsWithGcb = startsWithGraphemeClusterBoundary(metadataAst);
     boolean hasInternalGcb = hasInternalExplicitGraphemeBoundary(re);
     RejectDescriptor rejectDescriptor =
@@ -471,13 +452,9 @@ public final class Pattern implements Serializable {
         effectiveFlags,
         compiled,
         re,
-        named,
+        astAnalysis,
         startDescriptor,
         matchDescriptor,
-        hasLazy,
-        hasAlt,
-        hasNullableAlt,
-        canMatchEmpty,
         startsWithGcb,
         hasInternalGcb,
         rejectDescriptor,
@@ -1326,7 +1303,7 @@ public final class Pattern implements Serializable {
       // Lazy quantifiers are excluded because OnePass returns leftmost-longest capture group
       // boundaries, which differs from leftmost-first semantics for lazy groups. When hasLazy is
       // true, neither canPrimary nor canSubmatch can use OnePass, so we can skip building OnePass.
-      if (hasLazy || prog.numCaptures() > OnePass.MAX_CAPTURE_GROUPS) {
+      if (astAnalysis.hasLazy() || prog.numCaptures() > OnePass.MAX_CAPTURE_GROUPS) {
         analysis = OnePassAnalysis.DISABLED;
       } else {
         OnePass op = OnePass.build(prog);
@@ -1337,7 +1314,7 @@ public final class Pattern implements Serializable {
         boolean canPrimary =
             op != null
                 && op.search("", false, 0) == null
-                && !hasNullableAlternation
+                && !astAnalysis.hasNullableAlt()
                 && !prog.hasGraphemeSemantics();
         // canFind is canPrimary restricted to anchored patterns (legacy flag).
         boolean canFind = canPrimary && prog.anchorStart();
@@ -1406,38 +1383,6 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Returns {@code true} if the pattern contains alternation ({@code |}). Used by the Matcher to
-   * skip OnePass primary for find() — OnePass always uses longest-match semantics, which can pick
-   * the wrong alternative when a zero-width branch competes with a consuming branch.
-   */
-  boolean hasAlternation() {
-    return hasAlternation;
-  }
-
-  /**
-   * Returns {@code true} if the pattern contains an alternation where at least one branch can match
-   * zero characters. This is the specific case where OnePass's longest-match semantics produce
-   * incorrect results: a zero-width branch (assertion, nullable repetition) loses to a consuming
-   * branch under longest-match, but should win under first-match (leftmost-first).
-   *
-   * <p>When this returns {@code false}, alternations are safe for OnePass because all branches must
-   * consume at least one character, making longest-match and first-match equivalent.
-   */
-  boolean hasNullableAlternation() {
-    return hasNullableAlternation;
-  }
-
-  /** Returns {@code true} if this pattern can match zero characters. */
-  boolean canMatchEmpty() {
-    return canMatchEmpty;
-  }
-
-  /** Returns whether this pattern contains any lazy quantifiers. */
-  boolean hasLazyQuantifiers() {
-    return hasLazy;
-  }
-
-  /**
    * Returns true if this pattern can participate in reverse DFA matching (e.g. unanchored find or
    * end-anchored reverse-first rejection).
    */
@@ -1446,7 +1391,7 @@ public final class Pattern implements Serializable {
   }
 
   private boolean shouldEagerlyBuildOnePass() {
-    return !hasLazy && !matchDescriptor.hasFindFastPath();
+    return !astAnalysis.hasLazy() && !matchDescriptor.hasFindFastPath();
   }
 
   /**
@@ -1662,7 +1607,11 @@ public final class Pattern implements Serializable {
    * @since 20
    */
   public Map<String, Integer> namedGroups() {
-    return namedGroups;
+    return astAnalysis.namedGroups();
+  }
+
+  AstAnalysis astAnalysis() {
+    return astAnalysis;
   }
 
   /**
@@ -1712,17 +1661,17 @@ public final class Pattern implements Serializable {
     if (prog.numCaptures() > 1) {
       features.add(PatternFeature.CAPTURES);
     }
-    if (hasAlternation) {
+    if (astAnalysis.hasAlt()) {
       features.add(PatternFeature.ALTERNATION);
     }
-    if (hasLazy) {
+    if (astAnalysis.hasLazy()) {
       features.add(PatternFeature.LAZY_QUANTIFIER);
       limitations.add(PatternLimitation.LAZY_SEMANTICS_LIMIT_ONE_PASS);
     }
-    if (canMatchEmpty) {
+    if (astAnalysis.canMatchEmpty()) {
       features.add(PatternFeature.NULLABLE);
     }
-    if (hasNullableAlternation) {
+    if (astAnalysis.hasNullableAlt()) {
       features.add(PatternFeature.NULLABLE_ALTERNATION);
       limitations.add(PatternLimitation.NULLABLE_ALTERNATION_LIMITS_ONE_PASS);
     }
@@ -1782,7 +1731,7 @@ public final class Pattern implements Serializable {
       limitations.add(PatternLimitation.NULLABLE_LOOP_REQUIRES_EXACT_ENGINE);
     }
     if (features.contains(PatternFeature.CAPTURES)
-        && (hasAlternation || hasLazy || prog.numLoopRegs() > 0)) {
+        && (astAnalysis.hasAlt() || astAnalysis.hasLazy() || prog.numLoopRegs() > 0)) {
       limitations.add(PatternLimitation.CAPTURE_PRIORITY_REQUIRES_EXACT_ENGINE);
     }
 
@@ -1879,7 +1828,7 @@ public final class Pattern implements Serializable {
    * <p>The baseline is {@link ParseFlags#LIKE_PERL}, which includes {@code ONE_LINE} (single-line
    * mode where {@code ^} and {@code $} match only at the start/end of the entire input).
    */
-  private static int toParseFlags(int flags) {
+  static int toParseFlags(int flags) {
     // Start with LIKE_PERL as the baseline.
     int pf = ParseFlags.LIKE_PERL;
 
@@ -1913,153 +1862,8 @@ public final class Pattern implements Serializable {
   }
 
   // ---------------------------------------------------------------------------
-  // Named group extraction
+  // Grapheme cluster boundary analysis
   // ---------------------------------------------------------------------------
-
-  /** Walks the AST to extract named capture groups and their 1-based indices. */
-  private static Map<String, Integer> extractNamedGroups(Regexp re) {
-    Map<String, Integer> map = new HashMap<>();
-    Deque<Regexp> stack = new ArrayDeque<>();
-    stack.push(re);
-    while (!stack.isEmpty()) {
-      Regexp node = stack.pop();
-      if (node.op == RegexpOp.CAPTURE && node.name != null) {
-        map.put(node.name, node.cap);
-      }
-      if (node.subs != null) {
-        for (Regexp sub : node.subs) {
-          stack.push(sub);
-        }
-      }
-    }
-    return Collections.unmodifiableMap(map);
-  }
-
-  /**
-   * Returns {@code true} if the AST contains any lazy (non-greedy) quantifiers ({@code +?}, {@code
-   * *?}, {@code ??}, or {@code {n,m}?}). OnePass does not respect lazy vs greedy semantics for
-   * overall match boundaries, so patterns with lazy quantifiers must use the DFA pipeline in {@code
-   * find()}.
-   */
-  private static boolean hasLazyQuantifiers(Regexp re) {
-    Deque<Regexp> stack = new ArrayDeque<>();
-    stack.push(re);
-    while (!stack.isEmpty()) {
-      Regexp node = stack.pop();
-      if (node.nonGreedy()) {
-        return true;
-      }
-      if (node.subs != null) {
-        for (Regexp sub : node.subs) {
-          stack.push(sub);
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Returns {@code true} if the AST contains any explicit alternation ({@link RegexpOp#ALTERNATE}).
-   * Patterns with alternation may have branches of different match lengths, causing the DFA's
-   * leftmost-longest match to disagree with RE2's leftmost-first alternation priority. When this
-   * flag is set, the submatch engine must resolve the correct group(0) boundaries.
-   */
-  private static boolean hasAlternation(Regexp re) {
-    Deque<Regexp> stack = new ArrayDeque<>();
-    stack.push(re);
-    while (!stack.isEmpty()) {
-      Regexp node = stack.pop();
-      if (node.op == RegexpOp.ALTERNATE) {
-        return true;
-      }
-      if (node.subs != null) {
-        for (Regexp sub : node.subs) {
-          stack.push(sub);
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Returns {@code true} if the AST contains an alternation where at least one branch can match
-   * zero characters (is "nullable"). This detects the case where OnePass's longest-match semantics
-   * differ from first-match: a zero-width branch (assertion, empty match, nullable repetition)
-   * competing with a consuming branch. For alternations where all branches must consume at least
-   * one character (e.g., {@code GET|POST}), OnePass gives correct results.
-   */
-  private static boolean hasNullableAlternation(Regexp re) {
-    Deque<Regexp> stack = new ArrayDeque<>();
-    stack.push(re);
-    while (!stack.isEmpty()) {
-      Regexp node = stack.pop();
-      if (node.op == RegexpOp.ALTERNATE && node.subs != null) {
-        for (Regexp branch : node.subs) {
-          if (canMatchEmpty(branch)) {
-            return true;
-          }
-        }
-      }
-      if (node.subs != null) {
-        for (Regexp sub : node.subs) {
-          stack.push(sub);
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Returns {@code true} if the given regexp can match the empty string. Used to detect nullable
-   * alternation branches where OnePass's longest-match semantics may differ from first-match.
-   */
-  static boolean canMatchEmpty(Regexp re) {
-    return new CanMatchEmptyWalker().walk(re, false);
-  }
-
-  private static final class CanMatchEmptyWalker extends Walker<Boolean> {
-
-    @Override
-    protected Boolean shortVisit(Regexp re, Boolean parentArg) {
-      return false;
-    }
-
-    @Override
-    protected Boolean postVisit(
-        Regexp re, Boolean parentArg, Boolean preArg, List<Boolean> childArgs) {
-      return switch (re.op) {
-        case EMPTY_MATCH,
-            BEGIN_LINE,
-            END_LINE,
-            BEGIN_TEXT,
-            END_TEXT,
-            WORD_BOUNDARY,
-            NO_WORD_BOUNDARY,
-            GRAPHEME_CLUSTER_BOUNDARY ->
-            true;
-        case STAR, QUEST -> true;
-        case REPEAT -> re.min == 0 || (!childArgs.isEmpty() && childArgs.getFirst());
-        case PLUS, NON_CAPTURE, CAPTURE -> !childArgs.isEmpty() && childArgs.getFirst();
-        case CONCAT -> {
-          for (boolean childCanMatchEmpty : childArgs) {
-            if (!childCanMatchEmpty) {
-              yield false;
-            }
-          }
-          yield true;
-        }
-        case ALTERNATE -> {
-          for (boolean childCanMatchEmpty : childArgs) {
-            if (childCanMatchEmpty) {
-              yield true;
-            }
-          }
-          yield childArgs.isEmpty();
-        }
-        default -> false;
-      };
-    }
-  }
 
   private static boolean startsWithGraphemeClusterBoundary(Regexp re) {
     Regexp first = firstMeaningfulNode(re);

--- a/safere/src/test/java/org/safere/AstAnalysisTest.java
+++ b/safere/src/test/java/org/safere/AstAnalysisTest.java
@@ -1,0 +1,82 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AstAnalysisTest {
+
+  @Test
+  void nullRegexpYieldsSafeDefaults() {
+    AstAnalysis analysis = AstAnalysis.analyze(null);
+    assertThat(analysis.hasLazy()).isFalse();
+    assertThat(analysis.hasAlt()).isFalse();
+    assertThat(analysis.hasNullableAlt()).isFalse();
+    assertThat(analysis.canMatchEmpty()).isTrue();
+    assertThat(analysis.hasUserCaptures()).isFalse();
+    assertThat(analysis.minMatchLength()).isEqualTo(0);
+    assertThat(analysis.namedGroups()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'a+b', false, false, false, false, 2",
+    "'a+?b', true, false, false, false, 2",
+    "'a|b', false, true, false, false, 1",
+    "'a|', false, true, true, true, 0",
+    "'(a|b)?', false, true, false, true, 0",
+    "'(?:get|post)', false, true, false, false, 3",
+    "'(?:get|post|)', false, true, true, true, 0",
+    "'a{3,5}', false, false, false, false, 3",
+    "'a{3,5}?', true, false, false, false, 3",
+    "'.*', false, false, false, true, 0",
+    "'.+', false, false, false, false, 1",
+    "'^$', false, false, false, true, 0",
+    "'\\b', false, false, false, true, 0",
+  })
+  void structuralAnalysisFlags(
+      String regex,
+      boolean hasLazy,
+      boolean hasAlt,
+      boolean hasNullableAlt,
+      boolean canMatchEmpty,
+      int minMatchLength) {
+    Regexp re = Parser.parse(regex, Pattern.toParseFlags(0));
+    AstAnalysis analysis = AstAnalysis.analyze(re);
+
+    assertThat(analysis.hasLazy()).isEqualTo(hasLazy);
+    assertThat(analysis.hasAlt()).isEqualTo(hasAlt);
+    assertThat(analysis.hasNullableAlt()).isEqualTo(hasNullableAlt);
+    assertThat(analysis.canMatchEmpty()).isEqualTo(canMatchEmpty);
+    assertThat(analysis.minMatchLength()).isEqualTo(minMatchLength);
+  }
+
+  @Test
+  void namedGroupsAndUserCaptures() {
+    Regexp re =
+        Parser.parse("(?<year>\\d{4})-(?<month>\\d{2})-(?:\\d{2})", Pattern.toParseFlags(0));
+    AstAnalysis analysis = AstAnalysis.analyze(re);
+
+    assertThat(analysis.hasUserCaptures()).isTrue();
+    assertThat(analysis.namedGroups()).isEqualTo(Map.of("year", 1, "month", 2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "(?:abc)", "a[0-9]c", "^abc$"})
+  void patternsWithoutUserCaptures(String regex) {
+    Regexp re = Parser.parse(regex, Pattern.toParseFlags(0));
+    AstAnalysis analysis = AstAnalysis.analyze(re);
+
+    assertThat(analysis.hasUserCaptures()).isFalse();
+    assertThat(analysis.namedGroups()).isEmpty();
+  }
+}

--- a/safere/src/test/java/org/safere/AstAnalysisTest.java
+++ b/safere/src/test/java/org/safere/AstAnalysisTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class AstAnalysisTest {
 
   @Test

--- a/safere/src/test/java/org/safere/AstAnalysisTest.java
+++ b/safere/src/test/java/org/safere/AstAnalysisTest.java
@@ -71,6 +71,21 @@ class AstAnalysisTest {
     assertThat(analysis.namedGroups()).isEqualTo(Map.of("year", 1, "month", 2));
   }
 
+  @Test
+  void nulLiteralConsumesOneCodePoint() {
+    Regexp re = Parser.parse("\\x00", Pattern.toParseFlags(0));
+
+    AstAnalysis analysis = AstAnalysis.analyze(re);
+
+    assertThat(analysis.canMatchEmpty()).isFalse();
+    assertThat(analysis.minMatchLength()).isEqualTo(1);
+
+    PatternAnalysis publicAnalysis = Pattern.compile("\\x00|a").analysis();
+    assertThat(publicAnalysis.features())
+        .doesNotContain(PatternFeature.NULLABLE, PatternFeature.NULLABLE_ALTERNATION);
+    assertThat(publicAnalysis.capabilities()).contains(PatternCapability.ONE_PASS_PRIMARY);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"abc", "(?:abc)", "a[0-9]c", "^abc$"})
   void patternsWithoutUserCaptures(String regex) {


### PR DESCRIPTION
This is a pre-factoring / cleanup to prepare for some improvements to reject prefilters and start descriptor handling, see #769.

---

- Introduce `AstAnalysis` and `AstAnalysisWalker` to compute structural AST metadata in a single bottom-up traversal using the stack-safe `Walker`.
- Extract named capture groups, user capture presence, lazy quantifiers, alternation structure, nullable alternation, empty match capability, and minimum match length simultaneously.
- Replace separate, redundant AST traversals in `Pattern.compile` and `Compiler` (`extractNamedGroups`, `hasLazyQuantifiers`, `hasAlternation`, `hasNullableAlternation`, `canMatchEmpty`, `CanMatchEmptyWalker`).
- Add comprehensive unit tests in `AstAnalysisTest`.