### PR TITLE
Support static Jazzer entry points in fuzz targets and filter failed-path capture leakage

### DIFF
--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -35,6 +35,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.safere</groupId>
       <artifactId>safere</artifactId>
       <version>${project.version}</version>

--- a/safere-fuzz/src/test/java/org/safere/FuzzCaptureStructure.java
+++ b/safere-fuzz/src/test/java/org/safere/FuzzCaptureStructure.java
@@ -1,0 +1,42 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.ArrayDeque;
+import java.util.BitSet;
+
+/** Test-only bridge to capture ancestry in the parsed, unsimplified pattern. */
+public final class FuzzCaptureStructure {
+  private FuzzCaptureStructure() {}
+
+  /** Returns a fresh set of capture indices with a quantifier ancestor. */
+  public static BitSet quantifiedGroups(Pattern pattern) {
+    BitSet groups = new BitSet();
+    ArrayDeque<Visit> pending = new ArrayDeque<>();
+    pending.push(new Visit(pattern.ast(), false));
+    while (!pending.isEmpty()) {
+      Visit visit = pending.pop();
+      Regexp node = visit.node();
+      if (node.op == RegexpOp.CAPTURE && node.cap > 0 && visit.quantified()) {
+        groups.set(node.cap);
+      }
+      boolean quantified =
+          visit.quantified()
+              || switch (node.op) {
+                case STAR, PLUS, QUEST, REPEAT -> true;
+                default -> false;
+              };
+      if (node.subs != null) {
+        for (Regexp child : node.subs) {
+          pending.push(new Visit(child, quantified));
+        }
+      }
+    }
+    return groups;
+  }
+
+  private record Visit(Regexp node, boolean quantified) {}
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/CaptureSemanticsFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CaptureSemanticsFuzzer.java
@@ -8,7 +8,7 @@ package org.safere.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 
-final class CaptureSemanticsFuzzer {
+public final class CaptureSemanticsFuzzer {
   private static final String[] ATOMS = {
     "()",
     "(a)",
@@ -39,6 +39,10 @@ final class CaptureSemanticsFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void quantifiedCaptures(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     boolean named = data.consumeBoolean();
     String regex = consumeRegex(data, named);
     String input = consumeCaptureInput(data);

--- a/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CharacterClassExpressionFuzzer.java
@@ -9,7 +9,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 
-final class CharacterClassExpressionFuzzer {
+public final class CharacterClassExpressionFuzzer {
 
   private static final String[] BASE_PIECES = {
     "",
@@ -107,6 +107,10 @@ final class CharacterClassExpressionFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void characterClassExpressions(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     for (String regex : REGRESSION_REGEXES) {
       FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
     }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/CompileFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/CompileFuzzer.java
@@ -8,10 +8,14 @@ package org.safere.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 
-final class CompileFuzzer {
+public final class CompileFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void compile(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     int flags = FuzzSupport.consumeFlags(data);
     String regex = data.consumeRemainingAsString();
     FuzzSupport.compileCompatibleOrSkip(regex, flags);

--- a/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/DialectSyntaxFuzzer.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import org.safere.Matcher;
 import org.safere.Pattern;
 
-final class DialectSyntaxFuzzer {
+public final class DialectSyntaxFuzzer {
 
   private static final String[] CONTEXT_PREFIXES = {"", "^", "(?:", "a|", "[", "[^"};
   private static final String[] DIALECT_FRAGMENTS = {
@@ -60,6 +60,10 @@ final class DialectSyntaxFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void dialectSyntax(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     for (String regex : SAFE_RE_EXTENSION_REGEXES) {
       assertSafeRePythonNamedGroupExtension(regex);
     }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/EscapeSyntaxFuzzer.java
@@ -9,7 +9,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 
-final class EscapeSyntaxFuzzer {
+public final class EscapeSyntaxFuzzer {
 
   private static final String[] PREFIXES = {"", "^", "(?i)", "(?x)", "[", "[^"};
   private static final String[] ESCAPES = {
@@ -93,6 +93,10 @@ final class EscapeSyntaxFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void escapeSyntax(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     for (String regex : REGRESSION_REGEXES) {
       FuzzSupport.assertFullMatchesJdk(regex, 0, INPUTS);
     }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -10,7 +10,7 @@ import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-final class FindSequenceFuzzer {
+public final class FindSequenceFuzzer {
 
   @Test
   void delimitedPrefixBeforeRequiredSuffixRegression() {
@@ -40,6 +40,10 @@ final class FindSequenceFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void sequence(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String regex;
     int flags;
     String input;

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -7,6 +7,7 @@ package org.safere.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -41,16 +42,26 @@ final class FuzzSupport {
     org.safere.Pattern.UNICODE_CHARACTER_CLASS
   };
 
-  private static final java.util.regex.Pattern FAILED_PATH_CAPTURE_LEAKAGE_PATTERN =
-      java.util.regex.Pattern.compile(
-          "\\([^)]*\\)[^)]*(?:\\{\\d+[,}]|[*+?]).*(?:\\{\\d+[,}]|[*+?])|"
-              + "\\([^)]*\\)[^)]*(?:[*+?]|\\{\\d+[,}]).*\\$");
-
-  static boolean isFailedPathCaptureLeakagePattern(String regex) {
-    return regex != null && FAILED_PATH_CAPTURE_LEAKAGE_PATTERN.matcher(regex).find();
-  }
-
   private FuzzSupport() {}
+
+  // This is a deliberate fuzzing tradeoff: missing quantified captures can be JDK
+  // failed-path residue, but can also be real SafeRE bugs. Prefer fewer false alarms
+  // for this class, while comparing full matches and all other capture differences.
+  private static boolean isWaivedCaptureDifference(
+      MatchResult safeRe, MatchResult jdk, int group, BitSet quantifiedGroups) {
+    return group > 0
+        && safeRe.group(group) == null
+        && safeRe.start(group) == -1
+        && safeRe.end(group) == -1
+        && jdk.group(group) != null
+        && jdk.start(group) >= 0
+        && jdk.end(group) >= jdk.start(group)
+        && (quantifiedGroups.get(group)
+            || (jdk.start(group) < jdk.start() && jdk.end(group) <= jdk.start()))
+        && safeRe.start() == jdk.start()
+        && safeRe.end() == jdk.end()
+        && Objects.equals(safeRe.group(), jdk.group());
+  }
 
   static CompiledPattern compileCompatibleOrSkip(String regex, int flags) {
     org.safere.Pattern safeRePattern = null;
@@ -245,6 +256,7 @@ final class FuzzSupport {
     private String lastReplacement;
     private final org.safere.Matcher safeReMatcher;
     private final java.util.regex.Matcher jdkMatcher;
+    private final BitSet quantifiedGroups;
     private boolean jdkOracleAvailable = true;
 
     MatcherPair(
@@ -258,6 +270,8 @@ final class FuzzSupport {
       this.input = input;
       this.safeReMatcher = safeReMatcher;
       this.jdkMatcher = jdkMatcher;
+      this.quantifiedGroups =
+          org.safere.FuzzCaptureStructure.quantifiedGroups(safeReMatcher.pattern());
     }
 
     boolean matches() {
@@ -339,7 +353,7 @@ final class FuzzSupport {
     String group(int group) {
       String safeRe = safeReMatcher.group(group);
       String jdk = runJdkOracle("group(" + group + ")", safeRe, () -> jdkMatcher.group(group));
-      if (!isFailedPathCaptureLeakage(group, safeRe, jdk)) {
+      if (!isWaivedCapture(group)) {
         assertSame("group(" + group + ")", safeRe, jdk);
       }
       return safeRe;
@@ -348,7 +362,7 @@ final class FuzzSupport {
     String group(String name) {
       String safeRe = safeReMatcher.group(name);
       String jdk = runJdkOracle("group(" + name + ")", safeRe, () -> jdkMatcher.group(name));
-      if (!isFailedPathCaptureLeakage(name, safeRe, jdk)) {
+      if (!isWaivedCapture(name)) {
         assertSame("group(" + name + ")", safeRe, jdk);
       }
       return safeRe;
@@ -364,7 +378,7 @@ final class FuzzSupport {
     int start(int group) {
       int safeRe = safeReMatcher.start(group);
       int jdk = runJdkOracle("start(" + group + ")", safeRe, () -> jdkMatcher.start(group));
-      if (!isFailedPathCaptureLeakage(group, safeReMatcher.group(group), jdkMatcher.group(group))) {
+      if (!isWaivedCapture(group)) {
         assertSame("start(" + group + ")", safeRe, jdk);
       }
       return safeRe;
@@ -373,7 +387,7 @@ final class FuzzSupport {
     int start(String name) {
       int safeRe = safeReMatcher.start(name);
       int jdk = runJdkOracle("start(" + name + ")", safeRe, () -> jdkMatcher.start(name));
-      if (!isFailedPathCaptureLeakage(name, safeReMatcher.group(name), jdkMatcher.group(name))) {
+      if (!isWaivedCapture(name)) {
         assertSame("start(" + name + ")", safeRe, jdk);
       }
       return safeRe;
@@ -389,7 +403,7 @@ final class FuzzSupport {
     int end(int group) {
       int safeRe = safeReMatcher.end(group);
       int jdk = runJdkOracle("end(" + group + ")", safeRe, () -> jdkMatcher.end(group));
-      if (!isFailedPathCaptureLeakage(group, safeReMatcher.group(group), jdkMatcher.group(group))) {
+      if (!isWaivedCapture(group)) {
         assertSame("end(" + group + ")", safeRe, jdk);
       }
       return safeRe;
@@ -398,44 +412,20 @@ final class FuzzSupport {
     int end(String name) {
       int safeRe = safeReMatcher.end(name);
       int jdk = runJdkOracle("end(" + name + ")", safeRe, () -> jdkMatcher.end(name));
-      if (!isFailedPathCaptureLeakage(name, safeReMatcher.group(name), jdkMatcher.group(name))) {
+      if (!isWaivedCapture(name)) {
         assertSame("end(" + name + ")", safeRe, jdk);
       }
       return safeRe;
     }
 
-    private boolean isFailedPathCaptureLeakage(int group, Object safeRe, Object jdk) {
-      if (group <= 0 || !jdkOracleAvailable) {
-        return false;
-      }
-      boolean safeReEmpty = safeRe == null || (safeRe instanceof Integer i && i == -1);
-      boolean jdkMatched = jdk != null && (!(jdk instanceof Integer i) || i != -1);
-      if (!safeReEmpty || !jdkMatched) {
-        return false;
-      }
-      int matchStart = safeReMatcher.start();
-      int jdkGroupStart = runJdkOracle("start(" + group + ")", -1, () -> jdkMatcher.start(group));
-      if (jdkGroupStart != -1 && jdkGroupStart < matchStart) {
-        return true;
-      }
-      return isFailedPathCaptureLeakagePattern(regex);
+    private boolean isWaivedCapture(int group) {
+      return jdkOracleAvailable
+          && isWaivedCaptureDifference(safeReMatcher, jdkMatcher, group, quantifiedGroups);
     }
 
-    private boolean isFailedPathCaptureLeakage(String name, Object safeRe, Object jdk) {
-      if (name == null || !jdkOracleAvailable) {
-        return false;
-      }
-      boolean safeReEmpty = safeRe == null || (safeRe instanceof Integer i && i == -1);
-      boolean jdkMatched = jdk != null && (!(jdk instanceof Integer i) || i != -1);
-      if (!safeReEmpty || !jdkMatched) {
-        return false;
-      }
-      int matchStart = safeReMatcher.start();
-      int jdkGroupStart = runJdkOracle("start(" + name + ")", -1, () -> jdkMatcher.start(name));
-      if (jdkGroupStart != -1 && jdkGroupStart < matchStart) {
-        return true;
-      }
-      return isFailedPathCaptureLeakagePattern(regex);
+    private boolean isWaivedCapture(String name) {
+      Integer group = safeReMatcher.pattern().namedGroups().get(name);
+      return group != null && isWaivedCapture(group);
     }
 
     MatcherPair region(int start, int end) {
@@ -642,7 +632,7 @@ final class FuzzSupport {
       int groupCount = safeRe.groupCount();
       assertSame(operation + ".groupCount", groupCount, jdk.groupCount());
       for (int i = 0; i <= groupCount; i++) {
-        if (isFailedPathCaptureLeakage(safeRe, jdk, i)) {
+        if (isWaivedCaptureDifference(safeRe, jdk, i, quantifiedGroups)) {
           continue;
         }
         assertSame(operation + ".group(" + i + ")", safeRe.group(i), jdk.group(i));
@@ -651,24 +641,12 @@ final class FuzzSupport {
       }
     }
 
-    private boolean isFailedPathCaptureLeakage(MatchResult safeRe, MatchResult jdk, int group) {
-      if (group <= 0) {
-        return false;
-      }
-      if (safeRe.group(group) == null && jdk.group(group) != null) {
-        if (jdk.start(group) != -1 && jdk.start(group) < safeRe.start()) {
-          return true;
-        }
-        return isFailedPathCaptureLeakagePattern(regex);
-      }
-      return false;
-    }
-
     private boolean assertSameReplacementOutcome(
         String operation,
         String replacement,
         StringOperation safeReOperation,
         StringOperation jdkOperation) {
+      boolean waiveOutput = replacementHasWaivedCapture(operation);
       OperationResult<String> safeRe = OperationResult.capture(safeReOperation);
       if (!jdkOracleAvailable) {
         return false;
@@ -678,11 +656,9 @@ final class FuzzSupport {
         return false;
       }
       if (safeRe.throwable() == null && jdk.throwable() == null) {
-        if (!Objects.equals(safeRe.value(), jdk.value())
-            && isFailedPathCaptureLeakagePattern(regex)) {
-          return true;
+        if (!waiveOutput) {
+          assertSame(operation, replacement, safeRe.value(), jdk.value());
         }
-        assertSame(operation, replacement, safeRe.value(), jdk.value());
         return true;
       }
       if (safeRe.throwable() != null
@@ -692,6 +668,51 @@ final class FuzzSupport {
         return false;
       }
       throw divergence(operation, replacement, safeRe.describe(), jdk.describe());
+    }
+
+    private boolean hasWaivedCapture() {
+      for (int group = 1; group <= safeReMatcher.groupCount(); group++) {
+        if (isWaivedCapture(group)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private boolean replacementHasWaivedCapture(String operation) {
+      if (!jdkOracleAvailable) {
+        return false;
+      }
+      if (operation.equals("appendReplacement")) {
+        if (!safeReMatcher.hasMatch() || !jdkMatcher.hasMatch()) {
+          return false;
+        }
+        assertMatchState("appendReplacement captures");
+        return hasWaivedCapture();
+      }
+      // replaceAll/replaceFirst reset to the full input, retaining bounds settings.
+      // Check their match sequence on independent matchers before executing the actual
+      // replacement APIs. Do not invoke a functional replacer during this check.
+      MatcherPair probe =
+          new MatcherPair(
+              regex,
+              flags,
+              input,
+              safeReMatcher.pattern().matcher(input),
+              jdkMatcher.pattern().matcher(interruptible(input)));
+      probe.safeReMatcher.useAnchoringBounds(safeReMatcher.hasAnchoringBounds());
+      probe.safeReMatcher.useTransparentBounds(safeReMatcher.hasTransparentBounds());
+      probe.jdkMatcher.useAnchoringBounds(jdkMatcher.hasAnchoringBounds());
+      probe.jdkMatcher.useTransparentBounds(jdkMatcher.hasTransparentBounds());
+      boolean waived = false;
+      while (probe.find()) {
+        waived |= probe.hasWaivedCapture();
+        if (operation.equals("replaceFirst")) {
+          break;
+        }
+      }
+      // An incomplete oracle trace is not evidence for waiving output comparison.
+      return probe.jdkOracleAvailable && waived;
     }
 
     private AssertionError divergence(

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupport.java
@@ -41,6 +41,15 @@ final class FuzzSupport {
     org.safere.Pattern.UNICODE_CHARACTER_CLASS
   };
 
+  private static final java.util.regex.Pattern FAILED_PATH_CAPTURE_LEAKAGE_PATTERN =
+      java.util.regex.Pattern.compile(
+          "\\([^)]*\\)[^)]*(?:\\{\\d+[,}]|[*+?]).*(?:\\{\\d+[,}]|[*+?])|"
+              + "\\([^)]*\\)[^)]*(?:[*+?]|\\{\\d+[,}]).*\\$");
+
+  static boolean isFailedPathCaptureLeakagePattern(String regex) {
+    return regex != null && FAILED_PATH_CAPTURE_LEAKAGE_PATTERN.matcher(regex).find();
+  }
+
   private FuzzSupport() {}
 
   static CompiledPattern compileCompatibleOrSkip(String regex, int flags) {
@@ -330,14 +339,18 @@ final class FuzzSupport {
     String group(int group) {
       String safeRe = safeReMatcher.group(group);
       String jdk = runJdkOracle("group(" + group + ")", safeRe, () -> jdkMatcher.group(group));
-      assertSame("group(" + group + ")", safeRe, jdk);
+      if (!isFailedPathCaptureLeakage(group, safeRe, jdk)) {
+        assertSame("group(" + group + ")", safeRe, jdk);
+      }
       return safeRe;
     }
 
     String group(String name) {
       String safeRe = safeReMatcher.group(name);
       String jdk = runJdkOracle("group(" + name + ")", safeRe, () -> jdkMatcher.group(name));
-      assertSame("group(" + name + ")", safeRe, jdk);
+      if (!isFailedPathCaptureLeakage(name, safeRe, jdk)) {
+        assertSame("group(" + name + ")", safeRe, jdk);
+      }
       return safeRe;
     }
 
@@ -351,14 +364,18 @@ final class FuzzSupport {
     int start(int group) {
       int safeRe = safeReMatcher.start(group);
       int jdk = runJdkOracle("start(" + group + ")", safeRe, () -> jdkMatcher.start(group));
-      assertSame("start(" + group + ")", safeRe, jdk);
+      if (!isFailedPathCaptureLeakage(group, safeReMatcher.group(group), jdkMatcher.group(group))) {
+        assertSame("start(" + group + ")", safeRe, jdk);
+      }
       return safeRe;
     }
 
     int start(String name) {
       int safeRe = safeReMatcher.start(name);
       int jdk = runJdkOracle("start(" + name + ")", safeRe, () -> jdkMatcher.start(name));
-      assertSame("start(" + name + ")", safeRe, jdk);
+      if (!isFailedPathCaptureLeakage(name, safeReMatcher.group(name), jdkMatcher.group(name))) {
+        assertSame("start(" + name + ")", safeRe, jdk);
+      }
       return safeRe;
     }
 
@@ -372,15 +389,53 @@ final class FuzzSupport {
     int end(int group) {
       int safeRe = safeReMatcher.end(group);
       int jdk = runJdkOracle("end(" + group + ")", safeRe, () -> jdkMatcher.end(group));
-      assertSame("end(" + group + ")", safeRe, jdk);
+      if (!isFailedPathCaptureLeakage(group, safeReMatcher.group(group), jdkMatcher.group(group))) {
+        assertSame("end(" + group + ")", safeRe, jdk);
+      }
       return safeRe;
     }
 
     int end(String name) {
       int safeRe = safeReMatcher.end(name);
       int jdk = runJdkOracle("end(" + name + ")", safeRe, () -> jdkMatcher.end(name));
-      assertSame("end(" + name + ")", safeRe, jdk);
+      if (!isFailedPathCaptureLeakage(name, safeReMatcher.group(name), jdkMatcher.group(name))) {
+        assertSame("end(" + name + ")", safeRe, jdk);
+      }
       return safeRe;
+    }
+
+    private boolean isFailedPathCaptureLeakage(int group, Object safeRe, Object jdk) {
+      if (group <= 0 || !jdkOracleAvailable) {
+        return false;
+      }
+      boolean safeReEmpty = safeRe == null || (safeRe instanceof Integer i && i == -1);
+      boolean jdkMatched = jdk != null && (!(jdk instanceof Integer i) || i != -1);
+      if (!safeReEmpty || !jdkMatched) {
+        return false;
+      }
+      int matchStart = safeReMatcher.start();
+      int jdkGroupStart = runJdkOracle("start(" + group + ")", -1, () -> jdkMatcher.start(group));
+      if (jdkGroupStart != -1 && jdkGroupStart < matchStart) {
+        return true;
+      }
+      return isFailedPathCaptureLeakagePattern(regex);
+    }
+
+    private boolean isFailedPathCaptureLeakage(String name, Object safeRe, Object jdk) {
+      if (name == null || !jdkOracleAvailable) {
+        return false;
+      }
+      boolean safeReEmpty = safeRe == null || (safeRe instanceof Integer i && i == -1);
+      boolean jdkMatched = jdk != null && (!(jdk instanceof Integer i) || i != -1);
+      if (!safeReEmpty || !jdkMatched) {
+        return false;
+      }
+      int matchStart = safeReMatcher.start();
+      int jdkGroupStart = runJdkOracle("start(" + name + ")", -1, () -> jdkMatcher.start(name));
+      if (jdkGroupStart != -1 && jdkGroupStart < matchStart) {
+        return true;
+      }
+      return isFailedPathCaptureLeakagePattern(regex);
     }
 
     MatcherPair region(int start, int end) {
@@ -469,7 +524,7 @@ final class FuzzSupport {
               safeRe,
               () -> {
                 try {
-                  jdkMatcher.start();
+                  var unused = jdkMatcher.start();
                   return true;
                 } catch (IllegalStateException e) {
                   return false;
@@ -587,10 +642,26 @@ final class FuzzSupport {
       int groupCount = safeRe.groupCount();
       assertSame(operation + ".groupCount", groupCount, jdk.groupCount());
       for (int i = 0; i <= groupCount; i++) {
+        if (isFailedPathCaptureLeakage(safeRe, jdk, i)) {
+          continue;
+        }
         assertSame(operation + ".group(" + i + ")", safeRe.group(i), jdk.group(i));
         assertSame(operation + ".start(" + i + ")", safeRe.start(i), jdk.start(i));
         assertSame(operation + ".end(" + i + ")", safeRe.end(i), jdk.end(i));
       }
+    }
+
+    private boolean isFailedPathCaptureLeakage(MatchResult safeRe, MatchResult jdk, int group) {
+      if (group <= 0) {
+        return false;
+      }
+      if (safeRe.group(group) == null && jdk.group(group) != null) {
+        if (jdk.start(group) != -1 && jdk.start(group) < safeRe.start()) {
+          return true;
+        }
+        return isFailedPathCaptureLeakagePattern(regex);
+      }
+      return false;
     }
 
     private boolean assertSameReplacementOutcome(
@@ -607,6 +678,10 @@ final class FuzzSupport {
         return false;
       }
       if (safeRe.throwable() == null && jdk.throwable() == null) {
+        if (!Objects.equals(safeRe.value(), jdk.value())
+            && isFailedPathCaptureLeakagePattern(regex)) {
+          return true;
+        }
         assertSame(operation, replacement, safeRe.value(), jdk.value());
         return true;
       }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupportCaptureWaiverTest.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FuzzSupportCaptureWaiverTest.java
@@ -1,0 +1,151 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere.fuzz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class FuzzSupportCaptureWaiverTest {
+  @Test
+  void captureBeforeAcceptedStartIsWaivedAcrossAccessors() {
+    for (String regex : new String[] {"(?:(a){1})*$", "(?:(?<item>a){2})*$"}) {
+      var pair = FuzzSupport.compileOrSkip(regex, 0).matcher("aab");
+      assertThat(pair.find()).isTrue();
+      assertThat(pair.group(1)).isNull();
+      assertThat(pair.start(1)).isEqualTo(-1);
+      assertThat(pair.end(1)).isEqualTo(-1);
+      pair.toMatchResult();
+      if (regex.contains("?<item>")) {
+        assertThat(pair.group("item")).isNull();
+        assertThat(pair.start("item")).isEqualTo(-1);
+        assertThat(pair.end("item")).isEqualTo(-1);
+      }
+      pair.reset();
+      assertThat(pair.find()).isTrue();
+    }
+  }
+
+  @Test
+  void sameStartLeakageInQuantifiedCaptureIsWaived() {
+    var pair = FuzzSupport.compileOrSkip("(?:(?:())*{0}{1}?{1}|a).", 0).matcher("ab");
+    assertThat(pair.matches()).isTrue();
+    assertThat(pair.group(1)).isNull();
+    pair.toMatchResult();
+  }
+
+  @Test
+  void missingUnquantifiedCaptureIsReported() {
+    // Deliberately substitute a matcher with the wrong capture to simulate an engine defect.
+    var pair =
+        new FuzzSupport.MatcherPair(
+            "(a)b$",
+            0,
+            "ab",
+            org.safere.Pattern.compile("(?:()z|ab)$").matcher("ab"),
+            java.util.regex.Pattern.compile("(a)b$").matcher("ab"));
+    assertThatThrownBy(pair::matches).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void leakageWaivesReplacementOutput() {
+    var pair = FuzzSupport.compileOrSkip("(?:(a){1})*$", 0).matcher("ab");
+    assertThat(pair.replaceAll("$1")).isTrue();
+  }
+
+  @Test
+  void unrelatedReplacementDifferencesAreReported() {
+    var pair =
+        new FuzzSupport.MatcherPair(
+            "(a)?b$",
+            0,
+            "ab",
+            org.safere.Pattern.compile("b$").matcher("ab"),
+            java.util.regex.Pattern.compile("(a)?b$").matcher("ab"));
+    assertThatThrownBy(() -> pair.replaceAll("constant")).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void ancestryComesFromParsedSyntax() {
+    var groups =
+        org.safere.FuzzCaptureStructure.quantifiedGroups(
+            org.safere.Pattern.compile("(a*)(b)?(?:(?<item>c))+"));
+    assertThat(groups.get(1)).isFalse();
+    assertThat(groups.get(2)).isTrue();
+    assertThat(groups.get(3)).isTrue();
+    assertThat(
+            org.safere.FuzzCaptureStructure.quantifiedGroups(
+                    org.safere.Pattern.compile("(a)?", org.safere.Pattern.LITERAL))
+                .isEmpty())
+        .isTrue();
+    assertThat(
+            org.safere.FuzzCaptureStructure.quantifiedGroups(
+                    org.safere.Pattern.compile("(?x)(a) # ? * + {2}\n"))
+                .isEmpty())
+        .isTrue();
+  }
+
+  @Test
+  void missingQuantifiedCaptureIsAnIntentionalBlindSpot() {
+    var pair =
+        new FuzzSupport.MatcherPair(
+            "(a)?b$",
+            0,
+            "ab",
+            org.safere.Pattern.compile("()??ab$").matcher("ab"),
+            java.util.regex.Pattern.compile("(a)?b$").matcher("ab"));
+    assertThat(pair.matches()).isTrue();
+    pair.toMatchResult();
+  }
+
+  @Test
+  void differingParticipatingQuantifiedCapturesAreReported() {
+    var pair =
+        new FuzzSupport.MatcherPair(
+            "(a)?b$",
+            0,
+            "ab",
+            org.safere.Pattern.compile("a(b)?$").matcher("ab"),
+            java.util.regex.Pattern.compile("(a)?b$").matcher("ab"));
+    assertThatThrownBy(pair::matches).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void replacementWaiverHandlesEachApiAndDoesNotSurviveReset() {
+    String regex = "(?:(?<item>a){1})*$";
+    assertThat(FuzzSupport.compileOrSkip(regex, 0).matcher("ab").replaceFirst("${item}")).isTrue();
+    assertThat(
+            FuzzSupport.compileOrSkip(regex, 0)
+                .matcher("ab")
+                .replaceAll(result -> result.group(1) == null ? "empty" : "captured"))
+        .isTrue();
+    var pair = FuzzSupport.compileOrSkip(regex, 0).matcher("ab");
+    assertThat(pair.find()).isTrue();
+    StringBuilder builder = new StringBuilder();
+    assertThat(pair.appendReplacement(builder, "${item}")).isTrue();
+    pair.appendTail(builder);
+    assertThat(builder.toString()).isEqualTo("ab");
+    pair.reset();
+    assertThat(pair.find()).isTrue();
+    StringBuffer buffer = new StringBuffer();
+    assertThat(pair.appendReplacement(buffer, "${item}")).isTrue();
+    pair.appendTail(buffer);
+    assertThat(buffer.toString()).isEqualTo("ab");
+    pair.reset("aa");
+    assertThat(pair.replaceAll("${item}")).isTrue();
+  }
+
+  @Test
+  void namedSameStartCaptureIsWaivedButSafeReExpectedStateIsChecked() {
+    var pair = FuzzSupport.compileOrSkip("(?:(?:(?<item>))*{0}{1}?{1}|a).", 0).matcher("ab");
+    assertThat(pair.matches()).isTrue();
+    assertThat(pair.group("item")).isNull();
+    assertThat(pair.start("item")).isEqualTo(-1);
+    assertThat(pair.end("item")).isEqualTo(-1);
+    pair.toMatchResult();
+  }
+}

--- a/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/MatchFuzzer.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import org.safere.Pattern;
 
-final class MatchFuzzer {
+public final class MatchFuzzer {
   private static final int CI = Pattern.CASE_INSENSITIVE;
   private static final int CI_U = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
   private static final int CI_UCC = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS;
@@ -41,6 +41,10 @@ final class MatchFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void match(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     for (RegressionCase regression : CASE_FOLDING_REGRESSIONS) {
       FuzzSupport.assertFullMatchesJdk(regression.regex(), regression.flags(), regression.inputs());
     }

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserCompatibilityFuzzer.java
@@ -10,7 +10,7 @@ import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 import org.safere.Pattern;
 
-final class ParserCompatibilityFuzzer {
+public final class ParserCompatibilityFuzzer {
 
   private static final String[] ATOMS = {
     "",
@@ -144,6 +144,10 @@ final class ParserCompatibilityFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void parserCompatibility(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     int flags = FuzzSupport.consumeParserFlags(data);
     String regex;
     if (data.consumeBoolean()) {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ParserStackSafetyFuzzer.java
@@ -9,12 +9,16 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 
-final class ParserStackSafetyFuzzer {
+public final class ParserStackSafetyFuzzer {
 
   private static final List<String> INPUTS = List.of("", "a", "b");
 
   @FuzzTest(maxDuration = "30s")
   void parserStackSafety(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     for (int depth : List.of(1, 8, 64, 512)) {
       FuzzSupport.assertFullMatchesJdk(nestedCharacterClass(depth), 0, INPUTS);
       FuzzSupport.assertFullMatchesJdk(nestedGroups(depth), 0, INPUTS);

--- a/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/RegionBoundsFuzzer.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.safere.Matcher;
 import org.safere.Pattern;
 
-final class RegionBoundsFuzzer {
+public final class RegionBoundsFuzzer {
   private record GraphemeRegion(String input, int start, int end) {}
 
   private record SafeReModelCase(
@@ -58,6 +58,10 @@ final class RegionBoundsFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void regionBounds(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     compareGraphemeRegions();
 
     String regex = data.consumeString(256);

--- a/safere-fuzz/src/test/java/org/safere/fuzz/ReplacementFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/ReplacementFuzzer.java
@@ -9,10 +9,14 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 
-final class ReplacementFuzzer {
+public final class ReplacementFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void replacement(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String regex;
     int flags;
     String input;

--- a/safere-fuzz/src/test/java/org/safere/fuzz/SplitFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/SplitFuzzer.java
@@ -9,7 +9,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 
-final class SplitFuzzer {
+public final class SplitFuzzer {
   private static final List<String> GRAPHEME_CRLF_DELIMITERS =
       List.of("\\r\\b{g}\\n", "(?:\\r)\\b{g}\\n", "\\r(?:\\b{g})\\n");
   private static final List<String> ADJACENT_CRLF_INPUTS =
@@ -20,6 +20,10 @@ final class SplitFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void split(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String regex = data.consumeString(256);
     int flags = FuzzSupport.consumeFlags(data);
     String input = data.consumeString(2048);

--- a/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/UnicodeFuzzer.java
@@ -9,7 +9,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import java.util.List;
 
-final class UnicodeFuzzer {
+public final class UnicodeFuzzer {
 
   private static final List<String> GRAPHEME_CLUSTER_REGEXES =
       List.of(
@@ -58,6 +58,10 @@ final class UnicodeFuzzer {
 
   @FuzzTest(maxDuration = "30s")
   void unicode(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     for (String regex : GRAPHEME_CLUSTER_REGEXES) {
       FuzzSupport.CompiledPattern graphemePattern = FuzzSupport.compileOrSkip(regex, 0);
       for (String input : GRAPHEME_CLUSTER_INPUTS) {

--- a/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/Utf8InputFuzzer.java
@@ -20,11 +20,15 @@ import org.safere.Utf8Input;
 import org.safere.Utf8Matcher;
 
 /** Exercises arbitrary UTF-8 storage, windows, and repeated matcher transitions. */
-final class Utf8InputFuzzer {
+public final class Utf8InputFuzzer {
   private record RegionCaptureCase(String regex, String input, int start, int end) {}
 
   @FuzzTest(maxDuration = "30s")
   void arbitraryWindow(FuzzedDataProvider data) {
+    fuzzerTestOneInput(data);
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     assertLiteralSearchMatchesString("XXXXXX", "..XXXXXX");
     assertLiteralSearchMatchesString(data.consumeBoolean() ? "^XXXXXX" : "\\AXXXXXX", "..XXXXXX");
     assertStartAnchoredAccelerationMatchesJdk(data);


### PR DESCRIPTION
The goal of this change is to allow running the SafeRE fuzzers with Bazel (or Blaze).

This addes `public static fuzzerTestOneInput` entry points to the fuzzer classes and makes them final, allowing direct invocation from standalone Jazzer and Bazel, while preserving the current JUnit 5 `@FuzzTest` integration with Maven Surefire.

Also, this filters documented JDK failed-path capture leakage (#52) in `FuzzSupport` to prevent false-positive differential assertion failures during continuous random fuzzing.