### PR TITLE
Make scaling tests deterministic

### DIFF
--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -120,6 +120,7 @@
                         <exclude name="IntArrayListTest.java"/>
                         <exclude name="InputScannerTest.java"/>
                         <exclude name="MatcherDeferredCaptureStateTest.java"/>
+                        <exclude name="MatcherLinearTimeTest.java"/>
                         <exclude name="MatcherTransitionInventoryTest.java"/>
                         <exclude name="MatchDescriptorTest.java"/>
                         <exclude name="MultiAnchorCompilerTest.java"/>

--- a/safere/src/main/java/org/safere/AstAnalysis.java
+++ b/safere/src/main/java/org/safere/AstAnalysis.java
@@ -64,6 +64,9 @@ record AstAnalysis(
     @Override
     protected AnalysisNode postVisit(
         Regexp re, AnalysisNode parentArg, AnalysisNode preArg, List<AnalysisNode> childArgs) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       if (re.op == RegexpOp.CAPTURE && re.name != null && !re.name.isEmpty()) {
         named.put(re.name, re.cap);
       }

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -446,6 +446,9 @@ final class MultiAnchorCompiler {
     @Override
     protected NodeAnalysis postVisit(
         Regexp node, NodeAnalysis parentArg, NodeAnalysis preArg, List<NodeAnalysis> childArgs) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       NodeAnalysis analysis =
           switch (node.op) {
             case CAPTURE, NON_CAPTURE ->

--- a/safere/src/main/java/org/safere/Nfa.java
+++ b/safere/src/main/java/org/safere/Nfa.java
@@ -878,6 +878,9 @@ final class Nfa {
     int cachedFlags = -1;
 
     while (!stack.isEmpty()) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       stack.pop();
       if (stack.restoreIndex >= 0) {
         t0[stack.restoreIndex] = stack.restoreValue;
@@ -1127,6 +1130,9 @@ final class Nfa {
     nq.clear();
 
     for (int threadIndex = 0; threadIndex < rq.size; threadIndex++) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       NfaThread t = rq.threads[threadIndex];
       int id = t.id;
       int[] capture = t.capture;

--- a/safere/src/main/java/org/safere/Parser.java
+++ b/safere/src/main/java/org/safere/Parser.java
@@ -206,6 +206,9 @@ final class Parser {
       // Special parse loop for literal string.
       int i = 0;
       while (i < pattern.length()) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
         int r = pattern.codePointAt(i);
         i += Character.charCount(r);
         pushLiteral(r);
@@ -218,6 +221,9 @@ final class Parser {
     boolean lastTokenNonRepeatable = false;
     boolean lastTokenWasEmptyQuotedLiteral = false;
     while (pos < pattern.length()) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       // In comments mode, skip whitespace and #-comments before each token.
       if ((flags & ParseFlags.COMMENTS) != 0) {
         skipCommentsAndWhitespace();
@@ -1038,8 +1044,14 @@ final class Parser {
     for (int i = start; i < end; i++) {
       Regexp re = source.get(i);
       if (re.op == RegexpOp.LITERAL) {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record();
+        }
         runes[out++] = re.rune;
       } else {
+        if (WorkCounterConfig.ENABLED) {
+          WorkCounter.record(re.runes.length);
+        }
         System.arraycopy(re.runes, 0, runes, out, re.runes.length);
         out += re.runes.length;
       }

--- a/safere/src/test/java/org/safere/MatcherLinearTimeTest.java
+++ b/safere/src/test/java/org/safere/MatcherLinearTimeTest.java
@@ -1,0 +1,153 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Work-bound regression tests for matcher operations. */
+@DisabledForCrosscheck("work accounting is a SafeRE linear-time implementation check")
+@Tag("work-counter")
+class MatcherLinearTimeTest {
+  private static final Duration SCENARIO_TIMEOUT = Duration.ofSeconds(30);
+
+  @Test
+  @DisplayName("group access stays linear for ambiguous repeated captures")
+  void groupAccessWithAmbiguousRepeatedCapturesStaysLinear() {
+    Pattern pattern = Pattern.compile("((a|aa))*");
+
+    assertNoWorkCliff(
+        "matches()+group(1)",
+        "a".repeat(100),
+        "a".repeat(5_000),
+        input -> {
+          Matcher matcher = pattern.matcher(input);
+          assertThat(matcher.matches()).isTrue();
+          assertThat(matcher.group(1)).isEqualTo("a");
+          assertThat(matcher.group(2)).isEqualTo("a");
+        });
+  }
+
+  @Test
+  @DisplayName("matches() stays linear for repeated dot-star with bounded captures")
+  void matchesWithRepeatedDotStarAndBoundedCaptures() {
+    Pattern pattern = repeatedDotStarSqlUnionPattern();
+
+    assertNoWorkCliff(
+        "matches()",
+        blocks -> {
+          String input = repeatedDotStarSqlUnionInput(blocks);
+          Matcher matcher = pattern.matcher(input);
+          assertThat(matcher.matches()).isTrue();
+          assertThat(matcher.group()).isEqualTo(input);
+          assertThat(matcher.start()).isEqualTo(0);
+          assertThat(matcher.end()).isEqualTo(input.length());
+        });
+  }
+
+  @Test
+  @DisplayName("lookingAt() stays linear for repeated dot-star with bounded captures")
+  void lookingAtWithRepeatedDotStarAndBoundedCaptures() {
+    Pattern pattern = repeatedDotStarSqlUnionPattern();
+
+    assertNoWorkCliff(
+        "lookingAt()",
+        blocks -> {
+          Matcher matcher = pattern.matcher(repeatedDotStarSqlUnionInput(blocks));
+          assertThat(matcher.lookingAt()).isTrue();
+          assertThat(matcher.group(1)).contains("INFORMATION_SCHEMA");
+        });
+  }
+
+  @Test
+  @DisplayName("group access after find() stays linear for repeated dot-star captures")
+  void findGroupWithRepeatedDotStarAndBoundedCaptures() {
+    Pattern pattern = repeatedDotStarSqlUnionPattern();
+
+    assertNoWorkCliff(
+        "find()+group(1)",
+        blocks -> {
+          Matcher matcher = pattern.matcher(repeatedDotStarSqlUnionInput(blocks));
+          assertThat(matcher.find()).isTrue();
+          assertThat(matcher.group(1)).contains("INFORMATION_SCHEMA");
+        });
+  }
+
+  @Test
+  @DisplayName("region find stays linear for repeated dot-star captures")
+  void regionFindWithRepeatedDotStarAndBoundedCaptures() {
+    Pattern pattern = repeatedDotStarSqlUnionPattern();
+
+    assertNoWorkCliff(
+        "region().find()",
+        blocks -> {
+          String input = "prefix\n" + repeatedDotStarSqlUnionInput(blocks) + "suffix\n";
+          Matcher matcher = pattern.matcher(input);
+          matcher.region("prefix\n".length(), input.length() - "suffix\n".length());
+          assertThat(matcher.find()).isTrue();
+          assertThat(matcher.group(1)).contains("INFORMATION_SCHEMA");
+        });
+  }
+
+  private static String repeatedDotStarSqlUnionInput(int selectCount) {
+    StringBuilder input = new StringBuilder();
+    for (int i = 1; i <= selectCount; i++) {
+      input
+          .append("(SELECT *, PARSE_DATE('%Y-%m-%d', '2025-06-25') AS snapshot_date FROM ")
+          .append("`project-")
+          .append("%02d".formatted(i))
+          .append("`.`region2`.INFORMATION_SCHEMA.TABLE_OPTIONS)\n")
+          .append("UNION ALL\n");
+    }
+    return input.toString();
+  }
+
+  private static Pattern repeatedDotStarSqlUnionPattern() {
+    return Pattern.compile(
+        ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  }
+
+  private static void assertNoWorkCliff(String api, IntConsumer scenario) {
+    long largerPositiveWork = countedWork(() -> scenario.accept(16));
+    long nearMinimumWork = countedWork(() -> scenario.accept(5));
+
+    assertThat(largerPositiveWork).as("%s should use matcher work", api).isPositive();
+    assertThat(nearMinimumWork)
+        .as(
+            "%s near-minimum input should not be dramatically slower than a larger "
+                + "positive input; nearWork=%d largerWork=%d",
+            api, nearMinimumWork, largerPositiveWork)
+        .isLessThan(largerPositiveWork * 50);
+  }
+
+  private static void assertNoWorkCliff(
+      String api, String nearMinimumInput, String largerPositiveInput, Consumer<String> scenario) {
+    scenario.accept(nearMinimumInput);
+    scenario.accept(largerPositiveInput);
+    long largerPositiveWork = countedWork(() -> scenario.accept(largerPositiveInput));
+    long nearMinimumWork = countedWork(() -> scenario.accept(nearMinimumInput));
+
+    assertThat(largerPositiveWork).as("%s should use matcher work", api).isPositive();
+    assertThat(nearMinimumWork)
+        .as(
+            "%s near-minimum input should not be dramatically slower than a larger "
+                + "positive input; nearWork=%d largerWork=%d",
+            api, nearMinimumWork, largerPositiveWork)
+        .isLessThan(largerPositiveWork * 50);
+  }
+
+  private static long countedWork(Runnable task) {
+    return assertTimeoutPreemptively(SCENARIO_TIMEOUT, () -> WorkCounter.countForTesting(task));
+  }
+}

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -14,12 +14,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.time.Duration;
-import java.util.function.Consumer;
-import java.util.function.IntConsumer;
 import java.util.regex.MatchResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -243,25 +240,6 @@ class MatcherTest {
     }
 
     @Test
-    @Tag("work-counter")
-    @DisabledForCrosscheck("java.util.regex backtracking makes this a SafeRE linear-time check")
-    @DisplayName("group access stays linear for ambiguous repeated captures")
-    void groupAccessWithAmbiguousRepeatedCapturesStaysLinear() {
-      Pattern p = Pattern.compile("((a|aa))*");
-
-      assertNoWorkCliff(
-          "matches()+group(1)",
-          "a".repeat(100),
-          "a".repeat(5_000),
-          input -> {
-            Matcher m = p.matcher(input);
-            assertThat(m.matches()).isTrue();
-            assertThat(m.group(1)).isEqualTo("a");
-            assertThat(m.group(2)).isEqualTo("a");
-          });
-    }
-
-    @Test
     @DisabledForCrosscheck("java.util.regex backtracking makes this a SafeRE linear-time check")
     @DisplayName("group access stays stack-safe for large repeated captures")
     void groupAccessWithLargeRepeatedCapturesStaysStackSafe() {
@@ -299,41 +277,6 @@ class MatcherTest {
       assertThat(m.group(0)).isEqualTo("123abc");
       assertThat(m.group(1)).isEqualTo("123");
       assertThat(m.group(2)).isEqualTo("abc");
-    }
-
-    @Test
-    @Tag("work-counter")
-    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
-    @DisplayName("matches() stays linear for repeated dot-star with bounded captures")
-    void matchesWithRepeatedDotStarAndBoundedCaptures() {
-      Pattern p = repeatedDotStarSqlUnionPattern();
-
-      assertNoWorkCliff(
-          "matches()",
-          blocks -> {
-            String input = repeatedDotStarSqlUnionInput(blocks);
-            Matcher m = p.matcher(input);
-            assertThat(m.matches()).isTrue();
-            assertThat(m.group()).isEqualTo(input);
-            assertThat(m.start()).isEqualTo(0);
-            assertThat(m.end()).isEqualTo(input.length());
-          });
-    }
-
-    @Test
-    @Tag("work-counter")
-    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
-    @DisplayName("lookingAt() stays linear for repeated dot-star with bounded captures")
-    void lookingAtWithRepeatedDotStarAndBoundedCaptures() {
-      Pattern p = repeatedDotStarSqlUnionPattern();
-
-      assertNoWorkCliff(
-          "lookingAt()",
-          blocks -> {
-            Matcher m = p.matcher(repeatedDotStarSqlUnionInput(blocks));
-            assertThat(m.lookingAt()).isTrue();
-            assertThat(m.group(1)).contains("INFORMATION_SCHEMA");
-          });
     }
 
     @ParameterizedTest
@@ -374,22 +317,6 @@ class MatcherTest {
   @Nested
   @DisplayName("find()")
   class FindTests {
-
-    @Test
-    @Tag("work-counter")
-    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
-    @DisplayName("group access after find() stays linear for repeated dot-star captures")
-    void findGroupWithRepeatedDotStarAndBoundedCaptures() {
-      Pattern p = repeatedDotStarSqlUnionPattern();
-
-      assertNoWorkCliff(
-          "find()+group(1)",
-          blocks -> {
-            Matcher m = p.matcher(repeatedDotStarSqlUnionInput(blocks));
-            assertThat(m.find()).isTrue();
-            assertThat(m.group(1)).contains("INFORMATION_SCHEMA");
-          });
-    }
 
     @Test
     @DisplayName("find() locates a single match in the input")
@@ -2456,24 +2383,6 @@ class MatcherTest {
   class RegionTests {
 
     @Test
-    @Tag("work-counter")
-    @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
-    @DisplayName("region find stays linear for repeated dot-star captures")
-    void regionFindWithRepeatedDotStarAndBoundedCaptures() {
-      Pattern p = repeatedDotStarSqlUnionPattern();
-
-      assertNoWorkCliff(
-          "region().find()",
-          blocks -> {
-            String input = "prefix\n" + repeatedDotStarSqlUnionInput(blocks) + "suffix\n";
-            Matcher m = p.matcher(input);
-            m.region("prefix\n".length(), input.length() - "suffix\n".length());
-            assertThat(m.find()).isTrue();
-            assertThat(m.group(1)).contains("INFORMATION_SCHEMA");
-          });
-    }
-
-    @Test
     @DisplayName("find() respects region boundaries")
     void findRespectsRegion() {
       Pattern p = Pattern.compile("\\d+");
@@ -3270,59 +3179,6 @@ class MatcherTest {
     assertThat(m.find()).isTrue();
     assertThat(m.group()).isEmpty();
     assertThat(m.find()).isFalse();
-  }
-
-  private static String repeatedDotStarSqlUnionInput(int selectCount) {
-    StringBuilder input = new StringBuilder();
-    for (int i = 1; i <= selectCount; i++) {
-      input
-          .append("(SELECT *, PARSE_DATE('%Y-%m-%d', '2025-06-25') AS snapshot_date FROM ")
-          .append("`project-")
-          .append("%02d".formatted(i))
-          .append("`.`region2`.INFORMATION_SCHEMA.TABLE_OPTIONS)\n")
-          .append("UNION ALL\n");
-    }
-    return input.toString();
-  }
-
-  private static Pattern repeatedDotStarSqlUnionPattern() {
-    return Pattern.compile(
-        ".*SELECT.*FROM.*(.*INFORMATION_SCHEMA.*){5,}.*",
-        Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-  }
-
-  private static void assertNoWorkCliff(String api, IntConsumer scenario) {
-    long largerPositiveWork = countedWork(() -> scenario.accept(16));
-    long nearMinimumWork = countedWork(() -> scenario.accept(5));
-
-    assertThat(largerPositiveWork).as("%s should use matcher work", api).isPositive();
-    assertThat(nearMinimumWork)
-        .as(
-            "%s near-minimum input should not be dramatically slower than a larger "
-                + "positive input; nearWork=%d largerWork=%d",
-            api, nearMinimumWork, largerPositiveWork)
-        .isLessThan(largerPositiveWork * 50);
-  }
-
-  private static void assertNoWorkCliff(
-      String api, String nearMinimumInput, String largerPositiveInput, Consumer<String> scenario) {
-    scenario.accept(nearMinimumInput);
-    scenario.accept(largerPositiveInput);
-    long largerPositiveWork = countedWork(() -> scenario.accept(largerPositiveInput));
-    long nearMinimumWork = countedWork(() -> scenario.accept(nearMinimumInput));
-
-    assertThat(largerPositiveWork).as("%s should use matcher work", api).isPositive();
-    assertThat(nearMinimumWork)
-        .as(
-            "%s near-minimum input should not be dramatically slower than a larger "
-                + "positive input; nearWork=%d largerWork=%d",
-            api, nearMinimumWork, largerPositiveWork)
-        .isLessThan(largerPositiveWork * 50);
-  }
-
-  private static long countedWork(Runnable task) {
-    return assertTimeoutPreemptively(
-        PERFORMANCE_SCENARIO_TIMEOUT, () -> WorkCounter.countForTesting(task));
   }
 
   private static void assertZeroCountGroupBehavior(String regex, String input) {

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -14,12 +14,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.regex.MatchResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -243,12 +243,13 @@ class MatcherTest {
     }
 
     @Test
+    @Tag("work-counter")
     @DisabledForCrosscheck("java.util.regex backtracking makes this a SafeRE linear-time check")
     @DisplayName("group access stays linear for ambiguous repeated captures")
     void groupAccessWithAmbiguousRepeatedCapturesStaysLinear() {
       Pattern p = Pattern.compile("((a|aa))*");
 
-      assertNoPerformanceCliff(
+      assertNoWorkCliff(
           "matches()+group(1)",
           "a".repeat(100),
           "a".repeat(5_000),
@@ -301,12 +302,13 @@ class MatcherTest {
     }
 
     @Test
+    @Tag("work-counter")
     @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("matches() stays linear for repeated dot-star with bounded captures")
     void matchesWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
 
-      assertNoPerformanceCliff(
+      assertNoWorkCliff(
           "matches()",
           blocks -> {
             String input = repeatedDotStarSqlUnionInput(blocks);
@@ -319,12 +321,13 @@ class MatcherTest {
     }
 
     @Test
+    @Tag("work-counter")
     @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("lookingAt() stays linear for repeated dot-star with bounded captures")
     void lookingAtWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
 
-      assertNoPerformanceCliff(
+      assertNoWorkCliff(
           "lookingAt()",
           blocks -> {
             Matcher m = p.matcher(repeatedDotStarSqlUnionInput(blocks));
@@ -373,12 +376,13 @@ class MatcherTest {
   class FindTests {
 
     @Test
+    @Tag("work-counter")
     @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("group access after find() stays linear for repeated dot-star captures")
     void findGroupWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
 
-      assertNoPerformanceCliff(
+      assertNoWorkCliff(
           "find()+group(1)",
           blocks -> {
             Matcher m = p.matcher(repeatedDotStarSqlUnionInput(blocks));
@@ -2452,12 +2456,13 @@ class MatcherTest {
   class RegionTests {
 
     @Test
+    @Tag("work-counter")
     @DisabledForCrosscheck("java.util.regex backtracks on this SafeRE linear-time stress case")
     @DisplayName("region find stays linear for repeated dot-star captures")
     void regionFindWithRepeatedDotStarAndBoundedCaptures() {
       Pattern p = repeatedDotStarSqlUnionPattern();
 
-      assertNoPerformanceCliff(
+      assertNoWorkCliff(
           "region().find()",
           blocks -> {
             String input = "prefix\n" + repeatedDotStarSqlUnionInput(blocks) + "suffix\n";
@@ -3286,50 +3291,38 @@ class MatcherTest {
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
   }
 
-  private static void assertNoPerformanceCliff(String api, IntConsumer scenario) {
-    long largerPositiveNanos = medianRuntimeNanos(() -> scenario.accept(16));
-    long nearMinimumNanos = medianRuntimeNanos(() -> scenario.accept(5));
+  private static void assertNoWorkCliff(String api, IntConsumer scenario) {
+    long largerPositiveWork = countedWork(() -> scenario.accept(16));
+    long nearMinimumWork = countedWork(() -> scenario.accept(5));
 
-    assertThat(nearMinimumNanos)
+    assertThat(largerPositiveWork).as("%s should use matcher work", api).isPositive();
+    assertThat(nearMinimumWork)
         .as(
             "%s near-minimum input should not be dramatically slower than a larger "
-                + "positive input; near=%d ns, larger=%d ns",
-            api, nearMinimumNanos, largerPositiveNanos)
-        .isLessThan(largerPositiveNanos * 50);
+                + "positive input; nearWork=%d largerWork=%d",
+            api, nearMinimumWork, largerPositiveWork)
+        .isLessThan(largerPositiveWork * 50);
   }
 
-  private static void assertNoPerformanceCliff(
+  private static void assertNoWorkCliff(
       String api, String nearMinimumInput, String largerPositiveInput, Consumer<String> scenario) {
     scenario.accept(nearMinimumInput);
     scenario.accept(largerPositiveInput);
-    long largerPositiveNanos = medianRuntimeNanos(() -> scenario.accept(largerPositiveInput));
-    long nearMinimumNanos = medianRuntimeNanos(() -> scenario.accept(nearMinimumInput));
+    long largerPositiveWork = countedWork(() -> scenario.accept(largerPositiveInput));
+    long nearMinimumWork = countedWork(() -> scenario.accept(nearMinimumInput));
 
-    assertThat(nearMinimumNanos)
+    assertThat(largerPositiveWork).as("%s should use matcher work", api).isPositive();
+    assertThat(nearMinimumWork)
         .as(
             "%s near-minimum input should not be dramatically slower than a larger "
-                + "positive input; near=%d ns, larger=%d ns",
-            api, nearMinimumNanos, largerPositiveNanos)
-        .isLessThan(largerPositiveNanos * 50);
+                + "positive input; nearWork=%d largerWork=%d",
+            api, nearMinimumWork, largerPositiveWork)
+        .isLessThan(largerPositiveWork * 50);
   }
 
-  private static long medianRuntimeNanos(Runnable task) {
-    long[] samples = new long[5];
-    for (int i = 0; i < samples.length; i++) {
-      samples[i] = runtimeNanos(task);
-    }
-    Arrays.sort(samples);
-    return samples[samples.length / 2];
-  }
-
-  private static long runtimeNanos(Runnable task) {
+  private static long countedWork(Runnable task) {
     return assertTimeoutPreemptively(
-        PERFORMANCE_SCENARIO_TIMEOUT,
-        () -> {
-          long start = System.nanoTime();
-          task.run();
-          return System.nanoTime() - start;
-        });
+        PERFORMANCE_SCENARIO_TIMEOUT, () -> WorkCounter.countForTesting(task));
   }
 
   private static void assertZeroCountGroupBehavior(String regex, String input) {

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.safere.MultiAnchorDescriptor.Anchor;
@@ -242,63 +243,71 @@ class MultiAnchorCompilerTest {
   }
 
   @Test
+  @Tag("work-counter")
   void nestedConcatenationAnalysisScalesLinearly() {
     Regexp smaller = nestedConcatenation(1_000);
     Regexp larger = nestedConcatenation(2_000);
     MultiAnchorCompiler.analyze(smaller);
     MultiAnchorCompiler.analyze(larger);
 
-    long smallerNanos = medianAnalysisNanos(smaller);
-    long largerNanos = medianAnalysisNanos(larger);
+    long smallerWork = analysisWork(smaller);
+    long largerWork = analysisWork(larger);
 
-    assertThat(largerNanos)
-        .withFailMessage("smaller=%s larger=%s", smallerNanos, largerNanos)
-        .isLessThan(smallerNanos * 3);
+    assertThat(smallerWork).isPositive();
+    assertThat(largerWork)
+        .withFailMessage("smallerWork=%s largerWork=%s", smallerWork, largerWork)
+        .isLessThan(smallerWork * 3);
   }
 
   @Test
+  @Tag("work-counter")
   void nestedAlternationAnalysisScalesLinearly() {
     Regexp smaller = nestedAlternation(1_000);
     Regexp larger = nestedAlternation(2_000);
     MultiAnchorCompiler.analyze(smaller);
     MultiAnchorCompiler.analyze(larger);
 
-    long smallerNanos = medianAnalysisNanos(smaller);
-    long largerNanos = medianAnalysisNanos(larger);
+    long smallerWork = analysisWork(smaller);
+    long largerWork = analysisWork(larger);
 
-    assertThat(largerNanos)
-        .withFailMessage("smaller=%s larger=%s", smallerNanos, largerNanos)
-        .isLessThan(smallerNanos * 3);
+    assertThat(smallerWork).isPositive();
+    assertThat(largerWork)
+        .withFailMessage("smallerWork=%s largerWork=%s", smallerWork, largerWork)
+        .isLessThan(smallerWork * 3);
   }
 
   @Test
+  @Tag("work-counter")
   void nestedRequiredLiteralAnalysisScalesLinearly() {
     Regexp smaller = nestedRequiredLiteral(8_000);
     Regexp larger = nestedRequiredLiteral(16_000);
     MultiAnchorCompiler.analyze(smaller);
     MultiAnchorCompiler.analyze(larger);
 
-    long smallerNanos = medianAnalysisNanos(smaller);
-    long largerNanos = medianAnalysisNanos(larger);
+    long smallerWork = analysisWork(smaller);
+    long largerWork = analysisWork(larger);
 
-    assertThat(largerNanos)
-        .withFailMessage("smaller=%s larger=%s", smallerNanos, largerNanos)
-        .isLessThan(smallerNanos * 3);
+    assertThat(smallerWork).isPositive();
+    assertThat(largerWork)
+        .withFailMessage("smallerWork=%s largerWork=%s", smallerWork, largerWork)
+        .isLessThan(smallerWork * 3);
   }
 
   @Test
+  @Tag("work-counter")
   void reverseAnchorAnalysisScalesLinearlyForLongConcatenations() {
     Regexp smaller = repeatedCharacterClassConcat(4_000);
     Regexp larger = repeatedCharacterClassConcat(8_000);
     MultiAnchorCompiler.extractReverseMultiAnchor(smaller, 0, false);
     MultiAnchorCompiler.extractReverseMultiAnchor(larger, 0, false);
 
-    long smallerNanos = medianReverseAnalysisNanos(smaller);
-    long largerNanos = medianReverseAnalysisNanos(larger);
+    long smallerWork = reverseAnalysisWork(smaller);
+    long largerWork = reverseAnalysisWork(larger);
 
-    assertThat(largerNanos)
-        .withFailMessage("smaller=%s larger=%s", smallerNanos, largerNanos)
-        .isLessThan(smallerNanos * 3);
+    assertThat(smallerWork).isPositive();
+    assertThat(largerWork)
+        .withFailMessage("smallerWork=%s largerWork=%s", smallerWork, largerWork)
+        .isLessThan(smallerWork * 3);
   }
 
   @Test
@@ -399,25 +408,12 @@ class MultiAnchorCompilerTest {
     return Regexp.concat(children, 0);
   }
 
-  private static long medianAnalysisNanos(Regexp regexp) {
-    long[] timings = new long[5];
-    for (int index = 0; index < timings.length; index++) {
-      long start = System.nanoTime();
-      MultiAnchorCompiler.analyze(regexp);
-      timings[index] = System.nanoTime() - start;
-    }
-    Arrays.sort(timings);
-    return timings[timings.length / 2];
+  private static long analysisWork(Regexp regexp) {
+    return WorkCounter.countForTesting(() -> MultiAnchorCompiler.analyze(regexp));
   }
 
-  private static long medianReverseAnalysisNanos(Regexp regexp) {
-    long[] timings = new long[5];
-    for (int index = 0; index < timings.length; index++) {
-      long start = System.nanoTime();
-      MultiAnchorCompiler.extractReverseMultiAnchor(regexp, 0, false);
-      timings[index] = System.nanoTime() - start;
-    }
-    Arrays.sort(timings);
-    return timings[timings.length / 2];
+  private static long reverseAnalysisWork(Regexp regexp) {
+    return WorkCounter.countForTesting(
+        () -> MultiAnchorCompiler.extractReverseMultiAnchor(regexp, 0, false));
   }
 }

--- a/safere/src/test/java/org/safere/ParserTest.java
+++ b/safere/src/test/java/org/safere/ParserTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.regex.PatternSyntaxException;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -24,10 +25,6 @@ class ParserTest {
 
   /** Perl-compatible flags, used as the default for most tests. */
   private static final int PERL = ParseFlags.LIKE_PERL;
-
-  // Used as a sink to prevent JVM dead-code elimination in microbenchmarks.
-  @SuppressWarnings("unused")
-  private static Regexp parseTimingSink;
 
   /**
    * Flags matching the RE2 C++ test suite's default ({@code MatchNL | PerlX | PerlClasses |
@@ -57,15 +54,8 @@ class ParserTest {
     return result != null;
   }
 
-  private static long bestParseTimeNanos(String pattern) {
-    long best = Long.MAX_VALUE;
-    for (int i = 0; i < 3; i++) {
-      long start = System.nanoTime();
-      parseTimingSink = parse(pattern);
-      long elapsed = System.nanoTime() - start;
-      best = Math.min(best, elapsed);
-    }
-    return best;
+  private static long parseWork(String pattern) {
+    return WorkCounter.countForTesting(() -> parse(pattern));
   }
 
   private static String nestedCharacterClass(int depth) {
@@ -352,18 +342,20 @@ class ParserTest {
     }
 
     @Test
+    @Tag("work-counter")
     void manyPlainCharacterClassesParseWithLinearScaling() {
       String smaller = repeatedPlainCharacterClasses(8_000);
       String larger = repeatedPlainCharacterClasses(32_000);
 
-      long smallerNanos = bestParseTimeNanos(smaller);
-      long largerNanos = bestParseTimeNanos(larger);
+      long smallerWork = parseWork(smaller);
+      long largerWork = parseWork(larger);
 
-      assertThat(largerNanos)
+      assertThat(smallerWork).isPositive();
+      assertThat(largerWork)
           .as(
-              "4x input should stay near linear, smaller=%dns larger=%dns",
-              smallerNanos, largerNanos)
-          .isLessThan(smallerNanos * 10);
+              "4x input should stay near linear, smallerWork=%d largerWork=%d",
+              smallerWork, largerWork)
+          .isLessThan(smallerWork * 5);
     }
 
     @Test

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -23,11 +23,17 @@ class SearchScalingRegressionTest {
   void multiAnchorCompilationDoesNotRepeatAstAnalysis() {
     Regexp regexp = Parser.parse("foo.*bar.*baz", Pattern.toParseFlags(0));
 
-    long work = WorkCounter.countForTesting(() -> MultiAnchorCompiler.compile(regexp, 0));
+    long analysisWork = WorkCounter.countForTesting(() -> MultiAnchorCompiler.analyze(regexp));
+    long compilationWork =
+        WorkCounter.countForTesting(() -> MultiAnchorCompiler.compile(regexp, 0));
 
-    assertThat(work)
-        .as("Compilation work includes descriptor assembly but not a second full AST analysis")
-        .isLessThan(countAstNodes(regexp) * 4L);
+    assertThat(analysisWork).isPositive();
+    assertThat(compilationWork)
+        .as(
+            "Compilation work includes one analysis and descriptor assembly, "
+                + "analysisWork=%d compilationWork=%d",
+            analysisWork, compilationWork)
+        .isLessThan(analysisWork * 3);
   }
 
   @Test
@@ -1144,15 +1150,5 @@ class SearchScalingRegressionTest {
                     Utf8Input.trusted("  \u00e9\u00e9:target ".repeat(size).getBytes(UTF_8)))
                 ::find,
         "UTF-8");
-  }
-
-  private static int countAstNodes(Regexp regexp) {
-    int count = 1;
-    if (regexp.subs != null) {
-      for (Regexp child : regexp.subs) {
-        count += countAstNodes(child);
-      }
-    }
-    return count;
   }
 }


### PR DESCRIPTION
## Summary

- replace wall-clock scaling assertions in multi-anchor, parser, and matcher tests with deterministic work accounting
- count AST analysis visits, parser literal-copy work, and Pike NFA closure/thread processing
- preserve matcher completion timeouts as hang guards while keeping elapsed time out of scaling assertions
- tighten the existing multi-anchor repeated-analysis regression around an explicit analysis-work baseline

Fixes #792

## Verification

Ran successfully:

- `mvn -pl safere -Pwork-counters test -q`
- `mvn -pl safere test -q`
- `mvn -pl safere spotless:check -q`
- `git diff --check`

Not run:

- public API crosscheck validation (the change is limited to internal work-counter instrumentation and tests)
