### PR TITLE
Prepare README for SafeRE 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ SafeRE is available on [Maven Central](https://central.sonatype.com/artifact/org
 <dependency>
   <groupId>org.safere</groupId>
   <artifactId>safere</artifactId>
-  <version>0.10.0</version>
+  <version>0.11.0</version>
 </dependency>
 ```
 
 **Gradle (Kotlin DSL):**
 
 ```kotlin
-implementation("org.safere:safere:0.10.0")
+implementation("org.safere:safere:0.11.0")
 ```
 
 **Gradle (Groovy DSL):**
 
 ```groovy
-implementation 'org.safere:safere:0.10.0'
+implementation 'org.safere:safere:0.11.0'
 ```
 
 ## Quick Start


### PR DESCRIPTION
Update the Maven and both Gradle installation examples from 0.10.0 to 0.11.0 in preparation for the release. POM versions remain 0.11.0-SNAPSHOT; the release workflow derives the published version from the tag.

Verification run: inspected the README diff, checked all three installation versions, confirmed reactor POM versions remain 0.11.0-SNAPSHOT, and ran `git diff --check`.

Not run: Maven tests, public API crosschecks, or benchmarks, because this change only updates documentation version examples. Release build verification runs in the tag-triggered release workflow.

Refs #829 
