### PR TITLE
Fix find continuation after empty anchored matches

### DIFF
--- a/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
+++ b/safere-fuzz/src/test/java/org/safere/fuzz/FindSequenceFuzzer.java
@@ -18,6 +18,8 @@ final class FindSequenceFuzzer {
     assertAnchoredContinuation("a*", "a!", true, false);
     assertAnchoredContinuation("a", "ba a", false, true);
     assertAnchoredContinuation("a*", "!a", false, false);
+    assertAnchoredContinuation("^[ab]*", "!a😀b!", false, true);
+    assertAnchoredContinuation("\\A(a?)", "!a", true, true);
   }
 
   private static void assertAnchoredContinuation(
@@ -69,7 +71,7 @@ final class FindSequenceFuzzer {
     int flags;
     String input;
     boolean splitSurrogateFindStart = false;
-    switch (data.consumeInt(0, 8)) {
+    switch (data.consumeInt(0, 9)) {
       case 0 -> {
         regex = nestedCapturingGroups(data.consumeInt(0, 512)) + "*";
         flags = 0;
@@ -123,6 +125,24 @@ final class FindSequenceFuzzer {
         String prefix = data.consumeBoolean() ? "!" : "";
         input = prefix + "a😀b".repeat(data.consumeInt(1, 200)) + "!";
         assertAnchoredContinuation(regex, input, data.consumeBoolean(), data.consumeBoolean());
+      }
+      case 9 -> {
+        String anchor = data.pickValue(List.of("^", "\\A", "(?m)^"));
+        String body = data.pickValue(List.of("[ab]*", "(a?)", "(a|b)*", "(?:😀)*"));
+        regex = anchor + body;
+        flags = 0;
+        input = "!" + data.consumeString(64);
+        FuzzSupport.MatcherPair matcher = FuzzSupport.compileOrSkip(regex, flags).matcher(input);
+        if (data.consumeBoolean()) {
+          matcher.find(data.consumeInt(0, input.length()));
+        } else if (data.consumeBoolean()) {
+          matcher.find();
+        } else {
+          matcher.lookingAt();
+        }
+        for (int i = 0, steps = data.consumeInt(3, 8); i < steps; i++) {
+          matcher.find();
+        }
       }
       default -> throw new AssertionError();
     }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1306,10 +1306,11 @@ public final class Matcher implements MatchResult {
       applyFailedMatchResult();
       return false;
     }
+    int continuationAfterFailure = hasMatch ? previousMatchEnd : searchFrom;
     if (hasMatch && !advanceSearchPositionAfterPreviousMatch()) {
       return false;
     }
-    return doFind();
+    return findWithContinuation(continuationAfterFailure);
   }
 
   private boolean advanceSearchPositionAfterPreviousMatch() {
@@ -1410,7 +1411,7 @@ public final class Matcher implements MatchResult {
     modCount++;
     reset();
     searchFrom = start;
-    return doFind();
+    return findWithContinuation(previousMatchEnd);
   }
 
   /**
@@ -1440,6 +1441,18 @@ public final class Matcher implements MatchResult {
           }
         };
     return StreamSupport.stream(spliterator, false);
+  }
+
+  /** Restores the next search position when an engine search fails. */
+  private boolean findWithContinuation(int continuationAfterFailure) {
+    boolean matched = doFind();
+    if (!matched) {
+      // Advancement past an empty match belongs only to the immediately following attempt.
+      // After failure, restore the continuation before that advancement or explicit find(int)
+      // start. Keep positions established by bulk operations such as replaceAll intact.
+      searchFrom = continuationAfterFailure;
+    }
+    return matched;
   }
 
   /** Runs the engine search from {@link #searchFrom} and stores the result. */

--- a/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
+++ b/safere/src/test/java/org/safere/MatcherStateMachineTraceTest.java
@@ -20,6 +20,49 @@ import org.junit.jupiter.api.Test;
 class MatcherStateMachineTraceTest {
 
   @Test
+  void failedExplicitFindStartRetainsResetContinuation() {
+    for (String regex : List.of("^[ab]*", "\\A(a?)", "a")) {
+      assertTrace(
+          regex,
+          "a!",
+          Step.findFrom(1),
+          Step.findWithBounds(),
+          Step.findWithBounds(),
+          Step.findWithBounds());
+    }
+  }
+
+  @Test
+  @DisplayName("failed find after an empty anchored match preserves continuation like the JDK")
+  void emptyAnchoredMatchContinuation() {
+    // JDK 26 does not specify empty-match advancement after failure precisely (issue #817).
+    for (String regex : List.of("^[ab]*", "\\A(a?)", "^(a|b)*", "^(?:a*)", "(?m)^[ab]*")) {
+      for (String input : List.of("", "!", "!a😀b!", "a!", "!".repeat(512), "!\na")) {
+        for (boolean region : List.of(false, true)) {
+          for (boolean anchoring : List.of(false, true)) {
+            for (Step initial : List.of(Step.find(), Step.lookingAt())) {
+              for (Step attempt : List.of(Step.find(), Step.lookingAt(), Step.matches())) {
+                String text = region ? "xx" + input + "yy" : input;
+                assertTrace(
+                    regex,
+                    text,
+                    Step.region(region ? 2 : 0, region ? input.length() + 2 : input.length()),
+                    Step.useAnchoringBounds(anchoring),
+                    initial,
+                    attempt,
+                    Step.findWithBounds(),
+                    Step.findWithBounds(),
+                    Step.findWithBounds(),
+                    Step.findWithBounds());
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   @DisplayName("anchored attempts preserve find continuation after earlier matches")
   void anchoredAttemptsPreserveFindContinuation() {
     // Covers issue #808, including empty matches and repeated failed attempts.

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -493,6 +493,23 @@ class MatcherTest {
     }
 
     @Test
+    @DisplayName("failed find cancels advancement past an empty start-anchored match")
+    void failedFindPreservesEmptyAnchoredMatchEnd() {
+      // Compatibility with JDK 26's continuation after failure; regression for issue #817.
+      Matcher matcher = Pattern.compile("^[ab]*").matcher("!a😀b!");
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.lookingAt()).isTrue();
+      for (int i = 0; i < 3; i++) {
+        assertThat(matcher.find()).isFalse();
+        assertThatThrownBy(matcher::group).isInstanceOf(IllegalStateException.class);
+        assertThat(matcher.find()).isTrue();
+        assertThat(matcher.start()).isZero();
+        assertThat(matcher.end()).isZero();
+        assertThat(matcher.group()).isEmpty();
+      }
+    }
+
+    @Test
     @DisplayName("failed anchored attempts cancel advancement past an earlier empty match")
     void failedAnchoredAttemptsPreserveEmptyMatchEnd() {
       Matcher matcher = Pattern.compile("a*").matcher("!a");
@@ -1585,6 +1602,17 @@ class MatcherTest {
       m.appendTail(sb);
 
       assertThat(sb).hasToString("\n");
+    }
+
+    @Test
+    void repeatedFindAfterReplaceAllRemainsExhausted() {
+      for (String regex : new String[] {"a", "[ab]+", "^([a-z]+)$"}) {
+        Matcher matcher = Pattern.compile(regex).matcher("aba\n");
+        matcher.replaceAll("X");
+        for (int i = 0; i < 3; i++) {
+          assertThat(matcher.find()).as("find after replaceAll for %s", regex).isFalse();
+        }
+      }
     }
 
     @Test

--- a/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
+++ b/safere/src/test/java/org/safere/Utf8MatcherStateMachineTest.java
@@ -19,6 +19,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class Utf8MatcherStateMachineTest {
   @Test
+  void failedFindPreservesEmptyAnchoredMatchEnd() {
+    Utf8Matcher matcher = matcher("^[ab]*", "😀!a");
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.lookingAt()).isTrue();
+    for (int i = 0; i < 3; i++) {
+      assertThat(matcher.find()).isFalse();
+      assertThat(matcher.find()).isTrue();
+      assertThat(matcher.start()).isZero();
+      assertThat(matcher.end()).isZero();
+    }
+  }
+
+  @Test
   void stringSearchInitializationDoesNotCorruptExistingUtf8Matcher() {
     Pattern pattern = Pattern.compile("XXXXXX");
     Matcher stringMatcher = pattern.matcher("..XXXXXX");


### PR DESCRIPTION
After an empty start-anchored match, a failed `find()` retained the temporary empty-match advancement, causing later calls to keep failing. For `^[ab]*` on `!a😀b!`, the sequence `find()`, `lookingAt()`, `find()`, `find()` now returns `true, true, false, true`, matching the JDK.

Restore the continuation position after a failed search, including failures from explicit `find(int)` starts. Preserve positions established by bulk replacement and terminal-empty-match exhaustion. The change adds constant-time state bookkeeping without additional engine searches. JDK 26's Javadoc does not precisely specify empty-match advancement after failure, so the tests use observed JDK behavior as the compatibility target.

Add lifecycle coverage for anchor variants, regions, Unicode, interleaved operations, explicit starts, and repeated finds after replacement, plus UTF-8 regressions and expanded fuzz generation.

Fixes #817.

Verification passed on JDK 26.0.1:

- `mvn -pl safere test -q -Dtest=MatcherStateMachineTraceTest,MatcherTest,Utf8MatcherStateMachineTest`
- `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q` — full SafeRE suite, generated public API crosscheck, and verification checks.
- `mvn -pl safere-fuzz -am -Dtest=FindSequenceFuzzer -Dsurefire.failIfNoSpecifiedTests=false test -q` — regression replay.
- Independent read-only review: no findings.

Not run: sustained fuzzing, benchmarks, or the multi-JDK matrix. A separate failed-`matches()` continuation divergence discovered during testing is tracked in #818.
