### PR TITLE
Preserve CRLF context in cached DFA line-feed transitions

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -11,6 +11,19 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 final class FindSequenceFuzzer {
+  private static final List<String> LINE_TERMINATORS =
+      List.of("\n", "\r", "\r\n", "\u0085", "\u2028", "\u2029");
+
+  @Test
+  void reusedMultilineDollarKeepsCrLfAtomic() {
+    FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip("\\W*(?m:$)", 0);
+    pattern.matcher(" \na").find();
+    FuzzSupport.MatcherPair matcher = pattern.matcher("xb\r\n" + "a".repeat(30));
+    while (matcher.find()) {
+      matcher.start();
+      matcher.end();
+    }
+  }
 
   @Test
   void delimitedPrefixBeforeRequiredSuffixRegression() {
@@ -44,7 +57,8 @@ final class FindSequenceFuzzer {
     int flags;
     String input;
     boolean splitSurrogateFindStart = false;
-    switch (data.consumeInt(0, 7)) {
+    String warmInput = null;
+    switch (data.consumeInt(0, 8)) {
       case 0 -> {
         regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
         flags = 0;
@@ -90,11 +104,22 @@ final class FindSequenceFuzzer {
         input = "😀b" + data.consumeString(16) + "😀b";
         splitSurrogateFindStart = true;
       }
+      case 8 -> {
+        String atom = data.pickValue(List.of("\\W", "\\s", "[\\r\\n ]"));
+        String quantifier = data.pickValue(List.of("*", "+", "?", "*?", "{0,3}"));
+        regex = atom + quantifier + "(?m:$)";
+        flags = 0;
+        warmInput = " ".repeat(data.consumeInt(1, 8)) + data.pickValue(LINE_TERMINATORS) + "a";
+        input = "xb" + data.pickValue(LINE_TERMINATORS) + "a".repeat(data.consumeInt(1, 700));
+      }
       default -> throw new AssertionError();
     }
     FuzzSupport.CompiledPattern pattern = FuzzSupport.compileOrSkip(regex, flags);
     if (pattern == null) {
       return;
+    }
+    if (warmInput != null) {
+      pattern.matcher(warmInput).find();
     }
     if (splitSurrogateFindStart) {
       pattern.matcher(input).find(1);

--- a/safere/src/main/java/org/safere/Dfa.java
+++ b/safere/src/main/java/org/safere/Dfa.java
@@ -261,7 +261,7 @@ final class Dfa {
    */
   static Setup buildSetup(Prog prog) {
     int[] boundaries = buildBoundaries(prog);
-    int numClasses = boundaries.length + 1 + 1; // intervals + end-of-text
+    int numClasses = boundaries.length + 1 + 2; // intervals + CRLF context + end-of-text
     int[] asciiClassMap = buildAsciiClassMap(boundaries);
     return new Setup(boundaries, numClasses, asciiClassMap);
   }
@@ -463,6 +463,19 @@ final class Dfa {
     cacheCps[cacheIdx] = cp;
     cacheClasses[cacheIdx] = cls;
     return cls;
+  }
+
+  /**
+   * Adds the context used by deferred END_LINE evaluation to the transition key. A line feed
+   * following a carriage return cannot satisfy END_LINE, unlike a standalone line feed. All
+   * transition tables, including the flat ASCII table, must distinguish these cases.
+   */
+  private int transitionClass(int cp, int cls, InputScanner text, int nextPos) {
+    return isCrLfContinuation(cp, text, nextPos) ? numClasses - 2 : cls;
+  }
+
+  private boolean isCrLfContinuation(int cp, InputScanner text, int nextPos) {
+    return !prog.unixLines() && cp == '\n' && nextPos >= 2 && text.asciiAt(nextPos - 2) == '\r';
   }
 
   // ---------------------------------------------------------------------------
@@ -1064,7 +1077,7 @@ final class Dfa {
       endLineHere = Nfa.isLineTerminator(cp);
       // Don't fire END_LINE at the \n of an atomic \r\n pair. END_LINE fires before the \r
       // (the start of the pair), not between \r and \n.
-      if (endLineHere && cp == '\n' && nextPos >= 2 && text.asciiAt(nextPos - 2) == '\r') {
+      if (endLineHere && isCrLfContinuation(cp, text, nextPos)) {
         endLineHere = false;
       }
     }
@@ -1498,7 +1511,7 @@ final class Dfa {
         if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
           break;
         }
-        int cls = asciiClassMap[ch];
+        int cls = transitionClass(ch, asciiClassMap[ch], text, pos + 1);
         int nsId = transitions[sId + cls];
         if (nsId == 0) {
           break;
@@ -1533,7 +1546,7 @@ final class Dfa {
       if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
         break; // fall back to general loop
       }
-      int cls = asciiClassMap[ch];
+      int cls = transitionClass(ch, asciiClassMap[ch], text, pos + 1);
       State ns = s.next[cls];
       if (ns == null) {
         int effectiveNextPos = pos + 1;
@@ -1648,6 +1661,7 @@ final class Dfa {
       // is always safe to cache because it always means "at text end".
       int effectiveNextPos = Math.min(nextPos, textLen);
       State ns;
+      cls = transitionClass(cp, cls, text, effectiveNextPos);
       if (transitionDependsOnPosition(cp, effectiveNextPos, posDepThreshold)) {
         ns = computeNext(s, cp, text, effectiveNextPos);
         if (ns == null) {
@@ -1786,7 +1800,7 @@ final class Dfa {
           if (ch < 0 || transitionDependsOnPosition(ch, pos - 1, posDepThreshold)) {
             break;
           }
-          int cls = asciiClassMap[ch];
+          int cls = transitionClass(ch, asciiClassMap[ch], text, pos - 1);
           int nsId = transitions[sId + cls];
           if (nsId == 0) {
             break;
@@ -1840,7 +1854,7 @@ final class Dfa {
       if (ch < 0 || transitionDependsOnPosition(ch, pos - 1, posDepThreshold)) {
         break; // fall back
       }
-      int cls = asciiClassMap[ch];
+      int cls = transitionClass(ch, asciiClassMap[ch], text, pos - 1);
       State ns = s.next[cls];
       if (ns == null) {
         int effectivePrevPos = pos - 1;
@@ -1920,6 +1934,7 @@ final class Dfa {
       // Bypass cache for position-dependent transitions (same invariant as doSearch).
       int effectivePrevPos = Math.max(prevPos, startLimit);
       State ns;
+      cls = transitionClass(cp, cls, text, effectivePrevPos);
       if (transitionDependsOnPosition(cp, effectivePrevPos, posDepThreshold)) {
         ns = computeNext(s, cp, text, effectivePrevPos);
         if (ns == null) {
@@ -2054,7 +2069,7 @@ final class Dfa {
         if (ch < 0 || transitionDependsOnPosition(ch, pos + 1, posDepThreshold)) {
           break; // fall back
         }
-        int cls = asciiClassMap[ch];
+        int cls = transitionClass(ch, asciiClassMap[ch], text, pos + 1);
         int nsId = transitions[sId + cls];
         if (nsId == 0) {
           s = offsetToState[sId];
@@ -2130,6 +2145,7 @@ final class Dfa {
         // Bypass cache for position-dependent transitions (same invariant as doSearch).
         int effectiveNextPos = Math.min(nextPos, textLen);
         State ns;
+        cls = transitionClass(cp, cls, text, effectiveNextPos);
         if (transitionDependsOnPosition(cp, effectiveNextPos, posDepThreshold)) {
           ns = computeNext(s, cp, text, effectiveNextPos);
           if (ns == null) {

--- a/safere/src/test/java/org/safere/AnchoredDfaCachingTest.java
+++ b/safere/src/test/java/org/safere/AnchoredDfaCachingTest.java
@@ -65,6 +65,26 @@ class AnchoredDfaCachingTest {
         });
   }
 
+  @Test
+  void multilineEndingAnchorKeepsStringLineFeedTransitionsCached() {
+    Pattern pattern = Pattern.compile("(?m)(?:x+$)y");
+    assertCachedTransitionWork(
+        size -> assertThat(pattern.matcher("xxx\n".repeat(size)).find()).isFalse());
+  }
+
+  @Test
+  void multilineEndingAnchorKeepsUtf8LineFeedTransitionsCached() {
+    Prog prog = Compiler.compile(Parser.parse("(?m)(?:x+$)y", FLAGS));
+    Dfa dfa = new Dfa(prog, 10_000, Dfa.buildSetup(prog), false);
+    assertCachedTransitionWork(
+        size -> {
+          byte[] input = "xxx\n".repeat(size).getBytes(UTF_8);
+          Dfa.SearchResult result = dfa.doSearch(new Utf8InputScanner(input), false, false);
+          assertThat(result).isNotNull();
+          assertThat(result.matched()).isFalse();
+        });
+  }
+
   private static void assertCachedTransitionWork(IntConsumer operation) {
     operation.accept(1_000);
     operation.accept(10_000);

--- a/safere/src/test/java/org/safere/MultilineCrLfDfaCachingTest.java
+++ b/safere/src/test/java/org/safere/MultilineCrLfDfaCachingTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,6 +18,81 @@ import org.junit.jupiter.params.provider.MethodSource;
 /** Compatibility coverage for CRLF-sensitive multiline anchors in cached DFA transitions. */
 class MultilineCrLfDfaCachingTest {
   private static final String LONG_PREFIX = "a".repeat(500);
+
+  @Test
+  void reusedDollarStopsBeforeWholeCrLfTerminator() {
+    // JDK 26 Pattern defines CRLF as one line terminator. Refs #713.
+    Pattern pattern = Pattern.compile("\\W*(?m:$)");
+    pattern.matcher(" \na").find();
+    Matcher matcher = pattern.matcher("xb\r\n" + "a".repeat(30));
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(2);
+    assertThat(matcher.end()).isEqualTo(2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("reusedDollarCases")
+  void reusedDollarPreservesLineTerminatorBounds(
+      String regex, String warmTerminator, String targetTerminator, int suffixLength) {
+    Pattern pattern = Pattern.compile(regex);
+    pattern.matcher(" " + warmTerminator + "a").find();
+    String input = "xb" + targetTerminator + "a".repeat(suffixLength);
+    assertFindSequence(pattern.matcher(input), regex, input);
+  }
+
+  @ParameterizedTest
+  @MethodSource("reusedDollarCases")
+  @DisabledForCrosscheck("UTF-8 input API is SafeRE-specific")
+  void reusedUtf8DollarPreservesLineTerminatorBounds(
+      String regex, String warmTerminator, String targetTerminator, int suffixLength) {
+    Pattern pattern = Pattern.compile(regex);
+    pattern.matcher(Utf8Input.validated((" " + warmTerminator + "a").getBytes(UTF_8))).find();
+    String input = "xb" + targetTerminator + "a".repeat(suffixLength);
+    Utf8Matcher actual = pattern.matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+    java.util.regex.Matcher expected = java.util.regex.Pattern.compile(regex).matcher(input);
+    while (expected.find()) {
+      assertThat(actual.find()).isTrue();
+      assertThat(actual.start())
+          .isEqualTo(input.substring(0, expected.start()).getBytes(UTF_8).length);
+      assertThat(actual.end()).isEqualTo(input.substring(0, expected.end()).getBytes(UTF_8).length);
+      for (int group = 0; group <= expected.groupCount(); group++) {
+        assertThat(actual.start(group))
+            .isEqualTo(input.substring(0, expected.start(group)).getBytes(UTF_8).length);
+        assertThat(actual.end(group))
+            .isEqualTo(input.substring(0, expected.end(group)).getBytes(UTF_8).length);
+      }
+    }
+    assertThat(actual.find()).isFalse();
+  }
+
+  private static void assertFindSequence(Matcher actual, String regex, String input) {
+    java.util.regex.Matcher expected = java.util.regex.Pattern.compile(regex).matcher(input);
+    while (expected.find()) {
+      assertThat(actual.find()).isTrue();
+      assertThat(actual.start()).isEqualTo(expected.start());
+      assertThat(actual.end()).isEqualTo(expected.end());
+      for (int group = 0; group <= expected.groupCount(); group++) {
+        assertThat(actual.group(group)).isEqualTo(expected.group(group));
+      }
+    }
+    assertThat(actual.find()).isFalse();
+  }
+
+  private static Stream<Arguments> reusedDollarCases() {
+    return Stream.of("\\W*(?m:$)", "\\s*(?m:$)", "(\\W*)(?m:$)", "\\W*?(?m:$)")
+        .flatMap(
+            regex ->
+                Stream.of("\n", "\r", "\r\n", "\u0085", "\u2028", "\u2029")
+                    .flatMap(
+                        warm ->
+                            Stream.of("\n", "\r", "\r\n", "\u0085", "\u2028", "\u2029")
+                                .flatMap(
+                                    target ->
+                                        Stream.of(30, 500)
+                                            .map(
+                                                length ->
+                                                    Arguments.of(regex, warm, target, length)))));
+  }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("mixedCarriageReturnCases")


### PR DESCRIPTION
Reusing a compiled pattern after a standalone-LF search could make `\W*(?m:$)` return `[2,3)` on `xb\r\n` followed by text, instead of the correct `[2,2)`. Cached LF transitions omitted the preceding-CR context used by deferred `$` evaluation.

Give LF-in-CRLF its own transition-cache entry and use the same context predicate for cache selection and anchor evaluation across forward, reverse, and full-match DFA paths. This adds one cache slot per state and constant adjacent-character work, preserving linear-time matching and cached LF transitions.

Add systematic String/UTF-8 reuse coverage across line terminators, input lengths, captures, and greedy/reluctant matching; cache-work checks; and a pattern-reuse axis plus regression in `FindSequenceFuzzer`.

Fixes #713

Validation:
- Baseline regression matrix reproduced the failures before the fix.
- Focused DFA and multiline CRLF tests passed.
- `mvn -pl safere -Pwork-counters -Dtest=AnchoredDfaCachingTest test -q` passed.
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q` passed in regression mode.
- `mvn -pl safere test -q` passed.
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests` passed.
- Not run: sustained fuzzing, benchmarks, or a multi-JDK test matrix.


After merging current main (`19f6b90`), reran `FindSequenceFuzzer` in regression mode, `MultilineCrLfDfaCachingTest`, and `DfaTest` together with `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer,MultilineCrLfDfaCachingTest,DfaTest -Dsurefire.failIfNoSpecifiedTests=false test -q`; all passed. `mvn -pl safere,safere-fuzz spotless:check -q` also passed. The full suite, public API crosscheck, and work-counter validation listed above passed before this merge and were not rerun afterward. The conflict resolution preserves both newly added fuzz generators as separate cases.
