### PR TITLE
Cache compiled multi-anchor eligibility

### DIFF
--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -13,13 +13,15 @@ import java.util.Objects;
  * regular expression AST. Enables divide-and-conquer execution by pinning match positions around
  * fast SIMD anchors and verifying intermediate gaps.
  */
-@SuppressWarnings("ArrayRecordComponent")
-record MultiAnchorDescriptor(
-    Chain chain,
-    StartPlan startPlan,
-    RejectPlan rejectPlan,
-    String anchoredPrefix,
-    CharClassScanInfo anchoredCharClassPrefix) {
+final class MultiAnchorDescriptor {
+
+  private final Chain chain;
+  private final StartPlan startPlan;
+  private final RejectPlan rejectPlan;
+  private final String anchoredPrefix;
+  private final CharClassScanInfo anchoredCharClassPrefix;
+  private final boolean executableChain;
+  private final boolean executableUtf8Chain;
 
   public static final MultiAnchorDescriptor NONE =
       new MultiAnchorDescriptor(Chain.EMPTY, StartPlan.None.INSTANCE, RejectPlan.None.INSTANCE);
@@ -28,10 +30,42 @@ record MultiAnchorDescriptor(
     this(chain, startPlan, rejectPlan, null, null);
   }
 
-  public MultiAnchorDescriptor {
-    Objects.requireNonNull(chain, "chain");
-    Objects.requireNonNull(startPlan, "startPlan");
-    Objects.requireNonNull(rejectPlan, "rejectPlan");
+  MultiAnchorDescriptor(
+      Chain chain,
+      StartPlan startPlan,
+      RejectPlan rejectPlan,
+      String anchoredPrefix,
+      CharClassScanInfo anchoredCharClassPrefix) {
+    this.chain = Objects.requireNonNull(chain, "chain");
+    this.startPlan = Objects.requireNonNull(startPlan, "startPlan");
+    this.rejectPlan = Objects.requireNonNull(rejectPlan, "rejectPlan");
+    this.anchoredPrefix = anchoredPrefix;
+    this.anchoredCharClassPrefix = anchoredCharClassPrefix;
+    // Eligibility depends only on the compiled chain, whose segments are never mutated after
+    // construction. Cache both input domains so dispatch and execution can check it in constant
+    // time.
+    this.executableChain = computeExecutableChain();
+    this.executableUtf8Chain = computeExecutableUtf8Chain();
+  }
+
+  Chain chain() {
+    return chain;
+  }
+
+  StartPlan startPlan() {
+    return startPlan;
+  }
+
+  RejectPlan rejectPlan() {
+    return rejectPlan;
+  }
+
+  String anchoredPrefix() {
+    return anchoredPrefix;
+  }
+
+  CharClassScanInfo anchoredCharClassPrefix() {
+    return anchoredCharClassPrefix;
   }
 
   enum InputDomain {
@@ -427,6 +461,10 @@ record MultiAnchorDescriptor(
   }
 
   boolean isExecutableChain() {
+    return executableChain;
+  }
+
+  private boolean computeExecutableChain() {
     int n = chain.segments().length;
     if (n < 1 || chain.isEndAnchored() || !isExecutableLeadingGap(chain.segments()[0].gap())) {
       return false;
@@ -437,6 +475,9 @@ record MultiAnchorDescriptor(
       return false;
     }
     for (int i = 0; i < n; i++) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       Segment segment = chain.segments()[i];
       if (!isExecutableAnchor(segment.anchor())) {
         return false;
@@ -487,10 +528,17 @@ record MultiAnchorDescriptor(
   }
 
   boolean isExecutableUtf8Chain() {
+    return executableUtf8Chain;
+  }
+
+  private boolean computeExecutableUtf8Chain() {
     if (!isExecutableChain()) {
       return false;
     }
     for (Segment segment : chain.segments()) {
+      if (WorkCounterConfig.ENABLED) {
+        WorkCounter.record();
+      }
       switch (segment.anchor()) {
         case Anchor.Single single -> {
           if (single.foldCase() && !isAscii(single.literal())) {
@@ -1719,6 +1767,8 @@ record MultiAnchorDescriptor(
       }
     }
 
+    // Ranges share compiled class metadata; array value equality is not used.
+    @SuppressWarnings("ArrayRecordComponent")
     record CharClass(AsciiBitmap bitmap, int[] ranges, CharClassScanInfo scanInfo)
         implements Anchor {
       static CharClass create(AsciiBitmap bitmap) {

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -44,8 +44,8 @@ final class MultiAnchorDescriptor {
     // Eligibility depends only on the compiled chain, whose segments are never mutated after
     // construction. Cache both input domains so dispatch and execution can check it in constant
     // time.
-    this.executableChain = computeExecutableChain();
-    this.executableUtf8Chain = computeExecutableUtf8Chain();
+    this.executableChain = computeExecutableChain(chain);
+    this.executableUtf8Chain = computeExecutableUtf8Chain(chain, executableChain);
   }
 
   Chain chain() {
@@ -464,7 +464,7 @@ final class MultiAnchorDescriptor {
     return executableChain;
   }
 
-  private boolean computeExecutableChain() {
+  private static boolean computeExecutableChain(Chain chain) {
     int n = chain.segments().length;
     if (n < 1 || chain.isEndAnchored() || !isExecutableLeadingGap(chain.segments()[0].gap())) {
       return false;
@@ -531,8 +531,8 @@ final class MultiAnchorDescriptor {
     return executableUtf8Chain;
   }
 
-  private boolean computeExecutableUtf8Chain() {
-    if (!isExecutableChain()) {
+  private static boolean computeExecutableUtf8Chain(Chain chain, boolean executableChain) {
+    if (!executableChain) {
       return false;
     }
     for (Segment segment : chain.segments()) {
@@ -640,7 +640,7 @@ final class MultiAnchorDescriptor {
     }
 
     boolean isExecutorFixedGap() {
-      return equals(EMPTY)
+      return kind == GapKind.EMPTY
           || (kind == GapKind.BOUNDED_CLASS_REPEAT && isFixed() && scanInfo != null);
     }
 

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -8,6 +8,7 @@ package org.safere;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,6 +18,69 @@ import org.safere.MultiAnchorDescriptor.StartPlan;
 
 @DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
 class MultiAnchorGapEngineTest {
+
+  @ParameterizedTest
+  @Tag("work-counter")
+  @ValueSource(strings = {"AAA[0-9]BBB", "AAA[0-9]BBB[0-9]CCC[0-9]DDD"})
+  void eligibilityQueriesDoNotRevisitCompiledSegments(String regex) {
+    MultiAnchorDescriptor descriptor = Pattern.compile(regex).multiAnchor();
+    assertThat(descriptor.isExecutableChain()).isTrue();
+    assertThat(descriptor.isExecutableUtf8Chain()).isTrue();
+
+    long work =
+        WorkCounter.countForTesting(
+            () -> {
+              for (int i = 0; i < 100; i++) {
+                assertThat(descriptor.isExecutableChain()).isTrue();
+                assertThat(descriptor.isExecutableUtf8Chain()).isTrue();
+              }
+            });
+
+    assertThat(work).isZero();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z error",
+        "[0-9]{2}TOKEN",
+        "AAA[0-9]{2}TOKEN",
+        "AAA[0-9]{2}TOKEN[a-z]{2}",
+        "(?i)AAA[0-9]{2}TOKEN"
+      })
+  void fixedChainsReuseCompiledMetadataAcrossSearches(String regex) {
+    Pattern pattern = Pattern.compile(regex);
+    java.util.regex.Pattern jdkPattern = java.util.regex.Pattern.compile(regex);
+    String valid = regex.startsWith("[0-9]{4}") ? "2026-08-30T12:00:00Z error" : "AAA12TOKENab";
+    String noise = "2026/08/30 12:00:00 [worker-42] info: normal periodic heartbeat\n";
+    for (String input :
+        new String[] {
+          "",
+          noise.repeat(20),
+          valid,
+          noise + valid,
+          valid + noise + valid,
+          "Z error TOKEN AAAxxTOKEN " + noise + valid
+        }) {
+      Matcher matcher = pattern.matcher(input);
+      Utf8Matcher utf8Matcher = pattern.matcher(Utf8Input.validated(input.getBytes(UTF_8)));
+      for (int repeat = 0; repeat < 2; repeat++) {
+        java.util.regex.Matcher expected = jdkPattern.matcher(input);
+        while (expected.find()) {
+          assertThat(matcher.find()).as(regex).isTrue();
+          assertThat(matcher.start()).isEqualTo(expected.start());
+          assertThat(matcher.end()).isEqualTo(expected.end());
+          assertThat(utf8Matcher.find()).as(regex).isTrue();
+          assertThat(utf8Matcher.start()).isEqualTo(expected.start());
+          assertThat(utf8Matcher.end()).isEqualTo(expected.end());
+        }
+        assertThat(matcher.find()).isFalse();
+        assertThat(utf8Matcher.find()).isFalse();
+        matcher.reset();
+        utf8Matcher.reset();
+      }
+    }
+  }
 
   @Test
   void patternMultiAnchorIntegrationStructure() {


### PR DESCRIPTION
Fixes #825.

After #807 removes the redundant required-literal reject prefilter, short absent-literal searches reach multi-anchor eligibility checks in both matcher dispatch and execution. Each check walks the compiled segments. Cache String and UTF-8 eligibility at descriptor construction so both callers can check it in constant time, preserving #807's scan removal.

Convert the internal descriptor from a record to a final class to hold the derived fields. Static computation helpers take the chain and prerequisite eligibility explicitly. Check empty gaps by kind while retaining the required `scanInfo != null` guard for bounded class gaps. Driver selection, candidate scans, verification, work limits, and fallbacks are unchanged. The predicates depend only on compiled metadata, which production consumers do not mutate. Move the existing array-component suppression to the specific nested record that needs it.

Add String/UTF-8 coverage for fixed chains across absent literals, failed candidates, repeated finds, and resets. A deterministic work-counter regression reports 600/1,200 segment visits before caching and zero afterward.

## Performance

Caching comparison baseline: merged #807, `54284571860bb1dbdd7cbcaf1bc22f43f54e2728`. Candidate: `b1a182c19c1710b57e260bc587a62a32445f32ca`, before the static-helper and empty-kind cleanup. OpenJDK 26.0.2+10-55, default SafeRE String engine, unchanged declared workloads, sequential runs through `./run-java-benchmarks.sh --fastbuild`. Work counters were disabled for benchmarks; the long baseline included only the disabled counter hooks and tests, without caching.

Standard mode (2 forks, 2 × 500 ms warmup, 5 × 500 ms measurement) reduced `isoTimestampLog.noMatch.1000` from **126.703 ± 7.181 to 98.964 ± 5.202 ns/op**, about 22% less time.

Long confirmation (2 forks, 3 × 1 s warmup, 5 × 1 s measurement):

| isoTimestampLog outcome | Size | Before ns/op | After ns/op | After / before |
|---|---:|---:|---:|---:|
| noMatch | 1000 | 123.170 ± 1.231 | 96.776 ± 1.682 | 0.786 |
| noMatch | 10000 | 825.924 ± 7.279 | 783.583 ± 23.522 | 0.949 |
| noMatch | 100000 | 7962.745 ± 331.673 | 7831.486 ± 147.420 | 0.984 |
| match | 1000 | 321.712 ± 3.390 | 296.106 ± 9.882 | 0.920 |
| match | 10000 | 1724.512 ± 12.398 | 1707.925 ± 30.829 | 0.990 |
| match | 100000 | 15881.538 ± 337.455 | 15515.188 ± 306.146 | 0.977 |

Errors are JMH 99.9% confidence interval half-widths. Long mode confirms about **21% less time on the target** and 8% less time on the matching 1000-byte case. Small differences with overlapping intervals are not established improvements; no regression was measured across these six cases. The baseline CPU profile confirms eligibility and gap-equality work on the multi-anchor path.

To reproduce, select all six `RealWorldRegexBenchmark.runBenchmark.isoTimestampLog.{noMatch,match}.{1000,10000,100000}@safere-string` trials as the comma-separated `crossEngineTrial` parameter of `org.safere.benchmark.CrossEngineBenchmark.run`, using the wrapper in standard and `--long` modes. Raw JSON, logs, the profile, exact runner script, and source patch are retained locally in `/tmp/safere-825-evidence/`; they are not checked in.

### Final implementation measurements

The final implementation was also measured in standard and long mode. Standard target time was **98.796 ± 2.443 ns/op**. A fresh long-mode comparison against `b1a182c19c1710b57e260bc587a62a32445f32ca` gives:

| isoTimestampLog outcome | Size | Existing PR head ns/op | Final implementation ns/op |
|---|---:|---:|---:|
| noMatch | 1000 | 99.907 ± 2.216 | 102.446 ± 4.196 |
| noMatch | 10000 | 824.417 ± 16.469 | 850.320 ± 50.869 |
| noMatch | 100000 | 8113.088 ± 192.089 | 8578.748 ± 330.403 |
| match | 1000 | 323.779 ± 26.278 | 306.164 ± 9.115 |
| match | 10000 | 1906.596 ± 89.998 | 1753.894 ± 27.337 |
| match | 100000 | 16670.963 ± 895.304 | 16165.072 ± 213.487 |

The target intervals overlap, as do those for the other two no-match cases. These runs do not establish an additional speedup from the cleanup; the target remains below the original uncached baseline. Raw outputs are `review-after*` and `review-before-fresh-long*` under the same local evidence directory. The fresh existing-head baseline was run after the final implementation; no benchmark runs overlapped.

## Verification

Passed on the original cached commit `b1a182c19c1710b57e260bc587a62a32445f32ca`:

- `mvn -pl safere test -q` (full SafeRE suite).
- Independent read-only review of the complete change: no findings.

Passed again on the final implementation:

- `mvn -pl safere test -q -Pwork-counters -Dtest=MultiAnchorGapEngineTest`.
- `mvn -pl safere test -q -Dtest=MultiAnchorGapEngineTest,MultiAnchorCompilerTest,PatternInternalTest,WorkCounterTest`.
- `git diff --check`.
- Standard and long benchmark comparisons for all six timestamp workloads.

The full suite and independent review were not repeated for the final cleanup. Not run: generated public API crosscheck, additional JDK versions, dedicated fuzzing, compilation benchmarks, broader benchmark workloads, or the external OpenJDK-derived suite.
