### PR TITLE
Support stacked PRs in review scout

### DIFF
--- a/.agents/skills/safere-pr-review-scout/SKILL.md
+++ b/.agents/skills/safere-pr-review-scout/SKILL.md
@@ -24,7 +24,7 @@ Default repository: `/home/eaftan/safere`.
 
 Default storage root: `$HOME/.codex/safere-pr-review`.
 
-Default base branch: `origin/main`, refreshed before each sweep.
+Default integration trunk: `origin/main`, refreshed before each sweep.
 
 Default review threshold: P2 or higher.
 
@@ -41,10 +41,10 @@ the contributor. The helper script enforces this allowlist in `discover-prs`; us
 PR discovery instead of calling `gh pr list` directly.
 
 Use current PR head SHA as the primary freshness key. Review a PR again when its head SHA changed,
-its `updatedAt` is newer than the last processed value, the recorded base SHA is older than current
-`origin/main`, or the user explicitly asks for a forced review. The base-SHA check is required for
-accurate benchmark reproduction because optimization results must compare against current main and
-the experiment must include current main merged into the PR branch.
+its `updatedAt` is newer than the last processed value, its declared base head changed, the stack
+trunk changed, or the user explicitly asks for a forced review. Base freshness is required for
+accurate code review and benchmark reproduction. For an upper layer in a stack, the immediately
+lower layer is its comparison base; for a standalone PR, the declared target branch is its base.
 
 ## Serialization
 
@@ -55,7 +55,8 @@ the same time.
 
 This workflow is intended to run unattended for many hours. Long runtime is expected and is not a
 reason to stop, checkpoint, or release the lock early. Once a sweep starts, keep processing the
-eligible trusted PR queue in increasing PR number order until every eligible PR has reached one of
+eligible trusted PR queue in dependency order, then increasing PR number among independent PRs,
+until every eligible PR has reached one of
 these durable terminal states for the run:
 
 - `reviewed`: intent review, review-fix-loop, required verification, and any required benchmark
@@ -103,16 +104,24 @@ git fetch origin main
 git rev-parse origin/main
 ```
 
-Use the helper from the SafeRE repository. It runs a minimal GitHub query, filters by the hardcoded
-trusted-author allowlist in code, sorts trusted non-draft PRs by increasing PR number, and writes an
-untrusted-contributor report when needed:
+Use the helper from the SafeRE repository. It runs a minimal GitHub query over all open PRs without
+filtering on their direct base branch, filters by the hardcoded trusted-author allowlist in code,
+sorts trusted non-draft PRs by increasing PR number, and writes an untrusted-contributor report when
+needed. Discovering every direct base is necessary for GitHub stacked PRs, whose upper layers target
+the branch immediately below them rather than `main`:
 
 ```bash
-.agents/skills/safere-pr-review-scout/scripts/scout_workspace.py discover-prs --base main --limit 1000
+.agents/skills/safere-pr-review-scout/scripts/scout_workspace.py discover-prs --limit 1000
 ```
 
 Use only the `trusted` array from this helper output as the candidate PR set. Ignore the `drafts`
 array. For entries in `untrusted`, do not read more content.
+
+Review every trusted open non-draft PR regardless of its direct base branch. Use the discovered
+`headRefName` and `baseRefName` relationships, confirmed with GitHub's `stackEntry` GraphQL metadata
+when a chain is present, to identify official stacks, their trunk, and each PR's position. A PR that
+targets a non-`main` branch but is not in an official stack is still eligible; review it against its
+declared base and state that target clearly in the report.
 
 For untrusted authors, do not read more content. Add a report section listing the PR number, URL,
 author login, and "not on trusted contributor allowlist". These are candidates for a human to
@@ -152,7 +161,8 @@ use the previous scout run as the narrative point of view.
 Also inspect linked issues when the PR body or discussion clearly references them and the link is
 needed to understand the PR's intent.
 
-Process selected PRs in increasing PR number order so the oldest open PRs are reviewed first.
+Process each stack from its bottom layer upward so lower-layer changes and local fixes are included
+when reviewing dependent layers. Process independent PRs in increasing PR number order.
 
 ## Self-Contained Report Scope
 
@@ -168,8 +178,8 @@ report.
   assessment, recommendation, copy/paste review text, local-fix references, and benchmark evidence
   into the new report. Do not merely link to or tell the human to read an older report.
 - Carry evidence forward only after discovery confirms that the PR remains open and non-draft and
-  that its head SHA, discussion timestamp, and reviewed base SHA satisfy the normal skip rules. If
-  any freshness key changed, review the PR instead.
+  that its head SHA, discussion timestamp, declared-base SHA, and stack-trunk SHA satisfy the normal
+  skip rules. If any freshness key changed, review the PR instead.
 - Exclude merged, closed, and draft PRs. Include open deferred PRs with their defer reason.
 - Keep carried-forward author-facing text coherent from the public PR discussion and human-review
   cutoff. Do not describe it as old, carried forward, or unchanged in the copy/paste comment unless
@@ -188,8 +198,8 @@ the open trusted non-draft PRs in the report. Check:
 - commit ancestry between PR heads;
 - semantic dependencies, such as one PR changing data or behavior that another PR accelerates;
 - shared production APIs and files that make conflicts likely; and
-- whether each branch already conflicts with current `origin/main` independently of the other open
-  PRs.
+- whether each standalone branch conflicts with its declared base, and whether each stack remains
+  linear and current with its trunk.
 
 Distinguish three cases clearly:
 
@@ -199,8 +209,9 @@ Distinguish three cases clearly:
 - **Independent:** either order is reasonable despite possible file overlap.
 
 Do not infer a dependency from overlapping files alone. Explain the specific behavior, API, or
-conflict that supports each recommendation. Separate conflicts already caused by current main from
-conflicts likely to arise between the open PRs. If useful, provide a concrete sequence with
+conflict that supports each recommendation. Separate conflicts already caused by a declared base
+or stack trunk from conflicts likely to arise between the open PRs. If useful, provide a concrete
+sequence with
 parenthesized groups for PRs that can land in either order. Account for unresolved review feedback
 and local fixes that still need to be pushed; do not present a PR as merge-ready merely to make the
 sequence tidy.
@@ -226,26 +237,33 @@ Review a non-draft PR when any of these is true:
 - `status` is `needs_review` or `unknown`;
 - current PR head SHA differs from `lastHeadSha`;
 - current PR `updatedAt` differs from `lastSeenUpdatedAt`;
-- current `origin/main` SHA differs from `lastBaseSha`;
+- current declared-base head SHA differs from `lastBaseSha`;
+- current stack-trunk SHA differs from `lastTrunkSha`;
 - the user explicitly asks to force review.
 
-The `lastBaseSha` condition matters most for optimization PRs, but apply it consistently to every
-reviewed PR so design review, tests, and any benchmark reproduction reflect current main.
+The base and trunk conditions matter most for optimization and stacked PRs, but apply them
+consistently so design review, tests, and benchmark reproduction reflect the current dependency
+chain. Existing state without `lastTrunkSha` is stale and must be reviewed once to populate it.
 
 Skip a PR only when `status` is `reviewed`, the head SHA matches, the PR `updatedAt` matches, and
-`lastBaseSha` matches current `origin/main`. If `status` is `defer`, skip it and include the defer
-reason in the run report.
+`lastBaseSha` and `lastTrunkSha` match the current declared base and trunk. If `status` is `defer`,
+skip it and include the defer reason in the run report.
 
 ## Per-PR Workflow
 
 Process PRs one at a time.
 
-1. Refresh base state and record the exact remote base SHA used for this PR:
+1. Refresh the integration trunk and the PR's declared base, then record their exact remote SHAs:
 
 ```bash
 git fetch origin main
-baseSha="$(git rev-parse origin/main)"
+git fetch origin "<baseRefName>"
+trunkSha="$(git rev-parse origin/main)"
+declaredBaseSha="$(git rev-parse origin/<baseRefName>)"
 ```
+
+   For a stack rooted somewhere other than `main`, use that stack's declared trunk instead. Record
+   the stack number and position when applicable.
 
 2. Create a durable worktree path:
 
@@ -258,17 +276,26 @@ baseSha="$(git rev-parse origin/main)"
    `codex/review/pr-<number>/<short-sha>`. Preserve existing local work if the worktree already
    exists; inspect it before changing anything.
 
-4. Before doing intent review, automated review, tests, or benchmarks, bring the local review
-   branch up to date with current `origin/main`.
+4. Before doing intent review, automated review, tests, or benchmarks, prepare the local review
+   branch against its current effective base.
    - Record the original PR head SHA before merging.
-   - Merge `origin/main` into the local review branch.
+   - For a standalone PR, update it against the current head of its declared base branch.
+   - For the bottom of a stack, update it against the current stack trunk.
+   - For an upper stack layer, first finish the local review of the layer immediately below it,
+     including any local fixes. Replay only this PR's layer commits onto that prepared lower-layer
+     head. Use the resulting lower-layer head as this PR's review base. Do not merge `main` directly
+     into every upper layer or review the cumulative stack as though it were all introduced by the
+     upper PR.
+   - Keep the prepared stack linear. If the submitted stack is stale relative to its trunk, perform
+     the cascading update locally from the bottom upward. Do not push stack rebases during a scout
+     run.
    - Resolve conflicts when they are straightforward and principled.
-   - After a successful merge, record the post-merge/pre-fix `HEAD` SHA. Use this marker as the
-     starting point for local review-fix artifacts.
+   - Record both the prepared review-base SHA and the post-update/pre-fix `HEAD` SHA. Use the latter
+     as the starting point for local review-fix artifacts.
    - If conflicts require product/design judgment, stop that PR, report the conflict, mark it
      blocked in the run report/state, and continue with the next PR.
-   - Do not benchmark or run review-fix-loop on a PR branch that is stale relative to `origin/main`
-     unless the report clearly says the merge was blocked and no review was performed.
+   - Do not benchmark or run review-fix-loop on a PR branch whose effective base or stack trunk is
+     stale unless the report clearly says the update was blocked and no review was performed.
 
 5. Perform PR intent review before running automated review:
    - State the PR's claimed goal from title, description, linked issue, comments, and reviews.
@@ -280,27 +307,32 @@ baseSha="$(git rev-parse origin/main)"
    - Record a recommendation: ready after fixes, needs clarification, needs more tests, needs
      benchmark evidence, or needs redesign.
 
-6. Run `$review-fix-loop` in the PR worktree for P2+ findings against the recorded `baseSha`, not
-   the local `main` branch.
+6. Run `$review-fix-loop` in the PR worktree for P2+ findings against the recorded prepared
+   review-base SHA, not automatically against `main`.
    - Follow that skill's instructions exactly.
-   - Tell `$review-fix-loop` to use the recorded `baseSha` as the branch review base. Do not use
-     local `main`, which may be stale even after fetching `origin/main`.
+   - Tell `$review-fix-loop` to use the recorded review-base SHA. For an upper stack layer, this
+     ensures the review covers only that layer instead of reporting changes from lower PRs.
    - The final state should be no remaining P2+ findings, or a documented blocker/false positive.
    - If fixes are made, make a local-only commit in the review branch so fixes are durable and
      benchmarkable. Do not push.
-   - Save a patch file under the PR artifact directory by diffing from the post-merge/pre-fix
+   - Save a patch file under the PR artifact directory by diffing from the post-update/pre-fix
      marker to final `HEAD`. Do not diff from the original PR head, because that includes upstream
      main changes and any merge conflict resolutions.
 
 ```bash
 .agents/skills/safere-pr-review-scout/scripts/scout_workspace.py artifact-dir \
   --pr <number> --sha <head-sha>
-git diff <post-merge-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
+git diff <post-update-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
 ```
 
 7. For optimization PRs only, reproduce benchmarks:
-   - Baseline is current `origin/main`.
-   - Experiment is the PR branch after merging current `origin/main`, plus any local review fixes.
+   - For a standalone PR, baseline is the current declared base and experiment is the updated PR
+     plus local review fixes.
+   - For a stack bottom, baseline is the current trunk. For an upper layer, baseline is the prepared
+     lower-layer review head and experiment adds the current layer plus local fixes. This measures
+     the marginal effect claimed by that PR without attributing lower-layer changes to it.
+   - If the PR explicitly claims cumulative stack performance against the trunk, run that as a
+     separate labeled comparison; do not substitute it for the layer comparison.
    - For targeted SafeRE nanosecond workloads whose benchmark definitions are identical at both
      revisions, prefer `safere-benchmarks/scripts/compare-branch.sh` with explicit immutable refs.
      Run String and UTF-8 variants separately, add `--vector` only when the experimental provider is
@@ -320,7 +352,7 @@ git diff <post-merge-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
      mismatch before writing the final recommendation:
      - First check whether `$review-fix-loop` made local correctness fixes that could plausibly
        affect the benchmarked code path. If yes, run serial ablation benchmarks that isolate the
-       local fixes from the submitted PR: benchmark the post-merge/pre-fix marker, then each
+       local fixes from the submitted PR: benchmark the post-update/pre-fix marker, then each
        relevant local fix commit or small group of related commits, using the same benchmark
        command where possible. Save raw ablation logs and a short ablation summary under the PR
        artifact directory. Do not run ablations in parallel.
@@ -442,10 +474,13 @@ Use this structure:
 URL: <url>
 Classification: optimization | other
 Classification evidence: <short reason>
-Base: origin/main @ <sha>
+Trunk: origin/<trunk> @ <sha>
+Declared base: origin/<baseRefName> @ <sha>
+Prepared review base: <sha>
+Stack: none | #<stack-number>, position <position> of <size>
 PR head: <sha>
-Merged main: yes | blocked | already up to date
-Post-merge/pre-fix head: <sha or none>
+Base update: yes | blocked | already up to date
+Post-update/pre-fix head: <sha or none>
 Experiment branch: codex/review/pr-<number>/<short-sha>
 Artifacts: <path>
 Human review cutoff: <timestamp and comment/review summary, or "none; first-review perspective">
@@ -494,7 +529,7 @@ Claimed result:
 Commands run:
 - `./run-java-benchmarks.sh ...`
 
-| Benchmark | main | PR+fixes | PR/main | Interpretation |
+| Benchmark | baseline | PR+fixes | PR/baseline | Interpretation |
 |---|---:|---:|---:|---|
 | ... | ... | ... | ... | ... |
 
@@ -549,6 +584,7 @@ Maintain `$HOME/.codex/safere-pr-review/state.json` as JSON. Keep it simple and 
     "123": {
       "lastHeadSha": "abc123",
       "lastBaseSha": "789abc",
+      "lastTrunkSha": "012def",
       "lastSeenUpdatedAt": "2026-07-04T17:42:00Z",
       "lastReviewedAt": "2026-07-04T18:00:00Z",
       "classification": "optimization",
@@ -565,8 +601,8 @@ Seeded state may use these statuses:
 
 - `needs_review`: always review on the next sweep, then update to `reviewed` after a successful
   review.
-- `reviewed`: skip only while PR head SHA, PR `updatedAt`, and `lastBaseSha` still match current
-  GitHub/main state.
+- `reviewed`: skip only while PR head SHA, PR `updatedAt`, `lastBaseSha`, and `lastTrunkSha` still
+  match current GitHub state.
 - `defer`: skip regardless of SHA changes until a human changes the status; include `deferReason`
   in sweep reports.
 - `unknown`: treat like `needs_review`.
@@ -583,20 +619,25 @@ Run one serialized SafeRE PR review sweep.
 Run to completion even if the sweep takes many hours. Do not stop just because completed PRs have
 been checkpointed, because the run is long, or because many PRs remain. Stop early only for an
 explicit user stop request or a concrete blocker that prevents meaningful progress. Process all
-eligible trusted PRs discovered for the run in increasing PR number order.
+eligible trusted PRs discovered for the run in stack dependency order, then increasing PR number
+among independent PRs.
 
 Repository: /home/eaftan/safere.
-Skip draft PRs. Only inspect PRs authored by trusted GitHub logins: cushon, eamonnmcmanus, and
-kluever. For all other authors, do not read PR bodies, comments, reviews, linked issues, diffs, or
-code, and do not check out their branches; list them in the report as untrusted contributor
-candidates for human allowlist review. Review open trusted PRs targeting main whose head SHA
-changed, discussion changed, or recorded base SHA is older than current origin/main. Process PRs in
-increasing PR number order, oldest first. For every reviewed PR, create an isolated worktree, merge
-current origin/main into the PR branch, and resolve straightforward conflicts before doing any
-review, tests, or benchmarks. If conflicts require product/design judgment, mark that PR blocked
-and continue with the next PR. Read the PR description, comments, reviews, and linked issue context
-needed to understand intent. Assess whether the PR idea makes sense for SafeRE and whether the
-implementation matches that intent.
+Skip draft PRs. Discover open PRs regardless of their direct base branch so upper layers of GitHub
+PR stacks are included. Only inspect PRs authored by trusted GitHub logins: cushon,
+eamonnmcmanus, and kluever. For all other authors, do not read PR bodies, comments, reviews, linked
+issues, diffs, or code, and do not check out their branches; list them in the report as untrusted
+contributor candidates for human allowlist review. Review open trusted PRs whose head SHA,
+discussion, declared-base SHA, or stack-trunk SHA changed. Process stacks from bottom to top and
+independent PRs in increasing PR number order. For every reviewed PR, create an isolated worktree
+and prepare it against its current effective base before doing any review, tests, or benchmarks.
+For standalone PRs use the declared target branch; for stack bottoms use the trunk; for upper stack
+layers replay only that layer onto the prepared lower layer, including any local lower-layer fixes.
+Keep stack preparation local and linear; do not push a stack rebase. Resolve straightforward
+conflicts. If conflicts require product/design judgment, mark that PR blocked and continue with the
+next PR. Read the PR description, comments, reviews, and linked issue context needed to understand
+intent. Assess whether the PR idea makes sense for SafeRE and whether the implementation matches
+that intent.
 
 Make the resulting report self-contained. Include a summary row and detailed section for every open
 trusted non-draft PR, including PRs skipped because their prior review is still fresh. For each
@@ -612,13 +653,15 @@ constraint, and do not infer a dependency from file overlap alone.
 
 Run $review-fix-loop for P2-or-higher findings in an isolated worktree. Do not push branches, post
 comments, close issues, or publish review text. Local worktrees, local branches, local commits,
-patch files, benchmark logs, and Markdown reports are allowed. Use the recorded current
-origin/main SHA as the review base, not local main. Generate `review-fixes.patch` by diffing from
-the post-merge/pre-fix HEAD to final HEAD so the patch contains only scout fixes, not upstream main
-changes.
+patch files, benchmark logs, and Markdown reports are allowed. Use the recorded prepared
+review-base SHA; for an upper stack layer this is the prepared lower-layer head, not `main`.
+Generate `review-fixes.patch` by diffing from the post-update/pre-fix HEAD to final HEAD so the
+patch contains only scout fixes, not base updates.
 
-For optimization PRs, reproduce benchmark claims using current origin/main as baseline and the PR
-branch plus local review fixes as experiment. Prefer
+For optimization PRs, reproduce benchmark claims against the PR's effective base: the current
+declared base for standalone PRs, the trunk for a stack bottom, or the prepared lower-layer head for
+an upper stack layer. Treat a cumulative stack-to-trunk claim as a separate labeled comparison.
+Prefer
 safere-benchmarks/scripts/compare-branch.sh for comparable targeted SafeRE nanosecond workloads;
 otherwise use ./run-java-benchmarks.sh directly. Never run tests or benchmarks concurrently. If
 benchmark results do not roughly reproduce the PR claim, check whether

--- a/.agents/skills/safere-pr-review-scout/scripts/scout_workspace.py
+++ b/.agents/skills/safere-pr-review-scout/scripts/scout_workspace.py
@@ -146,8 +146,6 @@ def discover_prs(args: argparse.Namespace) -> int:
         "list",
         "--state",
         "open",
-        "--base",
-        args.base,
         "--limit",
         str(args.limit),
         "--json",
@@ -244,7 +242,6 @@ def main() -> int:
     worktree.set_defaults(func=worktree_path)
 
     discover = subparsers.add_parser("discover-prs")
-    discover.add_argument("--base", default="main")
     discover.add_argument("--limit", type=int, default=1000)
     discover.set_defaults(func=discover_prs)
 


### PR DESCRIPTION
## Summary

- discover trusted open PRs regardless of their direct base branch so upper layers of GitHub PR stacks are included
- process stacks from bottom to top and review each layer against the prepared layer below it
- track declared-base and stack-trunk freshness and use layer-aware benchmark baselines
- update the report format and unattended-run prompt for standalone and stacked PRs

## Verification

- `python3 -m py_compile .agents/skills/safere-pr-review-scout/scripts/scout_workspace.py`
- `python3 /home/eaftan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/safere-pr-review-scout`
- live discovery with an isolated storage root returned PRs #770, #771, and #774 as trusted non-draft candidates with their expected direct bases
- `git diff --check`

No SafeRE tests were run because this changes only scout instructions and its workspace helper.
