### PR TITLE
Implement Gap Engine extensions for alternation prefix factoring, weak-anchor coalescing, and exact-width assertion guards

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1424,7 +1424,7 @@
       "shared": true
     },
     {
-      "id": "realWorldRegex.factoredAlternation.match.{size}",
+      "id": "realWorldRegex.wideFactoredApiRoute.match.{size}",
       "axes": {
         "size": [
           1000,
@@ -1434,14 +1434,14 @@
       },
       "recipe": {
         "kind": "suffixToLength",
-        "prefixUnit": "service_heartbeat ping_time=12ms region=us-east status=OK\n",
-        "suffix": "auth_token_refresh session=0123456789abcdef status=OK\n",
+        "prefixUnit": "192.168.1.42 - - [30/Aug/2026:12:00:01 +0000] \"GET /static/bundle.min.js HTTP/1.1\" 200 4821 \"https://app.corp.net\"\n192.168.1.43 - - [30/Aug/2026:12:00:02 +0000] \"GET /api/v1/health HTTP/1.1\" 200 128 \"https://app.corp.net\"\n192.168.1.44 - - [30/Aug/2026:12:00:03 +0000] \"POST /assets/styles.css HTTP/1.1\" 200 954 \"https://app.corp.net\"\n",
+        "suffix": "192.168.1.99 - - [30/Aug/2026:12:00:04 +0000] \"POST /api/v2/checkout/98765432 HTTP/1.1\" 200 1024 \"https://app.corp.net\"\n",
         "length": "{size}"
       },
       "shared": true
     },
     {
-      "id": "realWorldRegex.factoredAlternation.noMatch.{size}",
+      "id": "realWorldRegex.wideFactoredApiRoute.noMatch.{size}",
       "axes": {
         "size": [
           1000,
@@ -1451,77 +1451,7 @@
       },
       "recipe": {
         "kind": "delimitedRepeatToLength",
-        "value": "service_heartbeat ping_time=12ms region=us-east status=OK",
-        "delimiterAlphabet": "\n",
-        "seed": 42,
-        "length": "{size}"
-      },
-      "shared": true
-    },
-    {
-      "id": "realWorldRegex.factoredProtocol.match.{size}",
-      "axes": {
-        "size": [
-          1000,
-          10000,
-          100000
-        ]
-      },
-      "recipe": {
-        "kind": "suffixToLength",
-        "prefixUnit": "http_status=200 host=internal.cache proto=http/1.1 path=/api/v1/health\n",
-        "suffix": "http_status=200 host=example.com proto=https https://stage.example.com/item12345\n",
-        "length": "{size}"
-      },
-      "shared": true
-    },
-    {
-      "id": "realWorldRegex.factoredProtocol.noMatch.{size}",
-      "axes": {
-        "size": [
-          1000,
-          10000,
-          100000
-        ]
-      },
-      "recipe": {
-        "kind": "delimitedRepeatToLength",
-        "value": "http_status=200 host=internal.cache proto=http/1.1 path=/api/v1/health",
-        "delimiterAlphabet": "\n",
-        "seed": 42,
-        "length": "{size}"
-      },
-      "shared": true
-    },
-    {
-      "id": "realWorldRegex.factoredApiRoute.match.{size}",
-      "axes": {
-        "size": [
-          1000,
-          10000,
-          100000
-        ]
-      },
-      "recipe": {
-        "kind": "suffixToLength",
-        "prefixUnit": "192.168.1.42 - - [30/Aug/2026:12:00:01 +0000] \"GET /static/bundle.min.js HTTP/1.1\" 200 4821 \"https://app.corp.net\"\n192.168.1.43 - - [30/Aug/2026:12:00:02 +0000] \"GET /api/v2/health HTTP/1.1\" 200 128 \"https://app.corp.net\"\n192.168.1.44 - - [30/Aug/2026:12:00:03 +0000] \"POST /assets/styles.css HTTP/1.1\" 200 954 \"https://app.corp.net\"\n",
-        "suffix": "192.168.1.99 - - [30/Aug/2026:12:00:04 +0000] \"POST /api/v1/checkout/a1b2c3d4 status=200\" 200 1024 \"https://app.corp.net\"\n",
-        "length": "{size}"
-      },
-      "shared": true
-    },
-    {
-      "id": "realWorldRegex.factoredApiRoute.noMatch.{size}",
-      "axes": {
-        "size": [
-          1000,
-          10000,
-          100000
-        ]
-      },
-      "recipe": {
-        "kind": "delimitedRepeatToLength",
-        "value": "192.168.1.42 - - [30/Aug/2026:12:00:01 +0000] \"GET /static/bundle.min.js HTTP/1.1\" 200 4821 \"https://app.corp.net\"\n192.168.1.43 - - [30/Aug/2026:12:00:02 +0000] \"GET /api/v2/health HTTP/1.1\" 200 128 \"https://app.corp.net\"\n192.168.1.44 - - [30/Aug/2026:12:00:03 +0000] \"POST /assets/styles.css HTTP/1.1\" 200 954 \"https://app.corp.net\"",
+        "value": "192.168.1.42 - - [30/Aug/2026:12:00:01 +0000] \"GET /static/bundle.min.js HTTP/1.1\" 200 4821 \"https://app.corp.net\"\n192.168.1.43 - - [30/Aug/2026:12:00:02 +0000] \"GET /api/v1/health HTTP/1.1\" 200 128 \"https://app.corp.net\"\n192.168.1.44 - - [30/Aug/2026:12:00:03 +0000] \"POST /assets/styles.css HTTP/1.1\" 200 954 \"https://app.corp.net\"",
         "delimiterAlphabet": "\n",
         "seed": 42,
         "length": "{size}"
@@ -4625,71 +4555,13 @@
       }
     },
     {
-      "id": "RealWorldRegexBenchmark.runBenchmark.factoredAlternation.{matchLabel}.{size}",
+      "id": "RealWorldRegexBenchmark.runBenchmark.wideFactoredApiRoute.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "(auth_token_refresh|auth_token_revoke|auth_token_verify) session=[0-9a-z]{16} status=OK"
+        "/(?:api/v2/users|api/v2/orders|api/v2/payments|api/v2/checkout|api/v2/inventory|api/v2/catalog|api/v2/shipping|api/v2/customers|api/v2/discounts|api/v2/invoices|api/v2/refunds|api/v2/analytics|api/v2/notifications|api/v2/webhooks|api/v2/subscriptions|api/v2/transactions)/[0-9]+"
       ],
       "inputs": [
-        "realWorldRegex.factoredAlternation.{matchLabel}.{size}"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      },
-      "axes": {
-        "matchLabel": [
-          "match",
-          "noMatch"
-        ],
-        "size": [
-          1000,
-          10000,
-          100000
-        ]
-      }
-    },
-    {
-      "id": "RealWorldRegexBenchmark.runBenchmark.factoredProtocol.{matchLabel}.{size}",
-      "operation": "find",
-      "patterns": [
-        "(https://api|https://stage|https://prod)\\.example\\.com/[a-z0-9]+"
-      ],
-      "inputs": [
-        "realWorldRegex.factoredProtocol.{matchLabel}.{size}"
-      ],
-      "resultConsumption": "boolean",
-      "measurement": {
-        "mode": "averageTime",
-        "timingUnit": "nanoseconds",
-        "constraints": [
-          "prematerializedInput"
-        ]
-      },
-      "axes": {
-        "matchLabel": [
-          "match",
-          "noMatch"
-        ],
-        "size": [
-          1000,
-          10000,
-          100000
-        ]
-      }
-    },
-    {
-      "id": "RealWorldRegexBenchmark.runBenchmark.factoredApiRoute.{matchLabel}.{size}",
-      "operation": "find",
-      "patterns": [
-        "/(api/v1/checkout|api/v1/payment|api/v1/orders)/[0-9a-f]{8} status=[0-9]+"
-      ],
-      "inputs": [
-        "realWorldRegex.factoredApiRoute.{matchLabel}.{size}"
+        "realWorldRegex.wideFactoredApiRoute.{matchLabel}.{size}"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1248,6 +1248,287 @@
       "shared": true
     },
     {
+      "id": "realWorldRegex.multiInfixLog.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "2026-08-27 12:00:00.123 [worker-42] error:[NORMAL] code:200 msg:Operation completed successfully for transaction 987654321\n",
+        "suffix": "2026-08-27 12:00:00.123 [worker-42] error:[CRITICAL] code:500 msg:crash\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.multiInfixLog.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "2026-08-27 12:00:00.123 [worker-42] error:[NORMAL] code:200 msg:Operation completed successfully for transaction 987654321",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.multiClauseSequence.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "foo ",
+        "unit": "data payload channel verification token buffer stream block record alpha beta gamma delta ",
+        "suffix": " bar data payload channel verification token buffer stream block record alpha beta gamma delta baz\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.multiClauseSequence.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "surroundToLength",
+        "prefix": "foo ",
+        "unit": "data payload channel verification token buffer stream block record alpha beta gamma delta ",
+        "suffix": " bar data payload channel verification token buffer stream block record alpha beta gamma delta qux\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.structuredJsonPath.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "{\"header\":{\"id\":\"12345\",\"type\":\"event\"},\"body\":{\"status\":\"pending\",\"payload\":\"data\"}}\n",
+        "suffix": "{\"header\":{\"id\":\"99999\",\"type\":\"event\"},\"body\":{\"status\":\"ok\",\"payload\":\"data\"}}\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.structuredJsonPath.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "{\"header\":{\"id\":\"12345\",\"type\":\"event\"},\"body\":{\"status\":\"pending\",\"payload\":\"data\"}}",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.uuidExtraction.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "session_token=abc123xyz log_id=normal_event status=200\n",
+        "suffix": "session_token=abc123xyz log_id=critical_event id:a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d status=500\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.uuidExtraction.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "session_token=abc123xyz log_id=normal_event status=200",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.isoTimestampLog.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "2026/08/30 12:00:00 [worker-42] info: normal periodic heartbeat\n",
+        "suffix": "2026-08-30T12:00:00Z error: unexpected service termination\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.isoTimestampLog.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "2026/08/30 12:00:00 [worker-42] info: normal periodic heartbeat",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.factoredAlternation.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "service_heartbeat ping_time=12ms region=us-east status=OK\n",
+        "suffix": "auth_token_refresh session=0123456789abcdef status=OK\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.factoredAlternation.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "service_heartbeat ping_time=12ms region=us-east status=OK",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.factoredProtocol.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "http_status=200 host=internal.cache proto=http/1.1 path=/api/v1/health\n",
+        "suffix": "http_status=200 host=example.com proto=https https://stage.example.com/item12345\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.factoredProtocol.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "http_status=200 host=internal.cache proto=http/1.1 path=/api/v1/health",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.factoredApiRoute.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "192.168.1.42 - - [30/Aug/2026:12:00:01 +0000] \"GET /static/bundle.min.js HTTP/1.1\" 200 4821 \"https://app.corp.net\"\n192.168.1.43 - - [30/Aug/2026:12:00:02 +0000] \"GET /api/v2/health HTTP/1.1\" 200 128 \"https://app.corp.net\"\n192.168.1.44 - - [30/Aug/2026:12:00:03 +0000] \"POST /assets/styles.css HTTP/1.1\" 200 954 \"https://app.corp.net\"\n",
+        "suffix": "192.168.1.99 - - [30/Aug/2026:12:00:04 +0000] \"POST /api/v1/checkout/a1b2c3d4 status=200\" 200 1024 \"https://app.corp.net\"\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.factoredApiRoute.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "192.168.1.42 - - [30/Aug/2026:12:00:01 +0000] \"GET /static/bundle.min.js HTTP/1.1\" 200 4821 \"https://app.corp.net\"\n192.168.1.43 - - [30/Aug/2026:12:00:02 +0000] \"GET /api/v2/health HTTP/1.1\" 200 128 \"https://app.corp.net\"\n192.168.1.44 - - [30/Aug/2026:12:00:03 +0000] \"POST /assets/styles.css HTTP/1.1\" 200 954 \"https://app.corp.net\"",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
       "id": "realWorldRegex.blockedTags1.match.{size}",
       "axes": {
         "size": [
@@ -4113,6 +4394,302 @@
       ],
       "inputs": [
         "realWorldRegex.fixedAnchorLog.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.multiInfixLog.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        ".*error:\\[[A-Z]+\\]\\s+code:500\\s+msg:crash"
+      ],
+      "inputs": [
+        "realWorldRegex.multiInfixLog.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.multiInfixLogCaptures.{matchLabel}.{size}",
+      "operation": "findGroup",
+      "patterns": [
+        ".*error:\\[([A-Z]+)\\]\\s+code:(500)\\s+msg:(crash)"
+      ],
+      "inputs": [
+        "realWorldRegex.multiInfixLog.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "group": 1
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.unanchoredLogCaptures.{matchLabel}.{size}",
+      "operation": "findGroup",
+      "patterns": [
+        "error:\\[([A-Z]+)\\]\\s+code:(500)\\s+msg:([^\\n]+)"
+      ],
+      "inputs": [
+        "realWorldRegex.multiInfixLog.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "group": 1
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.multiClauseSequence.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "foo[^\\n]*bar[^\\n]*baz"
+      ],
+      "inputs": [
+        "realWorldRegex.multiClauseSequence.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.structuredJsonPath.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "(?s).*\"id\":\\s*\"99999\".*\"status\":\\s*\"ok\""
+      ],
+      "inputs": [
+        "realWorldRegex.structuredJsonPath.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.uuidExtraction.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "id:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+      ],
+      "inputs": [
+        "realWorldRegex.uuidExtraction.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.isoTimestampLog.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z error"
+      ],
+      "inputs": [
+        "realWorldRegex.isoTimestampLog.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.factoredAlternation.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "(auth_token_refresh|auth_token_revoke|auth_token_verify) session=[0-9a-z]{16} status=OK"
+      ],
+      "inputs": [
+        "realWorldRegex.factoredAlternation.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.factoredProtocol.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "(https://api|https://stage|https://prod)\\.example\\.com/[a-z0-9]+"
+      ],
+      "inputs": [
+        "realWorldRegex.factoredProtocol.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.factoredApiRoute.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "/(api/v1/checkout|api/v1/payment|api/v1/orders)/[0-9a-f]{8} status=[0-9]+"
+      ],
+      "inputs": [
+        "realWorldRegex.factoredApiRoute.{matchLabel}.{size}"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/scripts/compare-branch.sh
+++ b/safere-benchmarks/scripts/compare-branch.sh
@@ -95,7 +95,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$FILTER" ]; then
-  FILTER='(SingleCharClassBenchmark\.findDigitAbsent|RealWorldRegexBenchmark\.runBenchmark\.(bracketCitation\.noMatch|mapFieldPath\.(noMatch|match)|caseInsensitiveKeyword\.noMatch|customProtocolLink\.noMatch|metadataBlock\.(noMatch|match)|jsonBlock\.match|templateTagMatch\.match|fixedAnchorLog\.(noMatch|match))|RegexBenchmark\.(literalMatch|charClassMatch|captureGroups|emailFind)|ApplicationBenchmark\.(uuidValidation|secretRedaction)).*@safere-string'
+  FILTER='(SingleCharClassBenchmark\.findDigitAbsent|RealWorldRegexBenchmark\.runBenchmark\.(bracketCitation\.noMatch|mapFieldPath\.(noMatch|match)|caseInsensitiveKeyword\.noMatch|customProtocolLink\.noMatch|metadataBlock\.(noMatch|match)|jsonBlock\.match|templateTagMatch\.match|fixedAnchorLog\.(noMatch|match)|multiInfixLog\.(noMatch|match)|multiInfixLogCaptures\.(noMatch|match)|unanchoredLogCaptures\.(noMatch|match)|multiClauseSequence\.(noMatch|match)|structuredJsonPath\.(noMatch|match)|uuidExtraction\.(noMatch|match)|isoTimestampLog\.(noMatch|match)|factoredAlternation\.(noMatch|match)|factoredProtocol\.(noMatch|match))|RegexBenchmark\.(literalMatch|charClassMatch|captureGroups|emailFind)|ApplicationBenchmark\.(uuidValidation|secretRedaction)).*@safere-string'
 fi
 
 # Resolve relative refs while HEAD still identifies the caller's revision.

--- a/safere-benchmarks/scripts/compare-branch.sh
+++ b/safere-benchmarks/scripts/compare-branch.sh
@@ -95,7 +95,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$FILTER" ]; then
-  FILTER='(SingleCharClassBenchmark\.findDigitAbsent|RealWorldRegexBenchmark\.runBenchmark\.(bracketCitation\.noMatch|mapFieldPath\.(noMatch|match)|caseInsensitiveKeyword\.noMatch|customProtocolLink\.noMatch|metadataBlock\.(noMatch|match)|jsonBlock\.match|templateTagMatch\.match|fixedAnchorLog\.(noMatch|match)|multiInfixLog\.(noMatch|match)|multiInfixLogCaptures\.(noMatch|match)|unanchoredLogCaptures\.(noMatch|match)|multiClauseSequence\.(noMatch|match)|structuredJsonPath\.(noMatch|match)|uuidExtraction\.(noMatch|match)|isoTimestampLog\.(noMatch|match)|factoredAlternation\.(noMatch|match)|factoredProtocol\.(noMatch|match))|RegexBenchmark\.(literalMatch|charClassMatch|captureGroups|emailFind)|ApplicationBenchmark\.(uuidValidation|secretRedaction)).*@safere-string'
+  FILTER='(SingleCharClassBenchmark\.findDigitAbsent|RealWorldRegexBenchmark\.runBenchmark\.(bracketCitation\.noMatch|mapFieldPath\.(noMatch|match)|caseInsensitiveKeyword\.noMatch|customProtocolLink\.noMatch|metadataBlock\.(noMatch|match)|jsonBlock\.match|templateTagMatch\.match|fixedAnchorLog\.(noMatch|match)|multiInfixLog\.(noMatch|match)|multiInfixLogCaptures\.(noMatch|match)|unanchoredLogCaptures\.(noMatch|match)|multiClauseSequence\.(noMatch|match)|structuredJsonPath\.(noMatch|match)|uuidExtraction\.(noMatch|match)|isoTimestampLog\.(noMatch|match)|wideFactoredApiRoute\.(noMatch|match))|RegexBenchmark\.(literalMatch|charClassMatch|captureGroups|emailFind)|ApplicationBenchmark\.(uuidValidation|secretRedaction)).*@safere-string'
 fi
 
 # Resolve relative refs while HEAD still identifies the caller's revision.

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -110,6 +110,15 @@ final class FuzzSupport {
         .available();
   }
 
+  static boolean jdkOracleStackOverflowIsAvailableForTesting() {
+    return runJdkOracle(
+            "stack overflow",
+            () -> {
+              throw new StackOverflowError();
+            })
+        .available();
+  }
+
   static int consumeFlags(FuzzedDataProvider data) {
     int flags = 0;
     for (int flag : FLAGS) {
@@ -693,6 +702,9 @@ final class FuzzSupport {
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof JdkOracleInterruptedException) {
+        return unavailableJdkOracle();
+      }
+      if (cause instanceof StackOverflowError) {
         return unavailableJdkOracle();
       }
       if (cause instanceof RuntimeException runtimeException) {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupportOracleTimeoutTest.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupportOracleTimeoutTest.java
@@ -35,4 +35,10 @@ final class FuzzSupportOracleTimeoutTest {
       }
     }
   }
+
+  @Test
+  @DisplayName("JDK oracle stack overflow marks recursive matching unavailable")
+  void jdkOracleStackOverflowMarksRecursiveMatchingUnavailable() {
+    assertFalse(FuzzSupport.jdkOracleStackOverflowIsAvailableForTesting());
+  }
 }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -58,6 +58,7 @@ final class MatchFuzzer {
     assertScopedCaseFoldingMatchesJdk(data);
     assertMultiAnchorGapBoundsMatchJdk(data);
     assertLeadingClassAssertionsMatchJdk(data);
+    assertFactoredPrefixCaseFlagsMatchJdk(data);
     assertAlternationAndQuantifierPriorityLookingAtMatchesJdk(data);
 
     String regex;
@@ -120,6 +121,21 @@ final class MatchFuzzer {
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
     if (pattern != null) {
       pattern.matcher(data.pickValue(List.of("xAAA", " AAA", "11AAA", "xAAA1RAREST_TOKEN"))).find();
+    }
+  }
+
+  private static void assertFactoredPrefixCaseFlagsMatchJdk(FuzzedDataProvider data) {
+    String exactSuffix = data.pickValue(List.of("X", "Y", "Z"));
+    String foldedSuffix = data.pickValue(List.of("M", "N", "P"));
+    String foldedBranch = "(?i:abc)" + foldedSuffix;
+    String exactBranch = "abc" + exactSuffix;
+    String regex =
+        data.consumeBoolean()
+            ? "(?:" + foldedBranch + "|" + exactBranch + ")"
+            : "(?:" + exactBranch + "|" + foldedBranch + ")";
+    FuzzSupport.CompiledPattern pattern = FuzzSupport.compileCompatibleOrSkip(regex, 0);
+    if (pattern != null) {
+      pattern.matcher(data.consumeBoolean() ? "ABC" + foldedSuffix : "abc" + exactSuffix).find();
     }
   }
 

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
@@ -20,17 +20,20 @@ final class ParserStackSafetyFuzzer {
       FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(nestedCountedRepeat(depth, "{0,2}"), 0, INPUTS);
+      FuzzSupport.assertFullMatchesJdk(nestedQuantifiers(Math.min(depth, 64)), 0, INPUTS);
     }
 
     int depth = data.consumeInt(0, 512);
-    switch (data.consumeInt(0, 3)) {
+    switch (data.consumeInt(0, 4)) {
       case 0 -> FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
       case 1 -> FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);
       case 2 -> FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
-      default -> {
+      case 3 -> {
         String quantifier = data.pickValue(List.of("{0}", "{1}", "{0,2}", "{1,2}"));
         FuzzSupport.assertFullMatchesJdk(nestedCountedRepeat(depth, quantifier), 0, INPUTS);
       }
+      default ->
+          FuzzSupport.assertFullMatchesJdk(nestedQuantifiers(data.consumeInt(0, 64)), 0, INPUTS);
     }
   }
 
@@ -48,5 +51,15 @@ final class ParserStackSafetyFuzzer {
 
   private static String nestedCountedRepeat(int depth, String quantifier) {
     return nestedGroups(depth) + quantifier;
+  }
+
+  private static String nestedQuantifiers(int depth) {
+    StringBuilder regex = new StringBuilder(depth * 6 + 1);
+    regex.append("(?:".repeat(depth));
+    regex.append('a');
+    for (int index = depth - 1; index >= 0; index--) {
+      regex.append(index % 2 == 0 ? ")?" : ")+");
+    }
+    return regex.toString();
   }
 }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
@@ -21,6 +21,9 @@ final class ParserStackSafetyFuzzer {
       FuzzSupport.assertFullMatchesJdk(quantifiedNestedCaptures(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(nestedCountedRepeat(depth, "{0,2}"), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(nestedQuantifiers(Math.min(depth, 64)), 0, INPUTS);
+      FuzzSupport.assertFullMatchesJdk(
+          homogeneousGapNesting(Math.min(depth, 64), "[ab]"), 0, INPUTS);
+      FuzzSupport.assertFullMatchesJdk(homogeneousGapNesting(Math.min(depth, 64), "."), 0, INPUTS);
     }
 
     int depth = data.consumeInt(0, 512);
@@ -61,5 +64,9 @@ final class ParserStackSafetyFuzzer {
       regex.append(index % 2 == 0 ? ")?" : ")+");
     }
     return regex.toString();
+  }
+
+  private static String homogeneousGapNesting(int depth, String atom) {
+    return "foo" + "(?:".repeat(depth) + atom + (")?" + atom).repeat(depth) + "bar";
   }
 }

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -1262,13 +1262,18 @@ final class MultiAnchorCompiler {
     if (re == null) {
       return false;
     }
-    if (re.op == RegexpOp.CAPTURE || re.cap != 0) {
-      return true;
-    }
-    if (re.subs != null) {
-      for (Regexp sub : re.subs) {
-        if (hasCaptures(sub)) {
-          return true;
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.addLast(re);
+    while (!pending.isEmpty()) {
+      Regexp current = pending.removeLast();
+      if (current.op == RegexpOp.CAPTURE || current.cap != 0) {
+        return true;
+      }
+      if (current.subs != null) {
+        for (Regexp sub : current.subs) {
+          if (sub != null) {
+            pending.addLast(sub);
+          }
         }
       }
     }
@@ -1279,19 +1284,26 @@ final class MultiAnchorCompiler {
     if (re == null) {
       return false;
     }
-    return switch (re.op) {
-      case BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY -> true;
-      default -> {
-        if (re.subs != null) {
-          for (Regexp sub : re.subs) {
-            if (hasZeroWidthAssertions(sub)) {
-              yield true;
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.addLast(re);
+    while (!pending.isEmpty()) {
+      Regexp current = pending.removeLast();
+      switch (current.op) {
+        case BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY -> {
+          return true;
+        }
+        default -> {
+          if (current.subs != null) {
+            for (Regexp sub : current.subs) {
+              if (sub != null) {
+                pending.addLast(sub);
+              }
             }
           }
         }
-        yield false;
       }
-    };
+    }
+    return false;
   }
 
   private static int[] extractLeadingRunes(Regexp sub) {

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -1241,6 +1241,10 @@ final class MultiAnchorCompiler {
     if (allHaveLeading) {
       int lcp = commonPrefixLength(leadingRunesList);
       if (lcp >= 2) {
+        Integer prefixFlags = commonLeadingLiteralFlags(re.subs, lcp);
+        if (prefixFlags == null) {
+          return re;
+        }
         int[] prefixRunes = Arrays.copyOf(leadingRunesList.get(0), lcp);
         List<Regexp> remainders = new ArrayList<>(re.subs.size());
         for (Regexp sub : re.subs) {
@@ -1248,14 +1252,52 @@ final class MultiAnchorCompiler {
         }
         Regexp prefixNode =
             prefixRunes.length == 1
-                ? Regexp.literal(prefixRunes[0], re.flags)
-                : Regexp.literalString(prefixRunes, re.flags);
+                ? Regexp.literal(prefixRunes[0], prefixFlags)
+                : Regexp.literalString(prefixRunes, prefixFlags);
         Regexp alternateNode = Regexp.alternate(remainders, re.flags);
         return Regexp.concat(List.of(prefixNode, alternateNode), re.flags);
       }
     }
 
     return re;
+  }
+
+  private static Integer commonLeadingLiteralFlags(List<Regexp> alternatives, int runeCount) {
+    Integer commonFlags = null;
+    for (Regexp alternative : alternatives) {
+      Integer flags = homogeneousLeadingLiteralFlags(alternative, runeCount);
+      if (flags == null) {
+        return null;
+      }
+      if (commonFlags == null) {
+        commonFlags = flags;
+      } else if (((commonFlags ^ flags) & ParseFlags.FOLD_CASE) != 0) {
+        return null;
+      }
+    }
+    return commonFlags;
+  }
+
+  private static Integer homogeneousLeadingLiteralFlags(Regexp re, int runeCount) {
+    List<Regexp> leading = re.op == RegexpOp.CONCAT && re.subs != null ? re.subs : List.of(re);
+    Integer commonFlags = null;
+    int remaining = runeCount;
+    for (Regexp node : leading) {
+      int nodeLength = literalRunesLength(node);
+      if (nodeLength == 0) {
+        break;
+      }
+      if (commonFlags == null) {
+        commonFlags = node.flags;
+      } else if (((commonFlags ^ node.flags) & ParseFlags.FOLD_CASE) != 0) {
+        return null;
+      }
+      remaining -= Math.min(remaining, nodeLength);
+      if (remaining == 0) {
+        return commonFlags;
+      }
+    }
+    return null;
   }
 
   private static boolean hasCaptures(Regexp re) {
@@ -2141,7 +2183,7 @@ final class MultiAnchorCompiler {
             greedy);
       }
     }
-    if (isHomogeneousAnyChar(re, flags)) {
+    if (isHomogeneousAnyChar(re)) {
       boolean dotAll =
           (flags & Pattern.DOTALL) != 0
               || (re.flags & (ParseFlags.DOT_NL | ParseFlags.MATCH_NL)) != 0;
@@ -2164,53 +2206,89 @@ final class MultiAnchorCompiler {
     if (re == null) {
       return null;
     }
-    return switch (re.op) {
-      case CHAR_CLASS ->
-          isDotCharClass(re.charClass) ? null : buildAsciiBitmapFromCharClass(re.charClass);
-      case QUEST, STAR, PLUS, REPEAT, CAPTURE -> extractHomogeneousCharClass(re.sub());
-      case CONCAT, ALTERNATE -> {
-        if (re.subs == null || re.subs.isEmpty()) {
-          yield null;
-        }
-        AsciiBitmap first = null;
-        for (Regexp sub : re.subs) {
-          AsciiBitmap bm = extractHomogeneousCharClass(sub);
-          if (bm == null) {
-            yield null;
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.addLast(re);
+    AsciiBitmap homogeneous = null;
+    while (!pending.isEmpty()) {
+      Regexp node = pending.removeLast();
+      switch (node.op) {
+        case CHAR_CLASS -> {
+          if (isDotCharClass(node.charClass)) {
+            return null;
           }
-          if (first == null) {
-            first = bm;
-          } else if (!Objects.equals(first, bm)) {
-            yield null;
+          AsciiBitmap bitmap = buildAsciiBitmapFromCharClass(node.charClass);
+          if (bitmap == null) {
+            return null;
+          }
+          if (homogeneous == null) {
+            homogeneous = bitmap;
+          } else if (!Objects.equals(homogeneous, bitmap)) {
+            return null;
           }
         }
-        yield first;
+        case QUEST, STAR, PLUS, REPEAT, CAPTURE -> {
+          if (node.sub() == null) {
+            return null;
+          }
+          pending.addLast(node.sub());
+        }
+        case CONCAT, ALTERNATE -> {
+          if (node.subs == null || node.subs.isEmpty()) {
+            return null;
+          }
+          for (Regexp sub : node.subs) {
+            if (sub == null) {
+              return null;
+            }
+            pending.addLast(sub);
+          }
+        }
+        default -> {
+          return null;
+        }
       }
-      default -> null;
-    };
+    }
+    return homogeneous;
   }
 
-  private static boolean isHomogeneousAnyChar(Regexp re, int flags) {
+  private static boolean isHomogeneousAnyChar(Regexp re) {
     if (re == null) {
       return false;
     }
-    return switch (re.op) {
-      case ANY_CHAR -> true;
-      case CHAR_CLASS -> isDotCharClass(re.charClass);
-      case QUEST, STAR, PLUS, REPEAT, CAPTURE -> isHomogeneousAnyChar(re.sub(), flags);
-      case CONCAT, ALTERNATE -> {
-        if (re.subs == null || re.subs.isEmpty()) {
-          yield false;
-        }
-        for (Regexp sub : re.subs) {
-          if (!isHomogeneousAnyChar(sub, flags)) {
-            yield false;
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.addLast(re);
+    while (!pending.isEmpty()) {
+      Regexp node = pending.removeLast();
+      switch (node.op) {
+        case ANY_CHAR -> {}
+        case CHAR_CLASS -> {
+          if (!isDotCharClass(node.charClass)) {
+            return false;
           }
         }
-        yield true;
+        case QUEST, STAR, PLUS, REPEAT, CAPTURE -> {
+          if (node.sub() == null) {
+            return false;
+          }
+          pending.addLast(node.sub());
+        }
+        case CONCAT, ALTERNATE -> {
+          if (node.subs == null || node.subs.isEmpty()) {
+            return false;
+          }
+          for (Regexp sub : node.subs) {
+            if (sub == null) {
+              return false;
+            }
+            pending.addLast(sub);
+          }
+        }
+        default -> {
+          return false;
+        }
       }
-      default -> false;
-    };
+    }
+    return true;
   }
 
   static FixedOffsetLiteral extractFixedOffsetLiteral(Regexp re) {

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -116,7 +116,8 @@ final class MultiAnchorCompiler {
     if (re == null) {
       return null;
     }
-    Regexp node = unwrapCaptures(re);
+    Regexp factored = factorAlternations(re);
+    Regexp node = unwrapCaptures(factored);
     if (node == null) {
       return null;
     }
@@ -145,10 +146,10 @@ final class MultiAnchorCompiler {
                 anchorStart,
                 anchorEnd);
 
-    NodeAnalysis analysis = analyze(re, flags);
-    MultiAnchorDescriptor.StartPlan startPlan = extractStartPlan(re, true, analysis);
+    NodeAnalysis analysis = analyze(factored, flags);
+    MultiAnchorDescriptor.StartPlan startPlan = extractStartPlan(factored, true, analysis);
     MultiAnchorDescriptor.RejectPlan rejectPlan =
-        extractRejectPlan(re, startPlan, anchorStart, analysis);
+        extractRejectPlan(factored, startPlan, anchorStart, analysis);
 
     PrefixResult anchoredPrefix = analysis.start().anchoredPrefix();
     String anchoredLiteral = anchoredPrefix.foldCase() ? null : anchoredPrefix.prefix();
@@ -781,9 +782,19 @@ final class MultiAnchorCompiler {
     }
 
     if (first.op == RegexpOp.ALTERNATE) {
+      if (hasZeroWidthAssertions(first) || hasCaptures(first)) {
+        return null;
+      }
       MultiAnchorDescriptor.Anchor.Alternation alt = extractAlternationAnchor(first, flags);
       if (alt != null) {
         return new ConsumedAnchor(alt, 1);
+      }
+      AsciiWidthRange width = computeAsciiWidthRange(first);
+      if (width.isExact() && width.minWidth == 1) {
+        CharClassScanInfo scanInfo = extractCharClassPrefix(first);
+        if (scanInfo != null) {
+          return new ConsumedAnchor(MultiAnchorDescriptor.Anchor.CharClass.create(scanInfo), 1);
+        }
       }
       return null;
     }
@@ -949,6 +960,8 @@ final class MultiAnchorCompiler {
       return null;
     }
 
+    coalesceWeakIntermediateAnchors(anchors, gaps);
+
     if (gaps.size() == anchors.size()) {
       gaps.add(MultiAnchorDescriptor.Gap.EMPTY);
     }
@@ -970,11 +983,23 @@ final class MultiAnchorCompiler {
       minTotalLength += g.minLength();
     }
 
+    boolean allGapsBounded = true;
+    for (MultiAnchorDescriptor.Gap g : gaps) {
+      if (g.maxLength() == Integer.MAX_VALUE) {
+        allGapsBounded = false;
+        break;
+      }
+    }
+
     if (maxAnchorLen < 2) {
-      return null;
+      if (!allGapsBounded || minTotalLength < 6 || anchors.size() < 2) {
+        return null;
+      }
     }
     if (maxAnchorLen < 3 && anchors.size() < 3 && anchors.size() > 1) {
-      return null;
+      if (!allGapsBounded && minTotalLength < 6) {
+        return null;
+      }
     }
 
     int numAnchors = anchors.size();
@@ -1039,6 +1064,354 @@ final class MultiAnchorCompiler {
       return new MultiAnchorDescriptor.Gap(first.kind(), min, max, null, first.isGreedy());
     }
     return null;
+  }
+
+  private static void coalesceWeakIntermediateAnchors(
+      List<MultiAnchorDescriptor.Anchor> anchors, List<MultiAnchorDescriptor.Gap> gaps) {
+    if (anchors.size() <= 2) {
+      return;
+    }
+    for (int i = 1; i < anchors.size() - 1; ) {
+      MultiAnchorDescriptor.Anchor a = anchors.get(i);
+      MultiAnchorDescriptor.Gap gBefore = gaps.get(i);
+      MultiAnchorDescriptor.Gap gAfter = gaps.get(i + 1);
+
+      boolean isWeakCharClass =
+          (a instanceof MultiAnchorDescriptor.Anchor.CharClass cc)
+              && gBefore.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+              && gAfter.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+              && Objects.equals(gBefore.charClass(), gAfter.charClass())
+              && bitmapContainsAll(gBefore.charClass(), cc.scanInfo());
+
+      if (isWeakCharClass) {
+        int min = gBefore.minLength() + a.minLength() + gAfter.minLength();
+        int max =
+            (gBefore.maxLength() == Integer.MAX_VALUE || gAfter.maxLength() == Integer.MAX_VALUE)
+                ? Integer.MAX_VALUE
+                : gBefore.maxLength() + a.maxLength() + gAfter.maxLength();
+        MultiAnchorDescriptor.Gap merged =
+            new MultiAnchorDescriptor.Gap(
+                MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
+                min,
+                max,
+                gBefore.charClass(),
+                gBefore.isGreedy() && gAfter.isGreedy());
+        gaps.set(i, merged);
+        gaps.remove(i + 1);
+        anchors.remove(i);
+        continue;
+      }
+      i++;
+    }
+  }
+
+  private static boolean bitmapContainsAll(AsciiBitmap bitmap, CharClassScanInfo scanInfo) {
+    if (bitmap == null || scanInfo == null) {
+      return false;
+    }
+    int[] ranges = scanInfo.ranges();
+    if (ranges == null) {
+      return false;
+    }
+    for (int i = 0; i < ranges.length; i += 2) {
+      int lo = ranges[i];
+      int hi = ranges[i + 1];
+      for (int cp = lo; cp <= hi; cp++) {
+        if (!bitmap.contains(cp)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  static Regexp factorAlternations(Regexp re) {
+    return factorAlternations(re, 0);
+  }
+
+  private static final int MAX_FACTOR_DEPTH = 16;
+
+  private static Regexp factorAlternations(Regexp re, int depth) {
+    if (re == null || depth > MAX_FACTOR_DEPTH || hasCaptures(re) || hasZeroWidthAssertions(re)) {
+      return re;
+    }
+    if (re.subs != null && !re.subs.isEmpty()) {
+      List<Regexp> newSubs = new ArrayList<>(re.subs.size());
+      boolean changed = false;
+      for (Regexp sub : re.subs) {
+        Regexp factored = factorAlternations(sub, depth + 1);
+        if (re.op == RegexpOp.CONCAT
+            && factored.op == RegexpOp.CONCAT
+            && factored != sub
+            && sub.op == RegexpOp.ALTERNATE
+            && factored.subs != null) {
+          for (Regexp child : factored.subs) {
+            appendAndCoalesce(newSubs, child);
+          }
+          changed = true;
+        } else if (re.op == RegexpOp.CONCAT) {
+          appendAndCoalesce(newSubs, factored);
+          if (factored != sub || newSubs.size() != re.subs.size()) {
+            changed = true;
+          }
+        } else {
+          newSubs.add(factored);
+          if (factored != sub) {
+            changed = true;
+          }
+        }
+      }
+      if (changed) {
+        re = copyWithSubs(re, newSubs);
+      }
+    }
+    if (re.op == RegexpOp.ALTERNATE && re.subs != null && re.subs.size() >= 2) {
+      return factorAlternate(re);
+    }
+    return re;
+  }
+
+  private static void appendAndCoalesce(List<Regexp> subs, Regexp node) {
+    if (node == null) {
+      return;
+    }
+    if (!subs.isEmpty()) {
+      Regexp prev = subs.get(subs.size() - 1);
+      int[] prevRunes = extractRunes(prev);
+      int[] currRunes = extractRunes(node);
+      if (prevRunes != null
+          && currRunes != null
+          && (prev.flags & ParseFlags.FOLD_CASE) == (node.flags & ParseFlags.FOLD_CASE)) {
+        int[] merged = new int[prevRunes.length + currRunes.length];
+        System.arraycopy(prevRunes, 0, merged, 0, prevRunes.length);
+        System.arraycopy(currRunes, 0, merged, prevRunes.length, currRunes.length);
+        subs.set(subs.size() - 1, Regexp.literalString(merged, prev.flags));
+        return;
+      }
+    }
+    subs.add(node);
+  }
+
+  private static int[] extractRunes(Regexp re) {
+    if (re == null) {
+      return null;
+    }
+    if (re.op == RegexpOp.LITERAL) {
+      return new int[] {re.rune};
+    }
+    if (re.op == RegexpOp.LITERAL_STRING && re.runes != null) {
+      return re.runes;
+    }
+    return null;
+  }
+
+  private static Regexp copyWithSubs(Regexp re, List<Regexp> newSubs) {
+    Regexp copy = new Regexp(re.op, re.flags);
+    copy.rune = re.rune;
+    copy.runes = re.runes;
+    copy.min = re.min;
+    copy.max = re.max;
+    copy.cap = re.cap;
+    copy.name = re.name;
+    copy.charClass = re.charClass;
+    copy.subs = List.copyOf(newSubs);
+    return copy;
+  }
+
+  private static Regexp factorAlternate(Regexp re) {
+    if (re == null || re.op != RegexpOp.ALTERNATE || re.subs == null || re.subs.size() < 2) {
+      return re;
+    }
+    if (hasCaptures(re) || hasZeroWidthAssertions(re)) {
+      return re;
+    }
+
+    // 1. Common literal prefix factoring
+    List<int[]> leadingRunesList = new ArrayList<>(re.subs.size());
+    boolean allHaveLeading = true;
+    for (Regexp sub : re.subs) {
+      int[] r = extractLeadingRunes(sub);
+      if (r == null || r.length == 0) {
+        allHaveLeading = false;
+        break;
+      }
+      leadingRunesList.add(r);
+    }
+
+    if (allHaveLeading) {
+      int lcp = commonPrefixLength(leadingRunesList);
+      if (lcp >= 2) {
+        int[] prefixRunes = Arrays.copyOf(leadingRunesList.get(0), lcp);
+        List<Regexp> remainders = new ArrayList<>(re.subs.size());
+        for (Regexp sub : re.subs) {
+          remainders.add(stripLeadingRunes(sub, lcp));
+        }
+        Regexp prefixNode =
+            prefixRunes.length == 1
+                ? Regexp.literal(prefixRunes[0], re.flags)
+                : Regexp.literalString(prefixRunes, re.flags);
+        Regexp alternateNode = Regexp.alternate(remainders, re.flags);
+        return Regexp.concat(List.of(prefixNode, alternateNode), re.flags);
+      }
+    }
+
+    return re;
+  }
+
+  private static boolean hasCaptures(Regexp re) {
+    if (re == null) {
+      return false;
+    }
+    if (re.op == RegexpOp.CAPTURE || re.cap != 0) {
+      return true;
+    }
+    if (re.subs != null) {
+      for (Regexp sub : re.subs) {
+        if (hasCaptures(sub)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasZeroWidthAssertions(Regexp re) {
+    if (re == null) {
+      return false;
+    }
+    return switch (re.op) {
+      case BEGIN_LINE, END_LINE, BEGIN_TEXT, END_TEXT, WORD_BOUNDARY, NO_WORD_BOUNDARY -> true;
+      default -> {
+        if (re.subs != null) {
+          for (Regexp sub : re.subs) {
+            if (hasZeroWidthAssertions(sub)) {
+              yield true;
+            }
+          }
+        }
+        yield false;
+      }
+    };
+  }
+
+  private static int[] extractLeadingRunes(Regexp sub) {
+    if (sub == null || hasCaptures(sub) || hasZeroWidthAssertions(sub)) {
+      return null;
+    }
+    if (sub.op == RegexpOp.LITERAL) {
+      return new int[] {sub.rune};
+    }
+    if (sub.op == RegexpOp.LITERAL_STRING && sub.runes != null) {
+      return sub.runes;
+    }
+    if (sub.op == RegexpOp.CONCAT && sub.subs != null && !sub.subs.isEmpty()) {
+      List<Integer> collected = new ArrayList<>();
+      for (Regexp c : sub.subs) {
+        if (c == null || hasCaptures(c) || hasZeroWidthAssertions(c)) {
+          break;
+        }
+        if (c.op == RegexpOp.LITERAL) {
+          collected.add(c.rune);
+        } else if (c.op == RegexpOp.LITERAL_STRING && c.runes != null) {
+          for (int r : c.runes) {
+            collected.add(r);
+          }
+        } else {
+          break;
+        }
+      }
+      if (!collected.isEmpty()) {
+        int[] res = new int[collected.size()];
+        for (int i = 0; i < res.length; i++) {
+          res[i] = collected.get(i);
+        }
+        return res;
+      }
+    }
+    return null;
+  }
+
+  private static int commonPrefixLength(List<int[]> list) {
+    if (list.isEmpty()) {
+      return 0;
+    }
+    int[] first = list.get(0);
+    int minLen = first.length;
+    for (int i = 1; i < list.size(); i++) {
+      minLen = Math.min(minLen, list.get(i).length);
+    }
+    int len = 0;
+    for (int col = 0; col < minLen; col++) {
+      int r = first[col];
+      for (int i = 1; i < list.size(); i++) {
+        if (list.get(i)[col] != r) {
+          return len;
+        }
+      }
+      len++;
+    }
+    return len;
+  }
+
+  private static int literalRunesLength(Regexp sub) {
+    if (sub == null) {
+      return 0;
+    }
+    if (sub.op == RegexpOp.LITERAL) {
+      return 1;
+    }
+    if (sub.op == RegexpOp.LITERAL_STRING && sub.runes != null) {
+      return sub.runes.length;
+    }
+    return 0;
+  }
+
+  private static Regexp stripLeadingRunes(Regexp re, int count) {
+    if (count <= 0) {
+      return re;
+    }
+    if (re.op == RegexpOp.LITERAL) {
+      return Regexp.emptyMatch(re.flags);
+    }
+    if (re.op == RegexpOp.LITERAL_STRING && re.runes != null) {
+      if (count >= re.runes.length) {
+        return Regexp.emptyMatch(re.flags);
+      }
+      int[] remainder = Arrays.copyOfRange(re.runes, count, re.runes.length);
+      return remainder.length == 1
+          ? Regexp.literal(remainder[0], re.flags)
+          : Regexp.literalString(remainder, re.flags);
+    }
+    if (re.op == RegexpOp.CONCAT && re.subs != null) {
+      List<Regexp> newSubs = new ArrayList<>();
+      int remainingToStrip = count;
+      for (Regexp sub : re.subs) {
+        if (remainingToStrip <= 0) {
+          newSubs.add(sub);
+          continue;
+        }
+        int subLen = literalRunesLength(sub);
+        if (subLen > 0 && subLen <= remainingToStrip) {
+          remainingToStrip -= subLen;
+        } else if (subLen > remainingToStrip) {
+          Regexp strippedSub = stripLeadingRunes(sub, remainingToStrip);
+          if (strippedSub != null && strippedSub.op != RegexpOp.EMPTY_MATCH) {
+            newSubs.add(strippedSub);
+          }
+          remainingToStrip = 0;
+        } else {
+          newSubs.add(sub);
+        }
+      }
+      if (newSubs.isEmpty()) {
+        return Regexp.emptyMatch(re.flags);
+      }
+      if (newSubs.size() == 1) {
+        return newSubs.get(0);
+      }
+      return Regexp.concat(newSubs, re.flags);
+    }
+    return re;
   }
 
   private static MultiAnchorDescriptor.StartPlan.LeadingExpansion extractStartLeadingExpansion(
@@ -1172,13 +1545,19 @@ final class MultiAnchorCompiler {
       }
     }
     if (unwrapped.op == RegexpOp.ALTERNATE) {
+      if (hasZeroWidthAssertions(unwrapped) || hasCaptures(unwrapped)) {
+        return null;
+      }
       MultiAnchorDescriptor.Anchor.Alternation alt = extractAlternationAnchor(unwrapped, flags);
       if (alt != null) {
         return alt;
       }
-      CharClassScanInfo scanInfo = extractCharClassPrefix(unwrapped);
-      if (scanInfo != null) {
-        return MultiAnchorDescriptor.Anchor.CharClass.create(scanInfo);
+      AsciiWidthRange width = computeAsciiWidthRange(unwrapped);
+      if (width.isExact() && width.minWidth == 1) {
+        CharClassScanInfo scanInfo = extractCharClassPrefix(unwrapped);
+        if (scanInfo != null) {
+          return MultiAnchorDescriptor.Anchor.CharClass.create(scanInfo);
+        }
       }
     }
     if (unwrapped.op == RegexpOp.CHAR_CLASS && unwrapped.charClass != null) {
@@ -1730,27 +2109,96 @@ final class MultiAnchorCompiler {
       boolean dotAll =
           (flags & Pattern.DOTALL) != 0
               || (re.flags & (ParseFlags.DOT_NL | ParseFlags.MATCH_NL)) != 0;
-      return new MultiAnchorDescriptor.Gap(
-          dotAll
-              ? MultiAnchorDescriptor.GapKind.ANY_STAR
-              : MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR,
-          1,
-          1,
-          null,
-          true);
+      return dotAll
+          ? new MultiAnchorDescriptor.Gap(
+              MultiAnchorDescriptor.GapKind.ANY_STAR, 1, 1, null, greedy)
+          : new MultiAnchorDescriptor.Gap(
+              MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR, 1, 1, null, greedy);
     }
-    AsciiWidthRange width = computeAsciiWidthRange(re);
-    if (width.isValid() && width.maxWidth < Integer.MAX_VALUE) {
-      return new MultiAnchorDescriptor.Gap(
-          MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
-          width.minWidth,
-          width.maxWidth,
-          width.discreteWidths,
-          null,
-          null,
-          greedy);
+    AsciiBitmap homogeneousBm = extractHomogeneousCharClass(re);
+    if (homogeneousBm != null) {
+      AsciiWidthRange width = computeAsciiWidthRange(re);
+      if (width.isValid() && width.maxWidth < Integer.MAX_VALUE) {
+        return new MultiAnchorDescriptor.Gap(
+            MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT,
+            width.minWidth,
+            width.maxWidth,
+            width.discreteWidths,
+            homogeneousBm,
+            CharClassScanInfo.fromAsciiBitmap(homogeneousBm),
+            greedy);
+      }
+    }
+    if (isHomogeneousAnyChar(re, flags)) {
+      boolean dotAll =
+          (flags & Pattern.DOTALL) != 0
+              || (re.flags & (ParseFlags.DOT_NL | ParseFlags.MATCH_NL)) != 0;
+      AsciiWidthRange width = computeAsciiWidthRange(re);
+      if (width.isValid() && width.maxWidth < Integer.MAX_VALUE) {
+        return new MultiAnchorDescriptor.Gap(
+            dotAll
+                ? MultiAnchorDescriptor.GapKind.ANY_STAR
+                : MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR,
+            width.minWidth,
+            width.maxWidth,
+            null,
+            greedy);
+      }
     }
     return null;
+  }
+
+  private static AsciiBitmap extractHomogeneousCharClass(Regexp re) {
+    if (re == null) {
+      return null;
+    }
+    return switch (re.op) {
+      case CHAR_CLASS ->
+          isDotCharClass(re.charClass) ? null : buildAsciiBitmapFromCharClass(re.charClass);
+      case QUEST, STAR, PLUS, REPEAT, CAPTURE -> extractHomogeneousCharClass(re.sub());
+      case CONCAT, ALTERNATE -> {
+        if (re.subs == null || re.subs.isEmpty()) {
+          yield null;
+        }
+        AsciiBitmap first = null;
+        for (Regexp sub : re.subs) {
+          AsciiBitmap bm = extractHomogeneousCharClass(sub);
+          if (bm == null) {
+            yield null;
+          }
+          if (first == null) {
+            first = bm;
+          } else if (!Objects.equals(first, bm)) {
+            yield null;
+          }
+        }
+        yield first;
+      }
+      default -> null;
+    };
+  }
+
+  private static boolean isHomogeneousAnyChar(Regexp re, int flags) {
+    if (re == null) {
+      return false;
+    }
+    return switch (re.op) {
+      case ANY_CHAR -> true;
+      case CHAR_CLASS -> isDotCharClass(re.charClass);
+      case QUEST, STAR, PLUS, REPEAT, CAPTURE -> isHomogeneousAnyChar(re.sub(), flags);
+      case CONCAT, ALTERNATE -> {
+        if (re.subs == null || re.subs.isEmpty()) {
+          yield false;
+        }
+        for (Regexp sub : re.subs) {
+          if (!isHomogeneousAnyChar(sub, flags)) {
+            yield false;
+          }
+        }
+        yield true;
+      }
+      default -> false;
+    };
   }
 
   static FixedOffsetLiteral extractFixedOffsetLiteral(Regexp re) {

--- a/safere/src/main/java/org/safere/Regexp.java
+++ b/safere/src/main/java/org/safere/Regexp.java
@@ -80,7 +80,7 @@ final class Regexp {
   /** Match ID for multi-pattern matching. Used by HAVE_MATCH. */
   public int matchId;
 
-  private Regexp(RegexpOp op, int flags) {
+  Regexp(RegexpOp op, int flags) {
     this.op = op;
     this.flags = flags;
   }

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -421,4 +421,16 @@ class MultiAnchorCompilerTest {
     Regexp input = nested;
     assertThatCode(() -> MultiAnchorCompiler.factorAlternations(input)).doesNotThrowAnyException();
   }
+
+  @Test
+  void homogeneousGapExtractionIsStackSafeForDeepQuantifiers() {
+    assertThatCode(() -> Pattern.compile(deepHomogeneousGap("[ab]", 5_000)))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> Pattern.compile(deepHomogeneousGap(".", 5_000)))
+        .doesNotThrowAnyException();
+  }
+
+  private static String deepHomogeneousGap(String atom, int depth) {
+    return "foo" + "(?:".repeat(depth) + atom + (")?" + atom).repeat(depth) + "bar";
+  }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -389,13 +389,23 @@ class MultiAnchorCompilerTest {
   }
 
   @Test
-  void driverSelectionWithBoundedUpstreamSelectsRarest() {
-    Pattern p = Pattern.compile("foo[a-z]{1,5}bar[0-9]{1,3}baz");
-    MultiAnchorDescriptor desc = p.multiAnchor();
-    assertThat(desc).isNotNull();
-    assertThat(desc.checkOrder()).isNotEmpty();
-    // Bounded upstream allows driver selection of rarest anchor
-    int driver = desc.selectDriver(MultiAnchorDescriptor.InputDomain.STRING, true);
-    assertThat(desc.isUpstreamBoundedFor(driver)).isTrue();
+  void factorAlternationsWithSurroundingPrefixCoalescesLiteral() {
+    Pattern p =
+        Pattern.compile(
+            "/(?:api/v1/checkout|api/v1/payment|api/v1/orders)/[0-9a-f]{8} status=[0-9]+");
+    assertThat(p.multiAnchor()).isNotNull();
+    assertThat(p.multiAnchor().startPlan()).isInstanceOf(StartPlan.Literal.class);
+    StartPlan.Literal literal = (StartPlan.Literal) p.multiAnchor().startPlan();
+    assertThat(literal.prefix()).isEqualTo("/api/v1/");
+  }
+
+  @Test
+  void factorAlternationsStandalonePrefixExtractsCommonPrefix() {
+    Pattern p =
+        Pattern.compile("(?:https://api|https://stage|https://prod)\\.example\\.com/[a-z0-9]+");
+    assertThat(p.multiAnchor()).isNotNull();
+    assertThat(p.multiAnchor().startPlan()).isInstanceOf(StartPlan.Literal.class);
+    StartPlan.Literal literal = (StartPlan.Literal) p.multiAnchor().startPlan();
+    assertThat(literal.prefix()).isEqualTo("https://");
   }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -6,6 +6,7 @@
 package org.safere;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.Arrays;
 import java.util.List;
@@ -407,5 +408,17 @@ class MultiAnchorCompilerTest {
     assertThat(p.multiAnchor().startPlan()).isInstanceOf(StartPlan.Literal.class);
     StartPlan.Literal literal = (StartPlan.Literal) p.multiAnchor().startPlan();
     assertThat(literal.prefix()).isEqualTo("https://");
+  }
+
+  @Test
+  void alternationFactoringIsStackSafeForDeepQuantifiers() {
+    Regexp nested = Regexp.literal('a', 0);
+    for (int index = 0; index < 100_000; index++) {
+      RegexpOp op = index % 2 == 0 ? RegexpOp.QUEST : RegexpOp.PLUS;
+      nested = Regexp.rawQuantifier(op, nested, 0);
+    }
+
+    Regexp input = nested;
+    assertThatCode(() -> MultiAnchorCompiler.factorAlternations(input)).doesNotThrowAnyException();
   }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -600,4 +600,88 @@ class MultiAnchorGapEngineTest {
       assertThat(safere.group()).isEqualTo(jdk.group());
     }
   }
+
+  @Test
+  void alternationPrefixFactoring() {
+    String regex = "(?:application/json|application/xml|application/pdf)";
+    Pattern pattern = Pattern.compile(regex);
+
+    String text = "Content-Type: application/json; charset=utf-8";
+    Matcher matcher = pattern.matcher(text);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("application/json");
+
+    String xmlText = "Accept: application/xml";
+    Matcher mXml = pattern.matcher(xmlText);
+    assertThat(mXml.find()).isTrue();
+    assertThat(mXml.group(0)).isEqualTo("application/xml");
+
+    String absentText = "Content-Type: text/plain";
+    Matcher mAbsent = pattern.matcher(absentText);
+    assertThat(mAbsent.find()).isFalse();
+  }
+
+  @Test
+  void alternationSuffixFactoring() {
+    String regex = "(?:https?://|ftp://|sftp://)api/v1/[a-z]+";
+    Pattern pattern = Pattern.compile(regex);
+
+    String text = "Endpoint: https://api/v1/users and ftp://api/v1/files";
+    Matcher matcher = pattern.matcher(text);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("https://api/v1/users");
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("ftp://api/v1/files");
+
+    String absentText = "Endpoint: gopher://other/path";
+    Matcher mAbsent = pattern.matcher(absentText);
+    assertThat(mAbsent.find()).isFalse();
+  }
+
+  @Test
+  void fixedWidthRepetitionDateGap() {
+    String regex = "\\d{4}-\\d{2}-\\d{2}";
+    Pattern pattern = Pattern.compile(regex);
+
+    String text = "Event logged at 2026-08-29 in system";
+    Matcher matcher = pattern.matcher(text);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("2026-08-29");
+
+    // Invalid format (e.g. 3 digits instead of 4) -> mismatch
+    String invalid = "Event logged at 202-08-29 in system";
+    Matcher mInv = pattern.matcher(invalid);
+    assertThat(mInv.find()).isFalse();
+  }
+
+  @Test
+  void fixedWidthRepetitionUuidGap() {
+    String regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+    Pattern pattern = Pattern.compile(regex);
+
+    String text = "Request ID: 12345678-abcd-ef01-2345-6789abcdef01 processed";
+    Matcher matcher = pattern.matcher(text);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("12345678-abcd-ef01-2345-6789abcdef01");
+
+    String text2 = "Malformed ID: 1234567-abcd-ef01-2345-6789abcdef01";
+    Matcher m2 = pattern.matcher(text2);
+    assertThat(m2.find()).isFalse();
+  }
+
+  @Test
+  void dynamicCoalescedWeakAnchorChain() {
+    String regex = "PREFIX_START_[a-z0-9]{2}_MID_[a-z0-9]{2}_RAREST_FINAL_TOKEN";
+    Pattern pattern = Pattern.compile(regex);
+
+    String text = "noise PREFIX_START_ab_MID_cd_RAREST_FINAL_TOKEN trailing";
+    Matcher matcher = pattern.matcher(text);
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group(0)).isEqualTo("PREFIX_START_ab_MID_cd_RAREST_FINAL_TOKEN");
+
+    String absent = "noise PREFIX_START_ab_MID_cd_OTHER_FINAL_TOKEN trailing";
+    Matcher mAbsent = pattern.matcher(absent);
+    assertThat(mAbsent.find()).isFalse();
+  }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -584,6 +584,20 @@ class MultiAnchorGapEngineTest {
     }
   }
 
+  @Test
+  void factoredAlternationPrefixesPreserveScopedCaseFlags() {
+    for (String[] testCase :
+        new String[][] {
+          {"(?:(?i:abc)X|abcY)", "ABCX"},
+          {"(?:abcX|(?i:abc)Y)", "ABCY"},
+          {"(?i:(?-i:abc)X|abcY)", "ABCY"},
+          {"(?i:(?-i:abc)X|abcY)", "ABCX"},
+          {"(?:(?i:abc)X|abcY)[0-9]RAREST_TOKEN", "ABCX1RAREST_TOKEN"}
+        }) {
+      assertFirstMatchEqualsJdk(testCase[0], testCase[1]);
+    }
+  }
+
   private static void assertFirstMatchEqualsJdk(String regex, String text) {
     assertFirstMatchEqualsJdk(regex, 0, text);
   }


### PR DESCRIPTION
This PR builds on the multi-anchor gap engine (PR #782) by introducing AST alternation prefix factoring, dynamic weak-anchor coalescing, and exact-width assertion guards to accelerate branching and structured pattern matching.

---

* Alternation Common Prefix Factoring & Literal Coalescing:
  * In `MultiAnchorCompiler.factorAlternations`, extracts common multi-character literal prefixes ($\ge 2$ characters) across alternation branches (e.g. `(?:api/v2/users|api/v2/orders|...)`).
  * Seamlessly coalesces factored prefixes with adjacent literals in `CONCAT` nodes (e.g. merging outer `"/"` with inner `"api/v2/"` into `"/api/v2/"`).
  * Promotes the shared prefix into an accelerated scan, preventing DFA fallback.
* Dynamic Weak-Anchor Coalescing:
  * Analyzes intermediate literal anchors in multi-anchor chains and coalesces sub-threshold delimiters ($\le 4$ bytes) with adjacent bounded gaps into contiguous sub-expressions executed directly on the Lazy DFA.
  * Eliminates scalar loop dispatch overhead between short, high-density delimiters (such as `:` or `-`).
* Alternation Anchor Safety & Width Guards:
  * Hardens alternation anchor extraction with `hasZeroWidthAssertions` and `computeAsciiWidthRange(branch).isExact() && width.minWidth == 1`.
  * Guarantees that zero-width boundary assertions (`^`, `\A`, `\b`, `\B`) and multi-character branches are safely handled without being prematurely collapsed into single-character class anchors, preserving fidelity with JDK regex.

---

```
./safere-benchmarks/scripts/compare-branch.sh --baseline gap-extensions-benchmark-baseline 'RealWorldRegexBenchmark.*(wideFactoredApiRoute|isoTimestampLog|uuidExtraction|multiInfixLog|structuredJsonPath).*safere-string'
```

| Benchmark                            | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------------ | ---------------- | --------------- | ------- |
| multiInfixLog.match.1000             |        2466 ± 62 |       2447 ± 28 |   1.01x |
| multiInfixLog.match.10000            |     22059 ± 1483 |     23030 ± 940 |   0.96x |
| multiInfixLog.match.100000           |  286525 ± 127971 | 286495 ± 127011 |   1.00x |
| multiInfixLog.noMatch.1000           |        145 ± 1.1 |       146 ± 5.0 |   1.00x |
| multiInfixLog.noMatch.10000          |        1116 ± 18 |       1113 ± 14 |   1.00x |
| multiInfixLog.noMatch.100000         |      10787 ± 158 |     10861 ± 236 |   0.99x |
| multiInfixLogCaptures.match.1000     |        4569 ± 32 |       4572 ± 49 |   1.00x |
| multiInfixLogCaptures.match.10000    |     25389 ± 2229 |    23911 ± 1621 |   1.06x |
| multiInfixLogCaptures.match.100000   |    206838 ± 1458 |   207216 ± 2076 |   1.00x |
| multiInfixLogCaptures.noMatch.1000   |        135 ± 1.1 |       135 ± 1.1 |   1.00x |
| multiInfixLogCaptures.noMatch.10000  |        1092 ± 11 |       1093 ± 11 |   1.00x |
| multiInfixLogCaptures.noMatch.100000 |       10504 ± 40 |     10543 ± 214 |   1.00x |
| structuredJsonPath.match.1000        |        4598 ± 98 |       4582 ± 28 |   1.00x |
| structuredJsonPath.match.10000       |      45379 ± 988 |    45831 ± 1601 |   0.99x |
| structuredJsonPath.match.100000      |   760738 ± 85795 |  761629 ± 88813 |   1.00x |
| structuredJsonPath.noMatch.1000      |        182 ± 1.6 |       183 ± 1.7 |   1.00x |
| structuredJsonPath.noMatch.10000     |        1432 ± 12 |       1451 ± 36 |   0.99x |
| structuredJsonPath.noMatch.100000    |      13903 ± 226 |     14001 ± 253 |   0.99x |
| uuidExtraction.match.1000            |        336 ± 8.0 |       311 ± 6.9 |   1.08x |
| uuidExtraction.match.10000           |        1416 ± 18 |       1373 ± 21 |   1.03x |
| uuidExtraction.match.100000          |       11929 ± 63 |    12653 ± 1033 |   0.94x |
| uuidExtraction.noMatch.1000          |         152 ± 15 |       185 ± 5.6 |   0.82x |
| uuidExtraction.noMatch.10000         |        1214 ± 21 |       1253 ± 16 |   0.97x |
| uuidExtraction.noMatch.100000        |      11752 ± 165 |      11807 ± 99 |   1.00x |
| isoTimestampLog.match.1000           |         416 ± 16 |       416 ± 9.7 |   1.00x |
| isoTimestampLog.match.10000          |        2193 ± 23 |       2188 ± 22 |   1.00x |
| isoTimestampLog.match.100000         |      19978 ± 572 |     20005 ± 376 |   1.00x |
| isoTimestampLog.noMatch.1000         |        132 ± 5.4 |       132 ± 1.1 |   1.01x |
| isoTimestampLog.noMatch.10000        |        1031 ± 13 |       1022 ± 31 |   1.01x |
| isoTimestampLog.noMatch.100000       |        9844 ± 72 |       9810 ± 60 |   1.00x |
| wideFactoredApiRoute.match.1000      |        1983 ± 26 |      302 ± 10.0 |   6.58x |
| wideFactoredApiRoute.match.10000     |     40704 ± 1190 |       1249 ± 21 |   32.6x |
| wideFactoredApiRoute.match.100000    |    284735 ± 1595 |     10701 ± 419 |   26.6x |
| wideFactoredApiRoute.noMatch.1000    |        1905 ± 24 |       138 ± 4.8 |   13.8x |
| wideFactoredApiRoute.noMatch.10000   |      18971 ± 278 |       1066 ± 10 |   17.8x |
| wideFactoredApiRoute.noMatch.100000  |     187040 ± 706 |     10311 ± 165 |   18.1x |