### PR TITLE
Document initial find behavior after failed full matches

### DIFF
--- a/INTENTIONAL_DIVERGENCES.md
+++ b/INTENTIONAL_DIVERGENCES.md
@@ -38,6 +38,38 @@ SafeRE preserves a coherent overall match instead of reproducing that
 implementation behavior. The JDK inconsistency is tracked upstream as
 [JDK-8390449](https://bugs.openjdk.org/browse/JDK-8390449).
 
+## Initial `find()` after a Failed Full Match
+
+Issue reference: #818.
+
+If a newly created or region-reset matcher fails `matches()` before any
+successful match, SafeRE preserves the region beginning as the initial
+`find()` search position. Failed full-match attempts do not consume input for
+that search. This follows the
+[JDK 26 `Matcher.find()` specification](https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/regex/Matcher.html#find()),
+which starts searching at the region beginning unless a previous `find()`
+succeeded and the matcher has not since been reset.
+
+For example:
+
+```java
+var matcher = Pattern.compile("\\A(a?)").matcher("a!");
+matcher.matches(); // false: the pattern cannot consume the trailing '!'
+matcher.find();    // SafeRE: true, matching "a" at [0, 1); JDK 26.0.1: false
+```
+
+The JDK result contradicts the documented initial search position. SafeRE
+intentionally preserves its specification-based behavior rather than copying
+state left by the JDK's failed full-match attempt. Calling `reset()` before
+`find()` also produces the initial match on the JDK.
+
+`FailedFullMatchFindTest` covers repeated failed full matches, optional and
+repeated captures, greedy and reluctant quantifiers, empty matches,
+supplementary characters, and nonzero region starts. These expectations are
+disabled only in generated JDK crosscheck tests because the difference is
+intentional. This policy concerns the initial search; it does not redefine
+continuation after an earlier successful match.
+
 ## Unsupported Backtracking Features
 
 Sweep names:

--- a/safere/src/test/java/org/safere/FailedFullMatchFindTest.java
+++ b/safere/src/test/java/org/safere/FailedFullMatchFindTest.java
@@ -1,0 +1,62 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Specification-based coverage for the first find after a failed full match. */
+@DisabledForCrosscheck(
+    "SafeRE follows the documented initial find position; JDK leaks failed full-match state")
+class FailedFullMatchFindTest {
+
+  @Test
+  void failedFullMatchesPreserveInitialFindPosition() {
+    // Issue #818: Matcher.find() starts at the region beginning when no find has succeeded.
+    // Preserve that documented behavior, even where JDK 26.0.1 skips the initial match.
+    for (String anchor : List.of("\\A", "^")) {
+      for (String atom : List.of("a", "😀")) {
+        for (String quantifier : List.of("?", "*", "{0,2}", "??", "*?")) {
+          for (boolean empty : List.of(false, true)) {
+            for (int offset : List.of(0, 2)) {
+              for (int attempts : List.of(1, 2)) {
+                String regex = anchor + "(" + atom + quantifier + ")";
+                String input = (empty ? "" : atom) + "!";
+                String text = offset == 0 ? input : "xx" + input + "yy";
+                Matcher matcher = Pattern.compile(regex).matcher(text);
+                if (offset != 0) {
+                  matcher.region(offset, offset + input.length());
+                }
+                for (int attempt = 0; attempt < attempts; attempt++) {
+                  assertThat(matcher.matches()).as("full match: %s", regex).isFalse();
+                  assertThat(matcher.hasMatch()).isFalse();
+                  assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+                }
+
+                boolean reluctant = quantifier.equals("??") || quantifier.equals("*?");
+                String expected = empty || reluctant ? "" : atom;
+                assertThat(matcher.find())
+                    .as("first find: %s, input=%s, offset=%s", regex, input, offset)
+                    .isTrue();
+                assertThat(matcher.start()).isEqualTo(offset);
+                assertThat(matcher.end()).isEqualTo(offset + expected.length());
+                assertThat(matcher.group()).isEqualTo(expected);
+                assertThat(matcher.group(1)).isEqualTo(expected);
+                assertThat(matcher.start(1)).isEqualTo(offset);
+                assertThat(matcher.end(1)).isEqualTo(offset + expected.length());
+                assertThat(matcher.find()).isFalse();
+                assertThat(matcher.find()).isFalse();
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
After a failed `matches()` on `\A(a?)` against `a!`, SafeRE's first `find()` matches `a`, while JDK 26.0.1 returns false. The documented initial search rule requires starting at the region beginning. Preserve SafeRE's behavior and document this as an intentional divergence, as approved in the issue assessment.

Add specification-based regression coverage for repeated failed full matches, greedy and reluctant quantifiers, empty matches, supplementary characters, and nonzero region starts. Exclude these intentional differences only from generated JDK crosscheck tests. No matcher implementation changes.

Fixes #818.

## Verification

Passed:
- `mvn -pl safere -Dtest=FailedFullMatchFindTest,MatcherStateMachineTraceTest test`
- `mvn -pl safere -Dtest=FailedFullMatchFindTest test -q` (review pass)
- `mvn -pl safere spotless:check -q`
- `git diff --check`
- Independent review: no findings.

Not run: full SafeRE test suite, generated public API crosscheck, fuzz regression targets, or benchmarks. This change preserves existing runtime behavior.
