### PR TITLE
Prune unanchored BitState start positions with earlier failed starts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -298,10 +298,21 @@ at most once.
 
 - **When used:** Text length ≤ `MAX_BITMAP_BITS / prog.size()` (roughly
   256 KB / program size).
-- **Epsilon-cycle optimization:** Only ALT instructions involved in
-  epsilon cycles are visit-tracked.  Non-cycle ALTs can be revisited,
-  which is essential for nested quantifiers where an outer repetition must
-  re-enter a shared ALT entry point.
+- **Epsilon-cycle optimization:** Within one start position, only ALT
+  instructions involved in epsilon cycles are blocked on revisit.
+  Non-cycle ALTs can be revisited, which is essential for nested
+  quantifiers where an outer repetition must re-enter a shared ALT entry
+  point.
+- **Cross-start pruning:** Every ALT reached by an unanchored start
+  position whose search fails is folded into a second bitmap, and later
+  start positions skip those `(ALT, position)` pairs.  Whether a match is
+  reachable from such a pair does not depend on capture values, so this is
+  exact.  It keeps unanchored search linear instead of re-walking the same
+  greedy run from every start until the work budget trips and forces an
+  NFA fallback.  PROGRESS_CHECK loop registers only guard nullable bodies,
+  so a failed start still explores every future a later start could reach
+  through a pruned pair.  Off for anchored searches, which have a single
+  start.
 
 ### NFA / Pike VM (`Nfa`)
 

--- a/safere/src/main/java/org/safere/BitState.java
+++ b/safere/src/main/java/org/safere/BitState.java
@@ -270,12 +270,16 @@ final class BitState {
     matchResult =
         resultBuffer != null && resultBuffer.length >= ncap ? resultBuffer : new int[ncap];
     int limit = anchored ? startPos + 1 : Math.min(searchLimit + 1, textLen + 1);
+    pruneAcrossStarts = !anchored;
     for (int searchStart = startPos; searchStart < limit; searchStart++) {
       if (trySearch(prog.start(), searchStart)) {
         return bestMatch;
       }
       if (budgetExceeded) {
         return null;
+      }
+      if (pruneAcrossStarts) {
+        foldVisitedIntoDead();
       }
       if (searchStart < textLen) {
         searchStart = InputScanner.position(text.decodeForward(searchStart)) - 1;
@@ -298,16 +302,56 @@ final class BitState {
   private GraphemeSupport.Context graphemeContext;
 
   /**
-   * Visited bitmap: bit {@code (instId * textSlots + pos)} tracks whether the given (instruction,
-   * position) pair has been explored. Sized for the full text so the instance can be reused across
-   * searches with different start/end bounds.
+   * Per-start visited bitmap: bit {@code ((pos - basePos) * progSize + instId)} tracks which (ALT,
+   * position) pairs the current start position's search has reached. Position-major layout keeps
+   * one start's marks contiguous, so folding them into {@link #dead} costs no more than the search
+   * that produced them. Sized for the full text so the instance can be reused across searches with
+   * different start/end bounds.
    */
   private final long[] visited;
 
-  private int textSlots;
+  /**
+   * Cross-start pruning bitmap, same layout as {@link #visited}: set for every ALT reached by an
+   * earlier start position whose search failed. Whether a match is reachable from an (ALT,
+   * position) pair does not depend on capture values, so a pair that led nowhere from one start
+   * leads nowhere from any later start either. Checking it makes unanchored search linear (RE2 gets
+   * the same effect by never clearing its visited bitmap between starts) while still letting
+   * non-cycle ALTs be revisited within a single start, which capture priority requires.
+   *
+   * <p>PROGRESS_CHECK loop registers do not break this. They only guard nullable loop bodies, so a
+   * first visit's body-only branch still reaches the exit through a zero-width iteration, and a
+   * path that arrives with the register equal to the current position (exit-only) exists only
+   * because the same start already took the body from that position. Either way the failed start
+   * explored every future a later start could have through the pruned pair.
+   *
+   * <p>Allocated unconditionally alongside {@link #visited}, even though anchored-only instances
+   * never use it: lazily allocating it on first unanchored use was tried and measured 40-60% slower
+   * on unanchored searches (the case that actually prunes), for a memory saving that only applies
+   * to anchored-only instances. Not a good trade.
+   */
+  private final long[] dead;
 
-  /** Which ALT instructions are part of epsilon cycles and need the visited bitmap. */
-  private final boolean[] cycleAlts;
+  /** Dirty word ranges of {@link #visited} and {@link #dead}; clears touch only these words. */
+  private int visitedLo;
+
+  private int visitedHi;
+  private int deadLo;
+  private int deadHi;
+
+  private int textSlots;
+  private final int progSize;
+
+  /** Whether the current {@link #doSearch} prunes later starts with {@link #dead}. */
+  private boolean pruneAcrossStarts;
+
+  /**
+   * Per-instruction kind for {@link #shouldVisit}: 0 = not an ALT, 1 = ALT, 2 = epsilon-cycle ALT.
+   */
+  private final byte[] altKind;
+
+  private static final byte NOT_ALT = 0;
+  private static final byte ALT = 1;
+  private static final byte CYCLE_ALT = 2;
 
   /** Current capture registers. */
   private final int[] cap;
@@ -351,12 +395,30 @@ final class BitState {
     this.endMatch = endMatch || prog.anchorEnd();
     this.ncap = ncap;
     this.textSlots = (endPos - basePos) + 2;
-    this.cycleAlts = prog.epsilonCycleAlts();
+    this.progSize = prog.size();
     this.graphemeContext = GraphemeSupport.Context.create(text, prog.hasGraphemeSemantics());
 
-    int totalBits = prog.size() * textSlots;
+    boolean[] cycleAlts = prog.epsilonCycleAlts();
+    this.altKind = new byte[progSize];
+    for (int i = 0; i < progSize; i++) {
+      if (cycleAlts[i]) {
+        altKind[i] = CYCLE_ALT;
+      } else {
+        int op = prog.inst(i).opCode;
+        if (op == InstOp.OP_ALT || op == InstOp.OP_ALT_MATCH) {
+          altKind[i] = ALT;
+        }
+      }
+    }
+
+    int totalBits = progSize * textSlots;
     int visitedLen = (totalBits + 63) / 64;
     this.visited = new long[visitedLen];
+    this.dead = new long[visitedLen];
+    this.visitedLo = Integer.MAX_VALUE;
+    this.visitedHi = -1;
+    this.deadLo = Integer.MAX_VALUE;
+    this.deadHi = -1;
 
     this.cap = new int[ncap];
     Arrays.fill(cap, -1);
@@ -376,9 +438,10 @@ final class BitState {
   }
 
   /**
-   * Returns true if (instId, pos) should be explored; marks epsilon-cycle ALTs as visited.
+   * Returns true if (instId, pos) should be explored. Records every ALT reached so a failed start
+   * can prune later ones via {@link #dead}; within one start, only epsilon-cycle ALTs are blocked.
    *
-   * <p>Only ALT/ALT_MATCH instructions that participate in epsilon cycles use the visited bitmap.
+   * <p>Only ALT/ALT_MATCH instructions that participate in epsilon cycles are blocked on revisit.
    * An epsilon cycle is a path from an ALT back to itself through only epsilon transitions (ALT,
    * NOP, CAPTURE, EMPTY_WIDTH) — without any CHAR_RANGE to consume input. Only these can cause
    * infinite loops.
@@ -398,19 +461,52 @@ final class BitState {
    * </ul>
    */
   private boolean shouldVisit(int instId, int pos) {
-    if (!cycleAlts[instId]) {
-      return true; // non-cycle or non-ALT instruction: safe to revisit
+    int kind = altKind[instId];
+    if (kind == NOT_ALT) {
+      return true;
     }
-    // Cycle ALT: use visited bitmap to prevent infinite epsilon loops.
-    int bit = instId * textSlots + (pos - basePos);
-    int word = bit / 64;
-    long mask = 1L << (bit % 64);
-    if ((visited[word] & mask) != 0) {
-      return false; // already visited
+    int bit = (pos - basePos) * progSize + instId;
+    int word = bit >>> 6;
+    long mask = 1L << (bit & 63);
+    if (pruneAcrossStarts) {
+      if ((dead[word] & mask) != 0) {
+        return false; // an earlier start already exhausted this pair without matching
+      }
+    } else if (kind == ALT) {
+      return true; // non-cycle ALT: safe to revisit
     }
-    visited[word] |= mask;
-
+    long w = visited[word];
+    if ((w & mask) != 0) {
+      // Cycle ALT: block the epsilon loop. Non-cycle ALT: revisitable, and already recorded.
+      return kind == ALT;
+    }
+    visited[word] = w | mask;
+    if (word < visitedLo) {
+      visitedLo = word;
+    }
+    if (word > visitedHi) {
+      visitedHi = word;
+    }
     return true;
+  }
+
+  /** Moves the failed start's marks into {@link #dead} and clears them for the next start. */
+  private void foldVisitedIntoDead() {
+    if (visitedHi < visitedLo) {
+      return;
+    }
+    for (int w = visitedLo; w <= visitedHi; w++) {
+      dead[w] |= visited[w];
+      visited[w] = 0L;
+    }
+    if (visitedLo < deadLo) {
+      deadLo = visitedLo;
+    }
+    if (visitedHi > deadHi) {
+      deadHi = visitedHi;
+    }
+    visitedLo = Integer.MAX_VALUE;
+    visitedHi = -1;
   }
 
   /** Pushes a job onto the stack, growing if needed. */
@@ -669,9 +765,16 @@ final class BitState {
     this.graphemeContext = GraphemeSupport.Context.create(text, prog.hasGraphemeSemantics());
     this.bestMatch = null;
     this.jobCount = 0;
-    int totalBits = prog.size() * textSlots;
-    int usedLen = (totalBits + 63) / 64;
-    Arrays.fill(visited, 0, usedLen, 0L);
+    if (visitedHi >= visitedLo) {
+      Arrays.fill(visited, visitedLo, visitedHi + 1, 0L);
+      visitedLo = Integer.MAX_VALUE;
+      visitedHi = -1;
+    }
+    if (deadHi >= deadLo) {
+      Arrays.fill(dead, deadLo, deadHi + 1, 0L);
+      deadLo = Integer.MAX_VALUE;
+      deadHi = -1;
+    }
     Arrays.fill(cap, 0, ncap, -1);
     if (loopRegs.length > 0) {
       Arrays.fill(loopRegs, -1);

--- a/safere/src/test/java/org/safere/BitStateTest.java
+++ b/safere/src/test/java/org/safere/BitStateTest.java
@@ -331,6 +331,71 @@ class BitStateTest {
 
       assertThat(shifted.stepBudgetForTesting()).isEqualTo(nearStart.stepBudgetForTesting());
     }
+
+    @Test
+    void failedStartsPruneLaterStartsSoGreedyRunsStayLinear() {
+      // Without cross-start pruning every start position re-walks the whole run of 'a's, which is
+      // quadratic and exhausts the work budget long before the last start is tried.
+      Regexp re = Parser.parse("(a*)b", FLAGS);
+      Prog prog = Compiler.compile(re);
+      int ncap = 2 * Math.max(prog.numCaptures(), 1);
+      String text = "a".repeat(20_000);
+      assertThat(text.length()).isLessThanOrEqualTo(BitState.maxTextSize(prog));
+
+      BitState bs = BitState.getOrCreate(null, prog, text, 0, text.length(), ncap, false, false);
+
+      assertThat(bs.doSearch(0, text.length(), false)).isNull();
+      assertThat(bs.budgetExceeded()).isFalse();
+    }
+
+    @Test
+    void reusedInstanceStaysCorrectAcrossAnchoredAndUnanchoredSearches() {
+      // The dead-pruning bitmap is allocated lazily on the first unanchored search. Exercise a
+      // single cached instance through anchored, then unanchored, then anchored again to make sure
+      // that lazy allocation and the reset() bookkeeping around it don't corrupt reused state.
+      Regexp re = Parser.parse("(a*)b", FLAGS);
+      Prog prog = Compiler.compile(re);
+      int ncap = 2 * Math.max(prog.numCaptures(), 1);
+      String text = "xxxaaab";
+
+      BitState bs = BitState.getOrCreate(null, prog, text, 3, text.length(), ncap, false, false);
+      assertThat(bs.doSearch(3, text.length(), true)).containsExactly(3, 7, 3, 6);
+
+      bs = BitState.getOrCreate(bs, prog, text, 0, text.length(), ncap, false, false);
+      assertThat(bs.doSearch(0, text.length(), false)).containsExactly(3, 7, 3, 6);
+
+      bs = BitState.getOrCreate(bs, prog, text, 3, text.length(), ncap, false, false);
+      assertThat(bs.doSearch(3, text.length(), true)).containsExactly(3, 7, 3, 6);
+    }
+
+    @Test
+    void prunedStartsDoNotHideALaterLeftmostMatch() {
+      Regexp re = Parser.parse("(a*)c", FLAGS);
+      Prog prog = Compiler.compile(re);
+      // Start 0 walks "aaa", fails at 'b', and marks those positions dead; the match begins at 5.
+      int[] result = BitState.search(prog, "aaabbaac", false, false, false, prog.numCaptures());
+
+      assertThat(result).containsExactly(5, 8, 5, 7);
+    }
+
+    @Test
+    void pruningStaysExactAcrossProgressCheckLoops() {
+      // Nullable loop bodies compile to PROGRESS_CHECK, whose behavior depends on a loop register.
+      // Failed starts must still be safe to prune; compare against the NFA on inputs where the
+      // leftmost match begins after several pruned starts.
+      String[] patterns = {
+        "(a*)+c", "(?:a?)+b(c|d)", "(a*)*b", "(?:(a*)+x)*y", "((a*)+b)+c", "(a|b*)+c", "(x*)+(a*)*b"
+      };
+      String[] texts = {
+        "aaabbaac", "aabaad", "aaaxaaab", "aaxaayxy", "aabaabc", "abbaaccab", "xxaaxbxb", "aaaa"
+      };
+      for (String pattern : patterns) {
+        for (String text : texts) {
+          assertConsistentUnanchored(pattern, text);
+          assertConsistentUnanchored(pattern, text.repeat(40));
+        }
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes unanchored BitState searches linear by pruning start positions with the results of earlier, failed start positions.

## Problem

BitState only visit-tracks ALT instructions that sit on epsilon cycles. Non-cycle ALTs must stay revisitable *within* one start position: an outer repetition has to be able to re-enter a shared ALT entry point, otherwise nested quantifiers match prematurely. The side effect is that nothing is remembered *across* start positions either. For an unanchored search over a pattern with a leading greedy loop and a failing tail (`(a*)b`, `(.*),(.*)` on a line without a comma, `[a-z]+@` on a run of letters), every start position re-walks the entire remaining run. That is quadratic until the `MAX_WORK_PER_SLOT` budget trips, at which point the engine has spent the whole budget (≈1.1M steps for a 20k-char text) and then falls back to the Pike NFA anyway.

This is a production path, not just a micro-benchmark one: `Matcher.searchWithBitStateOrNfa` is called unanchored over the full text from the `preferCaptureEngine` branch once a caller consumes inner captures.

## Change

`BitState` keeps a second bitmap, `dead`, alongside the per-start `visited` bitmap:

- Every ALT reached during a start position's search is recorded in `visited` (non-cycle ALTs are recorded but not blocked, so within-start semantics are unchanged; cycle ALTs are check-and-set exactly as before).
- When a start position's search fails, its `visited` marks are folded into `dead` and cleared.
- Every ALT checks `dead` first. Whether a match is reachable from an `(ALT, position)` pair does not depend on capture values, so a pair that led nowhere from one start leads nowhere from any later start. This is the same property RE2's `bitstate.cc` relies on when it never clears its visited bitmap between starts.
- `PROGRESS_CHECK` loop registers do not break this: they only guard nullable loop bodies, so a first visit's body-only branch still reaches the exit through a zero-width iteration, and a path arriving with the register equal to the current position (exit-only) exists only because the same start already took the body from that position. The pre-change code already relied on this implicitly, because cycle-ALT `visited` bits persisted across starts with `PROGRESS_CHECK` downstream.
- Pruning is off for anchored searches (single start, no benefit, no bitmap cost).

Supporting details:

- The bitmap layout changes from instruction-major to position-major (`(pos - basePos) * progSize + instId`) so one start's marks are contiguous and the fold costs no more than the search that produced them.
- `reset()` now clears only the dirty word ranges of both bitmaps instead of the whole used prefix.
- `cycleAlts` is replaced by a per-instruction `altKind` byte so `shouldVisit` can tell "record" from "record and block" with one load.
- `DESIGN.md` describes the mechanism.

The dispatch loop itself is untouched. Two other RE2 techniques were tried first and rejected because they measured slower on the JVM despite doing less work: inlining single-successor transitions instead of push/pop (44% fewer stack operations, ~20% slower — the nested loop hurt branch prediction more than the L1-resident stack ops cost) and run-length-encoded job-stack entries (~35% slower on `(a+)+b`).

## Benchmarks

### Standard Java benchmark configuration (`./run-java-benchmarks.sh --fastbuild`, 2 forks, 2×500ms warmup, 5×500ms measurement)

Trials selected because they exercise BitState capture extraction; `unanchoredLogCaptures` is the flow this change targets.

| Trial (safere-string) | Before | After | Change |
|---|---|---|---|
| `RealWorld.unanchoredLogCaptures.match.1000` | 1,371.2 ± 19.9 ns/op | 1,387.3 ± 18.3 ns/op | +1.2% |
| `RealWorld.unanchoredLogCaptures.noMatch.1000` | 257.6 ± 3.0 ns/op | 268.0 ± 3.9 ns/op | +4.0% |
| `RealWorld.unanchoredLogCaptures.match.10000` | 8,695.9 ± 251.7 ns/op | 8,710.3 ± 391.5 ns/op | +0.2% |
| `RealWorld.unanchoredLogCaptures.noMatch.10000` | 2,320.8 ± 18.4 ns/op | 2,408.5 ± 98.3 ns/op | +3.8% |
| `RealWorld.multiInfixLogCaptures.match.1000` | 4,058.3 ± 170.5 ns/op | 4,090.8 ± 141.8 ns/op | +0.8% |
| `RealWorld.multiInfixLogCaptures.noMatch.1000` | 2,164.7 ± 33.9 ns/op | 2,205.8 ± 25.9 ns/op | +1.9% |
| `CaptureScalingBenchmark.capture1` | 55.0 ± 2.7 ns/op | 54.6 ± 3.2 ns/op | -0.8% |
| `CaptureScalingBenchmark.capture3` | 75.1 ± 1.7 ns/op | 74.2 ± 0.8 ns/op | -1.2% |
| `CaptureScalingBenchmark.capture10` | 198.3 ± 5.6 ns/op | 193.8 ± 1.9 ns/op | -2.3% |
| `RegexBenchmark.captureGroups` | 74.5 ± 1.2 ns/op | 75.7 ± 1.1 ns/op | +1.6% |
| `DiagnosticsDisabledBenchmark.bitStateShortMatches` | 12.5 ± 0.2 ns/op | 12.5 ± 0.1 ns/op | -0.5% |

These are the standard plan's capture-extraction trials. Their patterns start with a required literal (`error:\[`, digit runs) or are bounded by the DFA first, so a start position that fails does so within a few instructions and there is no long greedy run for pruning to remove; they serve as the no-regression check for the extra per-ALT bitmap write. All differences are within a few percent. The two `noMatch` trials sit just outside their error bars, so they were re-run with `--long`:

| Trial (safere-string), `--long` | Before | After | Change |
|---|---|---|---|
| `RealWorld.unanchoredLogCaptures.noMatch.1000` | 267.2 ± 7.9 ns/op | 269.8 ± 7.7 ns/op | +1.0% |
| `RealWorld.unanchoredLogCaptures.noMatch.10000` | 2,396.5 ± 88.1 ns/op | 2,425.0 ± 87.3 ns/op | +1.2% |

Both are inside their error bars: no measurable regression.

The measured improvement is on unanchored BitState searches whose leading greedy loop fails, which the standard plan does not contain; those are shown with the direct harness below.

### Direct `BitState.search` micro-harness (ad hoc, not part of the repo; best-of-7 × reps, same JVM flags for both sides)

| Case | Before | After | Change |
|---|---|---|---|
| `a*b`, unanchored, 20 000 chars, no match | 2.97 ms/op | 0.29 ms/op | ~10× faster; no longer exhausts the work budget |
| `[a-z]+@`, unanchored, 20 000 chars, no match | 3.11 ms/op | 0.34 ms/op | ~9× faster |
| `Matcher.find()` loop, `(.*?)(\d+),`, 1 000 matches, BitState forced via `EnginePathOptions` | 0.21 ms/op | 0.16 ms/op | −22% |
| `(a+)+b`, unanchored, 3 000 chars | 0.66 ms/op | 0.68 ms/op | unchanged (blowup is within one start and still budget-capped) |
| 150 sequential groups, anchored | 0.0044 ms/op | 0.0044 ms/op | unchanged (pruning off when anchored) |

## Rejected follow-up: lazy-allocating `dead`

`dead` is the same size as `visited` but only used by unanchored searches, so it doubles the memory footprint of a `BitState` instance that only ever runs anchored (e.g. one backing only `matches()`/`lookingAt()`). Allocating it lazily, on the first unanchored `doSearch`, seemed like a free win — total allocation count for an unanchored-heavy workload is unchanged; only the anchored-only case saves anything.

Measured instead: 40-60% *slower* on unanchored searches, i.e. exactly the case that does prune and whose allocation count didn't change (`(a+)+b` micro-harness: 0.68ms → 1.09ms; isolated re-run: 0.67ms → 0.88ms). Moving the always-happens-anyway allocation from the constructor into `doSearch` was enough to cause it, which points at allocation-site/escape-analysis effects rather than allocation count. Reverted; `BitState.java` has a code comment recording this so it isn't retried blind. Left as a real but unclaimed opportunity if someone wants to chase the actual mechanism.

## Verification

Ran:

- `mvn -pl safere test -Dtest=BitStateTest,MatcherTest,RE2RegressionTest,CrossEngineExhaustiveTest,MatcherDeferredCaptureStateTest,ScopedLineModeAnchorTest,EnginePathEquivalenceTest,DiagnosticsTest,Utf8EnginePathEquivalenceTest,Utf8DiagnosticsTest` — pass (includes the exhaustive BitState-vs-NFA cross-engine suite).
- `mvn -pl safere test -Pwork-counters -Dtest=MatcherLinearTimeTest,SearchScalingRegressionTest,Utf8LinearTimeTest,GraphemeLinearTimeTest,WorkCounterTest` — pass.
- `mvn -pl safere spotless:check` — clean.
- Tests in `BitStateTest.Budget`: a 20k-char greedy run no longer exceeds the work budget; a leftmost match that begins after several pruned starts is still found with correct captures; BitState/NFA agreement on seven nullable-body (`PROGRESS_CHECK`) loop patterns × eight inputs, plain and ×40 repeated; a cached instance reused across anchored → unanchored → anchored searches still returns correct captures each time (added while investigating the lazy-allocation idea above; independent of it).
- Standard JMH benchmarks above, including the `--long` confirmation.

Not run:

- The full `safere` module test suite and the `safere-crosscheck` public-API crosscheck reactor.
- Fuzz targets (`safere-fuzz`).
