### PR TITLE
Precompute and reuse case-insensitive literal search state in Anchor.Single and Matcher.findNextMatchPacked

### DIFF
--- a/safere-benchmarks/benchmark-data.json
+++ b/safere-benchmarks/benchmark-data.json
@@ -1213,6 +1213,22 @@
       "shared": true
     },
     {
+      "id": "realWorldRegex.caseInsensitiveSplit.{size}",
+      "axes": {
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      },
+      "recipe": {
+        "kind": "repeatToLength",
+        "unit": "event payload record item with status pending and metadata\n----delimiter----\n",
+        "length": "{size}"
+      },
+      "shared": true
+    },
+    {
       "id": "realWorldRegex.fixedAnchorLog.match.{size}",
       "axes": {
         "size": [
@@ -4584,6 +4600,39 @@
           "match",
           "noMatch"
         ],
+        "size": [
+          1000,
+          10000,
+          100000
+        ]
+      }
+    },
+    {
+      "id": "RealWorldRegexBenchmark.runBenchmark.caseInsensitiveLiteralSplit.{size}",
+      "operation": "splitLengthSum",
+      "patterns": [
+        {
+          "java": "(?i)----DELIMITER----",
+          "alternates": {
+            "dotnet": {
+              "unsupported": true,
+              "reason": ".NET non-backtracking mode cannot express Java's ASCII-only case-insensitive semantics"
+            }
+          }
+        }
+      ],
+      "inputs": [
+        "realWorldRegex.caseInsensitiveSplit.{size}"
+      ],
+      "resultConsumption": "integer",
+      "measurement": {
+        "mode": "averageTime",
+        "timingUnit": "nanoseconds",
+        "constraints": [
+          "prematerializedInput"
+        ]
+      },
+      "axes": {
         "size": [
           1000,
           10000,

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -3534,14 +3534,14 @@ public final class Matcher implements MatchResult {
           char anchor = literal.charAt(0);
           anchorLow = Ascii.toLowerCase(anchor);
           anchorHigh = Ascii.toUpperCase(anchor);
-        } else {
+        } else if (literalLen > 1) {
           anchorOffset = RarityOracle.rarestAsciiOffset(literal, literalLen, true);
           char anchor = literal.charAt(anchorOffset);
           anchorLow = Ascii.toLowerCase(anchor);
           anchorHigh = Ascii.toUpperCase(anchor);
         }
         MatchDescriptor descriptor = parentPattern.matchDescriptor();
-        classHashChain = descriptor.classHashChain();
+        classHashChain = descriptor != null ? descriptor.classHashChain() : null;
       }
     }
 
@@ -4554,11 +4554,37 @@ public final class Matcher implements MatchResult {
         } else {
           idx = text.startsWith(literal) ? 0 : -1;
         }
-      } else {
+      } else if (parentPattern.literalFoldCase()) {
+        int anchorOffset = 0;
+        char anchorLow = 0;
+        char anchorHigh = 0;
+        ClassHashChain classHashChain = null;
+        PreparedMatchRunner runner = parentPattern.preparedMatchRunner(false);
+        if (runner instanceof LiteralPreparedRunner literalRunner) {
+          anchorOffset = literalRunner.anchorOffset();
+          anchorLow = literalRunner.anchorLow();
+          anchorHigh = literalRunner.anchorHigh();
+          classHashChain = literalRunner.classHashChain();
+        } else {
+          int literalLen = literal.length();
+          if (literalLen == 1) {
+            char anchor = literal.charAt(0);
+            anchorLow = Ascii.toLowerCase(anchor);
+            anchorHigh = Ascii.toUpperCase(anchor);
+          } else if (literalLen > 1) {
+            anchorOffset = RarityOracle.rarestAsciiOffset(literal, literalLen, true);
+            char anchor = literal.charAt(anchorOffset);
+            anchorLow = Ascii.toLowerCase(anchor);
+            anchorHigh = Ascii.toUpperCase(anchor);
+          }
+          MatchDescriptor descriptor = parentPattern.matchDescriptor();
+          classHashChain = descriptor != null ? descriptor.classHashChain() : null;
+        }
         idx =
-            parentPattern.literalFoldCase()
-                ? indexOfIgnoreCase(text, literal, fromIndex)
-                : text.indexOf(literal, fromIndex);
+            indexOfIgnoreCase(
+                text, literal, anchorOffset, anchorLow, anchorHigh, classHashChain, fromIndex);
+      } else {
+        idx = text.indexOf(literal, fromIndex);
       }
       if (idx < 0) {
         return -1L;

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -4558,7 +4558,7 @@ public final class Matcher implements MatchResult {
         int anchorOffset = 0;
         char anchorLow = 0;
         char anchorHigh = 0;
-        ClassHashChain classHashChain = null;
+        ClassHashChain classHashChain;
         PreparedMatchRunner runner = parentPattern.preparedMatchRunner(false);
         if (runner instanceof LiteralPreparedRunner literalRunner) {
           anchorOffset = literalRunner.anchorOffset();

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -1080,7 +1080,8 @@ final class MultiAnchorDescriptor {
         char anchorLowChar,
         char anchorHighChar,
         byte anchorLowByte,
-        byte anchorHighByte)
+        byte anchorHighByte,
+        ClassHashChain classHashChain)
         implements Anchor {
 
       static Single create(String literal) {
@@ -1094,13 +1095,15 @@ final class MultiAnchorDescriptor {
           int[] failure = Pattern.literalFailure(utf8);
           int[] shifts = Pattern.literalShifts(utf8);
           return new Single(
-              literal, false, utf8, failure, shifts, 0, '\0', '\0', (byte) 0, (byte) 0);
+              literal, false, utf8, failure, shifts, 0, '\0', '\0', (byte) 0, (byte) 0, null);
         }
         int[] failure = Ascii.ignoreCaseFailure(literal);
         int anchorOffset = RarityOracle.rarestAsciiOffset(literal, literal.length(), true);
         char anchor = literal.charAt(anchorOffset);
         char anchorLow = Ascii.toLowerCase(anchor);
         char anchorHigh = Ascii.toUpperCase(anchor);
+        ClassHashChain classHashChain =
+            literal.length() >= 4 ? ClassHashChain.compileCaseInsensitive(literal) : null;
         return new Single(
             literal,
             true,
@@ -1111,7 +1114,8 @@ final class MultiAnchorDescriptor {
             anchorLow,
             anchorHigh,
             (byte) anchorLow,
-            (byte) anchorHigh);
+            (byte) anchorHigh,
+            classHashChain);
       }
 
       @Override
@@ -1146,7 +1150,13 @@ final class MultiAnchorDescriptor {
           int candidate =
               foldCase
                   ? Matcher.indexOfIgnoreCase(
-                      text, literal, anchorOffset, anchorLowChar, anchorHighChar, position)
+                      text,
+                      literal,
+                      anchorOffset,
+                      anchorLowChar,
+                      anchorHighChar,
+                      classHashChain,
+                      position)
                   : text.indexOf(literal, position);
           if (candidate < 0 || hasCodePointBoundaries(text, candidate)) {
             return candidate;

--- a/safere/src/test/java/org/safere/MatcherTest.java
+++ b/safere/src/test/java/org/safere/MatcherTest.java
@@ -3624,5 +3624,33 @@ class MatcherTest {
       assertThat(m2.find()).isTrue();
       assertThat(m2.start()).isEqualTo(3);
     }
+
+    @Test
+    @DisplayName("split with case-insensitive literals reusing precomputed search state")
+    void splitWithCaseInsensitiveLiteralsReusingPrecomputedSearchState() {
+      // Length >= 4 without groups -> LiteralPreparedRunner path
+      Pattern p1 = Pattern.compile("(?i)DELIM");
+      String[] parts1 = p1.split("one delim two DELIM three DeLiM four");
+      assertThat(parts1).containsExactly("one ", " two ", " three ", " four");
+
+      // Length >= 4 with groups -> MatchDescriptor.classHashChain() path
+      Pattern p2 = Pattern.compile("(?i)(DELIM)");
+      String[] parts2 = p2.split("one delim two DELIM three DeLiM four");
+      assertThat(parts2).containsExactly("one ", " two ", " three ", " four");
+
+      // splitAsStream length >= 4 with and without groups
+      assertThat(p1.splitAsStream("alphaDELIMbeta").toList()).containsExactly("alpha", "beta");
+      assertThat(p2.splitAsStream("alphaDELIMbeta").toList()).containsExactly("alpha", "beta");
+
+      // Short literal (< 4 chars) case-insensitive
+      Pattern p3 = Pattern.compile("(?i)XYZ");
+      String[] parts3 = p3.split("1xyz2XYZ3xYz4");
+      assertThat(parts3).containsExactly("1", "2", "3", "4");
+
+      // Single char case-insensitive
+      Pattern p4 = Pattern.compile("(?i)X");
+      String[] parts4 = p4.split("1x2X3");
+      assertThat(parts4).containsExactly("1", "2", "3");
+    }
   }
 }

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -952,6 +952,32 @@ class MultiAnchorGapEngineTest {
     assertThat(utf8m1.end() - utf8m1.start()).isEqualTo(withCr.getBytes(UTF_8).length);
   }
 
+  @Test
+  void anchorSingleCaseInsensitivePrecomputedState() {
+    // Length >= 4 case-insensitive: ClassHashChain precomputed
+    MultiAnchorDescriptor.Anchor.Single singleLong =
+        MultiAnchorDescriptor.Anchor.Single.create("abcdef", true);
+    assertThat(singleLong.classHashChain()).isNotNull();
+    assertThat(singleLong.findNext("prefix_ABCDEF_suffix", 0)).isEqualTo(7);
+    assertThat(singleLong.findNext("prefix_aBcDeF_suffix", 0)).isEqualTo(7);
+    assertThat(singleLong.findNext("prefix_abcdef_suffix", 8)).isEqualTo(-1);
+
+    // Length < 4 case-insensitive: ClassHashChain is null
+    MultiAnchorDescriptor.Anchor.Single singleShort =
+        MultiAnchorDescriptor.Anchor.Single.create("abc", true);
+    assertThat(singleShort.classHashChain()).isNull();
+    assertThat(singleShort.findNext("xyz_ABC_123", 0)).isEqualTo(4);
+    assertThat(singleShort.findNext("xyz_aBc_123", 0)).isEqualTo(4);
+    assertThat(singleShort.findNext("xyz_abc_123", 5)).isEqualTo(-1);
+
+    // Case-sensitive: ClassHashChain is null
+    MultiAnchorDescriptor.Anchor.Single singleExact =
+        MultiAnchorDescriptor.Anchor.Single.create("abcdef", false);
+    assertThat(singleExact.classHashChain()).isNull();
+    assertThat(singleExact.findNext("prefix_ABCDEF_suffix", 0)).isEqualTo(-1);
+    assertThat(singleExact.findNext("prefix_abcdef_suffix", 0)).isEqualTo(7);
+  }
+
   private static List<String> findMatches(Pattern pattern, String text, boolean useUtf8) {
     List<String> matches = new ArrayList<>();
     if (useUtf8) {


### PR DESCRIPTION
This change avoids some runtime recompilation of `ClassHashChain`. This was inspired by #832.

When searching for case-insensitive literals of length $\ge 4$, `Matcher.indexOfIgnoreCase(...)` compiles a 2-gram `ClassHashChain` (allocating code-point fold variant arrays, stream pipelines, and a 1 KB shift table). Two literal search paths called un-cached overloads of `indexOfIgnoreCase`, triggering repeated dynamic recompilation during matching:
1. `Anchor.Single.findNext`: called the 6-argument overload on every candidate probe during multi-anchor scanning.
2. `Matcher.findNextMatchPacked`: called the 3-argument overload on every match iteration during `Pattern.split` and `Pattern.splitAsStream`.

---

1. **`MultiAnchorDescriptor.Anchor.Single`**:
   - Added `ClassHashChain classHashChain` component to `record Single`.
   - Precompute `classHashChain` in `Single.create(String literal, boolean foldCase)` when `foldCase && literal.length() >= 4`.
   - Forward `classHashChain` to the 7-argument `Matcher.indexOfIgnoreCase` overload in `Single.findNext`.

2. **`Matcher.findNextMatchPacked`**:
   - Replaced un-cached 3-arg `indexOfIgnoreCase` call.
   - Extract precomputed `anchorOffset`, `anchorLow`, `anchorHigh`, and `classHashChain` from `parentPattern.preparedMatchRunner(false)` when it is a `LiteralPreparedRunner`.
   - When not a `LiteralPreparedRunner` (e.g. when capturing groups exist on the literal pattern), fall back to `parentPattern.matchDescriptor().classHashChain()` and compute anchor offsets with empty-literal guards, matching `Matcher.replaceAllCore`.


