### PR TITLE
Decouple Multi-Anchor Gap Engine from preferCaptureEngine in Matcher

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1248,6 +1248,39 @@
       "shared": true
     },
     {
+      "id": "realWorldRegex.fixedAnchorLogCaptures.match.{size}",
+      "axes": {
+        "size": [
+          256,
+          1000
+        ]
+      },
+      "recipe": {
+        "kind": "suffixToLength",
+        "prefixUnit": "2026-08-27 12:00:00 error:[N] code:200 msg:ok\n",
+        "suffix": "2026-08-27 12:00:00 error:[C] code:500 msg:crash\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
+      "id": "realWorldRegex.fixedAnchorLogCaptures.noMatch.{size}",
+      "axes": {
+        "size": [
+          256,
+          1000
+        ]
+      },
+      "recipe": {
+        "kind": "delimitedRepeatToLength",
+        "value": "2026-08-27 12:00:00 error:[N] code:200 msg:ok",
+        "delimiterAlphabet": "\n",
+        "seed": 42,
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
       "id": "realWorldRegex.compoundDateLog.match.{size}",
       "axes": {
         "size": [
@@ -4588,6 +4621,37 @@
           1000,
           10000,
           100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.fixedAnchorLogCaptures.{matchLabel}.{size}",
+      "operation": "findGroup",
+      "patterns": [
+        "(error:\\[)[A-Z](\\] code:500)"
+      ],
+      "inputs": [
+        "realWorldRegex.fixedAnchorLogCaptures.{matchLabel}.{size}"
+      ],
+      "resultConsumption": "string",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "arguments": {
+        "group": 1
+      },
+      "axes": {
+        "matchLabel": [
+          "match",
+          "noMatch"
+        ],
+        "size": [
+          256,
+          1000
         ]
       }
     },

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -1704,10 +1704,8 @@ public final class Matcher implements MatchResult {
       }
     }
 
-    boolean preferCaptureEngine = shouldPreferCaptureEngine(prog, scanner);
     // Multi-anchor execution for deterministic unanchored chains with fixed, validated gaps.
-    if (!preferCaptureEngine
-        && options.multiAnchorGapEngine()
+    if (options.multiAnchorGapEngine()
         && !prog.anchorStart()
         && parentPattern.multiAnchor().isExecutableChain()) {
       if (scanner instanceof Utf8InputScanner utf8Scanner) {
@@ -1802,6 +1800,7 @@ public final class Matcher implements MatchResult {
     // Once callers have demonstrated that they consume inner captures, use the capture-aware
     // engine directly for bounded small inputs. This avoids finding group 0 with the DFA and then
     // replaying the same range through BitState on every successful find().
+    boolean preferCaptureEngine = shouldPreferCaptureEngine(prog, scanner);
     if (preferCaptureEngine) {
       int[] result =
           searchWithBitStateOrNfa(

--- a/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
+++ b/safere/src/test/java/org/safere/MatcherDeferredCaptureStateTest.java
@@ -141,8 +141,8 @@ class MatcherDeferredCaptureStateTest {
   }
 
   @Test
-  @DisplayName("capture demand bypasses later multi-anchor pre-scans")
-  void captureDemandBypassesLaterMultiAnchorPrescans() throws ReflectiveOperationException {
+  @DisplayName("capture demand does not bypass multi-anchor gap execution")
+  void captureDemandDoesNotBypassMultiAnchorGapExecution() throws ReflectiveOperationException {
     Pattern pattern = Pattern.compile("(AAA)[0-9](BB)");
     Matcher first = pattern.matcher("prefix AAA1BB suffix");
 
@@ -153,8 +153,9 @@ class MatcherDeferredCaptureStateTest {
 
     Matcher second = pattern.matcher("prefix AAA2BB suffix");
     assertThat(second.find()).isTrue();
-    assertThat(booleanField(second, "capturesResolved")).isTrue();
+    assertThat(booleanField(second, "capturesResolved")).isFalse();
     assertThat(second.group(2)).isEqualTo("BB");
+    assertThat(booleanField(second, "capturesResolved")).isTrue();
   }
 
   @Test


### PR DESCRIPTION
In `Matcher.java`, `shouldPreferCaptureEngine(prog, scanner)` evaluates to `true` when all of the following conditions are met:
1. `parentPattern.innerCapturesObserved()` is `true` (callers have accessed `matcher.group(...)` on the compiled `Pattern`).
2. `scanner.length() <= CAPTURE_DEMAND_TEXT_LIMIT` (the input is $\le 512$ bytes).
3. `options.bitState()` is enabled.

Historically, this check was designed to avoid running the full DFA for group 0 on short inputs only to immediately replay the entire search range through `BitState` once capture consumption was proven.

However, line 1709 previously gated the Multi-Anchor Gap Engine behind `!preferCaptureEngine`:

As a result, as soon as a caller read any capturing group on a pattern, all subsequent searches on inputs <512 bytes bypassed the gap engine, falling back into unanchored `searchWithBitStateOrNfa(...)`.

---

* **Decouple the Gap Engine**: Remove `!preferCaptureEngine` from the Multi-Anchor Gap Engine dispatch check in `Matcher.java`
* **Defer Capture Evaluation**: Move the `preferCaptureEngine` calculation down to line 1800 so it only executes when falling through to `BitState` / `Nfa`.
* **Preserve Deferred Capture Semantics**: The Multi-Anchor Gap Engine rapidly proves and bounds match limits $[S, E]$ (~150 ns) with deferred capture extraction. When `matcher.group(i)` is subsequently accessed, `resolveCaptures()` evaluates captures strictly over the tiny 15-byte matched slice $[S, E]$ (~90 ns) rather than rescanning the unanchored input from index 0.

---

```
./safere-benchmarks/scripts/compare-branch.sh --baseline decouple-gap-engine-capture-demand-baseline --current decouple-gap-engine-capture-demand 'RealWorldRegexBenchmark\.runBenchmark\.fixedAnchorLogCaptures.*@safere-string'
```

| Benchmark                           | baseline (ns/op) | current (ns/op) | Speedup |
| ----------------------------------- | ---------------- | --------------- | ------- |
| fixedAnchorLogCaptures.match.256    |        6023 ± 43 |       249 ± 8.9 |   24.2x |
| fixedAnchorLogCaptures.match.1000   |        489 ± 5.6 |        490 ± 19 |   1.00x |
| fixedAnchorLogCaptures.noMatch.256  |        63 ± 0.86 |        65 ± 6.7 |   0.96x |
| fixedAnchorLogCaptures.noMatch.1000 |        186 ± 3.7 |       185 ± 4.3 |   1.01x |