### PR TITLE
Preserve find continuation after failed anchored matches

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -13,6 +13,31 @@ import org.junit.jupiter.api.Test;
 final class FindSequenceFuzzer {
 
   @Test
+  void anchoredFailureAfterSuccessfulMatchRegression() {
+    assertAnchoredContinuation("a", "a a", false, false);
+    assertAnchoredContinuation("a*", "a!", true, false);
+    assertAnchoredContinuation("a", "ba a", false, true);
+    assertAnchoredContinuation("a*", "!a", false, false);
+  }
+
+  private static void assertAnchoredContinuation(
+      String regex, String input, boolean initialLookingAt, boolean attemptLookingAt) {
+    FuzzSupport.MatcherPair matcher = FuzzSupport.compileOrSkip(regex, 0).matcher(input);
+    if (initialLookingAt) {
+      matcher.lookingAt();
+    } else {
+      matcher.find();
+    }
+    if (attemptLookingAt) {
+      matcher.lookingAt();
+    } else {
+      matcher.matches();
+    }
+    matcher.find();
+    matcher.find();
+  }
+
+  @Test
   void delimitedPrefixBeforeRequiredSuffixRegression() {
     FuzzSupport.CompiledPattern pattern =
         FuzzSupport.compileOrSkip("[^{']*(?:'[^']*'[^{']*)*\\{([^}]*)\\}", 0);
@@ -44,7 +69,7 @@ final class FindSequenceFuzzer {
     int flags;
     String input;
     boolean splitSurrogateFindStart = false;
-    switch (data.consumeInt(0, 7)) {
+    switch (data.consumeInt(0, 8)) {
       case 0 -> {
         regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
         flags = 0;
@@ -89,6 +114,15 @@ final class FindSequenceFuzzer {
         flags = 0;
         input = "😀b" + data.consumeString(16) + "😀b";
         splitSurrogateFindStart = true;
+      }
+      case 8 -> {
+        String atom = data.pickValue(List.of("a", "😀", "[ab]", "(a|b)"));
+        String anchor = data.consumeBoolean() ? "^" : "";
+        regex = anchor + atom + data.pickValue(List.of("", "*", "+", "{1,3}"));
+        flags = 0;
+        String prefix = data.consumeBoolean() ? "!" : "";
+        input = prefix + "a😀b".repeat(data.consumeInt(1, 200)) + "!";
+        assertAnchoredContinuation(regex, input, data.consumeBoolean(), data.consumeBoolean());
       }
       default -> throw new AssertionError();
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -125,6 +125,8 @@ public final class Matcher implements MatchResult {
   private boolean hasMatch;
   private ResultStatus resultStatus = ResultStatus.RESET_NO_ATTEMPT;
   private int searchFrom;
+  // Retained across failed attempts; unlike searchFrom, excludes empty-match advancement.
+  private int previousMatchEnd;
   private int appendPos;
   private boolean transparentBounds;
   private boolean anchoringBounds = true;
@@ -462,10 +464,28 @@ public final class Matcher implements MatchResult {
 
   private void resetSearchStateForInputStart() {
     searchFrom = 0;
+    previousMatchEnd = 0;
   }
 
   private void resetSearchStateForRegionStart() {
     searchFrom = regionStart;
+    previousMatchEnd = regionStart;
+  }
+
+  private void rememberPreviousMatchEnd() {
+    if (hasMatch) {
+      if (!groupZeroResolved) {
+        resolveCaptures();
+      }
+      previousMatchEnd = groups[1];
+    }
+  }
+
+  private void prepareAnchoredAttempt() {
+    rememberPreviousMatchEnd();
+    findExhaustedAfterTerminalEmptyMatch = false;
+    // An anchored failure invalidates the result, but does not reset find's continuation.
+    searchFrom = previousMatchEnd;
   }
 
   private void resetStateForCurrentInput() {
@@ -903,8 +923,7 @@ public final class Matcher implements MatchResult {
 
   private boolean matchesImpl() {
     modCount++;
-    findExhaustedAfterTerminalEmptyMatch = false;
-    searchFrom = regionStart;
+    prepareAnchoredAttempt();
 
     if (cannotMatchLength(regionEnd - regionStart)) {
       return applyFailedMatchResult();
@@ -1152,8 +1171,7 @@ public final class Matcher implements MatchResult {
 
   private boolean lookingAtImpl() {
     modCount++;
-    findExhaustedAfterTerminalEmptyMatch = false;
-    searchFrom = regionStart;
+    prepareAnchoredAttempt();
 
     if (cannotMatchLength(regionEnd - regionStart)) {
       return applyFailedMatchResult();
@@ -1283,6 +1301,7 @@ public final class Matcher implements MatchResult {
 
   private boolean findImpl() {
     modCount++;
+    rememberPreviousMatchEnd();
     if (findExhaustedAfterTerminalEmptyMatch) {
       applyFailedMatchResult();
       return false;
@@ -4850,9 +4869,6 @@ public final class Matcher implements MatchResult {
     }
 
     private boolean matchLiteral(Matcher matcher, boolean fullMatch) {
-      if (isStartAnchored && matcher.searchFrom > 0) {
-        return matcher.applyFailedMatchResult();
-      }
       if (foldCase && matcher.text == null) {
         return fullMatch ? fallback.matches(matcher) : fallback.lookingAt(matcher);
       }
@@ -4941,9 +4957,6 @@ public final class Matcher implements MatchResult {
     }
 
     private boolean matchSingleCharClass(Matcher matcher, boolean fullMatch) {
-      if (isStartAnchored && matcher.searchFrom > 0) {
-        return matcher.applyFailedMatchResult();
-      }
       matcher.capturesResolved = true;
       if (charClassMatch != null && fullMatch && matcher.text != null) {
         matcher.diagnosticBoundary(MatchStrategy.CHARACTER_CLASS);

--- a/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
+++ b/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
@@ -20,6 +20,71 @@ import org.junit.jupiter.api.Test;
 class MatcherStateMachineTraceTest {
 
   @Test
+  @DisplayName("anchored attempts preserve find continuation after earlier matches")
+  void anchoredAttemptsPreserveFindContinuation() {
+    // Covers issue #808, including empty matches and repeated failed attempts.
+    for (String regex : List.of("a", "(a+)", "a*", "(a|b)+", "😀*", "^a", "^[ab]")) {
+      for (String input : List.of("a a", "ba a", "a!", "!a", "😀!😀", "a")) {
+        for (Step initial : List.of(Step.find(), Step.lookingAt())) {
+          for (Step attempt : List.of(Step.matches(), Step.lookingAt())) {
+            for (boolean region : List.of(false, true)) {
+              String text = region ? "xx" + input + "yy" : input;
+              assertTrace(
+                  regex,
+                  text,
+                  Step.region(region ? 2 : 0, region ? input.length() + 2 : input.length()),
+                  initial,
+                  attempt,
+                  Step.start(),
+                  attempt,
+                  Step.findWithBounds(),
+                  Step.findWithBounds(),
+                  Step.reset(),
+                  Step.find(),
+                  Step.start());
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("interleaved match attempts retain continuation through exhaustion and resets")
+  void interleavedAttemptsRetainContinuation() {
+    List<Step> operations = List.of(Step.findWithBounds(), Step.matches(), Step.lookingAt());
+    for (String regex : List.of("a", "a*", "(a|b)+", "^a", "^[ab]", "😀*")) {
+      for (String input : List.of("", "a", "a a", "!a", "😀!😀", "ba".repeat(300))) {
+        for (Step first : operations) {
+          for (Step second : operations) {
+            for (Step third : operations) {
+              for (Step fourth : operations) {
+                assertTrace(
+                    regex,
+                    input,
+                    first,
+                    second,
+                    third,
+                    fourth,
+                    Step.findWithBounds(),
+                    Step.usePattern("a*"),
+                    Step.matches(),
+                    Step.findWithBounds(),
+                    Step.region(0, input.length()),
+                    Step.matches(),
+                    Step.findWithBounds(),
+                    Step.findFrom(input.length()),
+                    Step.matches(),
+                    Step.findWithBounds());
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   @DisplayName("failed matches() leaves the next find() sequence JDK-compatible")
   void failedMatchesLeavesNextFindSequenceJdkCompatible() {
     assertTrace(
@@ -536,6 +601,12 @@ class MatcherStateMachineTraceTest {
       return value("find", subject -> subject.find());
     }
 
+    static Step findWithBounds() {
+      return value(
+          "findWithBounds",
+          subject -> subject.find() ? subject.start() + ":" + subject.end() : "false");
+    }
+
     static Step findFrom(int start) {
       return value("find(" + start + ")", subject -> subject.find(start));
     }
@@ -564,7 +635,6 @@ class MatcherStateMachineTraceTest {
       return value("end(" + group + ")", subject -> subject.end(group));
     }
 
-    @SuppressWarnings("UnusedMethod")
     static Step reset() {
       return effect("reset", TraceSubject::reset);
     }

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -465,6 +465,50 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("failed anchored attempts preserve the end of an earlier successful find")
+    void failedAnchoredAttemptsPreservePreviousFindEnd() {
+      // JDK 26 Matcher.find(): an intervening failed attempt does not reset the matcher.
+      for (boolean lookingAt : new boolean[] {false, true}) {
+        Matcher matcher = Pattern.compile("a").matcher("ba a");
+        assertThat(matcher.find()).isTrue();
+        assertThat(matcher.start()).isEqualTo(1);
+        assertThat(lookingAt ? matcher.lookingAt() : matcher.matches()).isFalse();
+        assertThatThrownBy(matcher::start).isInstanceOf(IllegalStateException.class);
+        assertThat(matcher.find()).isTrue();
+        assertThat(matcher.start()).isEqualTo(3);
+        assertThat(matcher.end()).isEqualTo(4);
+        assertThat(matcher.find()).isFalse();
+      }
+    }
+
+    @Test
+    @DisplayName("failed matches preserves find continuation after lookingAt")
+    void failedMatchesPreservesLookingAtEnd() {
+      Matcher matcher = Pattern.compile("a*").matcher("a!");
+      assertThat(matcher.lookingAt()).isTrue();
+      assertThat(matcher.matches()).isFalse();
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.start()).isEqualTo(1);
+      assertThat(matcher.end()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("failed anchored attempts cancel advancement past an earlier empty match")
+    void failedAnchoredAttemptsPreserveEmptyMatchEnd() {
+      Matcher matcher = Pattern.compile("a*").matcher("!a");
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.start()).isZero();
+      assertThat(matcher.end()).isZero();
+      assertThat(matcher.matches()).isFalse();
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.start()).isZero();
+      assertThat(matcher.end()).isZero();
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.start()).isEqualTo(1);
+      assertThat(matcher.end()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("find() at end of input returns false")
     void findAtEnd() {
       Pattern p = Pattern.compile("\\d+");


### PR DESCRIPTION
Failed `matches()` and `lookingAt()` attempts reset the search cursor and cause a subsequent `find()` to repeat an earlier match. For example, `find(); matches(); find()` with `a` on `a a` returns the match at 0 twice instead of advancing to 2.

Retain the previous successful match end independently of current result validity and empty-match advancement. Keep search-cursor checks in `find()` rather than anchored matching helpers. Add systematic lifecycle tests, direct public API regressions, and a fuzz generator axis covering interleaved attempts, empty matches, captures, Unicode, anchors, regions, exhaustion, and resets. The change adds constant-size bookkeeping and no search retry loop.

Fixes #808.

Verification passed on JDK 26.0.2:

- `mvn -pl safere -Dtest=MatcherStateMachineTraceTest test -q` (new regression failed before the fix and passed afterward).
- `mvn -pl safere test -q` (full SafeRE suite).
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q` (regression mode).
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests '-Dtest=*Test,!CrossEngineExhaustiveTest*' -q` (including the new direct regressions; the already-passed exhaustive suite was excluded from this repeat).
- `git diff --check`.
- Independent read-only review of the complete branch/worktree diff: no findings.

No live fuzzing campaign, benchmarks, or tests on other JDK versions were run.
