### PR TITLE
Dynamic runtime prefilter abandonment and DFA start-state re-acceleration

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1424,7 +1424,7 @@
       "shared": true
     },
     {
-      "id": "realWorldRegex.adversarialNoise.match.{size}",
+      "id": "realWorldRegex.candidateRecovery.match.{size}",
       "axes": {
         "size": [
           1000,
@@ -1433,15 +1433,16 @@
         ]
       },
       "recipe": {
-        "kind": "suffixToLength",
-        "prefixUnit": "q1234a",
-        "suffix": "q1234z",
+        "kind": "surroundToLength",
+        "prefix": "foox",
+        "unit": "a",
+        "suffix": "fo123",
         "length": "{size}"
       },
       "shared": true
     },
     {
-      "id": "realWorldRegex.adversarialNoise.noMatch.{size}",
+      "id": "realWorldRegex.candidateRecovery.noMatch.{size}",
       "axes": {
         "size": [
           1000,
@@ -1450,8 +1451,10 @@
         ]
       },
       "recipe": {
-        "kind": "repeatToLength",
-        "unit": "q1234a",
+        "kind": "surroundToLength",
+        "prefix": "foox",
+        "unit": "a",
+        "suffix": "x",
         "length": "{size}"
       },
       "shared": true
@@ -4661,13 +4664,13 @@
       }
     },
     {
-      "id": "RealWorldRegexBenchmark.runBenchmark.adversarialNoise.{matchLabel}.{size}",
+      "id": "RealWorldRegexBenchmark.runBenchmark.candidateRecovery.{matchLabel}.{size}",
       "operation": "find",
       "patterns": [
-        "q[0-9]{4}z"
+        "fo[0-9]+"
       ],
       "inputs": [
-        "realWorldRegex.adversarialNoise.{matchLabel}.{size}"
+        "realWorldRegex.candidateRecovery.{matchLabel}.{size}"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1424,6 +1424,39 @@
       "shared": true
     },
     {
+      "id": "realWorldRegex.adversarialNoise.match.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "q1234a",
+        "suffix": "q1234z",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.adversarialNoise.noMatch.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "q1234a",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
       "id": "realWorldRegex.wideFactoredApiRoute.match.{size}",
       "axes": {
         "size": [
@@ -4606,6 +4639,35 @@
       ],
       "inputs": [
         "realWorldRegex.isoTimestampLog.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "boolean",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.adversarialNoise.{matchLabel}.{size}",
+      "operation": "find",
+      "patterns": [
+        "q[0-9]{4}z"
+      ],
+      "inputs": [
+        "realWorldRegex.adversarialNoise.{matchLabel}.{size}"
       ],
       "resultConsumption": "boolean",
       "measurement": {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -248,7 +248,8 @@ final class Dfa {
 
   private int[] transitions;
   private State[] offsetToState;
-  private boolean[] isStartStateOffset;
+  private boolean[] isAcceleratedStateOffset;
+  private boolean hasStateAccelerators;
   private int nextStateId;
 
   private final Utf8StartAccelerator utf8StartAccelerator;
@@ -322,7 +323,7 @@ final class Dfa {
     this.nextStateId = 1;
     this.transitions = new int[1024];
     this.offsetToState = new State[1024];
-    this.isStartStateOffset = new boolean[1024];
+    this.isAcceleratedStateOffset = new boolean[1024];
     addStateToFlatArrays(deadState);
   }
 
@@ -332,10 +333,13 @@ final class Dfa {
       int newLen = Math.max(transitions.length * 2, minTransLen);
       transitions = Arrays.copyOf(transitions, newLen);
       offsetToState = Arrays.copyOf(offsetToState, newLen);
-      isStartStateOffset = Arrays.copyOf(isStartStateOffset, newLen);
+      isAcceleratedStateOffset = Arrays.copyOf(isAcceleratedStateOffset, newLen);
     }
     offsetToState[s.id * numClasses] = s;
-    isStartStateOffset[s.id * numClasses] = s.isStartState;
+    isAcceleratedStateOffset[s.id * numClasses] = s.isStartState || s.accelerator != null;
+    if (s.accelerator != null) {
+      hasStateAccelerators = true;
+    }
   }
 
   private void setTransition(int fromId, int cls, int toId) {
@@ -940,7 +944,7 @@ final class Dfa {
     State s = getOrCreate(insts, flags);
     if (s != null) {
       s.isStartState = true;
-      isStartStateOffset[s.id * numClasses] = true;
+      isAcceleratedStateOffset[s.id * numClasses] = true;
       startStateByContext[cacheKey] = s;
     }
     return s;
@@ -1453,7 +1457,7 @@ final class Dfa {
 
     int[] transitions = this.transitions;
     State[] offsetToState = this.offsetToState;
-    boolean[] isStartStateOffset = this.isStartStateOffset;
+    boolean[] isAcceleratedStateOffset = this.isAcceleratedStateOffset;
     int[] asciiClassMap = this.asciiClassMap;
     int pos = startPos;
     // Fast path: loop through ASCII characters (characters < 128)
@@ -1515,12 +1519,13 @@ final class Dfa {
           }
         }
       }
-      boolean breakOnStartState = canAccelerate && pos >= accelerationResumePos;
-      boolean hitStartState = false;
+      boolean breakOnAcceleratedState =
+          (canAccelerate && pos >= accelerationResumePos) || hasStateAccelerators;
+      boolean hitAcceleratedState = false;
       int limit =
           hasPositionDependentTransitions ? Math.min(textLen, posDepThreshold - 1) : textLen;
       int sId = s.id * numClasses;
-      if (breakOnStartState) {
+      if (breakOnAcceleratedState) {
         while (pos < limit) {
           int ch = text.asciiAt(pos);
           if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
@@ -1547,8 +1552,8 @@ final class Dfa {
           }
           sId = nsId;
           pos++;
-          if (isStartStateOffset[sId]) {
-            hitStartState = true;
+          if (isAcceleratedStateOffset[sId]) {
+            hitAcceleratedState = true;
             break;
           }
         }
@@ -1586,7 +1591,7 @@ final class Dfa {
       if (pos >= textLen) {
         break;
       }
-      if (hitStartState) {
+      if (hitAcceleratedState) {
         continue;
       }
       if (hasPositionDependentTransitions && pos + 1 >= posDepThreshold) {
@@ -1608,7 +1613,7 @@ final class Dfa {
         addTransition(s, cls, ns);
         transitions = this.transitions;
         offsetToState = this.offsetToState;
-        isStartStateOffset = this.isStartStateOffset;
+        isAcceleratedStateOffset = this.isAcceleratedStateOffset;
       }
       s = ns;
       if (s == deadState) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -74,6 +74,18 @@ final class Dfa {
   /** Maximum number of DFA states before bailing out to NFA. */
   private static final int DEFAULT_MAX_STATES = 10_000;
 
+  /** Initial quarantine window (in bytes/chars) when candidate density trips adaptive defeat. */
+  private static final int INITIAL_QUARANTINE_WINDOW = 2048;
+
+  /** Maximum quarantine window (in bytes/chars) under exponential backoff. */
+  private static final int MAX_QUARANTINE_WINDOW = 65536;
+
+  /** Number of candidate strikes tolerated before triggering a quarantine window. */
+  private static final int ADAPTIVE_STRIKE_LIMIT = 16;
+
+  /** Minimum candidate stride (in bytes/chars); candidates closer than this count as strikes. */
+  private static final int MIN_DENSITY_STRIDE = 64;
+
   // ---------------------------------------------------------------------------
   // State representation
   // ---------------------------------------------------------------------------
@@ -1421,18 +1433,18 @@ final class Dfa {
     AcceleratorPolicy activePolicy = startAccelerationPolicy(text, s);
     boolean canAccelerate = activePolicy != null && !anchored;
     int minSkip = AcceleratorPolicy.DEFAULT.minProfitableSkip();
-    int maxStrikes = AcceleratorPolicy.DEFAULT.strikeBudget();
-    boolean isExact = false;
     if (canAccelerate) {
       minSkip = activePolicy.minProfitableSkip();
-      maxStrikes = activePolicy.strikeBudget();
-      isExact = activePolicy.isExactMatchCandidate();
     }
 
-    // Adaptive defeat detection: track consecutive sub-threshold skips to avoid repeatedly paying
-    // accelerator setup and candidate check overhead on dense matching inputs.
-    boolean accelerationDisabled = false;
-    int consecutiveShortSkips = 0;
+    // Adaptive defeat detection: track candidate progress density to avoid repeatedly paying
+    // accelerator setup and candidate check overhead on dense non-matching inputs.
+    // When candidates occur too frequently without sufficient progress, temporarily quarantine
+    // acceleration and fall back to the linear scalar DFA with exponential backoff.
+    int candidateStrikes = 0;
+    int lastCandidatePos = startPos;
+    int accelerationResumePos = startPos;
+    int quarantineWindow = INITIAL_QUARANTINE_WINDOW;
 
     int[] transitions = this.transitions;
     State[] offsetToState = this.offsetToState;
@@ -1441,7 +1453,7 @@ final class Dfa {
     // Fast path: loop through ASCII characters (characters < 128)
     while (pos < textLen) {
       if (canAccelerate
-          && !accelerationDisabled
+          && pos >= accelerationResumePos
           && s.isStartState
           && (!startPositionPreselected || pos != startPos)
           && (textLen - pos >= minSkip)) {
@@ -1450,14 +1462,18 @@ final class Dfa {
           return new SearchResult(matched, matchEnd);
         }
         if (nextPos > pos) {
-          int skip = nextPos - pos;
-          if (!isExact) {
-            if (skip < minSkip) {
-              if (++consecutiveShortSkips >= maxStrikes) {
-                accelerationDisabled = true;
-              }
-            } else {
-              consecutiveShortSkips = 0;
+          int stride = nextPos - lastCandidatePos;
+          lastCandidatePos = nextPos;
+          if (stride < MIN_DENSITY_STRIDE) {
+            if (++candidateStrikes >= ADAPTIVE_STRIKE_LIMIT) {
+              accelerationResumePos = nextPos + quarantineWindow;
+              quarantineWindow = Math.min(quarantineWindow << 1, MAX_QUARANTINE_WINDOW);
+              candidateStrikes = ADAPTIVE_STRIKE_LIMIT >>> 1;
+            }
+          } else if (stride >= 256 && candidateStrikes > 0) {
+            candidateStrikes = Math.max(0, candidateStrikes - (stride >>> 8));
+            if (candidateStrikes == 0) {
+              quarantineWindow = INITIAL_QUARANTINE_WINDOW;
             }
           }
           pos = nextPos;
@@ -1471,9 +1487,12 @@ final class Dfa {
           if (s == deadState) {
             return new SearchResult(matched, matchEnd);
           }
-        } else if (!isExact) {
-          if (++consecutiveShortSkips >= maxStrikes) {
-            accelerationDisabled = true;
+        } else {
+          lastCandidatePos = pos;
+          if (++candidateStrikes >= ADAPTIVE_STRIKE_LIMIT) {
+            accelerationResumePos = pos + quarantineWindow;
+            quarantineWindow = Math.min(quarantineWindow << 1, MAX_QUARANTINE_WINDOW);
+            candidateStrikes = ADAPTIVE_STRIKE_LIMIT >>> 1;
           }
         }
       }
@@ -1567,7 +1586,7 @@ final class Dfa {
     // General loop handles non-ASCII, position-dependent checks, and trailing end-of-text sentinel
     while (pos <= textLen) {
       if (canAccelerate
-          && !accelerationDisabled
+          && pos >= accelerationResumePos
           && s.isStartState
           && (!startPositionPreselected || pos != startPos)
           && (textLen - pos >= minSkip)) {
@@ -1576,14 +1595,18 @@ final class Dfa {
           return new SearchResult(matched, matchEnd);
         }
         if (nextPos > pos) {
-          int skip = nextPos - pos;
-          if (!isExact) {
-            if (skip < minSkip) {
-              if (++consecutiveShortSkips >= maxStrikes) {
-                accelerationDisabled = true;
-              }
-            } else {
-              consecutiveShortSkips = 0;
+          int stride = nextPos - lastCandidatePos;
+          lastCandidatePos = nextPos;
+          if (stride < MIN_DENSITY_STRIDE) {
+            if (++candidateStrikes >= ADAPTIVE_STRIKE_LIMIT) {
+              accelerationResumePos = nextPos + quarantineWindow;
+              quarantineWindow = Math.min(quarantineWindow << 1, MAX_QUARANTINE_WINDOW);
+              candidateStrikes = ADAPTIVE_STRIKE_LIMIT >>> 1;
+            }
+          } else if (stride >= 256 && candidateStrikes > 0) {
+            candidateStrikes = Math.max(0, candidateStrikes - (stride >>> 8));
+            if (candidateStrikes == 0) {
+              quarantineWindow = INITIAL_QUARANTINE_WINDOW;
             }
           }
           pos = nextPos;
@@ -1597,9 +1620,12 @@ final class Dfa {
           if (s == deadState) {
             return new SearchResult(matched, matchEnd);
           }
-        } else if (!isExact) {
-          if (++consecutiveShortSkips >= maxStrikes) {
-            accelerationDisabled = true;
+        } else {
+          lastCandidatePos = pos;
+          if (++candidateStrikes >= ADAPTIVE_STRIKE_LIMIT) {
+            accelerationResumePos = pos + quarantineWindow;
+            quarantineWindow = Math.min(quarantineWindow << 1, MAX_QUARANTINE_WINDOW);
+            candidateStrikes = ADAPTIVE_STRIKE_LIMIT >>> 1;
           }
         }
       }

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -248,6 +248,7 @@ final class Dfa {
 
   private int[] transitions;
   private State[] offsetToState;
+  private boolean[] isStartStateOffset;
   private int nextStateId;
 
   private final Utf8StartAccelerator utf8StartAccelerator;
@@ -321,6 +322,7 @@ final class Dfa {
     this.nextStateId = 1;
     this.transitions = new int[1024];
     this.offsetToState = new State[1024];
+    this.isStartStateOffset = new boolean[1024];
     addStateToFlatArrays(deadState);
   }
 
@@ -330,8 +332,10 @@ final class Dfa {
       int newLen = Math.max(transitions.length * 2, minTransLen);
       transitions = Arrays.copyOf(transitions, newLen);
       offsetToState = Arrays.copyOf(offsetToState, newLen);
+      isStartStateOffset = Arrays.copyOf(isStartStateOffset, newLen);
     }
     offsetToState[s.id * numClasses] = s;
+    isStartStateOffset[s.id * numClasses] = s.isStartState;
   }
 
   private void setTransition(int fromId, int cls, int toId) {
@@ -936,6 +940,7 @@ final class Dfa {
     State s = getOrCreate(insts, flags);
     if (s != null) {
       s.isStartState = true;
+      isStartStateOffset[s.id * numClasses] = true;
       startStateByContext[cacheKey] = s;
     }
     return s;
@@ -1448,6 +1453,7 @@ final class Dfa {
 
     int[] transitions = this.transitions;
     State[] offsetToState = this.offsetToState;
+    boolean[] isStartStateOffset = this.isStartStateOffset;
     int[] asciiClassMap = this.asciiClassMap;
     int pos = startPos;
     // Fast path: loop through ASCII characters (characters < 128)
@@ -1509,40 +1515,79 @@ final class Dfa {
           }
         }
       }
+      boolean breakOnStartState = canAccelerate && pos >= accelerationResumePos;
+      boolean hitStartState = false;
       int limit =
           hasPositionDependentTransitions ? Math.min(textLen, posDepThreshold - 1) : textLen;
       int sId = s.id * numClasses;
-      while (pos < limit) {
-        int ch = text.asciiAt(pos);
-        if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
-          break;
-        }
-        int cls = asciiClassMap[ch];
-        int nsId = transitions[sId + cls];
-        if (nsId == 0) {
-          break;
-        }
-        if (nsId < 0) {
-          nsId = -nsId;
-          State ns = offsetToState[nsId];
-          if (ns.isMatch() && !needEndMatch) {
-            boolean useBefore =
-                (ns.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
-            int endPos = useBefore ? pos : pos + 1;
-            if (!longest && ns.isHighestPriorityMatch) {
-              return new SearchResult(true, endPos);
+      if (breakOnStartState) {
+        while (pos < limit) {
+          int ch = text.asciiAt(pos);
+          if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
+            break;
+          }
+          int cls = asciiClassMap[ch];
+          int nsId = transitions[sId + cls];
+          if (nsId == 0) {
+            break;
+          }
+          if (nsId < 0) {
+            nsId = -nsId;
+            State ns = offsetToState[nsId];
+            if (ns.isMatch() && !needEndMatch) {
+              boolean useBefore =
+                  (ns.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+              int endPos = useBefore ? pos : pos + 1;
+              if (!longest && ns.isHighestPriorityMatch) {
+                return new SearchResult(true, endPos);
+              }
+              matched = true;
+              matchEnd = endPos;
             }
-            matched = true;
-            matchEnd = endPos;
+          }
+          sId = nsId;
+          pos++;
+          if (isStartStateOffset[sId]) {
+            hitStartState = true;
+            break;
           }
         }
-        sId = nsId;
-        pos++;
+      } else {
+        while (pos < limit) {
+          int ch = text.asciiAt(pos);
+          if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
+            break;
+          }
+          int cls = asciiClassMap[ch];
+          int nsId = transitions[sId + cls];
+          if (nsId == 0) {
+            break;
+          }
+          if (nsId < 0) {
+            nsId = -nsId;
+            State ns = offsetToState[nsId];
+            if (ns.isMatch() && !needEndMatch) {
+              boolean useBefore =
+                  (ns.flags & (FLAG_MATCH_BEFORE | FLAG_MATCH_AFTER_DEFERRED)) == FLAG_MATCH_BEFORE;
+              int endPos = useBefore ? pos : pos + 1;
+              if (!longest && ns.isHighestPriorityMatch) {
+                return new SearchResult(true, endPos);
+              }
+              matched = true;
+              matchEnd = endPos;
+            }
+          }
+          sId = nsId;
+          pos++;
+        }
       }
       s = offsetToState[sId];
 
       if (pos >= textLen) {
         break;
+      }
+      if (hitStartState) {
+        continue;
       }
       if (hasPositionDependentTransitions && pos + 1 >= posDepThreshold) {
         break; // fall back to general loop for position-dependent flags
@@ -1563,6 +1608,7 @@ final class Dfa {
         addTransition(s, cls, ns);
         transitions = this.transitions;
         offsetToState = this.offsetToState;
+        isStartStateOffset = this.isStartStateOffset;
       }
       s = ns;
       if (s == deadState) {

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -1604,12 +1604,14 @@ final class Dfa {
               matchEnd = endPos;
             }
           }
-          sId = nsId;
-          pos++;
-          if (isAcceleratedStateOffset[sId]) {
+          if (nsId == sId && isAcceleratedStateOffset[sId]) {
+            sId = nsId;
+            pos++;
             hitAcceleratedState = true;
             break;
           }
+          sId = nsId;
+          pos++;
         }
       } else {
         while (pos < limit) {

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -890,4 +890,28 @@ class DfaTest {
     }
     assertThat(matchCount).isEqualTo(50);
   }
+
+  @Test
+  void dfaReacceleratesStartStateAfterFalseCandidate() {
+    Pattern pattern = Pattern.compile("fo[0-9]+");
+    String text = "foox" + "a".repeat(100000);
+    var utf8Input = Utf8Input.validated(text.getBytes(UTF_8));
+    assertThat(pattern.find(utf8Input)).isFalse();
+
+    Matcher stringMatcher = pattern.matcher(text);
+    assertThat(stringMatcher.find()).isFalse();
+  }
+
+  @Test
+  void dfaReacceleratesToNextMatchAfterFalseCandidate() {
+    Pattern pattern = Pattern.compile("fo[0-9]+");
+    String text = "foox" + "a".repeat(100000) + "fo123";
+    var utf8Input = Utf8Input.validated(text.getBytes(UTF_8));
+    assertThat(pattern.find(utf8Input)).isTrue();
+
+    Matcher stringMatcher = pattern.matcher(text);
+    assertThat(stringMatcher.find()).isTrue();
+    assertThat(stringMatcher.start()).isEqualTo(4 + 100000);
+    assertThat(stringMatcher.end()).isEqualTo(4 + 100000 + 5);
+  }
 }

--- a/safere/src/test/java/org/safere/DfaTest.java
+++ b/safere/src/test/java/org/safere/DfaTest.java
@@ -820,4 +820,74 @@ class DfaTest {
     assertThat(pattern.matcher(Utf8Input.validated(noMatch.getBytes(UTF_8))).find()).isFalse();
     assertThat(pattern.matcher(Utf8Input.validated(noMatch.getBytes(UTF_8))).matches()).isFalse();
   }
+
+  @Test
+  void adaptiveQuarantineOnAdversarialPeriodicNoise() {
+    String regex = "q[0-9]{4}z";
+    Pattern pattern = Pattern.compile(regex);
+
+    // 2,000 repetitions of "q1234a" (12,000 bytes). Distance between 'q' is 6 bytes.
+    // Downstream fails on 'a' instead of 'z'.
+    String adversarialNoise = "q1234a".repeat(2000);
+    assertThat(pattern.matcher(adversarialNoise).find()).isFalse();
+    assertThat(pattern.matcher(Utf8Input.validated(adversarialNoise.getBytes(UTF_8))).find())
+        .isFalse();
+
+    // Adversarial noise followed by an actual valid match at the end
+    String withMatch = adversarialNoise + "q1234z";
+    Matcher stringMatcher = pattern.matcher(withMatch);
+    assertThat(stringMatcher.find()).isTrue();
+    assertThat(stringMatcher.start()).isEqualTo(adversarialNoise.length());
+    assertThat(stringMatcher.end()).isEqualTo(withMatch.length());
+
+    var utf8Matcher = pattern.matcher(Utf8Input.validated(withMatch.getBytes(UTF_8)));
+    assertThat(utf8Matcher.find()).isTrue();
+    assertThat(utf8Matcher.start()).isEqualTo(adversarialNoise.length());
+    assertThat(utf8Matcher.end()).isEqualTo(withMatch.length());
+  }
+
+  @Test
+  void burstyHeaderRecoversAccelerationInCleanBody() {
+    String regex = "q[0-9]{4}z";
+    Pattern pattern = Pattern.compile(regex);
+
+    // 100 repetitions of noise (600 bytes header) followed by 50 KB of clean text, ending in a
+    // match
+    String header = "q1234a".repeat(100);
+    String cleanBody = "the quick brown fox jumps over the lazy dog. ".repeat(1000);
+    String target = "q1234z";
+    String input = header + cleanBody + target;
+
+    Matcher stringMatcher = pattern.matcher(input);
+    assertThat(stringMatcher.find()).isTrue();
+    assertThat(stringMatcher.start()).isEqualTo(header.length() + cleanBody.length());
+    assertThat(stringMatcher.end()).isEqualTo(input.length());
+
+    var utf8Matcher = pattern.matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+    assertThat(utf8Matcher.find()).isTrue();
+    assertThat(utf8Matcher.start()).isEqualTo(header.length() + cleanBody.length());
+    assertThat(utf8Matcher.end()).isEqualTo(input.length());
+  }
+
+  @Test
+  void denseConsecutiveValidMatchesNotThrottled() {
+    String regex = "q[0-9]{4}z";
+    Pattern pattern = Pattern.compile(regex);
+
+    // 50 valid consecutive matches back-to-back
+    String denseMatches = "q1234z".repeat(50);
+    Matcher stringMatcher = pattern.matcher(denseMatches);
+    int matchCount = 0;
+    while (stringMatcher.find()) {
+      matchCount++;
+    }
+    assertThat(matchCount).isEqualTo(50);
+
+    var utf8Matcher = pattern.matcher(Utf8Input.validated(denseMatches.getBytes(UTF_8)));
+    matchCount = 0;
+    while (utf8Matcher.find()) {
+      matchCount++;
+    }
+    assertThat(matchCount).isEqualTo(50);
+  }
 }

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -782,6 +782,50 @@ class SearchScalingRegressionTest {
   }
 
   @Test
+  void dfaReacceleratesStartStateAfterFalseCandidateWorkIsLinear() {
+    Pattern pattern = Pattern.compile("fo[0-9]+");
+    String input2000 = "foox" + "a".repeat(2_000) + "fo123";
+    String input10000 = "foox" + "a".repeat(10_000) + "fo123";
+
+    long work2000 =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input2000).find()).isTrue());
+    long work10000 =
+        WorkCounter.countForTesting(() -> assertThat(pattern.matcher(input10000).find()).isTrue());
+
+    assertThat(work10000)
+        .as("DFA start state re-acceleration work must scale linearly with non-matching span")
+        .isLessThan(work2000 * 6);
+  }
+
+  @Test
+  void dfaInteriorSelfLoopEscapeAccelerationIsLinearOnWarmDfa() {
+    Pattern pattern = Pattern.compile("\"[^\"]*\"");
+    String input2000 = "\"" + "a".repeat(2_000) + "\"";
+    String input10000 = "\"" + "a".repeat(10_000) + "\"";
+    Dfa dfa = pattern.forwardFirstMatchDfa();
+
+    // Warm up DFA transitions
+    dfa.doSearch(new StringInputScanner(input2000), 0, false, false);
+
+    long work2000 =
+        WorkCounter.countForTesting(
+            () ->
+                assertThat(
+                        dfa.doSearch(new StringInputScanner(input2000), 0, false, false).matched())
+                    .isTrue());
+    long work10000 =
+        WorkCounter.countForTesting(
+            () ->
+                assertThat(
+                        dfa.doSearch(new StringInputScanner(input10000), 0, false, false).matched())
+                    .isTrue());
+
+    assertThat(work10000)
+        .as("Warm DFA should scale linearly on interior self-loop escape")
+        .isLessThan(work2000 * 6);
+  }
+
+  @Test
   void singleCharClassFindFastPathIsLinearForStringInput() {
     Pattern pattern = Pattern.compile("\\d");
     String input2000 = "a".repeat(2_000);


### PR DESCRIPTION
This change adds:

* Adaptive defeat heuristics inspired by regex-automata, to use exponential backoff on accelerators in the DFA (https://github.com/eaftan/safere/issues/767)
* Re-enables DFA fast paths to re-use accelerators attached to DFA states inside the inner DFA loop, which previous PRs had laid groundwork for but which weren't actually being used in the core DFA loop

Previously, when inputs exhibited high candidate density with failing verifications (e.g. searching for `fo[0-9]+` or multi-anchor drivers in periodic noise like `"qaaaaz"`), the start accelerator repeatedly tripped and failed verification across every occurrence. The previous defeat detection relied on fragile `consecutiveShortSkips` counters, which were bypassed for exact literals (`!isExact`) and reset on any single skip, failing to handle dense periodic noise.

In `Dfa.java`, start-position fast-forwarding (`fastForward`) was effectively a one-shot optimization. When an unanchored search encountered an early false candidate prefix (e.g. `foox` in `fo[0-9]+`), the DFA transitioned back to the start state. However, because the inner primitive loop (`while (pos < limit)`) had no mechanism to break out on returning to the start state once ASCII transitions were cached in `transitions[]`, the DFA remained trapped in scalar execution.

DFA start-state acceleration was originally designed in PR #655 to fast-forward unanchored searches upon returning to the start state, but because the inner transition loop never broke out on start-state transitions, acceleration was trapped in the outer loop and only ever ran once at index 0.

Subsequent PRs prioritized simplifying and optimizing the inner transition loop: PR #760 scoped self-loop acceleration to anchored start states and interior loops, PR #765 removed redundant fastForward() calls at startPos on preselected paths, and PR #766 hoisted accelerators entirely out of the inner transition loop to maximize primitive loop throughput on warm states. These changes left the DFA without an inner-loop breakout mechanism to re-engage acceleration once unanchored matching moved past index 0. This change restores that capability with zero overhead on the fast path.

## Implementation Details

1. **Unified Breakout Table (`isAcceleratedStateOffset[]`)**: Consolidated start-state re-acceleration and interior self-loop acceleration into a single flat primitive boolean table parallel to `transitions[]`. The inner loop performs exactly one primitive lookup per byte, breaking out to the outer dispatcher on entering an accelerated state.
2. **Density-Calibrated Adaptive Quarantine**: Replaced consecutive-skip counters with a density stride (`MIN_DENSITY_STRIDE = 64` bytes) and strike limit (`ADAPTIVE_STRIKE_LIMIT = 16`). Dense noise triggers exponential backoff quarantine (`2048` to `65536` bytes), while clean text ($\ge 256$ bytes) decays strikes to allow vector recovery after noisy headers.

## Benchmarks

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline dynamic-prefilter-benchmark-baseline \
  'candidateRecovery.*@safere-string'
```

| Benchmark                        | baseline (ns/op) | current (ns/op) | Speedup |
| -------------------------------- | ---------------- | --------------- | ------- |
| candidateRecovery.match.1000     |        2068 ± 42 |        284 ± 47 |   7.28x |
| candidateRecovery.match.10000    |     19450 ± 1415 |       1162 ± 22 |   16.7x |
| candidateRecovery.match.100000   |    191415 ± 8079 |     10132 ± 367 |   18.9x |
| candidateRecovery.noMatch.1000   |        1946 ± 21 |       176 ± 7.3 |   11.1x |
| candidateRecovery.noMatch.10000  |      18856 ± 264 |       1067 ± 21 |   17.7x |
| candidateRecovery.noMatch.100000 |     187436 ± 901 |      9924 ± 111 |   18.9x |

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline dynamic-prefilter-benchmark-baseline \
  '(jsonBlock|templateTagMatch|fixedAnchorLog|bracketCitation|mapFieldPath).*@safere-string'
```

| Benchmark                       | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------- | ---------------- | --------------- | ------- |
| mapFieldPath.match.1000         |        4194 ± 25 |       4237 ± 45 |   0.99x |
| mapFieldPath.match.10000        |     41809 ± 1103 |     41413 ± 726 |   1.01x |
| mapFieldPath.match.100000       |  517990 ± 153289 |   422667 ± 6152 |   1.23x |
| mapFieldPath.noMatch.1000       |         636 ± 41 |        619 ± 15 |   1.03x |
| mapFieldPath.noMatch.10000      |       5900 ± 126 |       5844 ± 38 |   1.01x |
| mapFieldPath.noMatch.100000     |     59183 ± 1852 |    59154 ± 1659 |   1.00x |
| templateTagMatch.match.1000     |       3833 ± 153 |      3383 ± 101 |   1.13x |
| templateTagMatch.match.10000    |      35506 ± 402 |     32868 ± 733 |   1.08x |
| templateTagMatch.match.100000   |    345074 ± 4432 |  326376 ± 16701 |   1.06x |
| templateTagMatch.noMatch.1000   |        174 ± 6.3 |       174 ± 4.8 |   1.00x |
| templateTagMatch.noMatch.10000  |        1062 ± 12 |       1069 ± 21 |   0.99x |
| templateTagMatch.noMatch.100000 |        9892 ± 99 |      9926 ± 218 |   1.00x |
| jsonBlock.match.1000            |        2927 ± 79 |       1032 ± 47 |   2.83x |
| jsonBlock.match.10000           |     28378 ± 1914 |     9915 ± 1258 |   2.86x |
| jsonBlock.match.100000          |    303924 ± 9604 |    99434 ± 2551 |   3.06x |
| jsonBlock.noMatch.1000          |        153 ± 1.5 |       155 ± 6.8 |   0.99x |
| jsonBlock.noMatch.10000         |        1033 ± 13 |       1043 ± 21 |   0.99x |
| jsonBlock.noMatch.100000        |        9870 ± 55 |       9845 ± 55 |   1.00x |
| fixedAnchorLog.match.1000       |        553 ± 7.6 |       555 ± 8.0 |   1.00x |
| fixedAnchorLog.match.10000      |        4179 ± 24 |       4187 ± 43 |   1.00x |
| fixedAnchorLog.match.100000     |      40481 ± 574 |     40595 ± 674 |   1.00x |
| fixedAnchorLog.noMatch.1000     |        180 ± 2.8 |       180 ± 3.1 |   1.00x |
| fixedAnchorLog.noMatch.10000    |        1387 ± 17 |      1381 ± 9.3 |   1.00x |
| fixedAnchorLog.noMatch.100000   |      13597 ± 202 |     13536 ± 218 |   1.00x |
| bracketCitation.match.1000      |       8841 ± 275 |      8509 ± 125 |   1.04x |
| bracketCitation.match.10000     |     84840 ± 1257 |    92010 ± 2784 |   0.92x |
| bracketCitation.match.100000    |   840665 ± 43423 |  853017 ± 22018 |   0.99x |
| bracketCitation.noMatch.1000    |         564 ± 17 |       557 ± 4.5 |   1.01x |
| bracketCitation.noMatch.10000   |       5714 ± 545 |       5515 ± 89 |   1.04x |
| bracketCitation.noMatch.100000  |     56936 ± 3931 |    55656 ± 1287 |   1.02x |

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline dynamic-prefilter-benchmark-baseline \
  'SingleCharClassBenchmark.*@safere-string'
```

| Benchmark                                        | baseline (ns/op) | current (ns/op) | Speedup |
| ------------------------------------------------ | ---------------- | --------------- | ------- |
| SingleCharClassBenchmark.findDigitAbsent.1024    |        601 ± 5.5 |       602 ± 3.6 |   1.00x |
| SingleCharClassBenchmark.findDigitAbsent.32768   |     19771 ± 1368 |     19036 ± 440 |   1.04x |
| SingleCharClassBenchmark.findDigitAbsent.1048576 |   606281 ± 30197 |  599944 ± 13525 |   1.01x |

```
./safere-benchmarks/scripts/compare-branch.sh \
  --baseline dynamic-prefilter-benchmark-baseline \
  'RegexBenchmark\.(literalMatch|charClassMatch).*@safere-string'
```

| Benchmark                     | baseline (ns/op) | current (ns/op) | Speedup |
| ----------------------------- | ---------------- | --------------- | ------- |
| RegexBenchmark.literalMatch   |         27 ± 6.2 |        27 ± 4.5 |   1.01x |
| RegexBenchmark.charClassMatch |        38 ± 0.49 |        39 ± 4.1 |   0.97x |