### PR TITLE
Replace deprecated setup-java release inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
           java-version-file: .sdkmanrc
           cache: maven
           server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
+          server-username-env-var: MAVEN_CENTRAL_USERNAME
+          server-password-env-var: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase-env-var: GPG_PASSPHRASE
 
       - name: Set version from tag
         run: |


### PR DESCRIPTION
The release workflow emitted three deprecation warnings in [the v0.11.0 release run](https://github.com/eaftan/safere/actions/runs/34564769340). Replace setup-java's `server-username`, `server-password`, and `gpg-passphrase` inputs with their supported `-env-var` names, preserving the existing credential environment variable references.

Validation: parsed the release workflow YAML, checked every configured setup-java input against the pinned v6.0.0 action metadata for support and deprecation, verified the credential references resolve to the publishing step's environment variables, and ran `git diff --check`. All passed.

Not run: Maven tests, public API crosschecks, or the release/publishing workflow. This change only renames workflow inputs.
