### PR TITLE
Clarify JDK 26 build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,12 @@ For a detailed architecture walkthrough, see [DESIGN.md](DESIGN.md).
 
 ## Building
 
-Requires [OpenJDK 21 or newer](https://openjdk.org/install/) and
+Building from source requires [OpenJDK 26](https://openjdk.org/install/) and
 [Apache Maven 3.9 or newer](https://maven.apache.org/install.html).
+
+The core library targets Java 21 bytecode with `--release 21` and supports
+JDK 21 through 26 at runtime. CI verifies runtime compatibility using artifacts
+built with JDK 26. Building from source on older JDKs is not supported.
 
 ```bash
 # Build and install (library + benchmarks)


### PR DESCRIPTION
The README previously said source builds required JDK 21 or newer, although the supported build uses JDK 26 and compiler options unavailable on JDK 21. Require JDK 26 explicitly and clarify that the core library retains JDK 21–26 runtime support, tested in CI using artifacts compiled with JDK 26.

Resolves this issue through the agreed build-support policy; compiler configuration is unchanged.

Fixes #697

Validation: `git diff --check` passed. Checked the wording against `.sdkmanrc`, the Java release setting, and the CI runtime matrix. No builds, SafeRE tests, or public API crosscheck tests were run because this change only updates documentation.
