### PR TITLE
Test Vector scanner on JDK 27 and 28 EA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['21', '22', '23', '24', '25', '26']
+        java: ['21', '22', '23', '24', '25', '26', '27-ea', '28-ea']
 
     steps:
       - uses: actions/checkout@v7
@@ -179,6 +179,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          check-latest: ${{ endsWith(matrix.java, '-ea') }}
           cache: maven
 
       - name: Download runtime-test artifacts


### PR DESCRIPTION
## Summary

- test the experimental Vector scanner on Temurin JDK 27 EA and JDK 28 EA
- resolve the newest available build for EA matrix entries instead of accepting an older runner-cached build
- retain cache-first setup behavior for stable JDK matrix entries

Refs #752

## Verification

- `git diff --check`
- parsed `.github/workflows/ci.yml` with Ruby's YAML parser
- full tests not run locally; this is a GitHub Actions workflow-only change and the PR CI exercises the added matrix entries
