### PR TITLE
Keep the SWAR filter's scalar tail out of the hot word loop

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -9691,6 +9691,29 @@
       }
     },
     {
+      "id": "Utf8MatchingBenchmark.literalScan.longWordPrefix",
+      "operation": "find",
+      "patterns": [
+        "coolfunctionname.*"
+      ],
+      "inputs": [
+        "utf8Matching.literalScan.text"
+      ],
+      "inputRepresentations": [
+        "preexistingUtf8"
+      ],
+      "inputRepresentationReason": "Exercises the long-literal prefix through the start accelerator rather than the pure-literal fast path, matching how SQL engines rewrite LIKE-style patterns.",
+      "requirements": [],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      }
+    },
+    {
       "id": "Utf8MatchingBenchmark.hardFailure.1024",
       "operation": "find",
       "patterns": [

--- a/safere/src/main/java/org/safere/ByteSwarScan.java
+++ b/safere/src/main/java/org/safere/ByteSwarScan.java
@@ -408,6 +408,16 @@ abstract class ByteSwarScan {
         return -2;
       }
     }
+    return scalarTail(bytes, offset, length, literal, position);
+  }
+
+  /**
+   * Scans the trailing bytes that the word loop could not cover (fewer than {@link Long#BYTES} plus
+   * the literal length). Kept out of {@link #indexOfFiltered} so the hot word loop stays within
+   * C2's inlining budget; merging this loop into it measurably deoptimizes the SWAR loop.
+   */
+  private static int scalarTail(
+      byte[] bytes, int offset, int length, byte[] literal, int position) {
     while (position <= length - literal.length) {
       if (matchesAt(bytes, offset, literal, position)) {
         return position;


### PR DESCRIPTION
## Summary

- Extract the scalar tail scan out of `ByteSwarScan.indexOfFiltered` into a private `scalarTail` method, keeping the zero-allocation tail from #751 while letting C2 fully optimize the SWAR word loop again
- Add a `Utf8MatchingBenchmark.literalScan.longWordPrefix` workload that reaches the same long literal through the start accelerator (`coolfunctionname.*`), the shape SQL engines produce when rewriting LIKE-style patterns

## Root cause

#751 replaced `indexOfFiltered`'s tail call to linear KMP with an inlined scalar loop (to avoid materializing the now-lazy failure table on long-buffer misses). Inlining that loop into the method body pushed `indexOfFiltered` past C2's inlining budget and deoptimized the hot SWAR word loop: long-literal find over 32 KB of random lowercase text regressed from ~4.1 us to ~6.3 us (+54%). JFR shows both versions spending all samples in `indexOfFiltered` — same algorithm, same path, worse compilation.

This was first observed downstream in Trino, where `regexp_like('...', '.*coolfunctionname.*')` over 32 KB inputs slowed by ~80% after upgrading past #751.

## Measurements

Interleaved A/B, Apple M4 Max, OpenJDK 26, `--add-modules=jdk.incubator.vector`, min of 5 rounds x 3 alternating JVM runs, `Pattern.find(Utf8Input)` with `coolfunctionname.*` over 32 KB seeded random `a-z`:

| build | ns/op |
|---|---|
| before #751 (e58ce08) | 4,100-5,300 |
| after #751 (f6b5578) | 6,500-8,100 |
| this change | 4,000-5,200 |

The existing `literalScan.longWord` workload covers the pure-literal fast path for this shape; the new `longWordPrefix` workload covers the start-accelerator route where the regression was observed downstream.

Correctness is covered by the existing tail tests (`multiByteLiteralSearchCoversEveryWindowAlignmentAndPosition` exercises every window alignment and tail position); all `safere` scanner tests and `safere-benchmarks` plan tests pass.
