### PR TITLE
Highlight unresolved repo-assist review findings

### DIFF
--- a/.agents/skills/repo-assist/SKILL.md
+++ b/.agents/skills/repo-assist/SKILL.md
@@ -270,6 +270,18 @@ report.
   cutoff. Do not describe it as old, carried forward, or unchanged in the copy/paste comment unless
   that history is meaningful in the public discussion.
 
+Make unresolved findings after the two-batch repair limit impossible to miss when scanning the
+report. If any PR exhausts both semantic fix batches and still has an in-scope finding:
+
+- add a bold alert immediately below the PR summary table listing every affected PR number;
+- begin that PR's summary assessment with **OPEN REVIEW FINDINGS AFTER TWO FIX BATCHES**; and
+- add the same bold callout at the start of its detailed `Review Fix Loop` section, followed by a
+  concise statement of the remaining findings.
+
+Apply this treatment only when the two-batch limit was actually exhausted with unresolved in-scope
+findings. Do not use it for benchmark-evidence gaps, ordinary human-review focus, blocked reviews,
+or PRs returned to the author before two batches because the required change was already a redesign.
+
 The report may identify internally which sections were reviewed in this run and which reused valid
 evidence, but it must contain all information the human needs to decide and comment without opening
 an earlier scout report.
@@ -738,6 +750,8 @@ Recommendation:
 - ...
 
 ### Review Fix Loop
+
+**OPEN REVIEW FINDINGS AFTER TWO FIX BATCHES:** <remaining findings, only when applicable>
 
 Result: no P2+ findings | fixes committed locally | findings for author | blocked | false positive documented
 


### PR DESCRIPTION
Repo-assist reports currently present PRs that exhaust both semantic fix batches like ordinary human-review items, making unresolved code findings easy to miss in a large sweep.

Require these PRs to carry a bold alert below the summary table, a bold summary-row marker, and a matching callout in the detailed review-loop section. The marker is limited to unresolved in-scope findings after both fix batches; benchmark gaps, blocked reviews, and immediate redesign findings keep their existing presentation.

Also add a mandatory final audit after the complete report is written. Each fenced author-facing review must be read on its own and corrected for missing context, internal validation bookkeeping, local-only fix language, benchmark-table requirements, tone, formatting, and consistency with the report recommendation before the report is marked complete.

Validation:

- `python3 /home/eaftan/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/repo-assist`
- `git diff --check`

Not run: Maven tests (documentation-only skill guidance change).
