### PR TITLE
Subsume StartPlan.FixedOffset literal in RejectPlan extraction

### DIFF
--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -311,8 +311,6 @@ final class MultiAnchorCompiler {
             : startPlan instanceof MultiAnchorDescriptor.StartPlan.FixedOffset fo
                 ? fo.fol().literal()
                 : null;
-    String prefix =
-        startPlan instanceof MultiAnchorDescriptor.StartPlan.Literal lit ? lit.prefix() : null;
     CharClassScanInfo ccPrefix =
         startPlan instanceof MultiAnchorDescriptor.StartPlan.CharClass cc ? cc.scanInfo() : null;
     boolean hasLeadingExpansion =
@@ -328,7 +326,7 @@ final class MultiAnchorCompiler {
     }
 
     CharClassScanInfo requiredMatchClass = null;
-    if (!anchorStart && prefix == null && endAnchoredCharClass == null) {
+    if (!anchorStart && excludeStartLiteral == null && endAnchoredCharClass == null) {
       CharClass reqClass = reject.bestRequiredClass();
       if (reqClass != null) {
         if (ccPrefix == null) {
@@ -356,7 +354,7 @@ final class MultiAnchorCompiler {
     }
 
     String[] disjointLiterals =
-        (!anchorStart && prefix == null && requiredLiteral == null)
+        (!anchorStart && excludeStartLiteral == null && requiredLiteral == null)
             ? reject.disjointRequiredLiterals()
             : null;
     if (disjointLiterals != null && disjointLiterals.length > 1) {

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -305,6 +305,12 @@ final class MultiAnchorCompiler {
       plans.add(new MultiAnchorDescriptor.RejectPlan.EndAnchoredCharClass(endAnchoredCharClass));
     }
 
+    String excludeStartLiteral =
+        startPlan instanceof MultiAnchorDescriptor.StartPlan.Literal lit
+            ? lit.prefix()
+            : startPlan instanceof MultiAnchorDescriptor.StartPlan.FixedOffset fo
+                ? fo.fol().literal()
+                : null;
     String prefix =
         startPlan instanceof MultiAnchorDescriptor.StartPlan.Literal lit ? lit.prefix() : null;
     CharClassScanInfo ccPrefix =
@@ -315,7 +321,7 @@ final class MultiAnchorCompiler {
 
     String requiredLiteral =
         !anchorStart && !hasLeadingExpansion
-            ? extractRequiredLiteral(metadataAst, prefix, suffixStr)
+            ? extractRequiredLiteral(metadataAst, excludeStartLiteral, suffixStr)
             : null;
     if (requiredLiteral != null) {
       plans.add(new MultiAnchorDescriptor.RejectPlan.RequiredLiteral(requiredLiteral));
@@ -2760,8 +2766,8 @@ final class MultiAnchorCompiler {
           if (node.subs != null) {
             String exactAscii = extractExactAsciiLiteral(node);
             if (exactAscii != null && exactAscii.length() >= 2) {
-              if ((excludePrefix == null || !exactAscii.equals(excludePrefix))
-                  && (excludeSuffix == null || !exactAscii.equals(excludeSuffix))) {
+              if (!isLiteralSubsumed(exactAscii, excludePrefix)
+                  && !isLiteralSubsumed(exactAscii, excludeSuffix)) {
                 int score = RarityOracle.literalSelectivityScore(exactAscii);
                 if (best == null || score > bestScore) {
                   best = exactAscii;
@@ -2779,8 +2785,8 @@ final class MultiAnchorCompiler {
               && node.runes != null
               && node.runes.length >= 2) {
             String candidate = new String(node.runes, 0, node.runes.length);
-            if ((excludePrefix == null || !candidate.equals(excludePrefix))
-                && (excludeSuffix == null || !candidate.equals(excludeSuffix))) {
+            if (!isLiteralSubsumed(candidate, excludePrefix)
+                && !isLiteralSubsumed(candidate, excludeSuffix)) {
               int candidateScore = RarityOracle.literalSelectivityScore(candidate);
               if (best == null || candidateScore > bestScore) {
                 best = candidate;
@@ -2793,6 +2799,10 @@ final class MultiAnchorCompiler {
       }
     }
     return best;
+  }
+
+  private static boolean isLiteralSubsumed(String candidate, String excluded) {
+    return excluded != null && (candidate.equals(excluded) || excluded.contains(candidate));
   }
 
   private static String[] combineDisjointRequiredLiterals(List<NodeAnalysis> children) {

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -307,7 +307,7 @@ final class MultiAnchorCompiler {
     Set<String> excludeStartLiterals = new LinkedHashSet<>();
     boolean skipRequiredCharClass = false;
     CharClassScanInfo ccPrefix = null;
-    boolean hasLeadingExpansion = false;
+    boolean hasLeadingExpansion = startPlan instanceof StartPlan.LeadingExpansion;
 
     switch (startPlan) {
       case StartPlan.Literal lit -> {
@@ -320,7 +320,6 @@ final class MultiAnchorCompiler {
         skipRequiredCharClass = true;
       }
       case StartPlan.CharClass cc -> ccPrefix = cc.scanInfo();
-      case StartPlan.LeadingExpansion unusedLe -> hasLeadingExpansion = true;
       case null, default -> {}
     }
 
@@ -2762,33 +2761,38 @@ final class MultiAnchorCompiler {
     AsciiWidthRange prefixWidth = AsciiWidthRange.ZERO;
     for (int index = 0; index < node.subs.size(); index++) {
       Regexp sub = node.subs.get(index);
-      collectAsciiLiterals(sub, literals);
       prefixWidth = concatenateWidths(prefixWidth, computeAsciiWidthRange(sub));
       if (!prefixWidth.isValid()) {
         break;
       }
+      collectAsciiLiterals(sub, literals);
     }
     return literals;
   }
 
   private static void collectAsciiLiterals(Regexp re, Set<String> literals) {
-    Regexp unwrapped = unwrapCaptures(re);
-    if (unwrapped == null) {
-      return;
-    }
-    String exact = extractExactAsciiLiteral(unwrapped);
+    String exact = extractExactAsciiLiteral(re);
     if (exact != null && exact.length() >= 2) {
       literals.add(exact);
     }
-    if ((unwrapped.op == RegexpOp.LITERAL_STRING || unwrapped.op == RegexpOp.LITERAL)
-        && (unwrapped.flags & ParseFlags.FOLD_CASE) == 0
-        && unwrapped.runes != null
-        && unwrapped.runes.length >= 2) {
-      literals.add(new String(unwrapped.runes, 0, unwrapped.runes.length));
-    }
-    if (unwrapped.subs != null) {
-      for (Regexp child : unwrapped.subs) {
-        collectAsciiLiterals(child, literals);
+
+    Deque<Regexp> pending = new ArrayDeque<>();
+    pending.addLast(re);
+    while (!pending.isEmpty()) {
+      Regexp node = unwrapCaptures(pending.removeLast());
+      if (node == null) {
+        continue;
+      }
+      if ((node.op == RegexpOp.LITERAL_STRING || node.op == RegexpOp.LITERAL)
+          && (node.flags & ParseFlags.FOLD_CASE) == 0
+          && node.runes != null
+          && node.runes.length >= 2) {
+        literals.add(new String(node.runes, 0, node.runes.length));
+      }
+      if (node.subs != null) {
+        for (Regexp child : node.subs) {
+          pending.addLast(child);
+        }
       }
     }
   }
@@ -2851,16 +2855,12 @@ final class MultiAnchorCompiler {
       return false;
     }
     if (excludedSuffix != null
-        && (candidate.equals(excludedSuffix)
-            || excludedSuffix.contains(candidate)
-            || candidate.contains(excludedSuffix))) {
+        && (candidate.equals(excludedSuffix) || excludedSuffix.contains(candidate))) {
       return true;
     }
     if (excludedPrefixes != null) {
       for (String excluded : excludedPrefixes) {
-        if (candidate.equals(excluded)
-            || excluded.contains(candidate)
-            || candidate.contains(excluded)) {
+        if (candidate.equals(excluded) || excluded.contains(candidate)) {
           return true;
         }
       }

--- a/safere/src/main/java/org/safere/MultiAnchorCompiler.java
+++ b/safere/src/main/java/org/safere/MultiAnchorCompiler.java
@@ -15,6 +15,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import org.safere.MultiAnchorDescriptor.RejectPlan;
+import org.safere.MultiAnchorDescriptor.StartPlan;
 
 /**
  * Compiles AST representations of regular expressions into {@link MultiAnchorDescriptor}, {@link
@@ -273,60 +275,67 @@ final class MultiAnchorCompiler {
     return MultiAnchorDescriptor.StartPlan.None.INSTANCE;
   }
 
-  static MultiAnchorDescriptor.RejectPlan extractRejectPlan(
+  static RejectPlan extractRejectPlan(
       Regexp metadataAst,
       int flags,
-      MultiAnchorDescriptor.StartPlan startPlan,
+      StartPlan startPlan,
       boolean anchorStart,
       MultiAnchorDescriptor.Chain chain) {
     if (metadataAst == null) {
-      return MultiAnchorDescriptor.RejectPlan.None.INSTANCE;
+      return RejectPlan.None.INSTANCE;
     }
     return extractRejectPlan(metadataAst, startPlan, anchorStart, analyze(metadataAst, flags));
   }
 
-  private static MultiAnchorDescriptor.RejectPlan extractRejectPlan(
-      Regexp metadataAst,
-      MultiAnchorDescriptor.StartPlan startPlan,
-      boolean anchorStart,
-      NodeAnalysis analysis) {
+  private static RejectPlan extractRejectPlan(
+      Regexp metadataAst, StartPlan startPlan, boolean anchorStart, NodeAnalysis analysis) {
     RejectFacets reject = analysis.reject();
 
-    List<MultiAnchorDescriptor.RejectPlan> plans = new ArrayList<>();
+    List<RejectPlan> plans = new ArrayList<>();
 
     Pattern.SuffixInfo endAnchoredSuffix = reject.endAnchoredSuffix();
     if (endAnchoredSuffix != null) {
-      plans.add(new MultiAnchorDescriptor.RejectPlan.EndAnchoredSuffix(endAnchoredSuffix));
+      plans.add(new RejectPlan.EndAnchoredSuffix(endAnchoredSuffix));
     }
 
     Pattern.EndAnchoredCharClassInfo endAnchoredCharClass =
         endAnchoredSuffix == null ? reject.endAnchoredCharClass() : null;
     if (endAnchoredCharClass != null) {
-      plans.add(new MultiAnchorDescriptor.RejectPlan.EndAnchoredCharClass(endAnchoredCharClass));
+      plans.add(new RejectPlan.EndAnchoredCharClass(endAnchoredCharClass));
     }
 
-    String excludeStartLiteral =
-        startPlan instanceof MultiAnchorDescriptor.StartPlan.Literal lit
-            ? lit.prefix()
-            : startPlan instanceof MultiAnchorDescriptor.StartPlan.FixedOffset fo
-                ? fo.fol().literal()
-                : null;
-    CharClassScanInfo ccPrefix =
-        startPlan instanceof MultiAnchorDescriptor.StartPlan.CharClass cc ? cc.scanInfo() : null;
-    boolean hasLeadingExpansion =
-        startPlan instanceof MultiAnchorDescriptor.StartPlan.LeadingExpansion;
+    Set<String> excludeStartLiterals = new LinkedHashSet<>();
+    boolean skipRequiredCharClass = false;
+    CharClassScanInfo ccPrefix = null;
+    boolean hasLeadingExpansion = false;
+
+    switch (startPlan) {
+      case StartPlan.Literal lit -> {
+        excludeStartLiterals.add(lit.prefix());
+        skipRequiredCharClass = true;
+      }
+      case StartPlan.FixedOffset fo -> {
+        excludeStartLiterals.add(fo.fol().literal());
+        excludeStartLiterals.addAll(extractFixedPrefixLiterals(metadataAst));
+        skipRequiredCharClass = true;
+      }
+      case StartPlan.CharClass cc -> ccPrefix = cc.scanInfo();
+      case StartPlan.LeadingExpansion unusedLe -> hasLeadingExpansion = true;
+      case null, default -> {}
+    }
+
     String suffixStr = endAnchoredSuffix != null ? endAnchoredSuffix.suffix() : null;
 
     String requiredLiteral =
         !anchorStart && !hasLeadingExpansion
-            ? extractRequiredLiteral(metadataAst, excludeStartLiteral, suffixStr)
+            ? extractRequiredLiteral(metadataAst, excludeStartLiterals, suffixStr)
             : null;
     if (requiredLiteral != null) {
-      plans.add(new MultiAnchorDescriptor.RejectPlan.RequiredLiteral(requiredLiteral));
+      plans.add(new RejectPlan.RequiredLiteral(requiredLiteral));
     }
 
     CharClassScanInfo requiredMatchClass = null;
-    if (!anchorStart && excludeStartLiteral == null && endAnchoredCharClass == null) {
+    if (!anchorStart && !skipRequiredCharClass && endAnchoredCharClass == null) {
       CharClass reqClass = reject.bestRequiredClass();
       if (reqClass != null) {
         if (ccPrefix == null) {
@@ -350,25 +359,24 @@ final class MultiAnchorCompiler {
       }
     }
     if (requiredMatchClass != null) {
-      plans.add(new MultiAnchorDescriptor.RejectPlan.RequiredCharClass(requiredMatchClass));
+      plans.add(new RejectPlan.RequiredCharClass(requiredMatchClass));
     }
 
     String[] disjointLiterals =
-        (!anchorStart && excludeStartLiteral == null && requiredLiteral == null)
+        (!anchorStart && !skipRequiredCharClass && requiredLiteral == null)
             ? reject.disjointRequiredLiterals()
             : null;
     if (disjointLiterals != null && disjointLiterals.length > 1) {
-      plans.add(new MultiAnchorDescriptor.RejectPlan.DisjointLiterals(disjointLiterals));
+      plans.add(new RejectPlan.DisjointLiterals(disjointLiterals));
     }
 
     if (plans.isEmpty()) {
-      return MultiAnchorDescriptor.RejectPlan.None.INSTANCE;
+      return RejectPlan.None.INSTANCE;
     }
     if (plans.size() == 1) {
       return plans.get(0);
     }
-    return new MultiAnchorDescriptor.RejectPlan.Composite(
-        plans.toArray(MultiAnchorDescriptor.RejectPlan[]::new));
+    return new RejectPlan.Composite(plans.toArray(RejectPlan[]::new));
   }
 
   // --- Bottom-up MultiAnchorWalker ---
@@ -2745,8 +2753,48 @@ final class MultiAnchorCompiler {
     return null;
   }
 
+  private static Set<String> extractFixedPrefixLiterals(Regexp re) {
+    Regexp node = unwrapCaptures(re);
+    if (node == null || node.op != RegexpOp.CONCAT || node.subs == null) {
+      return Set.of();
+    }
+    Set<String> literals = new LinkedHashSet<>();
+    AsciiWidthRange prefixWidth = AsciiWidthRange.ZERO;
+    for (int index = 0; index < node.subs.size(); index++) {
+      Regexp sub = node.subs.get(index);
+      collectAsciiLiterals(sub, literals);
+      prefixWidth = concatenateWidths(prefixWidth, computeAsciiWidthRange(sub));
+      if (!prefixWidth.isValid()) {
+        break;
+      }
+    }
+    return literals;
+  }
+
+  private static void collectAsciiLiterals(Regexp re, Set<String> literals) {
+    Regexp unwrapped = unwrapCaptures(re);
+    if (unwrapped == null) {
+      return;
+    }
+    String exact = extractExactAsciiLiteral(unwrapped);
+    if (exact != null && exact.length() >= 2) {
+      literals.add(exact);
+    }
+    if ((unwrapped.op == RegexpOp.LITERAL_STRING || unwrapped.op == RegexpOp.LITERAL)
+        && (unwrapped.flags & ParseFlags.FOLD_CASE) == 0
+        && unwrapped.runes != null
+        && unwrapped.runes.length >= 2) {
+      literals.add(new String(unwrapped.runes, 0, unwrapped.runes.length));
+    }
+    if (unwrapped.subs != null) {
+      for (Regexp child : unwrapped.subs) {
+        collectAsciiLiterals(child, literals);
+      }
+    }
+  }
+
   private static String extractRequiredLiteral(
-      Regexp re, String excludePrefix, String excludeSuffix) {
+      Regexp re, Set<String> excludePrefixes, String excludeSuffix) {
     String best = null;
     int bestScore = 0;
     Deque<Regexp> pending = new ArrayDeque<>();
@@ -2764,8 +2812,7 @@ final class MultiAnchorCompiler {
           if (node.subs != null) {
             String exactAscii = extractExactAsciiLiteral(node);
             if (exactAscii != null && exactAscii.length() >= 2) {
-              if (!isLiteralSubsumed(exactAscii, excludePrefix)
-                  && !isLiteralSubsumed(exactAscii, excludeSuffix)) {
+              if (!isLiteralSubsumed(exactAscii, excludePrefixes, excludeSuffix)) {
                 int score = RarityOracle.literalSelectivityScore(exactAscii);
                 if (best == null || score > bestScore) {
                   best = exactAscii;
@@ -2783,8 +2830,7 @@ final class MultiAnchorCompiler {
               && node.runes != null
               && node.runes.length >= 2) {
             String candidate = new String(node.runes, 0, node.runes.length);
-            if (!isLiteralSubsumed(candidate, excludePrefix)
-                && !isLiteralSubsumed(candidate, excludeSuffix)) {
+            if (!isLiteralSubsumed(candidate, excludePrefixes, excludeSuffix)) {
               int candidateScore = RarityOracle.literalSelectivityScore(candidate);
               if (best == null || candidateScore > bestScore) {
                 best = candidate;
@@ -2799,8 +2845,27 @@ final class MultiAnchorCompiler {
     return best;
   }
 
-  private static boolean isLiteralSubsumed(String candidate, String excluded) {
-    return excluded != null && (candidate.equals(excluded) || excluded.contains(candidate));
+  private static boolean isLiteralSubsumed(
+      String candidate, Set<String> excludedPrefixes, String excludedSuffix) {
+    if (candidate == null) {
+      return false;
+    }
+    if (excludedSuffix != null
+        && (candidate.equals(excludedSuffix)
+            || excludedSuffix.contains(candidate)
+            || candidate.contains(excludedSuffix))) {
+      return true;
+    }
+    if (excludedPrefixes != null) {
+      for (String excluded : excludedPrefixes) {
+        if (candidate.equals(excluded)
+            || excluded.contains(candidate)
+            || candidate.contains(excluded)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static String[] combineDisjointRequiredLiterals(List<NodeAnalysis> children) {

--- a/safere/src/main/java/org/safere/RejectPrefilter.java
+++ b/safere/src/main/java/org/safere/RejectPrefilter.java
@@ -117,10 +117,12 @@ sealed interface RejectPrefilter
         return utf8Scanner.indexOf(utf8, failure, shifts, searchFrom) < 0;
       }
       if (text != null) {
+        int idx = text.indexOf(literal, searchFrom);
         if (WorkCounterConfig.ENABLED) {
-          WorkCounter.record(Math.max(0, text.length() - searchFrom));
+          int scanned = idx >= 0 ? idx - searchFrom + literal.length() : text.length() - searchFrom;
+          WorkCounter.record(Math.max(0, scanned));
         }
-        return text.indexOf(literal, searchFrom) < 0;
+        return idx < 0;
       }
       return false;
     }
@@ -199,10 +201,12 @@ sealed interface RejectPrefilter
         return false;
       }
       for (String literal : literals) {
+        int idx = text.indexOf(literal, searchFrom);
         if (WorkCounterConfig.ENABLED) {
-          WorkCounter.record(Math.max(0, text.length() - searchFrom));
+          int scanned = idx >= 0 ? idx - searchFrom + literal.length() : text.length() - searchFrom;
+          WorkCounter.record(Math.max(0, scanned));
         }
-        if (text.indexOf(literal, searchFrom) >= 0) {
+        if (idx >= 0) {
           return false;
         }
       }

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -430,6 +430,33 @@ class MultiAnchorCompilerTest {
         .doesNotThrowAnyException();
   }
 
+  @Test
+  void fixedOffsetLiteralSubsumedFromRejectPlan() {
+    // Single fixed-offset literal drives startPlan; should not be duplicated in rejectPlan
+    Pattern p1 = Pattern.compile("[0-9]{2}404_NOT_FOUND");
+    assertThat(p1.startPlan()).isInstanceOf(MultiAnchorDescriptor.StartPlan.FixedOffset.class);
+    MultiAnchorDescriptor.StartPlan.FixedOffset fo =
+        (MultiAnchorDescriptor.StartPlan.FixedOffset) p1.startPlan();
+    assertThat(fo.fol().literal()).isEqualTo("404_NOT_FOUND");
+
+    // The required literal "404_NOT_FOUND" is subsumed and excluded from rejectPlan
+    Stream<MultiAnchorDescriptor.RejectPlan.RequiredLiteral> reqLits1 =
+        rejectPlans(p1.rejectPlan())
+            .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
+            .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
+    assertThat(reqLits1).noneMatch(l -> l.literal().equals("404_NOT_FOUND"));
+
+    // Multiple required literals: fixed-offset literal is excluded, but downstream required literal
+    // is preserved
+    Pattern p2 = Pattern.compile("[0-9]{2}404_NOT_FOUND.*EXCEPTION_LOG");
+    assertThat(p2.startPlan()).isInstanceOf(MultiAnchorDescriptor.StartPlan.FixedOffset.class);
+    Stream<MultiAnchorDescriptor.RejectPlan.RequiredLiteral> reqLits2 =
+        rejectPlans(p2.rejectPlan())
+            .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
+            .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
+    assertThat(reqLits2).anyMatch(l -> l.literal().equals("EXCEPTION_LOG"));
+  }
+
   private static String deepHomogeneousGap(String atom, int depth) {
     return "foo" + "(?:".repeat(depth) + atom + (")?" + atom).repeat(depth) + "bar";
   }

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -465,6 +465,24 @@ class MultiAnchorCompilerTest {
             .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
             .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
     assertThat(reqLits3).isEmpty();
+
+    Pattern variableWidthBoundary = Pattern.compile("[0-9]{2}____(?:ALPHABET)+");
+    Stream<MultiAnchorDescriptor.RejectPlan.RequiredLiteral> boundaryLiterals =
+        rejectPlans(variableWidthBoundary.rejectPlan())
+            .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
+            .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
+    assertThat(boundaryLiterals)
+        .extracting(MultiAnchorDescriptor.RejectPlan.RequiredLiteral::literal)
+        .contains("ALPHABET");
+
+    Pattern repeatedPrefixToken = Pattern.compile("[0-9]{2}zz.*zzRARE");
+    Stream<MultiAnchorDescriptor.RejectPlan.RequiredLiteral> repeatedTokenLiterals =
+        rejectPlans(repeatedPrefixToken.rejectPlan())
+            .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
+            .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
+    assertThat(repeatedTokenLiterals)
+        .extracting(MultiAnchorDescriptor.RejectPlan.RequiredLiteral::literal)
+        .contains("zzRARE");
   }
 
   private static String deepHomogeneousGap(String atom, int depth) {

--- a/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorCompilerTest.java
@@ -455,6 +455,16 @@ class MultiAnchorCompilerTest {
             .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
             .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
     assertThat(reqLits2).anyMatch(l -> l.literal().equals("EXCEPTION_LOG"));
+
+    // Multiple literals in fixed-offset prefix: all prefix literals subsumed, none leaked to
+    // rejectPlan
+    Pattern p3 = Pattern.compile("[0-9]{2}____[a-z]zq[a-z]");
+    assertThat(p3.startPlan()).isInstanceOf(MultiAnchorDescriptor.StartPlan.FixedOffset.class);
+    Stream<MultiAnchorDescriptor.RejectPlan.RequiredLiteral> reqLits3 =
+        rejectPlans(p3.rejectPlan())
+            .filter(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::isInstance)
+            .map(MultiAnchorDescriptor.RejectPlan.RequiredLiteral.class::cast);
+    assertThat(reqLits3).isEmpty();
   }
 
   private static String deepHomogeneousGap(String atom, int depth) {

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -235,7 +235,7 @@ class PatternInternalTest {
 
   @Test
   void deeplyNestedFixedOffsetWidthExtractionIsStackSafe() {
-    Pattern p = Pattern.compile(nestedFixedOffsetPattern(2_000));
+    Pattern p = Pattern.compile(nestedFixedOffsetPattern(10_000));
 
     assertThat(p.startPlan()).isInstanceOf(MultiAnchorDescriptor.StartPlan.FixedOffset.class);
   }

--- a/safere/src/test/java/org/safere/PatternInternalTest.java
+++ b/safere/src/test/java/org/safere/PatternInternalTest.java
@@ -274,9 +274,9 @@ class PatternInternalTest {
 
   @ParameterizedTest
   @CsvSource({
-    "'\\d{3}/\\d{3}/\\d{4}', /, 0",
-    "'[A-Z]{2}:[0-9]{4}',    :, A",
-    "'\\w+#[a-f0-9]{8}',     #, a"
+    "'\\d+/\\d+/\\d+',    /, 0",
+    "'[A-Z]+:[0-9]+',     :, A",
+    "'\\w+#[a-f0-9]{8}',  #, a"
   })
   void requiredCharacterClassPrefersTheMostSelectiveMandatoryAtom(
       String regex, char expectedMember, char expectedNonMember) {


### PR DESCRIPTION
When extracting prefilter plans in `MultiAnchorCompiler`, `StartPlan.Literal` has always had its prefix excluded from `RejectPlan.RequiredLiteral` (`extractRequiredLiteral(metadataAst, prefix, suffixStr)`). This prevents SafeRE from running an uncoordinated existence probe in `RejectPrefilter` for the exact same literal that `StartPlan.Literal` is already scanning for.

However, when `StartPlan.FixedOffset` was introduced in PR #771, `extractRequiredLiteral` was not updated to exclude `fol.literal()`. As a result, for all fixed-offset patterns without a leading prefix literal (e.g. `"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z error"` or `"[0-9]{2}404_NOT_FOUND"`), `MultiAnchorCompiler` produced both:
- `StartPlan.FixedOffset` (which scans for the literal to locate candidate starts)
- `RejectPlan.RequiredLiteral` (which scans for the same literal across the entire document in `RejectPrefilter`)

On matching inputs, this forced SafeRE to scan the entire input text twice for the exact same literal string: first in `RejectPrefilter`, which threw the found offset away upon confirming existence, and then again in `StringStartAccelerator.FixedOffset` / `Utf8StartAccelerator.FixedOffset`.

```
./safere-benchmarks/scripts/compare-branch.sh     --baseline origin/main     --current fixed-offset-reject-subsumption     'isoTimestampLog.*@safere-string'
```

| Benchmark                      | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------ | ---------------- | --------------- | ------- |
| isoTimestampLog.match.1000     |         599 ± 18 |        458 ± 13 |   1.31x |
| isoTimestampLog.match.10000    |       3331 ± 114 |       2224 ± 14 |   1.50x |
| isoTimestampLog.match.100000   |      29846 ± 494 |     19923 ± 351 |   1.50x |
| isoTimestampLog.noMatch.1000   |        134 ± 5.3 |       175 ± 7.3 |   0.77x |
| isoTimestampLog.noMatch.10000  |        1041 ± 48 |       1065 ± 41 |   0.98x |
| isoTimestampLog.noMatch.100000 |       9948 ± 299 |       9866 ± 27 |   1.01x |