### PR TITLE
Bump version to 0.12.0-SNAPSHOT

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -163,6 +163,25 @@ git switch main
 git pull --ff-only
 git switch -c bump-to-NEXT-SNAPSHOT
 mvn versions:set -DnewVersion=NEXT-SNAPSHOT -DgenerateBackupPoms=false
+```
+
+The `safere-vector-benchmarks` project is intentionally outside the default
+Maven reactor, so `versions:set` does not update its inherited parent version.
+Before committing, manually update the `<parent>` version in
+`safere-vector-benchmarks/pom.xml` to the same `NEXT-SNAPSHOT` value. Then
+confirm that every project POM uses the new development version and that none
+retains the previous SNAPSHOT version:
+
+```bash
+rg -n '<version>[^<]+-SNAPSHOT</version>' --glob 'pom.xml' --glob '*/pom.xml'
+mvn validate -DskipTests --batch-mode --no-transfer-progress
+mvn -f safere-vector-benchmarks/pom.xml validate \
+  -DskipTests --batch-mode --no-transfer-progress
+```
+
+Commit and push the complete version change:
+
+```bash
 git add -A
 git commit -m "Bump version to NEXT-SNAPSHOT"
 git push -u origin bump-to-NEXT-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.safere</groupId>
   <artifactId>safere-parent</artifactId>
-  <version>0.11.0-SNAPSHOT</version>
+  <version>0.12.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SafeRE Parent</name>

--- a/safere-benchmarks/pom.xml
+++ b/safere-benchmarks/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-benchmarks</artifactId>

--- a/safere-crosscheck/pom.xml
+++ b/safere-crosscheck/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-crosscheck</artifactId>

--- a/safere-exhaustive/pom.xml
+++ b/safere-exhaustive/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-exhaustive</artifactId>

--- a/safere-ffm-re2/pom.xml
+++ b/safere-ffm-re2/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-ffm-re2</artifactId>

--- a/safere-fuzz/pom.xml
+++ b/safere-fuzz/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-fuzz</artifactId>

--- a/safere-unicode/pom.xml
+++ b/safere-unicode/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere-unicode-generator</artifactId>

--- a/safere-vector-benchmarks/pom.xml
+++ b/safere-vector-benchmarks/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/safere/pom.xml
+++ b/safere/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.safere</groupId>
     <artifactId>safere-parent</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>safere</artifactId>


### PR DESCRIPTION
Bump the parent version and all module parent references to `0.12.0-SNAPSHOT` after publishing SafeRE 0.11.0. This includes the standalone `safere-vector-benchmarks` module, which is outside the default Maven reactor. Document that exception and the validation commands in the release instructions so future version bumps do not leave its parent version behind.

Refs #829

Verification run:

- `mvn validate -DskipTests --batch-mode --no-transfer-progress`
- `mvn -f safere-vector-benchmarks/pom.xml validate -DskipTests --batch-mode --no-transfer-progress`
- `git diff --check`
- Checked the updated release instructions for the 100-character line limit
- Confirmed all nine project POMs use `0.12.0-SNAPSHOT` and no project POM retains `0.11.0-SNAPSHOT`

Not run: tests, public API crosschecks, fuzzing, or benchmarks. This change only updates Maven project versions and release documentation.
