### PR TITLE
Make repo-assist copy/paste reviews self-contained

### DIFF
--- a/.agents/skills/repo-assist/SKILL.md
+++ b/.agents/skills/repo-assist/SKILL.md
@@ -15,6 +15,8 @@ Prepare the data needed for a human SafeRE repository review while the reviewer 
 - benchmark reproduction for optimization PRs;
 - durable reports and artifacts that can be inspected later.
 - the current state, disposition, and linked-PR coverage of every trusted open issue.
+- one paste-ready, self-contained PR review containing everything the PR author needs to understand
+  the findings, evidence, fixes, requests, and recommendation.
 
 Do not push branches, post PR comments, close issues, or publish review text unless the user
 explicitly asks.
@@ -159,6 +161,32 @@ Keep two narrative baselines separate:
 
 Use scout state and earlier reports for freshness, crash recovery, and evidence reuse only. Do not
 use the previous scout run as the narrative point of view.
+
+## Author-Facing Copy/Paste Review
+
+The detailed scout report is private maintainer decision support. The fenced content under
+`Copy/Paste PR Review` is the only part of that report the PR author will see. Treat it as the actual
+review deliverable, not as a summary, excerpt, or pointer to the rest of the report.
+
+- Make the copy/paste review fully self-contained. Never rely on a finding, rationale, benchmark
+  table, tradeoff, requested measurement, or recommendation appearing elsewhere in the report.
+- Include every material finding and unresolved concern that affects the recommendation or asks the
+  author to act. For each one, state the concrete behavior, why it matters, and whether it was fixed
+  or what response or change is requested.
+- When fixes will be pushed before posting, identify the material fixes and their effects clearly
+  enough that the author understands what changed. Do not collapse distinct correctness problems
+  into “several issues” when their behavior and impact differ.
+- For optimization PRs, include the claimed benefit, the reproduced benchmark evidence, whether it
+  supports the claim, any material cost or missing measurement, and the exact question or next
+  evidence needed. Put all numeric benchmark evidence in the copy/paste review's own Markdown
+  table; a table elsewhere in the report does not count.
+- Omit only reviewer-internal bookkeeping such as local commands, test counts, worktree paths,
+  review-agent status, and artifact locations. Omitting internal bookkeeping must not remove facts
+  the author needs to understand the review decision.
+- Before finalizing, extract only the copy/paste review and read it without the rest of the report.
+  It passes only if the author can understand what was found, what was fixed, the evidence and
+  tradeoffs behind the recommendation, every requested action, and whether the reviewer approves.
+  Rewrite it if any answer depends on another report section.
 
 Inspect linked issues only through the same discovery and snapshot boundary. An untrusted linked
 item contributes metadata but never content.
@@ -434,13 +462,16 @@ git diff <post-update-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
      measured benefit, unresolved review findings, merge conflict, or scope concern.
    - Keep this section decision-oriented. It should tell the human reviewer what to focus on.
    - Write the copy/paste review in the human reviewer's first-person voice, addressed to the PR
-     author. When local fixes resolve the findings, assume the human will push those fixes to the PR
-     branch before posting the review but that the author has not been told separately. Briefly
-     state what was noticed, say "I've pushed a commit that fixes it" (or equivalent), summarize
-     only evidence material to the author's understanding or decision, and end with "LGTM" when
-     the fixed result satisfies the merge criteria. Do not ask the author to apply a local scout
-     commit or refer to a machine-local branch/path in the copy/paste text. Keep unresolved concerns
-     explicit and do not say "LGTM" when they remain.
+     author. This is the only report content the author will see, so include every material finding,
+     fix, benchmark conclusion, tradeoff, request, and rationale needed to understand the review and
+     its recommendation. Never shorten it on the assumption that the detailed report supplies
+     context. When local fixes resolve the findings, assume the human will push those fixes to the
+     PR branch before posting the review but that the author has not been told separately. State
+     what was noticed, explain its impact, say "I've pushed a commit that fixes it" (or equivalent),
+     explain the material fix, and end with "LGTM" when the fixed result satisfies the merge
+     criteria. Do not ask the author to apply a local scout commit or refer to a machine-local
+     branch/path in the copy/paste text. Keep unresolved concerns explicit and do not say "LGTM"
+     when they remain.
    - When the evidence does not yet justify a material tradeoff, make the missing decision explicit
      in the copy/paste review. Explain the cost and the unmeasured benefit, ask focused questions
      about evidence or simpler alternatives, and offer concrete measurements that would resolve the
@@ -451,13 +482,20 @@ git diff <post-update-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
      It is useful to say that a pushed fix adds regression coverage, to report benchmark evidence,
      or to explain an underlying problem discovered by a local check; do not report the status of
      the local check itself.
-   - Whenever the copy/paste review reports benchmark results, present the measurements in a
-     Markdown table, even when there is only one result. Do not report benchmark measurements only
-     in prose. Use columns that make the comparison self-contained, including the benchmark or
-     workload identity, the relevant representations or configurations, the normalized ratio or
-     baseline and experiment values, and a concise interpretation. State the ratio direction near
-     the table (for example, lower is better for `PR/main` time), and keep any explanation of the
-     cause, tradeoff, confidence intervals, or recommendation in prose around the table.
+   - Whenever the copy/paste review reports benchmark results, include those measurements in a
+     Markdown table, even when there is only one result and even when the detailed report already
+     contains a benchmark table. Never use prose as the only presentation of numeric benchmark
+     results or ratios in the copy/paste review. Use columns that make the comparison
+     self-contained, including the benchmark or workload identity, the relevant representations or
+     configurations, the normalized ratio or baseline and experiment values, and a concise
+     interpretation. State the ratio direction near the table (for example, lower is better for
+     `PR/main` time), and keep any explanation of the cause, tradeoff, confidence intervals, or
+     recommendation in prose around the table.
+   - Format the copy/paste review as a paste-ready GitHub comment without hard-wrapped prose. Each
+     prose paragraph must occupy one physical line, regardless of its rendered length. Use physical
+     line breaks only where Markdown structure requires them, such as between paragraphs and for
+     the header, separator, and rows of a benchmark table. Do not wrap a sentence or table cell
+     across source lines, and avoid lists in the copy/paste review when ordinary prose is clear.
    - Use precise, concrete language in author-facing text. Standard technical terminology is useful
      and encouraged when it accurately names the concept, such as SIMD, KMP, integer overflow,
      register pressure, or linear time. Do not replace precise terms with vague labels that merely
@@ -482,6 +520,10 @@ git diff <post-update-pre-fix-head>..HEAD > <artifact-dir>/review-fixes.patch
      or "refreshed against main" unless the public discussion makes that history meaningful to the
      author. When the author has not been told about a finding, introduce it directly: "I noticed
      that ... I've pushed a commit that fixes it."
+   - Perform the standalone-read check from `Author-Facing Copy/Paste Review` after writing the
+     entire report. Read only the fenced copy/paste content. If any material conclusion, request,
+     evidence, or rationale requires another section, copy the necessary author-relevant content
+     into the review and check it again.
 
 9. Update the durable report and state after each PR, not only at the end. Update that PR's row in
    the report's PR Summary table at the same checkpoint while preserving its reviewer-owned `Done`
@@ -658,16 +700,7 @@ Human review focus:
 ### Copy/Paste PR Review
 
 ```markdown
-<first-person review addressed to the author; for resolved scout fixes, explain the problem, say
-the reviewer pushed a fixing commit, include only author-relevant evidence, and conclude LGTM. Keep
-all local validation status, commands, test counts, shell checks, and internal automated-review
-status in the report rather than this comment. Use plain, concrete language and state requests in
-terms of the code, behavior, tests, or measurements wanted. Keep the tone respectful and
-collaborative: explain impact without blame and use genuine questions where design judgment is
-involved. Make the text self-contained from the public discussion; never rely on the author knowing
-about earlier scout runs or unposted local work. Whenever benchmark measurements are included,
-present them in a Markdown table rather than only in prose, define the normalization direction, and
-give each row a concise interpretation.>
+<the complete first-person review addressed to the author; this fenced content is the only part of the report the author will see. Include every material finding, pushed fix, benchmark conclusion, tradeoff, rationale, requested action, and recommendation needed to understand the review without any other report section. For resolved scout fixes, explain each distinct problem and impact, say the reviewer pushed a fixing commit, explain the material fix, and conclude LGTM only when appropriate. Keep only reviewer-internal validation status, commands, test counts, shell checks, worktree paths, artifacts, and automated-review status outside this comment. Use plain, concrete language and state requests in terms of the code, behavior, tests, or measurements wanted. Keep the tone respectful and collaborative: explain impact without blame and use genuine questions where design judgment is involved. Make the text self-contained from the public discussion; never rely on the author knowing about earlier scout runs or unposted local work. Whenever benchmark measurements are included, present every numeric result and ratio in this review's own Markdown table rather than only in prose, define the normalization direction, and give each row a concise interpretation. Do not hard-wrap prose: put each prose paragraph on one physical line and use additional line breaks only for required Markdown structure, especially the benchmark table. Before finalizing, read only this fenced content and rewrite it if any conclusion, evidence, rationale, request, or recommendation depends on another report section.>
 ```
 ````
 
@@ -760,6 +793,12 @@ skipped PR, copy and consolidate its latest still-valid assessment, recommendati
 review text, fix references, and benchmark evidence into the new report; do not require the human
 to read an earlier report. Exclude merged, closed, and draft PRs.
 
+The fenced Copy/Paste PR Review is the only report content the PR author will see. Treat it as the
+actual author-facing review, not a summary of the private report. It must stand alone and include
+every material finding, pushed fix, benchmark conclusion, tradeoff, rationale, requested action,
+and recommendation needed to understand the review. Before finalizing, read only that fenced
+content and rewrite it if anything depends on another report section.
+
 Also include every open trusted issue. Reprocess only issues whose sanitized fingerprint changed,
 but carry forward unchanged assessments in full. Review issues for maintainer state, decisions,
 remaining work, and linked-PR coverage; do not automatically implement them.
@@ -792,6 +831,9 @@ benchmark results do not roughly reproduce the PR claim, check whether
 local correctness fixes caused the difference by running serial ablation benchmarks where
 applicable; if not, include a concrete hypothesis for the discrepancy such as baseline drift, PR
 revision drift, workload changes, stale PR numbers, command differences, or measurement variance.
+In every copy/paste PR review, present numeric benchmark evidence in a Markdown table rather than
+prose alone. Keep each prose paragraph on one physical line without hard wrapping; use line breaks
+only where required for Markdown structure such as the table.
 
 For each PR, include an Assessment And Recommendation section. Recommend `can merge` only when the
 PR intent is reasonable, implementation matches intent, no major correctness/design/linear-time


### PR DESCRIPTION
## Summary

- Treat the copy/paste PR review as the complete author-facing deliverable rather than an excerpt of the private scout report.
- Require every material finding, fix, benchmark conclusion, tradeoff, request, and recommendation to stand alone in the review.
- Require numeric benchmark evidence to appear in the review's own Markdown table and keep prose paragraphs free of hard wrapping.
- Add a standalone-read check to catch reviews that depend on another report section.

## Verification

- `python3 /home/eaftan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/repo-assist`
- `uv run --project .agents/skills/repo-assist --locked pytest -q .agents/skills/repo-assist/tests` (9 passed)
- `git diff --check`

Not run: the SafeRE Maven test suite, because this change only updates repo-assist skill instructions.
