### PR TITLE
Implement bidirectional rarest-anchor candidate driving with backward scanning and start accelerator fixes

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -56,6 +56,7 @@ final class MatchFuzzer {
     assertDfaSandwichLeftmostStartCasesMatchJdk();
     assertMixedAsciiAndExactUnicodeCaseFoldingMatchesJdk(data);
     assertScopedCaseFoldingMatchesJdk(data);
+    assertMultiAnchorGapBoundsMatchJdk(data);
     assertAlternationAndQuantifierPriorityLookingAtMatchesJdk(data);
 
     String regex;
@@ -250,6 +251,26 @@ final class MatchFuzzer {
       literal.append((char) ('A' + i % 26));
     }
     return literal.toString();
+  }
+
+  private static void assertMultiAnchorGapBoundsMatchJdk(FuzzedDataProvider data) {
+    int repeatedDigits = data.consumeInt(3, 12);
+    String driver = distinctAsciiLiteral(data.consumeInt(8, 16));
+    String regex;
+    String input;
+    if (data.consumeBoolean()) {
+      regex = "111[0-9]+" + driver;
+      input = "1".repeat(repeatedDigits) + "2" + driver;
+    } else {
+      int maximum = data.consumeInt(1, 4);
+      regex = "(?s)TARGET.{1," + maximum + "}";
+      input = "TARGET" + "😀".repeat(maximum + 1);
+    }
+
+    FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
+    if (pattern != null) {
+      pattern.matcher(input).find();
+    }
   }
 
   private static void assertAlternationAndQuantifierPriorityLookingAtMatchesJdk(

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -57,6 +57,7 @@ final class MatchFuzzer {
     assertMixedAsciiAndExactUnicodeCaseFoldingMatchesJdk(data);
     assertScopedCaseFoldingMatchesJdk(data);
     assertMultiAnchorGapBoundsMatchJdk(data);
+    assertLeadingClassAssertionsMatchJdk(data);
     assertAlternationAndQuantifierPriorityLookingAtMatchesJdk(data);
 
     String regex;
@@ -109,6 +110,17 @@ final class MatchFuzzer {
     FuzzSupport.MatcherPair matcher = pattern.matcher(boundary);
     matcher.region(1, boundary.length()).lookingAt();
     matcher.reset(nonBoundary).region(1, nonBoundary.length()).lookingAt();
+  }
+
+  private static void assertLeadingClassAssertionsMatchJdk(FuzzedDataProvider data) {
+    String leadingClass = data.pickValue(List.of("[a-z]", "[ ]", "[0-9]", "[^A-Z]"));
+    String assertion = data.consumeBoolean() ? "\\b" : "\\B";
+    String suffix = data.consumeBoolean() ? "AAA" : "AAA[0-9]RAREST_TOKEN";
+    String regex = leadingClass + assertion + suffix;
+    FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
+    if (pattern != null) {
+      pattern.matcher(data.pickValue(List.of("xAAA", " AAA", "11AAA", "xAAA1RAREST_TOKEN"))).find();
+    }
   }
 
   private static void assertTrailingLineTerminatorEndAnchorFindsMatchJdk() {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -35,6 +35,7 @@ final class Utf8InputFuzzer {
     assertFinalLineTerminatorEndAnchorsMatchJdk(data);
     assertPositionDependentStartAccelerationMatchesJdk(data);
     assertGraphemeSearchMatchesString(data);
+    assertMultibyteMultiAnchorReverseWindowMatchesString(data);
     String repeatedLiteral =
         String.valueOf((char) data.consumeInt('A', 'Z')).repeat(data.consumeInt(2, 32));
     String suffix = new String(data.consumeBytes(data.consumeInt(0, 64)), StandardCharsets.UTF_8);
@@ -206,6 +207,27 @@ final class Utf8InputFuzzer {
           || !Objects.equals(stringMatcher.group(), decodeGroup(bytes, utf8Matcher))) {
         throw new AssertionError("UTF-8 grapheme search bounds differ from String search");
       }
+    }
+  }
+
+  private static void assertMultibyteMultiAnchorReverseWindowMatchesString(
+      FuzzedDataProvider data) {
+    String upstream = data.pickValue(List.of("é", "軖", "😀")).repeat(data.consumeInt(2, 12));
+    String downstream = "z".repeat(data.consumeInt(16, 40));
+    String regex = upstream + "[0-9]" + downstream;
+    String input = upstream + data.consumeInt(0, 9) + downstream;
+    Pattern pattern = Pattern.compile(regex);
+    org.safere.Matcher stringMatcher = pattern.matcher(input);
+    byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+    Utf8Matcher utf8Matcher = pattern.matcher(Utf8Input.validated(bytes));
+
+    boolean stringFound = stringMatcher.find();
+    boolean utf8Found = utf8Matcher.find();
+    if (utf8Found != stringFound
+        || (stringFound
+            && (utf8Matcher.start() != utf8Offset(input, stringMatcher.start())
+                || utf8Matcher.end() != utf8Offset(input, stringMatcher.end())))) {
+      throw new AssertionError("UTF-8 multi-anchor reverse window differs from String matching");
     }
   }
 

--- a/safere/src/main/java/org/safere/ByteSwarScan.java
+++ b/safere/src/main/java/org/safere/ByteSwarScan.java
@@ -74,6 +74,34 @@ abstract class ByteSwarScan {
     return -1;
   }
 
+  static int lastIndexOfByte(
+      byte[] bytes, int offset, int length, byte target, int fromIndex, int toIndex) {
+    int pos = Math.min(fromIndex, length - 1);
+    int minLimit = Math.max(0, toIndex);
+    if (pos < minLimit || minLimit >= length) {
+      return -1;
+    }
+    long repeatedTarget = (target & 0xFFL) * BYTE_ONES;
+    while (pos >= minLimit + Long.BYTES - 1) {
+      int wordStart = pos - Long.BYTES + 1;
+      long difference = (long) LONG_VIEW.get(bytes, offset + wordStart) ^ repeatedTarget;
+      if (((difference - BYTE_ONES) & ~difference & BYTE_HIGH_BITS) != 0) {
+        for (int index = Long.BYTES - 1; index >= 0; index--) {
+          if (bytes[offset + wordStart + index] == target) {
+            return wordStart + index;
+          }
+        }
+      }
+      pos -= Long.BYTES;
+    }
+    for (; pos >= minLimit; pos--) {
+      if (bytes[offset + pos] == target) {
+        return pos;
+      }
+    }
+    return -1;
+  }
+
   static int indexOfByteOrNonAscii(byte[] bytes, int offset, int length, byte target, int start) {
     return indexOfBytesOrNonAscii(bytes, offset, length, target, target, target, start, 1);
   }

--- a/safere/src/main/java/org/safere/ByteVectorScan.java
+++ b/safere/src/main/java/org/safere/ByteVectorScan.java
@@ -69,6 +69,45 @@ final class ByteVectorScan {
     return -1;
   }
 
+  static int lastIndexOfByte(
+      byte[] bytes, int offset, int length, byte target, int fromIndex, int toIndex) {
+    return lastIndexOfByte(SPECIES, bytes, offset, length, target, fromIndex, toIndex);
+  }
+
+  static int lastIndexOfByte(
+      VectorSpecies<Byte> species,
+      byte[] bytes,
+      int offset,
+      int length,
+      byte target,
+      int fromIndex,
+      int toIndex) {
+    int pos = Math.min(fromIndex, length - 1);
+    int minLimit = Math.max(0, toIndex);
+    if (pos < minLimit || minLimit >= length) {
+      return -1;
+    }
+    int speciesLen = species.length();
+    ByteVector targetVec = ByteVector.broadcast(species, target);
+    while (pos >= minLimit + speciesLen - 1) {
+      int chunkStart = pos - speciesLen + 1;
+      ByteVector values = ByteVector.fromArray(species, bytes, offset + chunkStart);
+      VectorMask<Byte> matches = values.compare(EQ, targetVec);
+      if (matches.anyTrue()) {
+        long activeLanes = matches.toLong();
+        int highestBit = Long.numberOfTrailingZeros(Long.highestOneBit(activeLanes));
+        return chunkStart + highestBit;
+      }
+      pos -= speciesLen;
+    }
+    for (; pos >= minLimit; pos--) {
+      if (bytes[offset + pos] == target) {
+        return pos;
+      }
+    }
+    return -1;
+  }
+
   static int indexOfAsciiPair(byte[] bytes, int offset, int length, byte b0, byte b1, int start) {
     int position = Math.max(0, start);
     int limit = position + SPECIES.loopBound(length - position);

--- a/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
+++ b/safere/src/main/java/org/safere/IncubatorVectorScanProvider.java
@@ -50,6 +50,12 @@ final class IncubatorVectorScanProvider implements VectorScanProvider {
   }
 
   @Override
+  public int lastIndexOfByte(
+      byte[] bytes, int offset, int length, byte target, int fromIndex, int toIndex) {
+    return ByteVectorScan.lastIndexOfByte(bytes, offset, length, target, fromIndex, toIndex);
+  }
+
+  @Override
   public int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start) {
     return ByteVectorScan.indexOfAsciiClass(bytes, offset, length, ranges, start);
   }

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -1004,6 +1004,7 @@ final class MultiAnchorCompiler {
     }
     if (first.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
         && second.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+        && first.isGreedy() == second.isGreedy()
         && Objects.equals(first.charClass(), second.charClass())
         && Objects.equals(first.scanInfo(), second.scanInfo())) {
       int min = first.minLength() + second.minLength();
@@ -1020,6 +1021,7 @@ final class MultiAnchorCompiler {
           first.isGreedy());
     }
     if (first.kind() == second.kind()
+        && first.isGreedy() == second.isGreedy()
         && (first.kind() == MultiAnchorDescriptor.GapKind.ANY_STAR
             || first.kind() == MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR)) {
       int min = first.minLength() + second.minLength();

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -846,7 +846,14 @@ final class MultiAnchorCompiler {
       Regexp sub = node.subs.get(idx);
       if (isLeadingZeroWidth(sub)) {
         MultiAnchorDescriptor.Gap zwGap = classifyGap(sub, flags);
-        if (zwGap != null && leadingGap.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
+        if (zwGap == null) {
+          return null;
+        }
+        if (!zwGap.equals(MultiAnchorDescriptor.Gap.EMPTY)
+            && !leadingGap.equals(MultiAnchorDescriptor.Gap.EMPTY)) {
+          return null;
+        }
+        if (!zwGap.equals(MultiAnchorDescriptor.Gap.EMPTY)) {
           leadingGap = zwGap;
         }
         idx++;

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -195,12 +195,7 @@ final class MultiAnchorCompiler {
       Regexp node, int flags, boolean anchorStart, boolean anchorEnd) {
     // 1. Multi-anchor sequence or anchored chain
     MultiAnchorDescriptor multiChain = extractMultiAnchorChain(node, flags, anchorStart, anchorEnd);
-    if (multiChain != null
-        && (multiChain.numSegments() >= 2
-            || multiChain.leadingGap().kind() != MultiAnchorDescriptor.GapKind.EMPTY
-            || multiChain.trailingGap().kind() != MultiAnchorDescriptor.GapKind.EMPTY
-            || multiChain.firstSegment().anchor()
-                instanceof MultiAnchorDescriptor.Anchor.Alternation)) {
+    if (multiChain != null) {
       return multiChain;
     }
 
@@ -214,93 +209,6 @@ final class MultiAnchorCompiler {
           MultiAnchorDescriptor.Gap.EMPTY,
           new int[] {0},
           directAnchor.minLength(),
-          anchorStart,
-          anchorEnd);
-    }
-
-    if (node.op != RegexpOp.CONCAT || node.subs == null || node.subs.isEmpty()) {
-      CharClassScanInfo ccPrefix = extractCharClassPrefix(node);
-      if (ccPrefix != null) {
-        MultiAnchorDescriptor.Anchor.CharClass ccAnchor =
-            MultiAnchorDescriptor.Anchor.CharClass.create(ccPrefix);
-        return new MultiAnchorDescriptor(
-            new MultiAnchorDescriptor.Segment[] {
-              new MultiAnchorDescriptor.Segment(MultiAnchorDescriptor.Gap.EMPTY, ccAnchor)
-            },
-            MultiAnchorDescriptor.Gap.EMPTY,
-            new int[] {0},
-            1,
-            anchorStart,
-            anchorEnd);
-      }
-      return null;
-    }
-
-    // 3. Literal prefix on the concat
-    PrefixResult prefixResult = extractPrefix(node);
-    if (prefixResult.prefix() == null && anchorStart) {
-      Regexp candidate = firstPrefixCandidateAfterTextAnchor(node);
-      if (candidate != null) {
-        prefixResult = extractPrefix(candidate);
-      }
-    }
-    if (prefixResult.prefix() != null) {
-      MultiAnchorDescriptor.Anchor.Single prefixAnchor =
-          MultiAnchorDescriptor.Anchor.Single.create(
-              prefixResult.prefix(), prefixResult.foldCase());
-      return new MultiAnchorDescriptor(
-          new MultiAnchorDescriptor.Segment[] {
-            new MultiAnchorDescriptor.Segment(MultiAnchorDescriptor.Gap.EMPTY, prefixAnchor)
-          },
-          MultiAnchorDescriptor.Gap.EMPTY,
-          new int[] {0},
-          prefixResult.prefix().length(),
-          anchorStart,
-          anchorEnd);
-    }
-
-    // 4. Fixed offset literal
-    FixedOffsetLiteral fol = extractFixedOffsetLiteral(node);
-    if (fol != null) {
-      CharClassScanInfo ccPrefix = extractCharClassPrefix(node);
-      MultiAnchorDescriptor.Gap gap =
-          new MultiAnchorDescriptor.Gap(
-              MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
-              fol.minOffset(),
-              fol.maxOffset(),
-              fol.discreteOffsets(),
-              null,
-              ccPrefix,
-              true);
-      MultiAnchorDescriptor.Anchor.Single anchor =
-          MultiAnchorDescriptor.Anchor.Single.create(fol.literal(), false);
-      return new MultiAnchorDescriptor(
-          new MultiAnchorDescriptor.Segment[] {new MultiAnchorDescriptor.Segment(gap, anchor)},
-          MultiAnchorDescriptor.Gap.EMPTY,
-          new int[] {0},
-          fol.minOffset() + fol.literal().length(),
-          anchorStart,
-          anchorEnd);
-    }
-
-    // 5. Character class prefix
-    CharClassScanInfo ccPrefix = extractCharClassPrefix(node);
-    if (ccPrefix == null && anchorStart) {
-      Regexp candidate = firstPrefixCandidateAfterTextAnchor(node);
-      if (candidate != null) {
-        ccPrefix = extractCharClassPrefix(candidate);
-      }
-    }
-    if (ccPrefix != null) {
-      MultiAnchorDescriptor.Anchor.CharClass ccAnchor =
-          MultiAnchorDescriptor.Anchor.CharClass.create(ccPrefix);
-      return new MultiAnchorDescriptor(
-          new MultiAnchorDescriptor.Segment[] {
-            new MultiAnchorDescriptor.Segment(MultiAnchorDescriptor.Gap.EMPTY, ccAnchor)
-          },
-          MultiAnchorDescriptor.Gap.EMPTY,
-          new int[] {0},
-          1,
           anchorStart,
           anchorEnd);
     }
@@ -668,8 +576,9 @@ final class MultiAnchorCompiler {
       CharClassScanInfo anchoredCc =
           anchoredCandidate != null ? extractCharClassPrefix(anchoredCandidate) : null;
 
+      CharClassScanInfo ccPrefix = extractCharClassPrefix(node);
       StartFacets start =
-          new StartFacets(prefix, null, fol, startAcc, anchoredPrefix, anchoredCc, null);
+          new StartFacets(prefix, ccPrefix, fol, startAcc, anchoredPrefix, anchoredCc, null);
       RejectFacets reject =
           new RejectFacets(bestReqLit, bestReqScore, bestReqClass, disjoint, endSuffix, endClass);
 
@@ -876,21 +785,7 @@ final class MultiAnchorCompiler {
       if (alt != null) {
         return new ConsumedAnchor(alt, 1);
       }
-      CharClassScanInfo scanInfo = extractCharClassPrefix(first);
-      if (scanInfo != null) {
-        return new ConsumedAnchor(MultiAnchorDescriptor.Anchor.CharClass.create(scanInfo), 1);
-      }
       return null;
-    }
-
-    if (first.op == RegexpOp.CHAR_CLASS && first.charClass != null) {
-      AsciiBitmap bm = buildAsciiBitmapFromCharClass(first.charClass);
-      if (bm != null && !bm.isEmpty() && bm.cardinality() <= 32) {
-        CharClassScanInfo scanInfo = CharClassScanInfo.fromCharClass(first.charClass);
-        if (scanInfo != null) {
-          return new ConsumedAnchor(MultiAnchorDescriptor.Anchor.CharClass.create(scanInfo), 1);
-        }
-      }
     }
 
     boolean globalFold =
@@ -951,7 +846,7 @@ final class MultiAnchorCompiler {
       Regexp sub = node.subs.get(idx);
       if (isLeadingZeroWidth(sub)) {
         MultiAnchorDescriptor.Gap zwGap = classifyGap(sub, flags);
-        if (zwGap != null) {
+        if (zwGap != null && leadingGap.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
           leadingGap = zwGap;
         }
         idx++;
@@ -961,32 +856,15 @@ final class MultiAnchorCompiler {
         break;
       }
       MultiAnchorDescriptor.Gap gapCandidate = classifyGap(sub, flags);
-      if (gapCandidate != null
-          && gapCandidate.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
-          && gapCandidate.maxLength() < Integer.MAX_VALUE) {
-        if (leadingGap.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
-          leadingGap = gapCandidate;
-        } else if (leadingGap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
-            && leadingGap.maxLength() < Integer.MAX_VALUE) {
-          leadingGap =
-              new MultiAnchorDescriptor.Gap(
-                  MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
-                  leadingGap.minLength() + gapCandidate.minLength(),
-                  leadingGap.maxLength() + gapCandidate.maxLength(),
-                  null,
-                  true);
-        }
-        idx++;
-        continue;
+      if (gapCandidate == null) {
+        break;
       }
-      if (gapCandidate != null
-          && gapCandidate.kind() != MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
-          && leadingGap.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
-        leadingGap = gapCandidate;
-        idx++;
-        continue;
+      MultiAnchorDescriptor.Gap merged = coalesceGaps(leadingGap, gapCandidate);
+      if (merged == null) {
+        break;
       }
-      break;
+      leadingGap = merged;
+      idx++;
     }
 
     if (idx < n) {
@@ -1021,35 +899,12 @@ final class MultiAnchorCompiler {
             if (nextGap == null) {
               break;
             }
-            if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
-                && nextGap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
-                && Objects.equals(gap.charClass(), nextGap.charClass())) {
-              int min = gap.minLength() + nextGap.minLength();
-              int max =
-                  (gap.maxLength() == Integer.MAX_VALUE || nextGap.maxLength() == Integer.MAX_VALUE)
-                      ? Integer.MAX_VALUE
-                      : gap.maxLength() + nextGap.maxLength();
-              gap =
-                  new MultiAnchorDescriptor.Gap(
-                      MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
-                      min,
-                      max,
-                      gap.charClass(),
-                      gap.isGreedy());
-              idx++;
-            } else if (gap.kind() == nextGap.kind()
-                && (gap.kind() == MultiAnchorDescriptor.GapKind.ANY_STAR
-                    || gap.kind() == MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR)) {
-              int min = gap.minLength() + nextGap.minLength();
-              int max =
-                  (gap.maxLength() == Integer.MAX_VALUE || nextGap.maxLength() == Integer.MAX_VALUE)
-                      ? Integer.MAX_VALUE
-                      : gap.maxLength() + nextGap.maxLength();
-              gap = new MultiAnchorDescriptor.Gap(gap.kind(), min, max, null, gap.isGreedy());
-              idx++;
-            } else {
+            MultiAnchorDescriptor.Gap merged = coalesceGaps(gap, nextGap);
+            if (merged == null) {
               break;
             }
+            gap = merged;
+            idx++;
           }
 
           if (idx >= n) {
@@ -1137,6 +992,44 @@ final class MultiAnchorCompiler {
 
     return new MultiAnchorDescriptor(
         segments, gaps.get(numAnchors), checkOrder, minTotalLength, anchorStart, anchorEnd);
+  }
+
+  private static MultiAnchorDescriptor.Gap coalesceGaps(
+      MultiAnchorDescriptor.Gap first, MultiAnchorDescriptor.Gap second) {
+    if (first == null || first.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
+      return second;
+    }
+    if (second == null || second.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
+      return first;
+    }
+    if (first.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+        && second.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+        && Objects.equals(first.charClass(), second.charClass())
+        && Objects.equals(first.scanInfo(), second.scanInfo())) {
+      int min = first.minLength() + second.minLength();
+      int max =
+          (first.maxLength() == Integer.MAX_VALUE || second.maxLength() == Integer.MAX_VALUE)
+              ? Integer.MAX_VALUE
+              : first.maxLength() + second.maxLength();
+      return new MultiAnchorDescriptor.Gap(
+          MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
+          min,
+          max,
+          first.charClass(),
+          first.scanInfo(),
+          first.isGreedy());
+    }
+    if (first.kind() == second.kind()
+        && (first.kind() == MultiAnchorDescriptor.GapKind.ANY_STAR
+            || first.kind() == MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR)) {
+      int min = first.minLength() + second.minLength();
+      int max =
+          (first.maxLength() == Integer.MAX_VALUE || second.maxLength() == Integer.MAX_VALUE)
+              ? Integer.MAX_VALUE
+              : first.maxLength() + second.maxLength();
+      return new MultiAnchorDescriptor.Gap(first.kind(), min, max, null, first.isGreedy());
+    }
+    return null;
   }
 
   private static MultiAnchorDescriptor.StartPlan.LeadingExpansion extractStartLeadingExpansion(
@@ -1706,7 +1599,8 @@ final class MultiAnchorCompiler {
               : MultiAnchorDescriptor.Gap.SINGLE_LINE_ANY_STAR_LAZY;
         }
         AsciiBitmap bitmap = buildAsciiBitmapFromCharClass(sub.charClass);
-        if (bitmap == null) {
+        CharClassScanInfo scanInfo = CharClassScanInfo.fromCharClass(sub.charClass);
+        if (bitmap == null && scanInfo == null) {
           return null;
         }
         return new MultiAnchorDescriptor.Gap(
@@ -1714,6 +1608,7 @@ final class MultiAnchorCompiler {
             0,
             Integer.MAX_VALUE,
             bitmap,
+            scanInfo,
             greedy);
       }
     } else if (re.op == RegexpOp.PLUS) {
@@ -1743,7 +1638,8 @@ final class MultiAnchorCompiler {
               greedy);
         }
         AsciiBitmap bitmap = buildAsciiBitmapFromCharClass(sub.charClass);
-        if (bitmap == null) {
+        CharClassScanInfo scanInfo = CharClassScanInfo.fromCharClass(sub.charClass);
+        if (bitmap == null && scanInfo == null) {
           return null;
         }
         return new MultiAnchorDescriptor.Gap(
@@ -1751,6 +1647,7 @@ final class MultiAnchorCompiler {
             1,
             Integer.MAX_VALUE,
             bitmap,
+            scanInfo,
             greedy);
       }
     } else if (re.op == RegexpOp.REPEAT) {
@@ -1773,11 +1670,17 @@ final class MultiAnchorCompiler {
               MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR, re.min, max, null, greedy);
         }
         AsciiBitmap bitmap = buildAsciiBitmapFromCharClass(sub.charClass);
-        if (bitmap == null) {
+        CharClassScanInfo scanInfo = CharClassScanInfo.fromCharClass(sub.charClass);
+        if (bitmap == null && scanInfo == null) {
           return null;
         }
         return new MultiAnchorDescriptor.Gap(
-            MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT, re.min, max, bitmap, greedy);
+            MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
+            re.min,
+            max,
+            bitmap,
+            scanInfo,
+            greedy);
       }
     } else if (re.op == RegexpOp.QUEST) {
       Regexp sub = unwrapCaptures(re.sub());
@@ -1798,31 +1701,32 @@ final class MultiAnchorCompiler {
               MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR, 0, 1, null, greedy);
         }
         AsciiBitmap bitmap = buildAsciiBitmapFromCharClass(sub.charClass);
-        if (bitmap == null) {
+        CharClassScanInfo scanInfo = CharClassScanInfo.fromCharClass(sub.charClass);
+        if (bitmap == null && scanInfo == null) {
           return null;
         }
         return new MultiAnchorDescriptor.Gap(
-            MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT, 0, 1, bitmap, greedy);
+            MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT, 0, 1, bitmap, scanInfo, greedy);
       }
     } else if (re.op == RegexpOp.CHAR_CLASS) {
-      if (isDotCharClass(re.charClass)) {
-        return new MultiAnchorDescriptor.Gap(
-            MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR, 1, 1, null, true);
-      }
       AsciiBitmap bitmap = buildAsciiBitmapFromCharClass(re.charClass);
-      if (bitmap == null) {
+      CharClassScanInfo scanInfo = CharClassScanInfo.fromCharClass(re.charClass);
+      if (bitmap == null && scanInfo == null) {
         return null;
       }
       return new MultiAnchorDescriptor.Gap(
-          MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT, 1, 1, bitmap, true);
+          MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT, 1, 1, bitmap, scanInfo, true);
     }
     if (re.op == RegexpOp.ANY_CHAR) {
+      boolean dotAll =
+          (flags & Pattern.DOTALL) != 0
+              || (re.flags & (ParseFlags.DOT_NL | ParseFlags.MATCH_NL)) != 0;
       return new MultiAnchorDescriptor.Gap(
-          MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
+          dotAll
+              ? MultiAnchorDescriptor.GapKind.ANY_STAR
+              : MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR,
           1,
           1,
-          new int[] {1},
-          null,
           null,
           true);
     }

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -96,7 +96,7 @@ record MultiAnchorDescriptor(
       }
       for (int candidate : checkOrder) {
         if (candidate >= 0 && candidate < segments.length) {
-          if (candidate > 0 && hasUpstreamGreedyUnboundedGap(segments, candidate)) {
+          if (candidate > 0 && !hasOnlyFixedUpstreamGaps(segments, candidate)) {
             continue;
           }
           Anchor a = segments[candidate].anchor();
@@ -115,15 +115,13 @@ record MultiAnchorDescriptor(
       return 0;
     }
 
-    private static boolean hasUpstreamGreedyUnboundedGap(Segment[] segments, int driverIdx) {
+    private static boolean hasOnlyFixedUpstreamGaps(Segment[] segments, int driverIdx) {
       for (int i = 1; i <= driverIdx; i++) {
-        Gap g = segments[i].gap();
-        if (g.isGreedy()
-            && (g.kind() == GapKind.ANY_STAR || g.kind() == GapKind.SINGLE_LINE_ANY_STAR)) {
-          return true;
+        if (!segments[i].gap().isExecutorFixedGap()) {
+          return false;
         }
       }
-      return false;
+      return true;
     }
 
     public boolean isUpstreamBoundedFor(int driverIdx) {
@@ -938,26 +936,8 @@ record MultiAnchorDescriptor(
           }
           yield isGreedy ? cur : minMatchPos;
         }
-        case SINGLE_LINE_ANY_STAR -> {
-          if (!isGreedy) {
-            yield anchorPos - minLength >= minPos ? anchorPos - minLength : -1;
-          }
-          int cur = anchorPos;
-          while (cur > minPos) {
-            int cp = text.codePointBefore(cur);
-            if (Nfa.isLineTerminator(cp)) {
-              break;
-            }
-            cur -= Character.charCount(cp);
-          }
-          yield (anchorPos - cur >= minLength) ? cur : -1;
-        }
-        case ANY_STAR -> {
-          if (!isGreedy) {
-            yield anchorPos - minLength >= minPos ? anchorPos - minLength : -1;
-          }
-          yield (anchorPos - minPos >= minLength) ? minPos : -1;
-        }
+        case SINGLE_LINE_ANY_STAR -> expandLeadingWildcard(text, anchorPos, minPos, true);
+        case ANY_STAR -> expandLeadingWildcard(text, anchorPos, minPos, false);
       };
     }
 
@@ -1004,27 +984,8 @@ record MultiAnchorDescriptor(
           }
           yield isGreedy ? cur : minMatchPos;
         }
-        case SINGLE_LINE_ANY_STAR -> {
-          if (!isGreedy) {
-            yield anchorPos - minLength >= minPos ? anchorPos - minLength : -1;
-          }
-          int cur = anchorPos;
-          while (cur > minPos) {
-            long decoded = scanner.decodeBackward(cur);
-            int cp = InputScanner.codePoint(decoded);
-            if (Nfa.isLineTerminator(cp)) {
-              break;
-            }
-            cur = InputScanner.position(decoded);
-          }
-          yield (anchorPos - cur >= minLength) ? cur : -1;
-        }
-        case ANY_STAR -> {
-          if (!isGreedy) {
-            yield anchorPos - minLength >= minPos ? anchorPos - minLength : -1;
-          }
-          yield (anchorPos - minPos >= minLength) ? minPos : -1;
-        }
+        case SINGLE_LINE_ANY_STAR -> expandLeadingWildcard(scanner, anchorPos, minPos, true);
+        case ANY_STAR -> expandLeadingWildcard(scanner, anchorPos, minPos, false);
       };
     }
 
@@ -1066,20 +1027,8 @@ record MultiAnchorDescriptor(
           }
           yield isGreedy ? cur : minMatchPos;
         }
-        case SINGLE_LINE_ANY_STAR -> {
-          if (!isGreedy) {
-            yield fromPos + minLength <= maxPos ? fromPos + minLength : -1;
-          }
-          int nl = text.indexOf('\n', fromPos);
-          int end = (nl >= fromPos && nl <= maxPos) ? nl : maxPos;
-          yield (end - fromPos >= minLength) ? end : -1;
-        }
-        case ANY_STAR -> {
-          if (!isGreedy) {
-            yield fromPos + minLength <= maxPos ? fromPos + minLength : -1;
-          }
-          yield (maxPos - fromPos >= minLength) ? maxPos : -1;
-        }
+        case SINGLE_LINE_ANY_STAR -> expandTrailingWildcard(text, fromPos, maxPos, true);
+        case ANY_STAR -> expandTrailingWildcard(text, fromPos, maxPos, false);
       };
     }
 
@@ -1123,21 +1072,99 @@ record MultiAnchorDescriptor(
           }
           yield isGreedy ? cur : minMatchPos;
         }
-        case SINGLE_LINE_ANY_STAR -> {
-          if (!isGreedy) {
-            yield fromPos + minLength <= maxPos ? fromPos + minLength : -1;
-          }
-          int nl = scanner.indexOfAscii('\n', fromPos, maxPos);
-          int end = (nl >= fromPos && nl <= maxPos) ? nl : maxPos;
-          yield (end - fromPos >= minLength) ? end : -1;
-        }
-        case ANY_STAR -> {
-          if (!isGreedy) {
-            yield fromPos + minLength <= maxPos ? fromPos + minLength : -1;
-          }
-          yield (maxPos - fromPos >= minLength) ? maxPos : -1;
-        }
+        case SINGLE_LINE_ANY_STAR -> expandTrailingWildcard(scanner, fromPos, maxPos, true);
+        case ANY_STAR -> expandTrailingWildcard(scanner, fromPos, maxPos, false);
       };
+    }
+
+    private int expandLeadingWildcard(
+        String text, int anchorPos, int minPos, boolean stopAtLineTerminator) {
+      int count = 0;
+      int cur = anchorPos;
+      int minMatchPos = minLength == 0 ? cur : -1;
+      while (count < maxLength && cur > minPos) {
+        int cp = text.codePointBefore(cur);
+        if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+          break;
+        }
+        cur -= Character.charCount(cp);
+        count++;
+        if (count == minLength) {
+          minMatchPos = cur;
+        }
+      }
+      if (count < minLength) {
+        return -1;
+      }
+      return isGreedy ? cur : minMatchPos;
+    }
+
+    private int expandLeadingWildcard(
+        Utf8InputScanner scanner, int anchorPos, int minPos, boolean stopAtLineTerminator) {
+      int count = 0;
+      int cur = anchorPos;
+      int minMatchPos = minLength == 0 ? cur : -1;
+      while (count < maxLength && cur > minPos) {
+        long decoded = scanner.decodeBackward(cur);
+        int cp = InputScanner.codePoint(decoded);
+        if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+          break;
+        }
+        cur = InputScanner.position(decoded);
+        count++;
+        if (count == minLength) {
+          minMatchPos = cur;
+        }
+      }
+      if (count < minLength) {
+        return -1;
+      }
+      return isGreedy ? cur : minMatchPos;
+    }
+
+    private int expandTrailingWildcard(
+        String text, int fromPos, int maxPos, boolean stopAtLineTerminator) {
+      int count = 0;
+      int cur = fromPos;
+      int minMatchPos = minLength == 0 ? cur : -1;
+      while (count < maxLength && cur < maxPos) {
+        int cp = text.codePointAt(cur);
+        if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+          break;
+        }
+        cur += Character.charCount(cp);
+        count++;
+        if (count == minLength) {
+          minMatchPos = cur;
+        }
+      }
+      if (count < minLength) {
+        return -1;
+      }
+      return isGreedy ? cur : minMatchPos;
+    }
+
+    private int expandTrailingWildcard(
+        Utf8InputScanner scanner, int fromPos, int maxPos, boolean stopAtLineTerminator) {
+      int count = 0;
+      int cur = fromPos;
+      int minMatchPos = minLength == 0 ? cur : -1;
+      while (count < maxLength && cur < maxPos) {
+        long decoded = scanner.decodeForward(cur);
+        int cp = InputScanner.codePoint(decoded);
+        if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+          break;
+        }
+        cur = InputScanner.position(decoded);
+        count++;
+        if (count == minLength) {
+          minMatchPos = cur;
+        }
+      }
+      if (count < minLength) {
+        return -1;
+      }
+      return isGreedy ? cur : minMatchPos;
     }
   }
 

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -1377,16 +1377,15 @@ record MultiAnchorDescriptor(
         if (fromIndex > maxStart) {
           return -1;
         }
-        if (foldCase) {
-          for (int i = maxStart; i >= fromIndex; i--) {
-            if (startsWith(text, i)) {
-              return i;
-            }
+        for (int i = maxStart; i >= fromIndex; i--) {
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record();
           }
-          return -1;
+          if (startsWith(text, i)) {
+            return i;
+          }
         }
-        int idx = text.lastIndexOf(literal, maxStart);
-        return idx >= fromIndex ? idx : -1;
+        return -1;
       }
 
       @Override

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -34,17 +34,24 @@ record MultiAnchorDescriptor(
     Objects.requireNonNull(rejectPlan, "rejectPlan");
   }
 
+  enum InputDomain {
+    STRING,
+    UTF8
+  }
+
   @SuppressWarnings("ArrayRecordComponent")
   record Chain(
       Segment[] segments,
       Gap trailingGap,
       int[] checkOrder,
+      int driverIndex,
+      boolean isUpstreamBounded,
       int minTotalLength,
       boolean isStartAnchored,
       boolean isEndAnchored) {
 
     public static final Chain EMPTY =
-        new Chain(new Segment[0], Gap.EMPTY, new int[0], 0, false, false);
+        new Chain(new Segment[0], Gap.EMPTY, new int[0], 0, false, 0, false, false);
 
     public Chain {
       Objects.requireNonNull(segments, "segments");
@@ -60,6 +67,93 @@ record MultiAnchorDescriptor(
           minTotalLength,
           isStartAnchored,
           false);
+    }
+
+    Chain(
+        Segment[] segments,
+        Gap trailingGap,
+        int[] checkOrder,
+        int minTotalLength,
+        boolean isStartAnchored,
+        boolean isEndAnchored) {
+      this(
+          segments,
+          trailingGap,
+          checkOrder,
+          computeDefaultDriverIndex(segments, checkOrder),
+          computeIsUpstreamBounded(segments, computeDefaultDriverIndex(segments, checkOrder)),
+          minTotalLength,
+          isStartAnchored,
+          isEndAnchored);
+    }
+
+    public int selectDriver(InputDomain domain, boolean vectorAvailable) {
+      if (checkOrder == null
+          || checkOrder.length == 0
+          || segments == null
+          || segments.length == 0) {
+        return 0;
+      }
+      for (int candidate : checkOrder) {
+        if (candidate >= 0 && candidate < segments.length) {
+          if (candidate > 0 && hasUpstreamGreedyUnboundedGap(segments, candidate)) {
+            continue;
+          }
+          Anchor a = segments[candidate].anchor();
+          if (domain == InputDomain.UTF8) {
+            if (a.isHardwareAccelerated(InputDomain.UTF8)
+                || (vectorAvailable && a.minLength() >= 1)) {
+              return candidate;
+            }
+          } else if (domain == InputDomain.STRING) {
+            if (a.isHardwareAccelerated(InputDomain.STRING)) {
+              return candidate;
+            }
+          }
+        }
+      }
+      return 0;
+    }
+
+    private static boolean hasUpstreamGreedyUnboundedGap(Segment[] segments, int driverIdx) {
+      for (int i = 1; i <= driverIdx; i++) {
+        Gap g = segments[i].gap();
+        if (g.isGreedy()
+            && (g.kind() == GapKind.ANY_STAR || g.kind() == GapKind.SINGLE_LINE_ANY_STAR)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    public boolean isUpstreamBoundedFor(int driverIdx) {
+      return computeIsUpstreamBounded(segments, driverIdx);
+    }
+
+    private static int computeDefaultDriverIndex(Segment[] segments, int[] checkOrder) {
+      if (segments == null || segments.length == 0) {
+        return 0;
+      }
+      if (checkOrder != null && checkOrder.length > 0) {
+        int rarest = checkOrder[0];
+        if (rarest >= 0 && rarest < segments.length) {
+          return rarest;
+        }
+      }
+      return 0;
+    }
+
+    private static boolean computeIsUpstreamBounded(Segment[] segments, int driverIdx) {
+      if (segments == null || segments.length == 0 || driverIdx <= 0) {
+        return true;
+      }
+      for (int i = 0; i <= driverIdx; i++) {
+        Gap g = segments[i].gap();
+        if (g.maxLength() == Integer.MAX_VALUE || g.kind() == GapKind.ANY_STAR) {
+          return false;
+        }
+      }
+      return true;
     }
   }
 
@@ -210,6 +304,22 @@ record MultiAnchorDescriptor(
     return chain.checkOrder();
   }
 
+  int driverIndex() {
+    return chain.driverIndex();
+  }
+
+  int selectDriver(InputDomain domain, boolean vectorAvailable) {
+    return chain.selectDriver(domain, vectorAvailable);
+  }
+
+  boolean isUpstreamBounded() {
+    return chain.isUpstreamBounded();
+  }
+
+  boolean isUpstreamBoundedFor(int driverIdx) {
+    return chain.isUpstreamBoundedFor(driverIdx);
+  }
+
   int minTotalLength() {
     return chain.minTotalLength();
   }
@@ -297,22 +407,86 @@ record MultiAnchorDescriptor(
             || chain.segments()[0].gap().kind() == GapKind.SINGLE_LINE_ANY_STAR);
   }
 
+  enum QuantifierFlavor {
+    EXACT,
+    GREEDY_UNBOUNDED,
+    GREEDY_BOUNDED,
+    RELUCTANT_UNBOUNDED,
+    RELUCTANT_BOUNDED,
+    POSSESSIVE;
+
+    boolean isGreedy() {
+      return this == GREEDY_UNBOUNDED || this == GREEDY_BOUNDED;
+    }
+
+    boolean isReluctant() {
+      return this == RELUCTANT_UNBOUNDED || this == RELUCTANT_BOUNDED;
+    }
+
+    boolean isExact() {
+      return this == EXACT;
+    }
+  }
+
   boolean isExecutableChain() {
     int n = chain.segments().length;
-    if (n < 2 || chain.isEndAnchored() || !chain.segments()[0].gap().equals(Gap.EMPTY)) {
+    if (n < 1 || chain.isEndAnchored() || !isExecutableLeadingGap(chain.segments()[0].gap())) {
+      return false;
+    }
+    if (n == 1
+        && chain.segments()[0].gap().kind() == GapKind.EMPTY
+        && chain.trailingGap().kind() == GapKind.EMPTY) {
       return false;
     }
     for (int i = 0; i < n; i++) {
       Segment segment = chain.segments()[i];
-      if (!(segment.anchor() instanceof Anchor.Single)
-          && !(segment.anchor() instanceof Anchor.CharClass)) {
+      if (!isExecutableAnchor(segment.anchor())) {
         return false;
       }
-      if (i > 0 && !segment.gap().isExecutorFixedGap()) {
+      if (i > 0 && !isExecutableInteriorGap(segment.gap())) {
         return false;
       }
     }
-    return chain.trailingGap().isExecutorFixedGap();
+    return isExecutableTrailingGap(chain.trailingGap());
+  }
+
+  private static boolean isExecutableAnchor(Anchor anchor) {
+    return anchor instanceof Anchor.Single || anchor instanceof Anchor.CharClass;
+  }
+
+  private static boolean isExecutableLeadingGap(Gap gap) {
+    return switch (gap.kind()) {
+      case EMPTY, TEXT_START, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
+      case BOUNDED_CLASS_REPEAT -> gap.scanInfo() != null || gap.charClass() != null;
+      case TEXT_END, LINE_START, LINE_END, WORD_BOUNDARY, NO_WORD_BOUNDARY -> false;
+    };
+  }
+
+  private static boolean isExecutableInteriorGap(Gap gap) {
+    return switch (gap.kind()) {
+      case EMPTY -> true;
+      case BOUNDED_CLASS_REPEAT -> gap.scanInfo() != null || gap.charClass() != null;
+      case ANY_STAR,
+          SINGLE_LINE_ANY_STAR,
+          TEXT_START,
+          TEXT_END,
+          LINE_START,
+          LINE_END,
+          WORD_BOUNDARY,
+          NO_WORD_BOUNDARY ->
+          false;
+    };
+  }
+
+  private static boolean isExecutableTrailingGap(Gap gap) {
+    if (gap.minLength() == 0 && !gap.isGreedy()) {
+      return true;
+    }
+    return switch (gap.kind()) {
+      case EMPTY, TEXT_END, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
+      case BOUNDED_CLASS_REPEAT -> gap.scanInfo() != null || gap.charClass() != null;
+      case TEXT_START, LINE_START, LINE_END, WORD_BOUNDARY, NO_WORD_BOUNDARY -> false;
+    };
   }
 
   boolean isExecutableUtf8Chain() {
@@ -320,10 +494,22 @@ record MultiAnchorDescriptor(
       return false;
     }
     for (Segment segment : chain.segments()) {
-      if (segment.anchor() instanceof Anchor.Single single
-          && single.foldCase()
-          && !isAscii(single.literal())) {
-        return false;
+      switch (segment.anchor()) {
+        case Anchor.Single single -> {
+          if (single.foldCase() && !isAscii(single.literal())) {
+            return false;
+          }
+        }
+        case Anchor.Alternation alt -> {
+          if (alt.foldCase()) {
+            for (String lit : alt.literals()) {
+              if (!isAscii(lit)) {
+                return false;
+              }
+            }
+          }
+        }
+        case Anchor.CharClass unusedCc -> {}
       }
     }
     return true;
@@ -393,9 +579,89 @@ record MultiAnchorDescriptor(
       return minLength == maxLength;
     }
 
-    private boolean isExecutorFixedGap() {
+    QuantifierFlavor quantifierFlavor() {
+      if (isFixed() || equals(EMPTY)) {
+        return QuantifierFlavor.EXACT;
+      }
+      if (isGreedy) {
+        return maxLength == Integer.MAX_VALUE
+            ? QuantifierFlavor.GREEDY_UNBOUNDED
+            : QuantifierFlavor.GREEDY_BOUNDED;
+      } else {
+        return maxLength == Integer.MAX_VALUE
+            ? QuantifierFlavor.RELUCTANT_UNBOUNDED
+            : QuantifierFlavor.RELUCTANT_BOUNDED;
+      }
+    }
+
+    boolean isExecutorFixedGap() {
       return equals(EMPTY)
           || (kind == GapKind.BOUNDED_CLASS_REPEAT && isFixed() && scanInfo != null);
+    }
+
+    int scanClassEnd(String text, int fromPos, int maxPos) {
+      if (kind == GapKind.BOUNDED_CLASS_REPEAT) {
+        int limit = Math.min(maxPos, maxLength == Integer.MAX_VALUE ? maxPos : fromPos + maxLength);
+        int cur = fromPos;
+        while (cur < limit) {
+          int cp = text.codePointAt(cur);
+          if (scanInfo != null && !scanInfo.contains(cp)) {
+            break;
+          }
+          cur += Character.charCount(cp);
+        }
+        return cur;
+      }
+      if (kind == GapKind.SINGLE_LINE_ANY_STAR) {
+        int limit = Math.min(maxPos, maxLength == Integer.MAX_VALUE ? maxPos : fromPos + maxLength);
+        int cur = fromPos;
+        while (cur < limit) {
+          int cp = text.codePointAt(cur);
+          if (Nfa.isLineTerminator(cp)) {
+            break;
+          }
+          cur += Character.charCount(cp);
+        }
+        return cur;
+      }
+      if (maxLength != Integer.MAX_VALUE) {
+        return Math.min(maxPos, fromPos + maxLength);
+      }
+      return maxPos;
+    }
+
+    int scanClassEnd(Utf8InputScanner scanner, int fromPos, int maxPos) {
+      if (kind == GapKind.BOUNDED_CLASS_REPEAT) {
+        int limit = Math.min(maxPos, maxLength == Integer.MAX_VALUE ? maxPos : fromPos + maxLength);
+        int cur = fromPos;
+        while (cur < limit) {
+          long decoded = scanner.decodeForward(cur);
+          int cp = InputScanner.codePoint(decoded);
+          int nextPos = InputScanner.position(decoded);
+          if (scanInfo != null && !scanInfo.contains(cp)) {
+            break;
+          }
+          cur = nextPos;
+        }
+        return cur;
+      }
+      if (kind == GapKind.SINGLE_LINE_ANY_STAR) {
+        int limit = Math.min(maxPos, maxLength == Integer.MAX_VALUE ? maxPos : fromPos + maxLength);
+        int cur = fromPos;
+        while (cur < limit) {
+          long decoded = scanner.decodeForward(cur);
+          int cp = InputScanner.codePoint(decoded);
+          if (Nfa.isLineTerminator(cp)) {
+            break;
+          }
+          cur = InputScanner.position(decoded);
+        }
+        return cur;
+      }
+      if (maxLength != Integer.MAX_VALUE) {
+        return Math.min(maxPos, fromPos + maxLength);
+      }
+      return maxPos;
     }
 
     int matchExecutorFixedForward(String text, int fromPos, int maxPos) {
@@ -535,10 +801,10 @@ record MultiAnchorDescriptor(
     }
 
     boolean matchesSlice(String text, int from, int to) {
-      int len = to - from;
-      if (len < minLength || len > maxLength) {
+      if (from > to) {
         return false;
       }
+      int len = to - from;
       return switch (kind) {
         case EMPTY -> len == 0;
         case TEXT_START -> len == 0 && from == 0;
@@ -547,28 +813,45 @@ record MultiAnchorDescriptor(
         case NO_WORD_BOUNDARY -> len == 0 && !isWordBoundary(text, from);
         case LINE_START -> len == 0 && isLineStart(text, from);
         case LINE_END -> len == 0 && isLineEnd(text, from);
-        case ANY_STAR -> true;
-        case SINGLE_LINE_ANY_STAR -> text.indexOf('\n', from) < 0 || text.indexOf('\n', from) >= to;
-        case BOUNDED_CLASS_REPEAT -> {
-          if (scanInfo == null) {
-            yield true;
-          }
-          for (int i = from; i < to; i++) {
-            char c = text.charAt(i);
-            if (c > 127 || !scanInfo.contains(c)) {
+        case ANY_STAR -> len >= minLength && len <= maxLength;
+        case SINGLE_LINE_ANY_STAR -> {
+          int count = 0;
+          for (int i = from; i < to; ) {
+            int cp = text.codePointAt(i);
+            if (Nfa.isLineTerminator(cp)) {
               yield false;
             }
+            count++;
+            i += Character.charCount(cp);
           }
-          yield true;
+          yield count >= minLength && count <= maxLength;
+        }
+        case BOUNDED_CLASS_REPEAT -> {
+          int count = 0;
+          for (int i = from; i < to; ) {
+            int cp = text.codePointAt(i);
+            if (scanInfo != null) {
+              if (!scanInfo.contains(cp)) {
+                yield false;
+              }
+            } else if (charClass != null) {
+              if (!charClass.contains(cp)) {
+                yield false;
+              }
+            }
+            count++;
+            i += Character.charCount(cp);
+          }
+          yield count >= minLength && count <= maxLength;
         }
       };
     }
 
     boolean matchesSlice(Utf8InputScanner scanner, int from, int to) {
-      int len = to - from;
-      if (len < minLength || len > maxLength) {
+      if (from > to) {
         return false;
       }
+      int len = to - from;
       return switch (kind) {
         case EMPTY -> len == 0;
         case TEXT_START -> len == 0 && from == 0;
@@ -577,26 +860,43 @@ record MultiAnchorDescriptor(
         case NO_WORD_BOUNDARY -> len == 0 && !isWordBoundary(scanner, from);
         case LINE_START -> len == 0 && isLineStart(scanner, from);
         case LINE_END -> len == 0 && isLineEnd(scanner, from);
-        case ANY_STAR -> true;
+        case ANY_STAR -> len >= minLength && len <= maxLength;
         case SINGLE_LINE_ANY_STAR -> {
-          int nl = scanner.indexOfAscii('\n', from, to);
-          yield nl < 0 || nl >= to;
-        }
-        case BOUNDED_CLASS_REPEAT -> {
-          if (scanInfo == null) {
-            yield true;
-          }
-          for (int i = from; i < to; i++) {
-            if (!scanInfo.contains(scanner.asciiAt(i))) {
+          int count = 0;
+          for (int i = from; i < to; ) {
+            long decoded = scanner.decodeForward(i);
+            int cp = InputScanner.codePoint(decoded);
+            if (Nfa.isLineTerminator(cp)) {
               yield false;
             }
+            count++;
+            i = InputScanner.position(decoded);
           }
-          yield true;
+          yield count >= minLength && count <= maxLength;
+        }
+        case BOUNDED_CLASS_REPEAT -> {
+          int count = 0;
+          for (int i = from; i < to; ) {
+            long decoded = scanner.decodeForward(i);
+            int cp = InputScanner.codePoint(decoded);
+            if (scanInfo != null) {
+              if (!scanInfo.contains(cp)) {
+                yield false;
+              }
+            } else if (charClass != null) {
+              if (!charClass.contains(cp)) {
+                yield false;
+              }
+            }
+            count++;
+            i = InputScanner.position(decoded);
+          }
+          yield count >= minLength && count <= maxLength;
         }
       };
     }
 
-    int matchBackward(String text, int anchorPos, int minPos) {
+    int expandLeading(String text, int anchorPos, int minPos) {
       return switch (kind) {
         case EMPTY -> anchorPos;
         case TEXT_START -> anchorPos == 0 ? 0 : -1;
@@ -606,12 +906,16 @@ record MultiAnchorDescriptor(
         case LINE_START -> isLineStart(text, anchorPos) ? anchorPos : -1;
         case LINE_END -> isLineEnd(text, anchorPos) ? anchorPos : -1;
         case BOUNDED_CLASS_REPEAT -> {
-          int limit = Math.max(minPos, maxLength == Integer.MAX_VALUE ? 0 : anchorPos - maxLength);
+          int count = 0;
           int cur = anchorPos;
-          while (cur > limit) {
+          int minMatchPos = -1;
+          if (minLength == 0) {
+            minMatchPos = cur;
+          }
+          while (count < maxLength && cur > minPos) {
             int cp = text.codePointBefore(cur);
             int prevPos = cur - Character.charCount(cp);
-            if (prevPos < limit) {
+            if (prevPos < minPos) {
               break;
             }
             if (scanInfo != null) {
@@ -624,20 +928,29 @@ record MultiAnchorDescriptor(
               }
             }
             cur = prevPos;
+            count++;
+            if (count == minLength) {
+              minMatchPos = cur;
+            }
           }
-          int matched = anchorPos - cur;
-          if (matched < minLength) {
+          if (count < minLength) {
             yield -1;
           }
-          yield isGreedy ? cur : anchorPos - minLength;
+          yield isGreedy ? cur : minMatchPos;
         }
         case SINGLE_LINE_ANY_STAR -> {
           if (!isGreedy) {
             yield anchorPos - minLength >= minPos ? anchorPos - minLength : -1;
           }
-          int nl = text.lastIndexOf('\n', anchorPos - 1);
-          int start = (nl >= minPos) ? nl + 1 : minPos;
-          yield (anchorPos - start >= minLength) ? start : -1;
+          int cur = anchorPos;
+          while (cur > minPos) {
+            int cp = text.codePointBefore(cur);
+            if (Nfa.isLineTerminator(cp)) {
+              break;
+            }
+            cur -= Character.charCount(cp);
+          }
+          yield (anchorPos - cur >= minLength) ? cur : -1;
         }
         case ANY_STAR -> {
           if (!isGreedy) {
@@ -648,7 +961,7 @@ record MultiAnchorDescriptor(
       };
     }
 
-    int matchBackward(Utf8InputScanner scanner, int anchorPos, int minPos) {
+    int expandLeading(Utf8InputScanner scanner, int anchorPos, int minPos) {
       return switch (kind) {
         case EMPTY -> anchorPos;
         case TEXT_START -> anchorPos == 0 ? 0 : -1;
@@ -658,13 +971,17 @@ record MultiAnchorDescriptor(
         case LINE_START -> isLineStart(scanner, anchorPos) ? anchorPos : -1;
         case LINE_END -> isLineEnd(scanner, anchorPos) ? anchorPos : -1;
         case BOUNDED_CLASS_REPEAT -> {
-          int limit = Math.max(minPos, maxLength == Integer.MAX_VALUE ? 0 : anchorPos - maxLength);
+          int count = 0;
           int cur = anchorPos;
-          while (cur > limit) {
+          int minMatchPos = -1;
+          if (minLength == 0) {
+            minMatchPos = cur;
+          }
+          while (count < maxLength && cur > minPos) {
             long decoded = scanner.decodeBackward(cur);
             int cp = InputScanner.codePoint(decoded);
             int prevPos = InputScanner.position(decoded);
-            if (prevPos < limit) {
+            if (prevPos < minPos) {
               break;
             }
             if (scanInfo != null) {
@@ -677,26 +994,30 @@ record MultiAnchorDescriptor(
               }
             }
             cur = prevPos;
+            count++;
+            if (count == minLength) {
+              minMatchPos = cur;
+            }
           }
-          int matched = anchorPos - cur;
-          if (matched < minLength) {
+          if (count < minLength) {
             yield -1;
           }
-          yield isGreedy ? cur : anchorPos - minLength;
+          yield isGreedy ? cur : minMatchPos;
         }
         case SINGLE_LINE_ANY_STAR -> {
           if (!isGreedy) {
             yield anchorPos - minLength >= minPos ? anchorPos - minLength : -1;
           }
-          int nl = -1;
-          for (int i = anchorPos - 1; i >= minPos; i--) {
-            if (scanner.asciiAt(i) == '\n') {
-              nl = i;
+          int cur = anchorPos;
+          while (cur > minPos) {
+            long decoded = scanner.decodeBackward(cur);
+            int cp = InputScanner.codePoint(decoded);
+            if (Nfa.isLineTerminator(cp)) {
               break;
             }
+            cur = InputScanner.position(decoded);
           }
-          int start = (nl >= minPos) ? nl + 1 : minPos;
-          yield (anchorPos - start >= minLength) ? start : -1;
+          yield (anchorPos - cur >= minLength) ? cur : -1;
         }
         case ANY_STAR -> {
           if (!isGreedy) {
@@ -707,7 +1028,7 @@ record MultiAnchorDescriptor(
       };
     }
 
-    int matchForward(String text, int fromPos, int maxPos) {
+    int expandTrailing(String text, int fromPos, int maxPos) {
       return switch (kind) {
         case EMPTY -> fromPos;
         case TEXT_START -> fromPos == 0 ? 0 : -1;
@@ -717,17 +1038,33 @@ record MultiAnchorDescriptor(
         case LINE_START -> isLineStart(text, fromPos) ? fromPos : -1;
         case LINE_END -> isLineEnd(text, fromPos) ? fromPos : -1;
         case BOUNDED_CLASS_REPEAT -> {
-          int limit =
-              Math.min(maxPos, maxLength == Integer.MAX_VALUE ? maxPos : fromPos + maxLength);
+          int count = 0;
           int cur = fromPos;
-          while (cur < limit && (scanInfo == null || scanInfo.contains(text.codePointAt(cur)))) {
-            cur += Character.charCount(text.codePointAt(cur));
+          int minMatchPos = -1;
+          if (minLength == 0) {
+            minMatchPos = cur;
           }
-          int matched = cur - fromPos;
-          if (matched < minLength) {
+          while (count < maxLength && cur < maxPos) {
+            int cp = text.codePointAt(cur);
+            if (scanInfo != null) {
+              if (!scanInfo.contains(cp)) {
+                break;
+              }
+            } else if (charClass != null) {
+              if (!charClass.contains(cp)) {
+                break;
+              }
+            }
+            cur += Character.charCount(cp);
+            count++;
+            if (count == minLength) {
+              minMatchPos = cur;
+            }
+          }
+          if (count < minLength) {
             yield -1;
           }
-          yield isGreedy ? cur : fromPos + minLength;
+          yield isGreedy ? cur : minMatchPos;
         }
         case SINGLE_LINE_ANY_STAR -> {
           if (!isGreedy) {
@@ -746,7 +1083,7 @@ record MultiAnchorDescriptor(
       };
     }
 
-    int matchForward(Utf8InputScanner scanner, int fromPos, int maxPos) {
+    int expandTrailing(Utf8InputScanner scanner, int fromPos, int maxPos) {
       return switch (kind) {
         case EMPTY -> fromPos;
         case TEXT_START -> fromPos == 0 ? 0 : -1;
@@ -756,23 +1093,35 @@ record MultiAnchorDescriptor(
         case LINE_START -> isLineStart(scanner, fromPos) ? fromPos : -1;
         case LINE_END -> isLineEnd(scanner, fromPos) ? fromPos : -1;
         case BOUNDED_CLASS_REPEAT -> {
-          int limit =
-              Math.min(maxPos, maxLength == Integer.MAX_VALUE ? maxPos : fromPos + maxLength);
+          int count = 0;
           int cur = fromPos;
-          while (cur < limit) {
+          int minMatchPos = -1;
+          if (minLength == 0) {
+            minMatchPos = cur;
+          }
+          while (count < maxLength && cur < maxPos) {
             long decoded = scanner.decodeForward(cur);
             int cp = InputScanner.codePoint(decoded);
             int nextPos = InputScanner.position(decoded);
-            if (scanInfo != null && !scanInfo.contains(cp)) {
-              break;
+            if (scanInfo != null) {
+              if (!scanInfo.contains(cp)) {
+                break;
+              }
+            } else if (charClass != null) {
+              if (!charClass.contains(cp)) {
+                break;
+              }
             }
             cur = nextPos;
+            count++;
+            if (count == minLength) {
+              minMatchPos = cur;
+            }
           }
-          int matched = cur - fromPos;
-          if (matched < minLength) {
+          if (count < minLength) {
             yield -1;
           }
-          yield isGreedy ? cur : fromPos + minLength;
+          yield isGreedy ? cur : minMatchPos;
         }
         case SINGLE_LINE_ANY_STAR -> {
           if (!isGreedy) {
@@ -819,6 +1168,8 @@ record MultiAnchorDescriptor(
 
     boolean foldCase();
 
+    boolean isHardwareAccelerated(InputDomain domain);
+
     default String literal() {
       return primaryLiteral();
     }
@@ -832,6 +1183,48 @@ record MultiAnchorDescriptor(
     int findNext(String text, int fromIndex);
 
     int findNext(Utf8InputScanner scanner, int fromIndex);
+
+    default int findNextWithin(String text, int fromIndex, int toIndex) {
+      if (fromIndex > toIndex) {
+        return -1;
+      }
+      int idx = findNext(text, fromIndex);
+      return idx >= 0 && idx <= toIndex ? idx : -1;
+    }
+
+    default int findNextWithin(Utf8InputScanner scanner, int fromIndex, int toIndex) {
+      if (fromIndex > toIndex) {
+        return -1;
+      }
+      int idx = findNext(scanner, fromIndex);
+      return idx >= 0 && idx <= toIndex ? idx : -1;
+    }
+
+    default int lastIndexOf(String text, int fromIndex, int toIndex) {
+      int upper = Math.min(toIndex, text.length() - minLength());
+      if (fromIndex > upper || fromIndex < 0) {
+        return -1;
+      }
+      for (int i = upper; i >= fromIndex; i--) {
+        if (startsWith(text, i)) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    default int lastIndexOf(Utf8InputScanner scanner, int fromIndex, int toIndex) {
+      int upper = Math.min(toIndex, scanner.length() - minLength());
+      if (fromIndex > upper || fromIndex < 0) {
+        return -1;
+      }
+      for (int i = upper; i >= fromIndex; i--) {
+        if (startsWith(scanner, i)) {
+          return i;
+        }
+      }
+      return -1;
+    }
 
     boolean startsWith(String text, int pos);
 
@@ -891,6 +1284,11 @@ record MultiAnchorDescriptor(
       }
 
       @Override
+      public boolean isHardwareAccelerated(InputDomain domain) {
+        return true;
+      }
+
+      @Override
       public int minLength() {
         return literal.length();
       }
@@ -921,6 +1319,80 @@ record MultiAnchorDescriptor(
               literal, failure, anchorOffset, anchorLowByte, anchorHighByte, fromIndex);
         }
         return scanner.indexOf(literalUtf8, failure, shifts, fromIndex);
+      }
+
+      @Override
+      public int findNextWithin(Utf8InputScanner scanner, int fromIndex, int toIndex) {
+        if (fromIndex > toIndex || fromIndex + literalUtf8.length > scanner.length()) {
+          return -1;
+        }
+        int maxStart = Math.min(toIndex, scanner.length() - literalUtf8.length);
+        if (fromIndex > maxStart) {
+          return -1;
+        }
+        if (maxStart - fromIndex <= 64) {
+          for (int i = fromIndex; i <= maxStart; i++) {
+            if (startsWith(scanner, i)) {
+              return i;
+            }
+          }
+          return -1;
+        }
+        int idx = findNext(scanner, fromIndex);
+        return idx >= 0 && idx <= maxStart ? idx : -1;
+      }
+
+      @Override
+      public int lastIndexOf(String text, int fromIndex, int toIndex) {
+        if (fromIndex > toIndex || fromIndex + literal.length() > text.length()) {
+          return -1;
+        }
+        int maxStart = Math.min(toIndex, text.length() - literal.length());
+        if (fromIndex > maxStart) {
+          return -1;
+        }
+        if (foldCase) {
+          for (int i = maxStart; i >= fromIndex; i--) {
+            if (startsWith(text, i)) {
+              return i;
+            }
+          }
+          return -1;
+        }
+        int idx = text.lastIndexOf(literal, maxStart);
+        return idx >= fromIndex ? idx : -1;
+      }
+
+      @Override
+      public int lastIndexOf(Utf8InputScanner scanner, int fromIndex, int toIndex) {
+        if (fromIndex > toIndex || fromIndex + literalUtf8.length > scanner.length()) {
+          return -1;
+        }
+        int maxStart = Math.min(toIndex, scanner.length() - literalUtf8.length);
+        if (fromIndex > maxStart) {
+          return -1;
+        }
+        if (foldCase) {
+          for (int i = maxStart; i >= fromIndex; i--) {
+            if (startsWith(scanner, i)) {
+              return i;
+            }
+          }
+          return -1;
+        }
+        int firstByte = literalUtf8[0] & 0xFF;
+        int p = maxStart;
+        while (p >= fromIndex) {
+          int nextP = scanner.lastIndexOfAscii(firstByte, p, fromIndex);
+          if (nextP < fromIndex) {
+            return -1;
+          }
+          if (startsWith(scanner, nextP)) {
+            return nextP;
+          }
+          p = nextP - 1;
+        }
+        return -1;
       }
 
       @Override
@@ -989,6 +1461,14 @@ record MultiAnchorDescriptor(
         TeddyModel teddy = !foldCase ? TeddyModel.compileForSelectedProvider(literals) : null;
 
         return new Alternation(literals.clone(), utf8, foldCase, min, max, multiLit, teddy);
+      }
+
+      @Override
+      public boolean isHardwareAccelerated(InputDomain domain) {
+        if (domain == InputDomain.UTF8) {
+          return !foldCase && (teddyModel != null || multiLiteral != null);
+        }
+        return false;
       }
 
       @Override
@@ -1226,6 +1706,14 @@ record MultiAnchorDescriptor(
             scanInfo.isAscii() ? new AsciiBitmap(scanInfo.bitmap0(), scanInfo.bitmap1()) : null;
         int[] ranges = scanInfo.ranges();
         return new CharClass(bitmap, ranges, scanInfo);
+      }
+
+      @Override
+      public boolean isHardwareAccelerated(InputDomain domain) {
+        if (domain == InputDomain.UTF8) {
+          return bitmap != null || (scanInfo != null && scanInfo.isAscii());
+        }
+        return bitmap != null && bitmap.cardinality() <= 64;
       }
 
       @Override

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -454,19 +454,10 @@ record MultiAnchorDescriptor(
 
   private static boolean isExecutableLeadingGap(Gap gap) {
     return switch (gap.kind()) {
-      case EMPTY, TEXT_START, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
-      case BOUNDED_CLASS_REPEAT -> gap.scanInfo() != null || gap.charClass() != null;
-      case TEXT_END, LINE_START, LINE_END, WORD_BOUNDARY, NO_WORD_BOUNDARY -> false;
-    };
-  }
-
-  private static boolean isExecutableInteriorGap(Gap gap) {
-    return switch (gap.kind()) {
-      case EMPTY -> true;
-      case BOUNDED_CLASS_REPEAT -> gap.scanInfo() != null || gap.charClass() != null;
+      case EMPTY, TEXT_START -> true;
+      case BOUNDED_CLASS_REPEAT -> gap.isExecutorFixedGap();
       case ANY_STAR,
           SINGLE_LINE_ANY_STAR,
-          TEXT_START,
           TEXT_END,
           LINE_START,
           LINE_END,
@@ -476,14 +467,22 @@ record MultiAnchorDescriptor(
     };
   }
 
+  private static boolean isExecutableInteriorGap(Gap gap) {
+    return gap.isExecutorFixedGap();
+  }
+
   private static boolean isExecutableTrailingGap(Gap gap) {
-    if (gap.minLength() == 0 && !gap.isGreedy()) {
-      return true;
-    }
     return switch (gap.kind()) {
-      case EMPTY, TEXT_END, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
-      case BOUNDED_CLASS_REPEAT -> gap.scanInfo() != null || gap.charClass() != null;
-      case TEXT_START, LINE_START, LINE_END, WORD_BOUNDARY, NO_WORD_BOUNDARY -> false;
+      case EMPTY, TEXT_END -> true;
+      case BOUNDED_CLASS_REPEAT -> gap.isExecutorFixedGap();
+      case ANY_STAR,
+          SINGLE_LINE_ANY_STAR,
+          TEXT_START,
+          LINE_START,
+          LINE_END,
+          WORD_BOUNDARY,
+          NO_WORD_BOUNDARY ->
+          false;
     };
   }
 

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -217,7 +217,6 @@ final class MultiAnchorExecutor {
         }
 
         if (!upstreamMatched) {
-          minReverseWatermark = Math.max(minReverseWatermark, pDriver);
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
           verificationWork++;
           if (WorkLimit.isExhausted(verificationWork, workLimit)) {
@@ -235,7 +234,6 @@ final class MultiAnchorExecutor {
         } else {
           resolvedStart = leadingGap.expandLeading(scanner, p0, minReverseWatermark);
           if (resolvedStart < 0) {
-            minReverseWatermark = Math.max(minReverseWatermark, pDriver);
             candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
             continue;
           }
@@ -493,7 +491,6 @@ final class MultiAnchorExecutor {
         }
 
         if (!upstreamMatched) {
-          minReverseWatermark = Math.max(minReverseWatermark, pDriver);
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
           verificationWork++;
           if (WorkLimit.isExhausted(verificationWork, workLimit)) {
@@ -511,7 +508,6 @@ final class MultiAnchorExecutor {
         } else {
           resolvedStart = leadingGap.expandLeading(text, p0, minReverseWatermark);
           if (resolvedStart < 0) {
-            minReverseWatermark = Math.max(minReverseWatermark, pDriver);
             candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
             continue;
           }

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -169,7 +169,7 @@ final class MultiAnchorExecutor {
                   ? (curAnchorStart - minReverseWatermark)
                   : (int)
                       Math.min(
-                          (long) gap.maxLength() * 4 + upstreamAnchor.maxLength(),
+                          ((long) gap.maxLength() + upstreamAnchor.maxLength()) * 4,
                           curAnchorStart - minReverseWatermark);
           int minHop = gap.minLength() + upstreamAnchor.minLength();
 

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -5,6 +5,7 @@
 
 package org.safere;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -86,10 +87,29 @@ final class MultiAnchorExecutor {
       }
     }
 
+    int driverIdx =
+        descriptor.selectDriver(
+            MultiAnchorDescriptor.InputDomain.UTF8, VectorScanProviders.teddyProviderAvailable());
+    if (driverIdx < 0 || driverIdx >= numSegments) {
+      driverIdx = 0;
+    }
+
+    int minUpstreamLen = 0;
+    for (int i = 0; i < driverIdx; i++) {
+      minUpstreamLen += segments[i].gap().minLength() + segments[i].anchor().minLength();
+    }
+    minUpstreamLen += segments[driverIdx].gap().minLength();
+
+    long workLimit = WorkLimit.forRemaining(textLen - searchFrom);
+    long verificationWork = 0;
+
+    int minReverseWatermark = Math.max(0, searchFrom);
+    int[] downstreamWatermarks = new int[numSegments];
+    Arrays.fill(downstreamWatermarks, searchFrom);
     int candidatePos = Math.max(0, searchFrom);
-    MultiAnchorDescriptor.Segment firstSeg = segments[0];
-    MultiAnchorDescriptor.Gap leadingGap = firstSeg.gap();
-    MultiAnchorDescriptor.Anchor firstAnchor = firstSeg.anchor();
+    MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
+    MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
+    MultiAnchorDescriptor.Gap leadingGap = segments[0].gap();
     MultiAnchorDescriptor.Gap trailingGap = descriptor.trailingGap();
     boolean isStartAnchored =
         descriptor.chain().isStartAnchored()
@@ -102,45 +122,180 @@ final class MultiAnchorExecutor {
       return Result.MISMATCH;
     }
 
+    boolean hasLeadingAnyStar = leadingGap.kind() == MultiAnchorDescriptor.GapKind.ANY_STAR;
+
     while (candidatePos <= textLen - minTotalLength) {
-      // Phase 1: Locate candidate for Anchor 0 (primary anchor)
-      int p0 = firstAnchor.findNext(scanner, candidatePos + leadingGap.minLength());
-      if (p0 < 0) {
-        // First anchor not found anywhere downstream -> document-level mismatch
+      // Phase 1: Locate candidate for Driver Anchor
+      int pDriver = driverAnchor.findNext(scanner, candidatePos + minUpstreamLen);
+      if (pDriver < 0) {
         return Result.MISMATCH;
       }
       if (isStartAnchored
-          && p0 > 0
+          && driverIdx == 0
+          && pDriver > 0
           && leadingGap.kind() == MultiAnchorDescriptor.GapKind.TEXT_START) {
         return Result.MISMATCH;
       }
 
-      // Resolve match start from p0 using leading gap
-      int matchStart = leadingGap.matchBackward(scanner, p0, candidatePos);
-      if (matchStart < 0) {
-        candidatePos = p0 + 1;
-        continue;
+      int matchStart;
+      int currentPos;
+
+      if (driverIdx == 0) {
+        matchStart = leadingGap.expandLeading(scanner, pDriver, candidatePos);
+        if (matchStart < 0) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          continue;
+        }
+
+        int len0 = driverAnchor.lengthAt(scanner, pDriver);
+        if (len0 <= 0) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          continue;
+        }
+        currentPos = pDriver + len0;
+      } else {
+        // Upstream reverse verification for A_{driverIdx-1} down to A_0
+        boolean upstreamMatched = true;
+        int curAnchorStart = pDriver;
+        int p0 = -1;
+
+        for (int k = driverIdx - 1; k >= 0; k--) {
+          MultiAnchorDescriptor.Segment nextSeg = segments[k + 1];
+          MultiAnchorDescriptor.Gap gap = nextSeg.gap();
+          MultiAnchorDescriptor.Anchor upstreamAnchor = segments[k].anchor();
+
+          int maxHop =
+              (gap.maxLength() == Integer.MAX_VALUE)
+                  ? (curAnchorStart - minReverseWatermark)
+                  : (int)
+                      Math.min(
+                          (long) gap.maxLength() * 4 + upstreamAnchor.maxLength(),
+                          curAnchorStart - minReverseWatermark);
+          int minHop = gap.minLength() + upstreamAnchor.minLength();
+
+          int searchUpperBound = curAnchorStart - minHop;
+          int searchLowerBound = Math.max(minReverseWatermark, curAnchorStart - maxHop);
+
+          if (searchUpperBound < searchLowerBound) {
+            upstreamMatched = false;
+            break;
+          }
+
+          int pUpstream = upstreamAnchor.lastIndexOf(scanner, searchLowerBound, searchUpperBound);
+          if (pUpstream < 0) {
+            upstreamMatched = false;
+            break;
+          }
+
+          int uLen = upstreamAnchor.lengthAt(scanner, pUpstream);
+          if (uLen <= 0 || !gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart)) {
+            // Gap check failed: retry reverse search for earlier candidate
+            boolean retryMatched = false;
+            int nextUpper = pUpstream - 1;
+            while (nextUpper >= searchLowerBound) {
+              pUpstream = upstreamAnchor.lastIndexOf(scanner, searchLowerBound, nextUpper);
+              if (pUpstream < 0) {
+                break;
+              }
+              uLen = upstreamAnchor.lengthAt(scanner, pUpstream);
+              if (uLen > 0 && gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart)) {
+                retryMatched = true;
+                break;
+              }
+              nextUpper = pUpstream - 1;
+            }
+            if (!retryMatched) {
+              upstreamMatched = false;
+              break;
+            }
+          }
+
+          curAnchorStart = pUpstream;
+          if (k == 0) {
+            p0 = pUpstream;
+          }
+        }
+
+        if (!upstreamMatched) {
+          minReverseWatermark = Math.max(minReverseWatermark, pDriver);
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          verificationWork++;
+          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+            return Result.FALLBACK;
+          }
+          continue;
+        }
+
+        // Verify leading gap before A_0
+        int resolvedStart;
+        if (hasLeadingAnyStar) {
+          resolvedStart = Math.max(0, searchFrom);
+        } else if (leadingGap.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
+          resolvedStart = p0;
+        } else {
+          resolvedStart = leadingGap.expandLeading(scanner, p0, minReverseWatermark);
+          if (resolvedStart < 0) {
+            minReverseWatermark = Math.max(minReverseWatermark, pDriver);
+            candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+            continue;
+          }
+        }
+
+        int driverLen = driverAnchor.lengthAt(scanner, pDriver);
+        if (driverLen <= 0) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          continue;
+        }
+
+        matchStart = resolvedStart;
+        currentPos = pDriver + driverLen;
       }
 
-      int len0 = firstAnchor.lengthAt(scanner, p0);
-      if (len0 <= 0) {
-        candidatePos = p0 + 1;
-        continue;
-      }
-
-      // Phase 2: Sequentially locate downstream anchors with bounded gap windows
+      // Phase 2: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1}
       boolean chainMatched = true;
-      int currentPos = p0 + len0;
-
-      for (int i = 1; i < numSegments; i++) {
+      for (int i = driverIdx + 1; i < numSegments; i++) {
         MultiAnchorDescriptor.Segment seg = segments[i];
         MultiAnchorDescriptor.Gap gap = seg.gap();
         MultiAnchorDescriptor.Anchor anchor = seg.anchor();
 
-        int p = gap.matchExecutorFixedForward(scanner, currentPos, textLen);
-        if (p < 0) {
-          chainMatched = false;
-          break;
+        int p;
+        if (gap.isExecutorFixedGap()) {
+          p = gap.matchExecutorFixedForward(scanner, currentPos, textLen);
+          if (p < 0 || !anchor.startsWith(scanner, p)) {
+            chainMatched = false;
+            break;
+          }
+        } else {
+          int minHop = currentPos + gap.minLength();
+          if (minHop > textLen) {
+            chainMatched = false;
+            break;
+          }
+          int maxScan = gap.scanClassEnd(scanner, currentPos, textLen);
+          int maxHop = Math.min(textLen, maxScan + anchor.maxLength());
+
+          int searchStart = Math.max(minHop, downstreamWatermarks[i]);
+          if (searchStart > maxHop) {
+            chainMatched = false;
+            break;
+          }
+
+          if (gap.isGreedy()) {
+            p = anchor.lastIndexOf(scanner, searchStart, maxHop);
+          } else {
+            p = anchor.findNextWithin(scanner, searchStart, maxHop);
+          }
+          if (p < 0) {
+            downstreamWatermarks[i] = maxHop;
+            chainMatched = false;
+            break;
+          }
+          downstreamWatermarks[i] = p;
+
+          if (!gap.matchesSlice(scanner, currentPos, p)) {
+            chainMatched = false;
+            break;
+          }
         }
 
         int anchorLen = anchor.lengthAt(scanner, p);
@@ -153,14 +308,17 @@ final class MultiAnchorExecutor {
       }
 
       if (!chainMatched) {
-        candidatePos = p0 + 1;
+        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         continue;
       }
 
       // Phase 3: Trailing gap resolution
-      int matchEnd = trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen);
+      int matchEnd =
+          trailingGap.isExecutorFixedGap()
+              ? trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen)
+              : trailingGap.expandTrailing(scanner, currentPos, textLen);
       if (matchEnd < 0) {
-        candidatePos = p0 + 1;
+        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         continue;
       }
 
@@ -207,10 +365,27 @@ final class MultiAnchorExecutor {
       }
     }
 
+    int driverIdx = descriptor.selectDriver(MultiAnchorDescriptor.InputDomain.STRING, true);
+    if (driverIdx < 0 || driverIdx >= numSegments) {
+      driverIdx = 0;
+    }
+
+    int minUpstreamLen = 0;
+    for (int i = 0; i < driverIdx; i++) {
+      minUpstreamLen += segments[i].gap().minLength() + segments[i].anchor().minLength();
+    }
+    minUpstreamLen += segments[driverIdx].gap().minLength();
+
+    long workLimit = WorkLimit.forRemaining(textLen - searchFrom);
+    long verificationWork = 0;
+
+    int minReverseWatermark = Math.max(0, searchFrom);
+    int[] downstreamWatermarks = new int[numSegments];
+    Arrays.fill(downstreamWatermarks, searchFrom);
     int candidatePos = Math.max(0, searchFrom);
-    MultiAnchorDescriptor.Segment firstSeg = segments[0];
-    MultiAnchorDescriptor.Gap leadingGap = firstSeg.gap();
-    MultiAnchorDescriptor.Anchor firstAnchor = firstSeg.anchor();
+    MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
+    MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
+    MultiAnchorDescriptor.Gap leadingGap = segments[0].gap();
     MultiAnchorDescriptor.Gap trailingGap = descriptor.trailingGap();
     boolean isStartAnchored =
         descriptor.chain().isStartAnchored()
@@ -223,45 +398,181 @@ final class MultiAnchorExecutor {
       return Result.MISMATCH;
     }
 
+    boolean hasLeadingAnyStar = leadingGap.kind() == MultiAnchorDescriptor.GapKind.ANY_STAR;
+
     while (candidatePos <= textLen - minTotalLength) {
-      // Phase 1: Locate candidate for Anchor 0
-      int p0 = findNextCountingWork(firstAnchor, text, candidatePos + leadingGap.minLength());
-      if (p0 < 0) {
-        // First anchor not found anywhere downstream -> document-level mismatch
+      // Phase 1: Locate candidate for Driver Anchor
+      int pDriver =
+          findNextCountingWork(driverAnchor, text, candidatePos + minUpstreamLen);
+      if (pDriver < 0) {
         return Result.MISMATCH;
       }
       if (isStartAnchored
-          && p0 > 0
+          && driverIdx == 0
+          && pDriver > 0
           && leadingGap.kind() == MultiAnchorDescriptor.GapKind.TEXT_START) {
         return Result.MISMATCH;
       }
 
-      // Resolve match start from p0 using leading gap
-      int matchStart = leadingGap.matchBackward(text, p0, candidatePos);
-      if (matchStart < 0) {
-        candidatePos = p0 + 1;
-        continue;
+      int matchStart;
+      int currentPos;
+
+      if (driverIdx == 0) {
+        matchStart = leadingGap.expandLeading(text, pDriver, candidatePos);
+        if (matchStart < 0) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          continue;
+        }
+
+        int len0 = driverAnchor.lengthAt(text, pDriver);
+        if (len0 <= 0) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          continue;
+        }
+        currentPos = pDriver + len0;
+      } else {
+        // Upstream reverse verification for A_{driverIdx-1} down to A_0
+        boolean upstreamMatched = true;
+        int curAnchorStart = pDriver;
+        int p0 = -1;
+
+        for (int k = driverIdx - 1; k >= 0; k--) {
+          MultiAnchorDescriptor.Segment nextSeg = segments[k + 1];
+          MultiAnchorDescriptor.Gap gap = nextSeg.gap();
+          MultiAnchorDescriptor.Anchor upstreamAnchor = segments[k].anchor();
+
+          int maxHop =
+              (gap.maxLength() == Integer.MAX_VALUE)
+                  ? (curAnchorStart - minReverseWatermark)
+                  : (int)
+                      Math.min(
+                          (long) gap.maxLength() * 2 + upstreamAnchor.maxLength(),
+                          curAnchorStart - minReverseWatermark);
+          int minHop = gap.minLength() + upstreamAnchor.minLength();
+
+          int searchUpperBound = curAnchorStart - minHop;
+          int searchLowerBound = Math.max(minReverseWatermark, curAnchorStart - maxHop);
+
+          if (searchUpperBound < searchLowerBound) {
+            upstreamMatched = false;
+            break;
+          }
+
+          int pUpstream = upstreamAnchor.lastIndexOf(text, searchLowerBound, searchUpperBound);
+          if (pUpstream < 0) {
+            upstreamMatched = false;
+            break;
+          }
+
+          int uLen = upstreamAnchor.lengthAt(text, pUpstream);
+          if (uLen <= 0 || !gap.matchesSlice(text, pUpstream + uLen, curAnchorStart)) {
+            // Gap check failed: retry reverse search for earlier candidate
+            boolean retryMatched = false;
+            int nextUpper = pUpstream - 1;
+            while (nextUpper >= searchLowerBound) {
+              pUpstream = upstreamAnchor.lastIndexOf(text, searchLowerBound, nextUpper);
+              if (pUpstream < 0) {
+                break;
+              }
+              uLen = upstreamAnchor.lengthAt(text, pUpstream);
+              if (uLen > 0 && gap.matchesSlice(text, pUpstream + uLen, curAnchorStart)) {
+                retryMatched = true;
+                break;
+              }
+              nextUpper = pUpstream - 1;
+            }
+            if (!retryMatched) {
+              upstreamMatched = false;
+              break;
+            }
+          }
+
+          curAnchorStart = pUpstream;
+          if (k == 0) {
+            p0 = pUpstream;
+          }
+        }
+
+        if (!upstreamMatched) {
+          minReverseWatermark = Math.max(minReverseWatermark, pDriver);
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          verificationWork++;
+          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+            return Result.FALLBACK;
+          }
+          continue;
+        }
+
+        // Verify leading gap before A_0
+        int resolvedStart;
+        if (hasLeadingAnyStar) {
+          resolvedStart = Math.max(0, searchFrom);
+        } else if (leadingGap.kind() == MultiAnchorDescriptor.GapKind.EMPTY) {
+          resolvedStart = p0;
+        } else {
+          resolvedStart = leadingGap.expandLeading(text, p0, minReverseWatermark);
+          if (resolvedStart < 0) {
+            minReverseWatermark = Math.max(minReverseWatermark, pDriver);
+            candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+            continue;
+          }
+        }
+
+        int driverLen = driverAnchor.lengthAt(text, pDriver);
+        if (driverLen <= 0) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          continue;
+        }
+
+        matchStart = resolvedStart;
+        currentPos = pDriver + driverLen;
       }
 
-      int len0 = firstAnchor.lengthAt(text, p0);
-      if (len0 <= 0) {
-        candidatePos = p0 + 1;
-        continue;
-      }
-
-      // Phase 2: Sequentially locate downstream anchors with bounded gap windows
+      // Phase 2: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1}
       boolean chainMatched = true;
-      int currentPos = p0 + len0;
-
-      for (int i = 1; i < numSegments; i++) {
+      for (int i = driverIdx + 1; i < numSegments; i++) {
         MultiAnchorDescriptor.Segment seg = segments[i];
         MultiAnchorDescriptor.Gap gap = seg.gap();
         MultiAnchorDescriptor.Anchor anchor = seg.anchor();
 
-        int p = gap.matchExecutorFixedForward(text, currentPos, textLen);
-        if (p < 0) {
-          chainMatched = false;
-          break;
+        int p;
+        if (gap.isExecutorFixedGap()) {
+          p = gap.matchExecutorFixedForward(text, currentPos, textLen);
+          if (p < 0 || !anchor.startsWith(text, p)) {
+            chainMatched = false;
+            break;
+          }
+        } else {
+          int minHop = currentPos + gap.minLength();
+          if (minHop > textLen) {
+            chainMatched = false;
+            break;
+          }
+          int maxScan = gap.scanClassEnd(text, currentPos, textLen);
+          int maxHop = Math.min(textLen, maxScan + anchor.maxLength());
+
+          int searchStart = Math.max(minHop, downstreamWatermarks[i]);
+          if (searchStart > maxHop) {
+            chainMatched = false;
+            break;
+          }
+
+          if (gap.isGreedy()) {
+            p = anchor.lastIndexOf(text, searchStart, maxHop);
+          } else {
+            p = anchor.findNextWithin(text, searchStart, maxHop);
+          }
+          if (p < 0) {
+            downstreamWatermarks[i] = maxHop;
+            chainMatched = false;
+            break;
+          }
+          downstreamWatermarks[i] = p;
+
+          if (!gap.matchesSlice(text, currentPos, p)) {
+            chainMatched = false;
+            break;
+          }
         }
 
         int anchorLen = anchor.lengthAt(text, p);
@@ -274,14 +585,17 @@ final class MultiAnchorExecutor {
       }
 
       if (!chainMatched) {
-        candidatePos = p0 + 1;
+        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         continue;
       }
 
       // Phase 3: Trailing gap resolution
-      int matchEnd = trailingGap.matchExecutorFixedForward(text, currentPos, textLen);
+      int matchEnd =
+          trailingGap.isExecutorFixedGap()
+              ? trailingGap.matchExecutorFixedForward(text, currentPos, textLen)
+              : trailingGap.expandTrailing(text, currentPos, textLen);
       if (matchEnd < 0) {
-        candidatePos = p0 + 1;
+        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         continue;
       }
 
@@ -299,5 +613,9 @@ final class MultiAnchorExecutor {
       WorkCounter.record(Math.max(0, examinedEnd - fromIndex));
     }
     return result;
+  }
+
+  private static int advanceCandidatePos(int currentCandidatePos, int pDriver, int minUpstreamLen) {
+    return Math.max(currentCandidatePos + 1, pDriver + 1 - minUpstreamLen);
   }
 }

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -402,8 +402,7 @@ final class MultiAnchorExecutor {
 
     while (candidatePos <= textLen - minTotalLength) {
       // Phase 1: Locate candidate for Driver Anchor
-      int pDriver =
-          findNextCountingWork(driverAnchor, text, candidatePos + minUpstreamLen);
+      int pDriver = findNextCountingWork(driverAnchor, text, candidatePos + minUpstreamLen);
       if (pDriver < 0) {
         return Result.MISMATCH;
       }

--- a/safere/src/main/java/org/safere/StringStartAccelerator.java
+++ b/safere/src/main/java/org/safere/StringStartAccelerator.java
@@ -170,26 +170,30 @@ sealed interface StringStartAccelerator {
         if (literalStart < 0) {
           return -1;
         }
-        if (discreteOffsets != null && discreteOffsets.length == 1 && firstCharClass != null) {
-          boolean matchFound = false;
-          int earliestValid = -1;
-          for (int offset : discreteOffsets) {
-            int candidateStart = literalStart - offset;
+        if (firstCharClass != null) {
+          if (discreteOffsets != null && discreteOffsets.length == 1) {
+            int candidateStart = literalStart - discreteOffsets[0];
             if (candidateStart >= fromIndex) {
-              int first = candidateStart < text.length() ? text.charAt(candidateStart) : -1;
+              int first = candidateStart < text.length() ? text.codePointAt(candidateStart) : -1;
               if (first >= 0 && firstCharClass.contains(first)) {
-                matchFound = true;
-                if (earliestValid < 0 || candidateStart < earliestValid) {
-                  earliestValid = candidateStart;
-                }
+                return candidateStart;
               }
             }
+            literalFrom = literalStart + 1;
+            continue;
+          } else if (discreteOffsets == null
+              && fixedOffsetLiteral.minOffset() == fixedOffsetLiteral.maxOffset()) {
+            int candidateStart =
+                retreatByCodePoints(text, literalStart, fixedOffsetLiteral.maxOffset(), fromIndex);
+            if (candidateStart >= fromIndex) {
+              int first = candidateStart < text.length() ? text.codePointAt(candidateStart) : -1;
+              if (first >= 0 && firstCharClass.contains(first)) {
+                return candidateStart;
+              }
+            }
+            literalFrom = literalStart + 1;
+            continue;
           }
-          if (matchFound) {
-            return earliestValid;
-          }
-          literalFrom = literalStart + 1;
-          continue;
         }
         return Math.max(
             fromIndex,

--- a/safere/src/main/java/org/safere/Utf8InputScanner.java
+++ b/safere/src/main/java/org/safere/Utf8InputScanner.java
@@ -72,6 +72,30 @@ final class Utf8InputScanner extends ByteSwarScan implements InputScanner {
     return (res >= 0 && res < limit) ? res : -1;
   }
 
+  public int lastIndexOfAscii(int ascii, int fromIndex, int minLimit) {
+    int start = Math.min(length - 1, fromIndex);
+    int limit = Math.max(0, minLimit);
+    if (start < limit || limit >= length) {
+      return -1;
+    }
+    if (WorkCounterConfig.ENABLED) {
+      for (int i = start; i >= limit; i--) {
+        WorkCounter.record();
+        if (unsignedByteAt(i) == ascii) {
+          return i;
+        }
+      }
+      return -1;
+    }
+    if (scanProvider != null) {
+      int res = scanProvider.lastIndexOfByte(bytes, offset, length, (byte) ascii, start, limit);
+      if (res != VectorScanProvider.UNSUPPORTED) {
+        return res;
+      }
+    }
+    return ByteSwarScan.lastIndexOfByte(bytes, offset, length, (byte) ascii, start, limit);
+  }
+
   @Override
   public int indexOfAsciiOrNonAscii(int ascii, int fromIndex, int limit) {
     int start = Math.max(0, fromIndex);

--- a/safere/src/main/java/org/safere/Utf8StartAccelerator.java
+++ b/safere/src/main/java/org/safere/Utf8StartAccelerator.java
@@ -183,25 +183,32 @@ sealed interface Utf8StartAccelerator {
         if (literalStart < 0) {
           return -1;
         }
-        if (discreteOffsets != null && discreteOffsets.length == 1 && charClassPrefix != null) {
-          int earliestValid = -1;
-          for (int offset : discreteOffsets) {
-            int candidateStart = literalStart - offset;
+        if (charClassPrefix != null) {
+          if (discreteOffsets != null && discreteOffsets.length == 1) {
+            int candidateStart = literalStart - discreteOffsets[0];
             if (candidateStart >= searchFrom) {
               int first =
                   candidateStart < scanner.length() ? scanner.codePointAt(candidateStart) : -1;
-              if (first >= 0
-                  && charClassPrefix.contains(first)
-                  && (earliestValid < 0 || candidateStart < earliestValid)) {
-                earliestValid = candidateStart;
+              if (first >= 0 && charClassPrefix.contains(first)) {
+                return candidateStart;
               }
             }
+            literalFrom = literalStart + 1;
+            continue;
+          } else if (discreteOffsets == null
+              && fixedOffsetLiteral.minOffset() == fixedOffsetLiteral.maxOffset()) {
+            int candidateStart =
+                scanner.retreatByCodePoints(literalStart, fixedOffsetLiteral.maxOffset());
+            if (candidateStart >= searchFrom) {
+              int first =
+                  candidateStart < scanner.length() ? scanner.codePointAt(candidateStart) : -1;
+              if (first >= 0 && charClassPrefix.contains(first)) {
+                return candidateStart;
+              }
+            }
+            literalFrom = literalStart + 1;
+            continue;
           }
-          if (earliestValid >= 0) {
-            return earliestValid;
-          }
-          literalFrom = literalStart + 1;
-          continue;
         }
         return Math.max(
             searchFrom, scanner.retreatByCodePoints(literalStart, fixedOffsetLiteral.maxOffset()));

--- a/safere/src/main/java/org/safere/VectorScanProvider.java
+++ b/safere/src/main/java/org/safere/VectorScanProvider.java
@@ -26,6 +26,12 @@ interface VectorScanProvider {
   }
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
+  default int lastIndexOfByte(
+      byte[] bytes, int offset, int length, byte target, int fromIndex, int toIndex) {
+    return UNSUPPORTED;
+  }
+
+  /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */
   int indexOfAsciiClass(byte[] bytes, int offset, int length, int[] ranges, int start);
 
   /** Returns a match position, {@code -1} when absent, or {@link #UNSUPPORTED}. */

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -730,7 +730,7 @@ class DiagnosticsTest {
   }
 
   @Test
-  void variableGapChainsFallBackToTheGeneralEngine() {
+  void variableGapChainsExecuteViaMultiAnchor() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile(".*error:\\[[A-Z]+\\]\\s+code:500\\s+msg:crash");
     String input = "2026-08-27 12:00:00 [worker-1] error:[CRITICAL] code:500 msg:crash\n";
@@ -741,8 +741,8 @@ class DiagnosticsTest {
         .singleElement()
         .satisfies(
             event -> {
-              assertThat(event.boundaryStrategy()).isNotEqualTo(MatchStrategy.MULTI_ANCHOR);
-              assertThat(event.forwardDfaSearchCount()).isPositive();
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.MULTI_ANCHOR);
+              assertThat(event.forwardDfaSearchCount()).isZero();
             });
   }
 

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -730,7 +730,7 @@ class DiagnosticsTest {
   }
 
   @Test
-  void variableGapChainsExecuteViaMultiAnchor() {
+  void variableGapChainsFallBackToGeneralEngine() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile(".*error:\\[[A-Z]+\\]\\s+code:500\\s+msg:crash");
     String input = "2026-08-27 12:00:00 [worker-1] error:[CRITICAL] code:500 msg:crash\n";
@@ -741,8 +741,8 @@ class DiagnosticsTest {
         .singleElement()
         .satisfies(
             event -> {
-              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.MULTI_ANCHOR);
-              assertThat(event.forwardDfaSearchCount()).isZero();
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
+              assertThat(event.forwardDfaSearchCount()).isPositive();
             });
   }
 

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -373,4 +373,29 @@ class MultiAnchorCompilerTest {
   private static long analysisWork(Regexp regexp) {
     return WorkCounter.countForTesting(() -> MultiAnchorCompiler.analyze(regexp));
   }
+
+  @Test
+  void driverSelectionSelectsRarestAnchor() {
+    Pattern p = Pattern.compile(".*error:\\[[A-Z]+\\]\\s+code:500\\s+msg:crash");
+    MultiAnchorDescriptor desc = p.multiAnchor();
+    assertThat(desc).isNotNull();
+    assertThat(desc.checkOrder()).isNotEmpty();
+    assertThat(desc.checkOrder()[0]).isNotEqualTo(0); // Rarest anchor is downstream
+    // Rarest anchor is selected as driver for reverse candidate evaluation
+    assertThat(desc.selectDriver(MultiAnchorDescriptor.InputDomain.STRING, true))
+        .isEqualTo(desc.checkOrder()[0]);
+    assertThat(desc.selectDriver(MultiAnchorDescriptor.InputDomain.UTF8, true))
+        .isEqualTo(desc.checkOrder()[0]);
+  }
+
+  @Test
+  void driverSelectionWithBoundedUpstreamSelectsRarest() {
+    Pattern p = Pattern.compile("foo[a-z]{1,5}bar[0-9]{1,3}baz");
+    MultiAnchorDescriptor desc = p.multiAnchor();
+    assertThat(desc).isNotNull();
+    assertThat(desc.checkOrder()).isNotEmpty();
+    // Bounded upstream allows driver selection of rarest anchor
+    int driver = desc.selectDriver(MultiAnchorDescriptor.InputDomain.STRING, true);
+    assertThat(desc.isUpstreamBoundedFor(driver)).isTrue();
+  }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -376,7 +376,7 @@ class MultiAnchorCompilerTest {
 
   @Test
   void driverSelectionSelectsRarestAnchor() {
-    Pattern p = Pattern.compile(".*error:\\[[A-Z]+\\]\\s+code:500\\s+msg:crash");
+    Pattern p = Pattern.compile("error:\\[[A-Z]\\] code:500");
     MultiAnchorDescriptor desc = p.multiAnchor();
     assertThat(desc).isNotNull();
     assertThat(desc.checkOrder()).isNotEmpty();

--- a/safere/src/test/java/org/safere/MultiAnchorDescriptorBuilder.java
+++ b/safere/src/test/java/org/safere/MultiAnchorDescriptorBuilder.java
@@ -25,6 +25,8 @@ final class MultiAnchorDescriptorBuilder {
   private final List<Segment> segments = new ArrayList<>();
   private Gap trailingGap = Gap.EMPTY;
   private int[] checkOrder = null;
+  private Integer driverIndex = null;
+  private Boolean isUpstreamBounded = null;
   private Integer minTotalLength = null;
   private boolean isStartAnchored = false;
   private boolean isEndAnchored = false;
@@ -70,6 +72,16 @@ final class MultiAnchorDescriptorBuilder {
     return this;
   }
 
+  MultiAnchorDescriptorBuilder driverIndex(int driverIndex) {
+    this.driverIndex = driverIndex;
+    return this;
+  }
+
+  MultiAnchorDescriptorBuilder isUpstreamBounded(boolean isUpstreamBounded) {
+    this.isUpstreamBounded = isUpstreamBounded;
+    return this;
+  }
+
   MultiAnchorDescriptorBuilder minTotalLength(int minTotalLength) {
     this.minTotalLength = minTotalLength;
     return this;
@@ -108,11 +120,24 @@ final class MultiAnchorDescriptorBuilder {
   MultiAnchorDescriptor build() {
     Segment[] segs = segments.toArray(new Segment[0]);
     int[] order = this.checkOrder != null ? this.checkOrder : defaultOrder(segs.length);
+    int driver = this.driverIndex != null ? this.driverIndex : (order.length > 0 ? order[0] : 0);
     int minLen =
         this.minTotalLength != null ? this.minTotalLength : computeMinLength(segs, trailingGap);
+    boolean upstreamBounded =
+        this.isUpstreamBounded != null
+            ? this.isUpstreamBounded
+            : computeUpstreamBounded(segs, driver);
 
     return new MultiAnchorDescriptor(
-        new Chain(segs, trailingGap, order, minLen, isStartAnchored, isEndAnchored),
+        new Chain(
+            segs,
+            trailingGap,
+            order,
+            driver,
+            upstreamBounded,
+            minLen,
+            isStartAnchored,
+            isEndAnchored),
         startPlan,
         rejectPlan,
         anchoredPrefix,
@@ -153,5 +178,14 @@ final class MultiAnchorDescriptorBuilder {
       len += trailingGap.minLength();
     }
     return len;
+  }
+
+  private static boolean computeUpstreamBounded(Segment[] segs, int driverIdx) {
+    for (int i = 0; i <= driverIdx && i < segs.length; i++) {
+      if (segs[i].gap().maxLength() == Integer.MAX_VALUE) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -560,6 +560,30 @@ class MultiAnchorGapEngineTest {
     assertThat(matcher.end()).isEqualTo(22);
   }
 
+  @Test
+  void assertionsAfterLeadingCharacterClassFallBackToGeneralEngine() {
+    for (String[] testCase :
+        new String[][] {
+          {"[a-z]\\bAAA", "xAAA"},
+          {"[ ]\\BAAA", " AAA"},
+          {"(?m)[a-z]^AAA", "xAAA"},
+          {"(?m)[a-z]$AAA", "xAAA"},
+          {"[a-z]\\bAAA[0-9]RAREST_TOKEN", "xAAA1RAREST_TOKEN"}
+        }) {
+      String regex = testCase[0];
+      String text = testCase[1];
+      Pattern pattern = Pattern.compile(regex);
+
+      assertThat(pattern.multiAnchor().isExecutableChain()).as(regex).isFalse();
+      assertFirstMatchEqualsJdk(regex, text);
+
+      Utf8Matcher utf8Matcher = pattern.matcher(Utf8Input.validated(text.getBytes(UTF_8)));
+      assertThat(utf8Matcher.find())
+          .as("UTF-8 membership for %s", regex)
+          .isEqualTo(java.util.regex.Pattern.compile(regex).matcher(text).find());
+    }
+  }
+
   private static void assertFirstMatchEqualsJdk(String regex, String text) {
     assertFirstMatchEqualsJdk(regex, 0, text);
   }

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -445,6 +445,45 @@ class MultiAnchorGapEngineTest {
   }
 
   @Test
+  void reverseDriverPreservesLeftmostStartAcrossVariableGap() {
+    assertFirstMatchEqualsJdk("111[0-9]+RAREST_TOKEN", "1111112RAREST_TOKEN");
+  }
+
+  @Test
+  void variableUpstreamGapsStayOnForwardExecution() {
+    MultiAnchorDescriptor descriptor = Pattern.compile("AAA[A-Z]+RAREST_TOKEN").multiAnchor();
+
+    assertThat(descriptor.selectDriver(MultiAnchorDescriptor.InputDomain.STRING, true)).isZero();
+    assertThat(descriptor.selectDriver(MultiAnchorDescriptor.InputDomain.UTF8, true)).isZero();
+  }
+
+  @Test
+  void utf8ReverseWindowAllowsMultibyteUpstreamLiteral() {
+    String regex = "é".repeat(10) + "[0-9]" + "z".repeat(30);
+    String text = regex.replace("[0-9]", "7");
+    Pattern pattern = Pattern.compile(regex);
+
+    assertThat(pattern.matcher(text).find()).isTrue();
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.validated(text.getBytes(UTF_8)));
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isZero();
+    assertThat(matcher.end()).isEqualTo(text.getBytes(UTF_8).length);
+  }
+
+  @Test
+  void finiteDotallWildcardGapsHonorTheirCodePointBounds() {
+    assertFirstMatchEqualsJdk("(?s)TARGET.", "TARGETabc");
+    assertFirstMatchEqualsJdk("(?s).TARGET", "abcTARGET");
+    assertFirstMatchEqualsJdk("(?s)TARGET.{1,2}", "TARGETabc");
+
+    Pattern pattern = Pattern.compile("(?s)TARGET.");
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.validated("TARGET😀x".getBytes(UTF_8)));
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isZero();
+    assertThat(matcher.end()).isEqualTo("TARGET😀".getBytes(UTF_8).length);
+  }
+
+  @Test
   void multipleLeadingWildcardsCoalesce() {
     Pattern pattern = Pattern.compile(".*.*AAA.*.*");
     assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -271,10 +271,11 @@ class MultiAnchorGapEngineTest {
   }
 
   @Test
-  void boundedInteriorGapsRemainExecutable() {
-    assertThat(Pattern.compile("AAA[0-9]+BBB").multiAnchor().isExecutableChain()).isTrue();
+  void onlyFixedInteriorGapsRemainExecutable() {
+    assertThat(Pattern.compile("AAA[0-9]+BBB").multiAnchor().isExecutableChain()).isFalse();
     assertThat(Pattern.compile("AAA[0-9]BBB").multiAnchor().isExecutableChain()).isTrue();
-    assertThat(Pattern.compile(".*AAA\\s+BBB\\s+CCC.*").multiAnchor().isExecutableChain()).isTrue();
+    assertThat(Pattern.compile(".*AAA\\s+BBB\\s+CCC.*").multiAnchor().isExecutableChain())
+        .isFalse();
   }
 
   @Test
@@ -484,27 +485,59 @@ class MultiAnchorGapEngineTest {
   }
 
   @Test
+  void variableLeadingAndInteriorGapsPreserveQuantifierPriority() {
+    assertFirstMatchEqualsJdk(".*AAA", "AAA x AAA");
+    assertFirstMatchEqualsJdk(".*?AAA", "xAAA");
+    assertFirstMatchEqualsJdk("AAA[A-Z]+BBB", "AAAXBBB1BBB");
+  }
+
+  @Test
+  void boundedUnicodeClassGapsCountCodePoints() {
+    String regex = "AAA[éê]{1,10}BBB";
+    String text = "AAA" + "éê".repeat(5) + "BBB";
+    assertFirstMatchEqualsJdk(regex, text);
+
+    Pattern pattern = Pattern.compile(regex);
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.validated(text.getBytes(UTF_8)));
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isZero();
+    assertThat(matcher.end()).isEqualTo(text.getBytes(UTF_8).length);
+  }
+
+  @Test
+  void adjacentMixedFlavorGapsPreservePriority() {
+    assertFirstMatchEqualsJdk("AAA.*?.*", "AAAxyz");
+    assertFirstMatchEqualsJdk("AAA.*.*?", "AAAxyz");
+  }
+
+  @Test
+  void broadCharacterClassesRetainTheirExactMembership() {
+    assertFirstMatchEqualsJdk("AAA[^\\nX]*", "AAAabXcd");
+    assertFirstMatchEqualsJdk("AAA.*", Pattern.UNIX_LINES, "AAAa\rnext");
+  }
+
+  @Test
   void multipleLeadingWildcardsCoalesce() {
     Pattern pattern = Pattern.compile(".*.*AAA.*.*");
-    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+    assertThat(pattern.multiAnchor().isExecutableChain()).isFalse();
     assertFirstMatchEqualsJdk(".*.*AAA.*.*", "hello world AAA foo bar\nnext line");
   }
 
   @Test
-  void singleAnchorWithLeadingAndTrailingGapsExecutes() {
+  void singleAnchorWithVariableLeadingAndTrailingGapsFallsBack() {
     Pattern pattern = Pattern.compile(".*AAA.*");
-    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+    assertThat(pattern.multiAnchor().isExecutableChain()).isFalse();
     assertFirstMatchEqualsJdk(".*AAA.*", "noise AAA trailing\nsecond line");
 
     Pattern patternBounded = Pattern.compile("\\s+AAA\\s+");
-    assertThat(patternBounded.multiAnchor().isExecutableChain()).isTrue();
+    assertThat(patternBounded.multiAnchor().isExecutableChain()).isFalse();
     assertFirstMatchEqualsJdk("\\s+AAA\\s+", "hello   AAA   world");
   }
 
   @Test
-  void singleAnchorWithLeadingWildcardExecutesInUtf8() {
+  void singleAnchorWithLeadingWildcardFallsBackInUtf8() {
     Pattern pattern = Pattern.compile(".*TARGET_KEY");
-    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+    assertThat(pattern.multiAnchor().isExecutableChain()).isFalse();
 
     byte[] bytes = "prefix data TARGET_KEY trailing".getBytes(UTF_8);
     Utf8Input input = Utf8Input.validated(bytes);

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -260,9 +260,26 @@ class MultiAnchorGapEngineTest {
   }
 
   @Test
-  void variableInternalGapsAreOutsideTheAuthoritativeSubset() {
+  void subthresholdAnchorsFallBackToGeneralEngine() {
     assertThat(Pattern.compile("A.*B.*C").multiAnchor().isExecutableChain()).isFalse();
     assertThat(Pattern.compile("A[0-9]{3}B").multiAnchor().isExecutableChain()).isFalse();
+  }
+
+  @Test
+  void unboundedInteriorGapsFallBackToGeneralEngine() {
+    assertThat(Pattern.compile("AAA.*BBB.*CCC").multiAnchor().isExecutableChain()).isFalse();
+  }
+
+  @Test
+  void boundedInteriorGapsRemainExecutable() {
+    assertThat(Pattern.compile("AAA[0-9]+BBB").multiAnchor().isExecutableChain()).isTrue();
+    assertThat(Pattern.compile("AAA[0-9]BBB").multiAnchor().isExecutableChain()).isTrue();
+    assertThat(Pattern.compile(".*AAA\\s+BBB\\s+CCC.*").multiAnchor().isExecutableChain()).isTrue();
+  }
+
+  @Test
+  void ambiguousInteriorWildcardMatchesCorrectlyViaGeneralEngine() {
+    assertFirstMatchEqualsJdk("AAA.*BBB.*CCC", "AAA xxx BBB yyy CCC zzz BBB www");
   }
 
   @Test
@@ -327,6 +344,135 @@ class MultiAnchorGapEngineTest {
         new String[] {"(?-i:AAA)[0-9]BB", "AAA[0-9](?-i:BB)", "(?-i:AAA)([0-9])BB"}) {
       assertFirstMatchEqualsJdk(regex, Pattern.CASE_INSENSITIVE, "aaa1bb");
     }
+  }
+
+  @Test
+  void rarestAnchorBidirectionalExecution() {
+    // "security_alert_code" is rarest anchor at index 2
+    String regex = "user:([a-z]+)\\s+action:([a-z]+)\\s+security_alert_code:(\\d+)";
+    Pattern saferePattern = Pattern.compile(regex);
+    java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(regex);
+
+    String text =
+        "user:alice action:read status:200 user:bob action:write security_alert_code:999 trailing";
+    Matcher safereMatcher = saferePattern.matcher(text);
+    java.util.regex.Matcher jdkMatcher = jdkPattern.matcher(text);
+
+    assertThat(safereMatcher.find()).isTrue();
+    assertThat(jdkMatcher.find()).isTrue();
+    assertThat(safereMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safereMatcher.end()).isEqualTo(jdkMatcher.end());
+    assertThat(safereMatcher.group(0)).isEqualTo(jdkMatcher.group(0));
+    assertThat(safereMatcher.group(1)).isEqualTo("bob");
+    assertThat(safereMatcher.group(2)).isEqualTo("write");
+    assertThat(safereMatcher.group(3)).isEqualTo("999");
+  }
+
+  @Test
+  void rarestAnchorBoundedUpstreamVerification() {
+    String regex = "PREFIX[0-9]MIDDLE[0-9]RAREST_TOKEN_XYZ[0-9]SUFFIX";
+    Pattern pattern = Pattern.compile(regex);
+
+    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+
+    String text = "noise PREFIX1MIDDLE2RAREST_TOKEN_XYZ3SUFFIX trailing";
+    Matcher matcher = pattern.matcher(text);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("PREFIX1MIDDLE2RAREST_TOKEN_XYZ3SUFFIX");
+
+    // Absent rarest token -> instant mismatch
+    String absent = "noise PREFIX1MIDDLE2OTHER_TOKEN_1233SUFFIX trailing";
+    Matcher m2 = pattern.matcher(absent);
+    assertThat(m2.find()).isFalse();
+  }
+
+  @Test
+  void rarestAnchorUnboundedUpstreamVerification() {
+    String regex = "START.*RAREST_ANCHOR_12345.*END";
+    Pattern saferePattern = Pattern.compile(regex);
+    java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(regex);
+
+    String text = "START noise intermediate RAREST_ANCHOR_12345 more noise END";
+    Matcher safereMatcher = saferePattern.matcher(text);
+    java.util.regex.Matcher jdkMatcher = jdkPattern.matcher(text);
+
+    assertThat(safereMatcher.find()).isTrue();
+    assertThat(jdkMatcher.find()).isTrue();
+    assertThat(safereMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safereMatcher.end()).isEqualTo(jdkMatcher.end());
+    assertThat(safereMatcher.group(0)).isEqualTo(jdkMatcher.group(0));
+  }
+
+  @Test
+  void rarestAnchorMultipleOccurrencesLeftmost() {
+    String regex = "HEAD[0-9]{2}RAREST[0-9]{2}TAIL";
+    Pattern saferePattern = Pattern.compile(regex);
+    java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(regex);
+
+    String text = "HEAD11RAREST22TAIL noise HEAD33RAREST44TAIL";
+    Matcher safereMatcher = saferePattern.matcher(text);
+    java.util.regex.Matcher jdkMatcher = jdkPattern.matcher(text);
+
+    assertThat(safereMatcher.find()).isTrue();
+    assertThat(jdkMatcher.find()).isTrue();
+    assertThat(safereMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safereMatcher.end()).isEqualTo(jdkMatcher.end());
+    assertThat(safereMatcher.group(0)).isEqualTo("HEAD11RAREST22TAIL");
+
+    assertThat(safereMatcher.find()).isTrue();
+    assertThat(jdkMatcher.find()).isTrue();
+    assertThat(safereMatcher.start()).isEqualTo(jdkMatcher.start());
+    assertThat(safereMatcher.end()).isEqualTo(jdkMatcher.end());
+    assertThat(safereMatcher.group(0)).isEqualTo("HEAD33RAREST44TAIL");
+  }
+
+  @Test
+  void rarestAnchorUtf8Equivalence() {
+    String regex = "tag:([a-z]+)\\s+RAREST_KEY_TOKEN=(\\d+)";
+    Pattern pattern = Pattern.compile(regex);
+
+    byte[] bytes = "noise tag:alpha RAREST_KEY_TOKEN=42 trailing".getBytes(UTF_8);
+    Utf8Input input = Utf8Input.validated(bytes);
+
+    Utf8Matcher matcher = pattern.matcher(input);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(6);
+    assertThat(matcher.end()).isEqualTo(35);
+    assertThat(matcher.start(1)).isEqualTo(10);
+    assertThat(matcher.end(1)).isEqualTo(15);
+    assertThat(matcher.start(2)).isEqualTo(33);
+    assertThat(matcher.end(2)).isEqualTo(35);
+  }
+
+  @Test
+  void multipleLeadingWildcardsCoalesce() {
+    Pattern pattern = Pattern.compile(".*.*AAA.*.*");
+    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+    assertFirstMatchEqualsJdk(".*.*AAA.*.*", "hello world AAA foo bar\nnext line");
+  }
+
+  @Test
+  void singleAnchorWithLeadingAndTrailingGapsExecutes() {
+    Pattern pattern = Pattern.compile(".*AAA.*");
+    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+    assertFirstMatchEqualsJdk(".*AAA.*", "noise AAA trailing\nsecond line");
+
+    Pattern patternBounded = Pattern.compile("\\s+AAA\\s+");
+    assertThat(patternBounded.multiAnchor().isExecutableChain()).isTrue();
+    assertFirstMatchEqualsJdk("\\s+AAA\\s+", "hello   AAA   world");
+  }
+
+  @Test
+  void singleAnchorWithLeadingWildcardExecutesInUtf8() {
+    Pattern pattern = Pattern.compile(".*TARGET_KEY");
+    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+
+    byte[] bytes = "prefix data TARGET_KEY trailing".getBytes(UTF_8);
+    Utf8Input input = Utf8Input.validated(bytes);
+    Utf8Matcher matcher = pattern.matcher(input);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(0);
+    assertThat(matcher.end()).isEqualTo(22);
   }
 
   private static void assertFirstMatchEqualsJdk(String regex, String text) {

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -472,6 +472,19 @@ class MultiAnchorGapEngineTest {
   }
 
   @Test
+  void overlappingReverseDriverCandidatesRetainUpstreamSearchRange() {
+    String regex = "aaaaaaaaaa[zZ]zzzz";
+    String text = "Xaaaaaaaaaazzzzz";
+    assertFirstMatchEqualsJdk(regex, text);
+
+    Pattern pattern = Pattern.compile(regex);
+    Utf8Matcher matcher = pattern.matcher(Utf8Input.validated(text.getBytes(UTF_8)));
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(1);
+    assertThat(matcher.end()).isEqualTo(16);
+  }
+
+  @Test
   void finiteDotallWildcardGapsHonorTheirCodePointBounds() {
     assertFirstMatchEqualsJdk("(?s)TARGET.", "TARGETabc");
     assertFirstMatchEqualsJdk("(?s).TARGET", "abcTARGET");

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -72,6 +72,27 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void variableGapCandidateFailuresRemainLinear() {
+    Pattern pattern = Pattern.compile("AAA[A-Z]+RAREST_TOKEN");
+
+    long smallerWork =
+        WorkCounter.countForTesting(
+            () ->
+                assertThat(pattern.matcher("AAA".repeat(2_000) + "xRAREST_TOKEN").find())
+                    .isFalse());
+    long largerWork =
+        WorkCounter.countForTesting(
+            () ->
+                assertThat(pattern.matcher("AAA".repeat(10_000) + "xRAREST_TOKEN").find())
+                    .isFalse());
+
+    assertThat(smallerWork).isPositive();
+    assertThat(largerWork)
+        .as("variable-gap candidate failures must not rescan overlapping suffixes")
+        .isLessThan(smallerWork * 6);
+  }
+
+  @Test
   void multiAnchorCompilationDoesNotRepeatAstAnalysis() {
     Regexp regexp = Parser.parse("foo.*bar.*baz", Pattern.toParseFlags(0));
 

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -72,6 +72,19 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void reverseLiteralSearchExaminesOnlyTheRequestedWindow() {
+    MultiAnchorDescriptor.Anchor anchor = MultiAnchorDescriptor.Anchor.Single.create("AAA");
+    String text = "x".repeat(10_000);
+
+    long work =
+        WorkCounter.countForTesting(
+            () -> assertThat(anchor.lastIndexOf(text, 9_900, 9_999)).isEqualTo(-1));
+
+    assertThat(work).as("bounded reverse search work must be observed").isPositive();
+    assertThat(work).as("reverse search must stay within its requested window").isLessThan(200);
+  }
+
+  @Test
   void variableGapCandidateFailuresRemainLinear() {
     Pattern pattern = Pattern.compile("AAA[A-Z]+RAREST_TOKEN");
 


### PR DESCRIPTION
This builds on the multi-anchor gap engine to unify reject prefilter and start acceleration handling (#769).

Instead of having a separate reject prefilter using the rarest anchor and then scanning from the beginning, the engine selects the rarest anchor as the primary candidate driver. When a candidate is found, it validates the input backwards to resolve the match start, and forwards for downstream anchors, instead of restarting from the beginning.

---

1. Bidirectional Candidate Driving (`MultiAnchorExecutor`):
   - The outer search loop leaps forward on the rarest anchor using accelerated scans.
   - Upstream anchors are verified backwards (`lastIndexOf`) within bounded hop ranges to resolve match start without restarting from the beginning of the text.
   - Downstream anchors are verified forward with direction-aware paths.
   - Tracks a monotonic reverse watermark to preserve linear time guarantees.
2. Backward SIMD Scanning Kernels:
   - Added `ByteVectorScan.lastIndexOf` and `ByteSwarScan.lastIndexOf` for UTF-8 vector scanning.
   - Unified `lastIndexOf` across `MultiAnchorDescriptor.Anchor` for both `String` and `Utf8InputScanner`.
3. Start Accelerator Unicode Safety (`StringStartAccelerator` & `Utf8StartAccelerator`):
   - Refactored `FixedOffset` start accelerators to check `firstCharClass` via `codePointAt` rather than `charAt`, ensuring correctness on supplementary Unicode characters.
   - Replaced arithmetic byte retreats with `retreatByCodePoints` across UTF-16 code units and UTF-8 byte sequences.
   - Unified discrete offset arrays (`discreteOffsets.length == 1`) and fixed-distance spans (`minOffset == maxOffset`) with early candidate rejection.
4. AST Gap Coalescing (`MultiAnchorCompiler`):
   - Centralized adjacent AST gap node merging in `coalesceGaps`, producing canonical `BOUNDED_CLASS_REPEAT` metadata.
5. Formalized Standalone Execution Contract (`isExecutableChain`):
   - Restricted `MultiAnchorExecutor` standalone execution strictly to deterministic fixed-gap chains ($n \ge 2$ or $n = 1$ with non-empty wildcards/bounded gaps) separated by `isExecutorFixedGap()` with `Anchor.Single` or `Anchor.CharClass`.
   - Variable interior gaps, alternations, and complex zero-width boundaries (`\b`, `\B`, multiline `^`/`$`) delegate match verification to `DFA` / `OnePass` while leveraging Tier 1 start acceleration and Tier 0 whole-buffer rejection.
   - 
---

```
./safere-benchmarks/scripts/compare-branch.sh --baseline pr-multi-anchor-descriptors 'RealWorldRegexBenchmark.*(fixedAnchorLog|metadataBlock|templateTagMatch).*safere-string'
```

| Benchmark                       | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------- | ---------------- | --------------- | ------- |
| metadataBlock.match.1000        |        4803 ± 80 |       4789 ± 37 |   1.00x |
| metadataBlock.match.10000       |      49392 ± 916 |    49513 ± 1227 |   1.00x |
| metadataBlock.match.100000      |   497834 ± 27825 |   483787 ± 5664 |   1.03x |
| metadataBlock.noMatch.1000      |        135 ± 1.9 |       136 ± 3.6 |   0.99x |
| metadataBlock.noMatch.10000     |       1038 ± 8.5 |       1047 ± 26 |   0.99x |
| metadataBlock.noMatch.100000    |      10114 ± 124 |     10103 ± 140 |   1.00x |
| templateTagMatch.match.1000     |        3793 ± 87 |      3702 ± 154 |   1.02x |
| templateTagMatch.match.10000    |     36250 ± 1742 |    36354 ± 1280 |   1.00x |
| templateTagMatch.match.100000   |    336685 ± 6843 |  349780 ± 18300 |   0.96x |
| templateTagMatch.noMatch.1000   |        181 ± 4.8 |       177 ± 1.2 |   1.02x |
| templateTagMatch.noMatch.10000  |        1063 ± 19 |       1062 ± 21 |   1.00x |
| templateTagMatch.noMatch.100000 |        9897 ± 65 |       9845 ± 21 |   1.01x |
| fixedAnchorLog.match.1000       |        1172 ± 31 |       547 ± 6.9 |   2.14x |
| fixedAnchorLog.match.10000      |       10470 ± 57 |       4174 ± 21 |   2.51x |
| fixedAnchorLog.match.100000     |     105995 ± 642 |     40768 ± 980 |   2.60x |
| fixedAnchorLog.noMatch.1000     |        180 ± 1.6 |       181 ± 3.4 |   0.99x |
| fixedAnchorLog.noMatch.10000    |        1386 ± 12 |      1384 ± 9.5 |   1.00x |
| fixedAnchorLog.noMatch.100000   |      13533 ± 169 |     13519 ± 190 |   1.00x |