### PR TITLE
Fix Unicode word-boundary DFA transition classes

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -32,6 +32,14 @@ final class FindSequenceFuzzer {
   }
 
   @Test
+  void unicodeBoundaryTransitionClassesRegression() {
+    for (String word : List.of("α", "中", "\u0301", "\u0660", "\u200c")) {
+      assertFindSequence("(?U).\\B", " " + word + "`\u180e");
+      assertFindSequence("(?U)\\b.", "x".repeat(300) + " " + word + "`\u180e");
+    }
+  }
+
+  @Test
   void leadingExpansionDoesNotCrossSplitSurrogateFindStart() {
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip("[\\x{1F600}]+b", 0);
 
@@ -44,7 +52,7 @@ final class FindSequenceFuzzer {
     int flags;
     String input;
     boolean splitSurrogateFindStart = false;
-    switch (data.consumeInt(0, 7)) {
+    switch (data.consumeInt(0, 8)) {
       case 0 -> {
         regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
         flags = 0;
@@ -89,6 +97,15 @@ final class FindSequenceFuzzer {
         flags = 0;
         input = "😀b" + data.consumeString(16) + "😀b";
         splitSurrogateFindStart = true;
+      }
+      case 8 -> {
+        String boundary = data.pickValue(List.of("\\b", "\\B"));
+        String atom = data.pickValue(List.of(".", "(.)", "[\\s\\S]"));
+        regex = "(?U)" + (data.consumeBoolean() ? atom + boundary : boundary + atom);
+        flags = 0;
+        String word = data.pickValue(List.of("α", "中", "\u0301", "\u0660", "\u200c"));
+        String nonWord = data.pickValue(List.of("`", "\u180e", "!"));
+        input = "x".repeat(data.consumeInt(0, 512)) + " " + word + nonWord + nonWord;
       }
       default -> throw new AssertionError();
     }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -175,8 +175,13 @@ final class Dfa {
   /** Sorted code point boundaries defining equivalence classes. */
   private final int[] boundaries;
 
-  /** Total number of equivalence classes (intervals between boundaries + 1 for end-of-text). */
+  /**
+   * Total transition classes, including any Unicode word split and a separate end-of-text class.
+   */
   private final int numClasses;
+
+  /** Whether each interval is split by Unicode word-character membership. */
+  private final boolean splitUnicodeWordClasses;
 
   /**
    * Fast ASCII-to-class lookup table. For code points 0–127, {@code asciiClassMap[cp]} gives the
@@ -253,7 +258,8 @@ final class Dfa {
    */
   // TODO(#98): Replace int[] with Guava ImmutableIntArray to get proper value semantics.
   @SuppressWarnings("ArrayRecordComponent")
-  record Setup(int[] boundaries, int numClasses, int[] asciiClassMap) {}
+  record Setup(
+      int[] boundaries, int numClasses, int[] asciiClassMap, boolean splitUnicodeWordClasses) {}
 
   /**
    * Builds a reusable {@link Setup} from a compiled program. The result is immutable and can be
@@ -261,9 +267,27 @@ final class Dfa {
    */
   static Setup buildSetup(Prog prog) {
     int[] boundaries = buildBoundaries(prog);
-    int numClasses = boundaries.length + 1 + 1; // intervals + end-of-text
+    boolean splitUnicodeWordClasses = false;
+    for (int i = 0; i < prog.size(); i++) {
+      Inst inst = prog.inst(i);
+      if (inst.opCode == InstOp.OP_EMPTY_WIDTH
+          && (inst.arg & (EmptyOp.UNICODE_WORD_BOUNDARY | EmptyOp.UNICODE_NON_WORD_BOUNDARY))
+              != 0) {
+        splitUnicodeWordClasses = true;
+        break;
+      }
+    }
+    // Unicode word membership is a separate discriminator, avoiding a transition column for
+    // every Unicode word range. Each original interval needs at most two columns, and EOF
+    // retains its own column. Classification must agree with computeNext's word predicate.
+    int numClasses = (boundaries.length + 1) * (splitUnicodeWordClasses ? 2 : 1) + 1;
     int[] asciiClassMap = buildAsciiClassMap(boundaries);
-    return new Setup(boundaries, numClasses, asciiClassMap);
+    if (splitUnicodeWordClasses) {
+      for (int cp = 0; cp < asciiClassMap.length; cp++) {
+        asciiClassMap[cp] = asciiClassMap[cp] * 2 + (Nfa.isWordChar(cp) ? 1 : 0);
+      }
+    }
+    return new Setup(boundaries, numClasses, asciiClassMap, splitUnicodeWordClasses);
   }
 
   Dfa(Prog prog, int maxStates, Setup setup, boolean longest) {
@@ -299,6 +323,7 @@ final class Dfa {
     this.startStateByContext = new State[anchoredCacheBit << 1];
     this.boundaries = setup.boundaries;
     this.numClasses = setup.numClasses;
+    this.splitUnicodeWordClasses = setup.splitUnicodeWordClasses;
     this.asciiClassMap = setup.asciiClassMap;
     Arrays.fill(this.cacheCps, -1);
     this.expandVisitedGen = new int[prog.size()];
@@ -341,13 +366,14 @@ final class Dfa {
   /**
    * Collects all code point range boundaries from the program's CHAR_RANGE instructions. The
    * boundaries define equivalence classes: code points within the same interval between consecutive
-   * boundaries are indistinguishable to the DFA.
+   * boundaries have identical consuming-instruction behavior. Unicode word-boundary programs
+   * additionally split these intervals by word membership in {@link #buildSetup}.
    *
    * <p>When the program contains word-boundary assertions ({@code \b} or {@code \B}), additional
    * boundaries are added at the edges of the word-character ranges ({@code [A-Za-z0-9_]}) so that
-   * no equivalence class straddles the word/non-word boundary. This is necessary because the DFA
-   * caches transitions per (state, class) and the word-boundary computation depends on whether the
-   * current character is a word character.
+   * no equivalence class straddles the ASCII word/non-word boundary. This is necessary because the
+   * DFA caches transitions per (state, class) and the word-boundary computation depends on whether
+   * the current character is a word character.
    */
   private static int[] buildBoundaries(Prog prog) {
     IntArrayList bounds = new IntArrayList();
@@ -460,6 +486,9 @@ final class Dfa {
     }
     int idx = Arrays.binarySearch(boundaries, cp);
     int cls = (idx >= 0) ? idx : (-idx - 1) - 1;
+    if (splitUnicodeWordClasses) {
+      cls = cls * 2 + (Nfa.isUnicodeWordChar(cp) ? 1 : 0);
+    }
     cacheCps[cacheIdx] = cp;
     cacheClasses[cacheIdx] = cls;
     return cls;

--- a/safere/src/test/java/org/safere/UnicodeBoundaryDfaCachingTest.java
+++ b/safere/src/test/java/org/safere/UnicodeBoundaryDfaCachingTest.java
@@ -1,0 +1,85 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Regression coverage for Unicode word classification in cached DFA transitions. */
+class UnicodeBoundaryDfaCachingTest {
+  @ParameterizedTest
+  @MethodSource("cases")
+  void findSequenceMatchesJdk(String regex, String input) {
+    var expected = java.util.regex.Pattern.compile(regex).matcher(input);
+    var actual = Pattern.compile(regex).matcher(input);
+    while (expected.find()) {
+      assertThat(actual.find()).as("find for %s", regex).isTrue();
+      assertThat(actual.start()).isEqualTo(expected.start());
+      assertThat(actual.end()).isEqualTo(expected.end());
+    }
+    assertThat(actual.find()).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("cases")
+  @DisabledForCrosscheck("UTF-8 input is a SafeRE extension")
+  void utf8FindSequenceMatchesJdk(String regex, String input) {
+    var expected = java.util.regex.Pattern.compile(regex).matcher(input);
+    var actual = Pattern.compile(regex).matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+    while (expected.find()) {
+      assertThat(actual.find()).as("UTF-8 find for %s", regex).isTrue();
+      assertThat(actual.start())
+          .isEqualTo(input.substring(0, expected.start()).getBytes(UTF_8).length);
+      assertThat(actual.end()).isEqualTo(input.substring(0, expected.end()).getBytes(UTF_8).length);
+    }
+    assertThat(actual.find()).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("supplementaryCases")
+  @DisabledForCrosscheck("SafeRE intentionally prevents matching bounds inside surrogate pairs")
+  void supplementaryWordClassesPreserveScalarBounds(String regex, int[] bounds) {
+    var actual = Pattern.compile(regex).matcher(" 𐐀`\u180e");
+    for (int i = 0; i < bounds.length; i += 2) {
+      assertThat(actual.find()).isTrue();
+      assertThat(actual.start()).isEqualTo(bounds[i]);
+      assertThat(actual.end()).isEqualTo(bounds[i + 1]);
+    }
+    assertThat(actual.find()).isFalse();
+  }
+
+  static Stream<Arguments> supplementaryCases() {
+    return Stream.of(
+        Arguments.of("(?U).\\b", new int[] {0, 1, 1, 3}),
+        Arguments.of("(?U).\\B", new int[] {3, 4, 4, 5}),
+        Arguments.of("(?U)\\b.", new int[] {1, 3, 3, 4}),
+        Arguments.of("(?U)\\B.", new int[] {0, 1, 4, 5}));
+  }
+
+  static Stream<Arguments> cases() {
+    return Stream.of("α", "中", "\u0301", "\u0660", "\u200c")
+        .flatMap(
+            word ->
+                Stream.of("\\b", "\\B", "(?:(?-U:\\b)|\\B)")
+                    .flatMap(
+                        boundary ->
+                            Stream.of("", "x".repeat(300))
+                                .flatMap(
+                                    prefix ->
+                                        Stream.of(
+                                            Arguments.of(
+                                                "(?U)." + boundary,
+                                                prefix + " " + word + "`\u180e"),
+                                            Arguments.of(
+                                                "(?U)" + boundary + ".",
+                                                prefix + " " + word + "`\u180e")))));
+  }
+}


### PR DESCRIPTION
Unicode word-boundary patterns can miss matches or return incorrect match positions when non-ASCII word and non-word characters share a DFA transition class. For example, `(?U).\B` misses the match beginning at offset 2 in an input containing a space, Greek alpha, grave accent, and U+180E.

Split transition classes by Unicode word membership when the compiled program contains Unicode boundary assertions. The discriminator uses the same predicate as transition computation, preserves linear-time matching, and requires at most two consuming transition columns per existing interval rather than a column for every Unicode word range.

Add String and UTF-8 find-sequence regressions, mixed ASCII/Unicode boundary coverage, supplementary-character coverage preserving SafeRE's existing scalar-boundary behavior, and a structured fuzz-generator branch for nearby cases.

Fixes #810.

Validation passed on JDK 26.0.2:

- `mvn -pl safere test -q` (full library suite).
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q` (fuzz regression mode).
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -Dtest=UnicodeBoundaryDfaCachingTest,BoundaryMatcherTest,MultilineCrLfDfaCachingTest -Dsurefire.failIfNoSpecifiedTests=false -q` (focused public API crosschecks and formatting checks).
- `git diff --check`.
- Independent review/fix-loop pass: no findings.

The initial regression matrix exposed failures before the fix. The full library suite passed before a final Javadoc-only formatting reflow; focused verification passed afterward. Full generated public API crosschecks, sustained fuzzing, benchmarks, and other JDK versions were not run. The bounded transition-table memory increase has not been benchmarked.
