### PR TITLE
Document usePattern group-zero semantics

### DIFF
--- a/INTENTIONAL_DIVERGENCES.md
+++ b/INTENTIONAL_DIVERGENCES.md
@@ -19,6 +19,25 @@ unbounded rescans. When observed JDK behavior appears to expose implementation
 details rather than a stable regex rule, SafeRE keeps the simpler documented
 model and records the difference here.
 
+## Match State after `Matcher.usePattern()`
+
+Issue reference: #715.
+
+After a successful match, SafeRE's `Matcher.usePattern()` preserves the valid
+overall match reported by `hasMatch()`, including the group-zero bounds and
+text. It clears the inner captures associated with the old pattern and reports
+the capturing-group count of the new pattern. As documented for group zero,
+`start()` remains equivalent to `start(0)`, `end()` remains equivalent to
+`end(0)`, and `group()` remains equivalent to `group(0)`.
+
+Observed JDK 26 behavior preserves `hasMatch()`, `start()`, and `end()`, but
+clears group zero along with the inner groups. Consequently, `start(0)` and
+`end(0)` return `-1`, while `group()` and `group(0)` return `null`. This breaks
+the documented group-zero equivalences and can make `toMatchResult()` fail.
+SafeRE preserves a coherent overall match instead of reproducing that
+implementation behavior. The JDK inconsistency is tracked upstream as
+[JDK-8390449](https://bugs.openjdk.org/browse/JDK-8390449).
+
 ## Unsupported Backtracking Features
 
 Sweep names:

--- a/safere/src/test/java/org/safere/MatcherUsePatternTest.java
+++ b/safere/src/test/java/org/safere/MatcherUsePatternTest.java
@@ -71,6 +71,8 @@ class MatcherUsePatternTest {
   }
 
   @Test
+  @DisabledForCrosscheck(
+      "SafeRE keeps group-zero access coherent after usePattern; JDK clears indexed group zero")
   @DisplayName("usePattern preserves coherent group zero and clears inner groups")
   void usePatternPreservesCoherentGroupZeroAndClearsInnerGroups() {
     Pattern p1 = Pattern.compile("(a)(b)");

--- a/safere/src/test/java/org/safere/MatcherUsePatternTest.java
+++ b/safere/src/test/java/org/safere/MatcherUsePatternTest.java
@@ -71,8 +71,8 @@ class MatcherUsePatternTest {
   }
 
   @Test
-  @DisplayName("usePattern preserves match state and groupCount")
-  void usePatternPreservesMatchState() {
+  @DisplayName("usePattern preserves coherent group zero and clears inner groups")
+  void usePatternPreservesCoherentGroupZeroAndClearsInnerGroups() {
     Pattern p1 = Pattern.compile("(a)(b)");
     Pattern p2 = Pattern.compile("(x)(y)(z)");
     Matcher m = p1.matcher("ab");
@@ -87,5 +87,20 @@ class MatcherUsePatternTest {
     m.usePattern(p2);
     assertThat(m.hasMatch()).isTrue();
     assertThat(m.groupCount()).isEqualTo(3);
+    assertThat(m.start()).isZero();
+    assertThat(m.start(0)).isEqualTo(m.start());
+    assertThat(m.end()).isEqualTo(2);
+    assertThat(m.end(0)).isEqualTo(m.end());
+    assertThat(m.group()).isEqualTo("ab");
+    assertThat(m.group(0)).isEqualTo(m.group());
+    assertThat(m.start(1)).isEqualTo(-1);
+    assertThat(m.end(1)).isEqualTo(-1);
+    assertThat(m.group(1)).isNull();
+    assertThat(m.start(2)).isEqualTo(-1);
+    assertThat(m.end(2)).isEqualTo(-1);
+    assertThat(m.group(2)).isNull();
+    assertThat(m.start(3)).isEqualTo(-1);
+    assertThat(m.end(3)).isEqualTo(-1);
+    assertThat(m.group(3)).isNull();
   }
 }


### PR DESCRIPTION
## Summary

- document SafeRE's intentional post-`usePattern()` group-zero semantics
- expand regression coverage for coherent group-zero access and cleared inner captures
- link the corresponding upstream OpenJDK inconsistency

Fixes #715

## Verification

Ran:

```text
mvn -pl safere -Dtest=MatcherUsePatternTest,MatcherDeferredCaptureStateTest test -q
git diff --check
```

Both passed. A P2 review-fix loop also completed with no findings.

Not run: the full SafeRE test suite or public API crosscheck suite. This is a documentation and
regression-assertion change; production behavior is unchanged.
