### PR TITLE
Precompute case-insensitive search state for multi-anchor Alternation

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -3174,6 +3174,16 @@
         "length": "{size}"
       },
       "shared": true
+    },
+    {
+      "id": "alternationFindNext.shortGapPool",
+      "recipe": {
+        "kind": "randomChars",
+        "alphabet": "abcdefghijklmnopqrstuvwxyz",
+        "length": 327680,
+        "seed": 20260910
+      },
+      "shared": false
     }
   ],
   "workloads": [
@@ -13059,6 +13069,34 @@
       "expected": {
         "type": "boolean",
         "value": true
+      }
+    },
+    {
+      "id": "AlternationFindNextBenchmark.foldedShortGapNoMatch",
+      "operation": "alternationFindNext",
+      "patterns": [
+        "NETWORK",
+        "STORAGE",
+        "DATABASE",
+        "SECURITY"
+      ],
+      "inputs": [
+        "alternationFindNext.shortGapPool"
+      ],
+      "arguments": {
+        "inputLength": 40
+      },
+      "resultConsumption": "integer",
+      "expected": {
+        "type": "integer",
+        "value": -1
+      },
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
       }
     }
   ]

--- a/safere-benchmarks/src/main/java/org/safere/AlternationFindNextBenchmarkRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/AlternationFindNextBenchmarkRunner.java
@@ -1,0 +1,42 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import java.util.List;
+
+/** Benchmark-only adapter for measuring package-private alternation anchor searches directly. */
+public final class AlternationFindNextBenchmarkRunner {
+  private final MultiAnchorDescriptor.Anchor.Alternation alternation;
+  private final String[] inputs;
+  private int nextInput;
+
+  /** Creates a runner over fixed-width slices of a materialized input pool. */
+  public AlternationFindNextBenchmarkRunner(
+      List<String> literals, String inputPool, int inputLength) {
+    if (inputLength <= 0 || inputPool.length() % inputLength != 0) {
+      throw new IllegalArgumentException("Input pool must contain equal non-empty slices");
+    }
+    this.alternation =
+        MultiAnchorDescriptor.Anchor.Alternation.create(literals.toArray(String[]::new), true);
+    this.inputs = new String[inputPool.length() / inputLength];
+    for (int i = 0; i < inputs.length; i++) {
+      inputs[i] = inputPool.substring(i * inputLength, (i + 1) * inputLength);
+      if (alternation.findNext(inputs[i], 0) >= 0) {
+        throw new IllegalArgumentException("Alternation benchmark input pool contains a match");
+      }
+    }
+  }
+
+  /** Searches the next input in the rotating pool and returns the match position. */
+  public int findNext() {
+    String input = inputs[nextInput];
+    nextInput++;
+    if (nextInput == inputs.length) {
+      nextInput = 0;
+    }
+    return alternation.findNext(input, 0);
+  }
+}

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/DeclarativeBenchmarkPlan.java
@@ -1623,7 +1623,8 @@ final class DeclarativeBenchmarkPlan {
     CACHED_ANALYSIS("cachedAnalysis", false, false, Feature.DIAGNOSTICS),
     COMPILE_AND_ANALYZE("compileAndAnalyze", false, false, Feature.DIAGNOSTICS),
     DFA_CACHE_GROWTH("dfaCacheGrowth", false, true, Feature.DFA_CACHE),
-    DIAGNOSTICS_FIND("diagnosticsFind", false, true, Feature.FIND, Feature.DIAGNOSTICS);
+    DIAGNOSTICS_FIND("diagnosticsFind", false, true, Feature.FIND, Feature.DIAGNOSTICS),
+    ALTERNATION_FIND_NEXT("alternationFindNext", false, true, Feature.DIAGNOSTICS);
 
     private final String jsonName;
     private final boolean lifecycleRequired;
@@ -1750,7 +1751,7 @@ final class DeclarativeBenchmarkPlan {
         case COMPILE, PATTERN_SET_COMPILE -> consumption == ResultConsumption.COMPILED_OBJECT;
         case MATCHER_CONSTRUCTION, ANALYZE_PATTERN, CACHED_ANALYSIS, COMPILE_AND_ANALYZE ->
             consumption == ResultConsumption.BLACKHOLE_OBJECT;
-        case DFA_CACHE_GROWTH -> consumption == ResultConsumption.INTEGER;
+        case DFA_CACHE_GROWTH, ALTERNATION_FIND_NEXT -> consumption == ResultConsumption.INTEGER;
       };
     }
 
@@ -1782,6 +1783,7 @@ final class DeclarativeBenchmarkPlan {
                 "action", RecipeValueType.STRING,
                 "listener", RecipeValueType.STRING,
                 "replacement", RecipeValueType.STRING);
+        case ALTERNATION_FIND_NEXT -> Map.of("inputLength", RecipeValueType.INTEGER);
         case PATTERN_SET_COMPILE, PATTERN_SET_FIND, PATTERN_SET_MATCHES ->
             Map.of(
                 "anchor", RecipeValueType.STRING,
@@ -1807,6 +1809,7 @@ final class DeclarativeBenchmarkPlan {
             Set.of("replacement");
         case PATTERN_SET_COMPILE, PATTERN_SET_FIND, PATTERN_SET_MATCHES -> Set.of("anchor");
         case FIND_ROTATING_UTF16, COMPILE_AND_FIND_ROTATING_UTF16 -> Set.of("seed", "count");
+        case ALTERNATION_FIND_NEXT -> Set.of("inputLength");
         default -> Set.of();
       };
     }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedBenchmarkPlan.java
@@ -57,7 +57,8 @@ final class SpecializedBenchmarkPlan {
               ANALYZE_PATTERN,
               CACHED_ANALYSIS,
               COMPILE_AND_ANALYZE,
-              DIAGNOSTICS_FIND ->
+              DIAGNOSTICS_FIND,
+              ALTERNATION_FIND_NEXT ->
               true;
           default -> false;
         }

--- a/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedTrialRunner.java
+++ b/safere-benchmarks/src/main/java/org/safere/benchmark/SpecializedTrialRunner.java
@@ -8,6 +8,7 @@ package org.safere.benchmark;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.LongAdder;
 import org.openjdk.jmh.infra.Blackhole;
+import org.safere.AlternationFindNextBenchmarkRunner;
 import org.safere.OperationDiagnostics;
 import org.safere.Pattern;
 import org.safere.PatternSet;
@@ -46,6 +47,8 @@ final class SpecializedTrialRunner implements AutoCloseable {
       case CACHED_ANALYSIS -> new SpecializedTrialRunner(cachedAnalysis(workload), false);
       case COMPILE_AND_ANALYZE -> new SpecializedTrialRunner(compileAndAnalyze(workload), false);
       case DIAGNOSTICS_FIND -> new SpecializedTrialRunner(diagnostics(workload), true);
+      case ALTERNATION_FIND_NEXT ->
+          new SpecializedTrialRunner(alternationFindNext(workload), false);
       default ->
           throw new IllegalArgumentException(
               "Unsupported specialized operation: " + workload.operation());
@@ -169,6 +172,15 @@ final class SpecializedTrialRunner implements AutoCloseable {
           blackhole -> blackhole.consume(pattern.matcher(input).replaceAll(replacement));
       default -> throw new IllegalArgumentException("Unknown diagnostics action: " + action);
     };
+  }
+
+  private static Task alternationFindNext(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {
+    AlternationFindNextBenchmarkRunner runner =
+        new AlternationFindNextBenchmarkRunner(
+            workload.patterns(),
+            inputString(workload),
+            integerArgument(workload, "inputLength", 0));
+    return blackhole -> blackhole.consume(runner.findNext());
   }
 
   private static String inputString(DeclarativeBenchmarkPlan.ExpandedWorkload workload) {

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -100,6 +100,7 @@
                         <include name="ExhaustiveUtils.java"/>
                         <!-- Compile-time structural excludes. Each excluded test class is also
                              annotated with @DisabledForCrosscheck in the original source. -->
+                        <exclude name="AlternationFindNextTest.java"/>
                         <exclude name="AnchorOptTest.java"/>
                         <exclude name="AnchoredDfaCachingTest.java"/>
                         <exclude name="AsciiBitmapTest.java"/>

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -1331,7 +1331,15 @@ final class MultiAnchorDescriptor {
         int minLength,
         int maxLength,
         MultiLiteralInfo multiLiteral,
-        TeddyModel teddyModel)
+        TeddyModel teddyModel,
+        // Per-literal case-insensitive search state, precomputed once here instead of on every
+        // findNext() probe: Matcher.indexOfIgnoreCase's 3-arg convenience overload otherwise
+        // recomputes the rarest-ASCII-char anchor and rebuilds the ClassHashChain (a ~1KB table
+        // plus Unicode fold expansion) from scratch on every call. Null when !foldCase.
+        int[] anchorOffsets,
+        char[] anchorLows,
+        char[] anchorHighs,
+        ClassHashChain[] classHashChains)
         implements Anchor {
 
       static Alternation create(String[] literals, boolean foldCase) {
@@ -1352,7 +1360,42 @@ final class MultiAnchorDescriptor {
         MultiLiteralInfo multiLit = !foldCase ? MultiLiteralInfo.create(literals) : null;
         TeddyModel teddy = !foldCase ? TeddyModel.compileForSelectedProvider(literals) : null;
 
-        return new Alternation(literals.clone(), utf8, foldCase, min, max, multiLit, teddy);
+        int[] anchorOffsets = null;
+        char[] anchorLows = null;
+        char[] anchorHighs = null;
+        ClassHashChain[] classHashChains = null;
+        if (foldCase) {
+          anchorOffsets = new int[literals.length];
+          anchorLows = new char[literals.length];
+          anchorHighs = new char[literals.length];
+          classHashChains = new ClassHashChain[literals.length];
+          for (int i = 0; i < literals.length; i++) {
+            String lit = literals[i];
+            int len = lit.length();
+            if (len == 0) {
+              continue; // indexOfIgnoreCase short-circuits on empty prefixes; anchor unused.
+            }
+            int anchorOffset = len == 1 ? 0 : RarityOracle.rarestAsciiOffset(lit, len, true);
+            char anchor = lit.charAt(anchorOffset);
+            anchorOffsets[i] = anchorOffset;
+            anchorLows[i] = Ascii.toLowerCase(anchor);
+            anchorHighs[i] = Ascii.toUpperCase(anchor);
+            classHashChains[i] = ClassHashChain.compileCaseInsensitive(lit);
+          }
+        }
+
+        return new Alternation(
+            literals.clone(),
+            utf8,
+            foldCase,
+            min,
+            max,
+            multiLit,
+            teddy,
+            anchorOffsets,
+            anchorLows,
+            anchorHighs,
+            classHashChains);
       }
 
       @Override
@@ -1380,22 +1423,27 @@ final class MultiAnchorDescriptor {
         return literals[0];
       }
 
+      private int indexOfLiteral(String text, int i, int fromIndex) {
+        return foldCase
+            ? Matcher.indexOfIgnoreCase(
+                text,
+                literals[i],
+                anchorOffsets[i],
+                anchorLows[i],
+                anchorHighs[i],
+                classHashChains[i],
+                fromIndex)
+            : text.indexOf(literals[i], fromIndex);
+      }
+
       @Override
       public int findNext(String text, int fromIndex) {
         if (literals.length == 2) {
-          String lit0 = literals[0];
-          String lit1 = literals[1];
-          int p0 =
-              foldCase
-                  ? Matcher.indexOfIgnoreCase(text, lit0, fromIndex)
-                  : text.indexOf(lit0, fromIndex);
+          int p0 = indexOfLiteral(text, 0, fromIndex);
           if (p0 == fromIndex) {
             return p0;
           }
-          int p1 =
-              foldCase
-                  ? Matcher.indexOfIgnoreCase(text, lit1, fromIndex)
-                  : text.indexOf(lit1, fromIndex);
+          int p1 = indexOfLiteral(text, 1, fromIndex);
           if (p0 < 0) {
             return p1;
           }
@@ -1405,11 +1453,8 @@ final class MultiAnchorDescriptor {
           return Math.min(p0, p1);
         }
         int bestPos = Integer.MAX_VALUE;
-        for (String lit : literals) {
-          int pos =
-              foldCase
-                  ? Matcher.indexOfIgnoreCase(text, lit, fromIndex)
-                  : text.indexOf(lit, fromIndex);
+        for (int i = 0; i < literals.length; i++) {
+          int pos = indexOfLiteral(text, i, fromIndex);
           if (pos >= 0 && pos < bestPos) {
             bestPos = pos;
             if (bestPos == fromIndex) {

--- a/safere/src/test/java/org/safere/AlternationFindNextTest.java
+++ b/safere/src/test/java/org/safere/AlternationFindNextTest.java
@@ -1,0 +1,99 @@
+// This file is part of a Java port of RE2 (https://github.com/google/re2).
+// Original RE2 code is Copyright (c) 2009 The RE2 Authors.
+// Modifications and Java port Copyright (c) 2026 Eddie Aftandilian.
+// Licensed under the BSD 3-Clause License (see LICENSE file).
+
+package org.safere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.safere.MultiAnchorDescriptor.Anchor.Alternation;
+
+/**
+ * Tests for {@link Alternation#findNext(String, int)}'s case-insensitive search, which precomputes
+ * per-literal anchor and {@link ClassHashChain} state once at {@link Alternation#create} instead of
+ * rebuilding it on every probe. Covers the 2-literal fast path and the general N-literal loop,
+ * ASCII and non-ASCII literals (which take different code paths in {@code
+ * Matcher.indexOfIgnoreCase}), and that per-literal state isn't cross-contaminated by index.
+ */
+@DisabledForCrosscheck("implementation test uses package-private SafeRE internals")
+class AlternationFindNextTest {
+
+  @Test
+  @DisplayName("two ASCII literals: finds either, case-insensitively")
+  void twoAsciiLiterals() {
+    Alternation alt = Alternation.create(new String[] {"foo", "bar"}, true);
+
+    assertThat(alt.findNext("xxxBARyyy", 0)).isEqualTo(3);
+    assertThat(alt.findNext("xxxFOOyyy", 0)).isEqualTo(3);
+    assertThat(alt.findNext("no match here", 0)).isEqualTo(-1);
+  }
+
+  @Test
+  @DisplayName("N (>2) ASCII literals of length >= 4: each literal matches at its own position")
+  void manyAsciiLiteralsEachMatchIndependently() {
+    String[] literals = {"alpha", "bravo", "charlie", "delta"};
+    Alternation alt = Alternation.create(literals, true);
+
+    assertThat(alt.findNext("zzzzzALPHAzzzz", 0)).isEqualTo(5);
+    assertThat(alt.findNext("zzzzzBRAVOzzzz", 0)).isEqualTo(5);
+    assertThat(alt.findNext("zzzzzCHARLIEzzzz", 0)).isEqualTo(5);
+    assertThat(alt.findNext("zzzzzDELTAzzzz", 0)).isEqualTo(5);
+    assertThat(alt.findNext("zzzzzECHOzzzz", 0)).isEqualTo(-1);
+  }
+
+  @Test
+  @DisplayName("fromIndex skips an earlier match to find a later one, per literal")
+  void fromIndexSkipsEarlierMatch() {
+    String[] literals = {"alpha", "bravo", "charlie", "delta"};
+    Alternation alt = Alternation.create(literals, true);
+    String text = "..ALPHA....BRAVO....CHARLIE....DELTA..";
+
+    int p0 = alt.findNext(text, 0);
+    assertThat(p0).isEqualTo(2);
+    int p1 = alt.findNext(text, p0 + 1);
+    assertThat(p1).isEqualTo(11);
+    int p2 = alt.findNext(text, p1 + 1);
+    assertThat(p2).isEqualTo(20);
+    int p3 = alt.findNext(text, p2 + 1);
+    assertThat(p3).isEqualTo(31);
+    assertThat(alt.findNext(text, p3 + 1)).isEqualTo(-1);
+  }
+
+  @Test
+  @DisplayName("non-ASCII literal (length >= 4) takes the Unicode fold path and still matches")
+  void nonAsciiLiteralUnicodeFold() {
+    // "MÜNCHEN" is non-ASCII (Ü); "BERLIN" is ASCII. Mixing both in one Alternation exercises
+    // both the pure-Unicode branch and the ASCII branch of Matcher.indexOfIgnoreCase in the same
+    // findNext call, from the same precomputed per-literal state.
+    String[] literals = {"MÜNCHEN", "BERLIN"};
+    Alternation alt = Alternation.create(literals, true);
+
+    assertThat(alt.findNext("prefix münchen suffix", 0)).isEqualTo(7);
+    assertThat(alt.findNext("prefix München suffix", 0)).isEqualTo(7);
+    assertThat(alt.findNext("prefix berlin suffix", 0)).isEqualTo(7);
+    assertThat(alt.findNext("prefix münchen and berlin suffix", 8)).isEqualTo(19);
+    assertThat(alt.findNext("no city here", 0)).isEqualTo(-1);
+  }
+
+  @Test
+  @DisplayName("single-character literals use anchor low/high directly, no ClassHashChain")
+  void singleCharacterLiterals() {
+    Alternation alt = Alternation.create(new String[] {"x", "q"}, true);
+
+    assertThat(alt.findNext("...X...", 0)).isEqualTo(3);
+    assertThat(alt.findNext("...Q...", 0)).isEqualTo(3);
+    assertThat(alt.findNext("no match", 0)).isEqualTo(-1);
+  }
+
+  @Test
+  @DisplayName("non-folded (case-sensitive) alternation is unaffected by the precomputed fields")
+  void nonFoldedAlternationUnaffected() {
+    Alternation alt = Alternation.create(new String[] {"foo", "bar"}, false);
+
+    assertThat(alt.findNext("xxxbarYYY", 0)).isEqualTo(3);
+    assertThat(alt.findNext("xxxBARYYY", 0)).isEqualTo(-1);
+  }
+}


### PR DESCRIPTION
Precomputes per-literal case-insensitive search state for the multi-anchor engine's `Alternation` anchor, instead of rebuilding it on every `findNext()` probe.

## Problem

`MultiAnchorDescriptor.Anchor.Alternation.findNext(String, int)` (the multi-anchor engine's literal-set prefilter for `foo|bar|baz`-shaped alternations) calls `Matcher.indexOfIgnoreCase(text, lit, fromIndex)` per literal on every probe. That 3-arg convenience overload recomputes, from scratch, on every call:

- the "rarest ASCII anchor character" for the literal (`RarityOracle.rarestAsciiOffset`, an O(literal length) scan), and
- a `ClassHashChain` (a ~1KB shift table plus a nested Unicode case-fold expansion; `ClassHashChain.compileCaseInsensitive`), used both to accelerate false-anchor-hit verification on the ASCII path and to drive the search entirely on the non-ASCII (Unicode-fold) path.

Every other call site that needs this state (`LiteralPreparedRunner`, the descriptor's own single-literal path at `Matcher.java:3520-3544`) precomputes it once and threads it through the 7-arg overload. `Alternation` was the one path that didn't — it was presumably missed when those other call sites were built out, since `Alternation.create()` already precomputes the analogous non-fold-case state (`MultiLiteralInfo`, `TeddyModel`).

This matters most exactly where the multi-anchor engine calls `findNext` a lot: `MultiAnchorExecutor`'s dense per-gap probing, where each individual call only scans a short remaining range, so the previously-per-call rebuild cost is a large fraction of total time instead of being amortized over a long scan.

## Change

`Alternation` gains four parallel arrays (`anchorOffsets`, `anchorLows`, `anchorHighs`, `classHashChains`), populated once in `create()` using the same per-literal logic `LiteralPreparedRunner`'s constructor already uses, only when `foldCase` is true. `findNext(String, int)` now calls the 7-arg `Matcher.indexOfIgnoreCase` overload with the precomputed values instead of the 3-arg one. `findNext(Utf8InputScanner, int)` is unaffected — it never called `indexOfIgnoreCase` in the first place.

## Benchmark

Ad-hoc micro-harness (not part of the repo), best-of-7 over 400k reps, JIT-warmed, calling `Alternation.findNext` over a pool of 8192 distinct 40-char random-text gaps (to prevent the JIT from proving the loop body redundant across iterations — an earlier same-input-every-call version of this benchmark showed no difference for exactly that reason) with 4 literals of length 7-8, `foldCase=true`, no match present:

| | Before | After | Change |
|---|---|---|---|
| `Alternation.findNext` (foldCase, short-gap, no match) | ~1250 ns/op | ~140 ns/op | ~9x faster |

Reproduced across 3 alternating before/after runs on an idle machine (1189-1272 ns/op baseline vs. 123-153 ns/op fixed each time), not noise.

An earlier version of this same benchmark using one long (50k-char) text with a single `findNext(text, 0)` call per rep showed no measurable difference — the O(n) scan cost dominates the O(1) setup cost at that scale, and for all-ASCII literals the anchor-char occurrences during that scan also dominate. The win specifically shows up in the dense/many-short-probes shape, which is what the real caller (`MultiAnchorExecutor`) does.

## Verification

Ran:
- `mvn -pl safere test -Dtest=AlternationFindNextTest,MultiAnchorGapEngineTest,MultiAnchorCompilerTest,MatcherTest,RE2RegressionTest,CrossEngineExhaustiveTest,PatternSetTest` — pass.
- `mvn -pl safere spotless:check` — clean.
- New `AlternationFindNextTest`: 2-literal and N(>2)-literal alternations; ASCII and non-ASCII (mixed in the same `Alternation`, to exercise both the ASCII-with-ClassHashChain and pure-Unicode-fold branches of `indexOfIgnoreCase`) literals; single-character literals (bypass `ClassHashChain` entirely); `fromIndex` advancing past an earlier match to find a later one of a different literal (catches per-literal-index bookkeeping bugs); non-folded alternation unaffected.

Not run:
- The full `safere` module test suite and the `safere-crosscheck` public-API crosscheck reactor.
- Fuzz targets (`safere-fuzz`).
- Standard JMH benchmark suite (`run-java-benchmarks.sh`) — the change is internal to an acceleration heuristic with no dedicated JMH trial; the ad-hoc harness above targets the mechanism directly.
