### PR TITLE
Fix multi-anchor variable-gap matching invariants

### DIFF
--- a/safere/src/main/java/org/safere/GapScanner.java
+++ b/safere/src/main/java/org/safere/GapScanner.java
@@ -243,7 +243,7 @@ final class GapScanner {
       return cur;
     }
     if (gap.maxLength() != Integer.MAX_VALUE) {
-      return (int) Math.min(maxPos, (long) fromPos + (long) gap.maxLength() * 2);
+      return (int) Math.min(maxPos, fromPos + (long) gap.maxLength() * 2);
     }
     return maxPos;
   }
@@ -303,7 +303,7 @@ final class GapScanner {
       return cur;
     }
     if (gap.maxLength() != Integer.MAX_VALUE) {
-      return (int) Math.min(maxPos, (long) fromPos + (long) gap.maxLength() * 4);
+      return (int) Math.min(maxPos, fromPos + (long) gap.maxLength() * 4);
     }
     return maxPos;
   }

--- a/safere/src/main/java/org/safere/GapScanner.java
+++ b/safere/src/main/java/org/safere/GapScanner.java
@@ -539,6 +539,12 @@ final class GapScanner {
             yield false;
           }
           if (gap.guardBytes().length == 1 && gap.isPureComplement()) {
+            if (len < gap.minLength()) {
+              yield false;
+            }
+            if (gap.maxLength() == Integer.MAX_VALUE && gap.minLength() == 0) {
+              yield true;
+            }
             int count = Character.codePointCount(text, from, to);
             yield count >= gap.minLength() && count <= gap.maxLength();
           }
@@ -612,6 +618,12 @@ final class GapScanner {
             yield false;
           }
           if (gap.guardBytes().length == 1 && gap.isPureComplement()) {
+            if (len < gap.minLength()) {
+              yield false;
+            }
+            if (gap.maxLength() == Integer.MAX_VALUE && gap.minLength() == 0) {
+              yield true;
+            }
             int count = 0;
             for (int i = from; i < to; ) {
               long decoded = scanner.decodeForward(i);
@@ -799,9 +811,11 @@ final class GapScanner {
           int limit = boundedCodePointEnd(gap, text, fromPos, maxPos);
           int g = findFirstGuardByte(gap.guardBytes(), text, fromPos, limit);
           int end = (g >= fromPos && g < limit) ? g : limit;
-          int count = Character.codePointCount(text, fromPos, end);
-          if (count < gap.minLength()) {
-            yield -1;
+          if (gap.minLength() > 0) {
+            int count = Character.codePointCount(text, fromPos, end);
+            if (count < gap.minLength()) {
+              yield -1;
+            }
           }
           yield end;
         }
@@ -867,14 +881,16 @@ final class GapScanner {
           int limit = boundedCodePointEnd(gap, scanner, fromPos, maxPos);
           int g = findFirstGuardByte(gap.guardBytes(), scanner, fromPos, limit);
           int end = (g >= fromPos && g < limit) ? g : limit;
-          int count = 0;
-          for (int p = fromPos; p < end; ) {
-            long decoded = scanner.decodeForward(p);
-            p = InputScanner.position(decoded);
-            count++;
-          }
-          if (count < gap.minLength()) {
-            yield -1;
+          if (gap.minLength() > 0) {
+            int count = 0;
+            for (int p = fromPos; p < end; ) {
+              long decoded = scanner.decodeForward(p);
+              p = InputScanner.position(decoded);
+              count++;
+            }
+            if (count < gap.minLength()) {
+              yield -1;
+            }
           }
           yield end;
         }

--- a/safere/src/main/java/org/safere/GapScanner.java
+++ b/safere/src/main/java/org/safere/GapScanner.java
@@ -204,40 +204,46 @@ final class GapScanner {
         }
       }
       int cur = fromPos;
-      while (cur < limit) {
+      int count = 0;
+      while (cur < limit && count < gap.maxLength()) {
         int cp = text.codePointAt(cur);
         if (gap.scanInfo() != null && !gap.scanInfo().contains(cp)) {
           break;
         }
+        count++;
         cur += Character.charCount(cp);
       }
       return cur;
     }
     if (gap.kind() == GapKind.SINGLE_LINE_ANY_STAR) {
-      int limit =
-          Math.min(
-              maxPos, gap.maxLength() == Integer.MAX_VALUE ? maxPos : fromPos + gap.maxLength());
+      int maxCharDistance =
+          gap.maxLength() == Integer.MAX_VALUE
+              ? maxPos - fromPos
+              : (int) Math.min(maxPos - fromPos, (long) gap.maxLength() * 2);
+      int limit = fromPos + maxCharDistance;
       if (gap.guardBytes() != null) {
         int g = findFirstGuardByte(gap.guardBytes(), text, fromPos, limit);
         if (g >= fromPos && g < limit) {
-          return g;
+          limit = g;
         }
-        if (gap.isPureComplement()) {
+        if (gap.guardBytes().length == 1 && gap.isPureComplement()) {
           return limit;
         }
       }
       int cur = fromPos;
-      while (cur < limit) {
+      int count = 0;
+      while (cur < limit && count < gap.maxLength()) {
         int cp = text.codePointAt(cur);
-        if (Nfa.isLineTerminator(cp)) {
+        if (isTerminator(gap, cp)) {
           break;
         }
+        count++;
         cur += Character.charCount(cp);
       }
       return cur;
     }
     if (gap.maxLength() != Integer.MAX_VALUE) {
-      return Math.min(maxPos, fromPos + gap.maxLength());
+      return (int) Math.min(maxPos, (long) fromPos + (long) gap.maxLength() * 2);
     }
     return maxPos;
   }
@@ -255,45 +261,175 @@ final class GapScanner {
         }
       }
       int cur = fromPos;
-      while (cur < limit) {
+      int count = 0;
+      while (cur < limit && count < gap.maxLength()) {
         long decoded = scanner.decodeForward(cur);
         int cp = InputScanner.codePoint(decoded);
         int nextPos = InputScanner.position(decoded);
         if (gap.scanInfo() != null && !gap.scanInfo().contains(cp)) {
           break;
         }
+        count++;
         cur = nextPos;
       }
       return cur;
     }
     if (gap.kind() == GapKind.SINGLE_LINE_ANY_STAR) {
-      int limit =
-          Math.min(
-              maxPos, gap.maxLength() == Integer.MAX_VALUE ? maxPos : fromPos + gap.maxLength());
+      int maxByteDistance =
+          gap.maxLength() == Integer.MAX_VALUE
+              ? maxPos - fromPos
+              : (int) Math.min(maxPos - fromPos, (long) gap.maxLength() * 4);
+      int limit = fromPos + maxByteDistance;
       if (gap.guardBytes() != null) {
         int g = findFirstGuardByte(gap.guardBytes(), scanner, fromPos, limit);
         if (g >= fromPos && g < limit) {
-          return g;
+          limit = g;
         }
-        if (gap.isPureComplement()) {
+        if (gap.guardBytes().length == 1 && gap.isPureComplement()) {
           return limit;
         }
       }
       int cur = fromPos;
-      while (cur < limit) {
+      int count = 0;
+      while (cur < limit && count < gap.maxLength()) {
         long decoded = scanner.decodeForward(cur);
         int cp = InputScanner.codePoint(decoded);
-        if (Nfa.isLineTerminator(cp)) {
+        if (isTerminator(gap, cp)) {
           break;
         }
+        count++;
         cur = InputScanner.position(decoded);
       }
       return cur;
     }
     if (gap.maxLength() != Integer.MAX_VALUE) {
-      return Math.min(maxPos, fromPos + gap.maxLength());
+      return (int) Math.min(maxPos, (long) fromPos + (long) gap.maxLength() * 4);
     }
     return maxPos;
+  }
+
+  static int scanClassStart(Gap gap, String text, int minLimit, int curAnchorStart) {
+    if (curAnchorStart <= minLimit) {
+      return curAnchorStart;
+    }
+    int maxCharDistance =
+        gap.maxLength() == Integer.MAX_VALUE
+            ? curAnchorStart - minLimit
+            : (int) Math.min(curAnchorStart - minLimit, (long) gap.maxLength() * 2);
+    int minPossible = curAnchorStart - maxCharDistance;
+    if (gap.guardBytes() != null) {
+      int lastGuard = findLastGuardByte(gap.guardBytes(), text, minPossible, curAnchorStart - 1);
+      if (lastGuard >= 0) {
+        minPossible = Math.max(minPossible, lastGuard + 1);
+      }
+      if (gap.isPureComplement()) {
+        return minPossible;
+      }
+    }
+    if (gap.kind() == GapKind.BOUNDED_CLASS_REPEAT) {
+      int cur = curAnchorStart;
+      int count = 0;
+      while (cur > minPossible && count < gap.maxLength()) {
+        int cp = text.codePointBefore(cur);
+        int prev = cur - Character.charCount(cp);
+        if (prev < minPossible) {
+          break;
+        }
+        if (gap.scanInfo() != null) {
+          if (!gap.scanInfo().contains(cp)) {
+            return cur;
+          }
+        } else if (gap.charClass() != null) {
+          if (!gap.charClass().contains(cp)) {
+            return cur;
+          }
+        }
+        count++;
+        cur = prev;
+      }
+      return cur;
+    }
+    if (gap.kind() == GapKind.SINGLE_LINE_ANY_STAR) {
+      int cur = curAnchorStart;
+      int count = 0;
+      while (cur > minPossible && count < gap.maxLength()) {
+        int cp = text.codePointBefore(cur);
+        int prev = cur - Character.charCount(cp);
+        if (prev < minPossible) {
+          break;
+        }
+        if (isTerminator(gap, cp)) {
+          return cur;
+        }
+        count++;
+        cur = prev;
+      }
+      return cur;
+    }
+    return minPossible;
+  }
+
+  static int scanClassStart(Gap gap, Utf8InputScanner scanner, int minLimit, int curAnchorStart) {
+    if (curAnchorStart <= minLimit) {
+      return curAnchorStart;
+    }
+    int maxByteDistance =
+        gap.maxLength() == Integer.MAX_VALUE
+            ? curAnchorStart - minLimit
+            : (int) Math.min(curAnchorStart - minLimit, (long) gap.maxLength() * 4);
+    int minPossible = curAnchorStart - maxByteDistance;
+    if (gap.guardBytes() != null) {
+      int lastGuard = findLastGuardByte(gap.guardBytes(), scanner, minPossible, curAnchorStart - 1);
+      if (lastGuard >= 0) {
+        minPossible = Math.max(minPossible, lastGuard + 1);
+      }
+      if (gap.isPureComplement()) {
+        return minPossible;
+      }
+    }
+    if (gap.kind() == GapKind.BOUNDED_CLASS_REPEAT) {
+      int cur = curAnchorStart;
+      int count = 0;
+      while (cur > minPossible && count < gap.maxLength()) {
+        long decoded = scanner.decodeBackward(cur);
+        int cp = InputScanner.codePoint(decoded);
+        int prev = InputScanner.position(decoded);
+        if (prev < minPossible) {
+          break;
+        }
+        if (gap.scanInfo() != null) {
+          if (!gap.scanInfo().contains(cp)) {
+            return cur;
+          }
+        } else if (gap.charClass() != null) {
+          if (!gap.charClass().contains(cp)) {
+            return cur;
+          }
+        }
+        count++;
+        cur = prev;
+      }
+      return cur;
+    }
+    if (gap.kind() == GapKind.SINGLE_LINE_ANY_STAR) {
+      int cur = curAnchorStart;
+      int count = 0;
+      while (cur > minPossible && count < gap.maxLength()) {
+        long decoded = scanner.decodeBackward(cur);
+        int cp = InputScanner.codePoint(decoded);
+        int prev = InputScanner.position(decoded);
+        if (prev < minPossible) {
+          break;
+        }
+        if (isTerminator(gap, cp)) {
+          return cur;
+        }
+        count++;
+        cur = prev;
+      }
+      return cur;
+    }
+    return minPossible;
   }
 
   static int matchExecutorFixedForward(Gap gap, String text, int fromPos, int maxPos) {
@@ -402,11 +538,15 @@ final class GapScanner {
           if (g >= from && g < to) {
             yield false;
           }
+          if (gap.guardBytes().length == 1 && gap.isPureComplement()) {
+            int count = Character.codePointCount(text, from, to);
+            yield count >= gap.minLength() && count <= gap.maxLength();
+          }
         }
         int count = 0;
         for (int i = from; i < to; ) {
           int cp = text.codePointAt(i);
-          if (Nfa.isLineTerminator(cp)) {
+          if (isTerminator(gap, cp)) {
             yield false;
           }
           count++;
@@ -471,12 +611,21 @@ final class GapScanner {
           if (g >= from && g < to) {
             yield false;
           }
+          if (gap.guardBytes().length == 1 && gap.isPureComplement()) {
+            int count = 0;
+            for (int i = from; i < to; ) {
+              long decoded = scanner.decodeForward(i);
+              count++;
+              i = InputScanner.position(decoded);
+            }
+            yield count >= gap.minLength() && count <= gap.maxLength();
+          }
         }
         int count = 0;
         for (int i = from; i < to; ) {
           long decoded = scanner.decodeForward(i);
           int cp = InputScanner.codePoint(decoded);
-          if (Nfa.isLineTerminator(cp)) {
+          if (isTerminator(gap, cp)) {
             yield false;
           }
           count++;
@@ -771,7 +920,7 @@ final class GapScanner {
     int minMatchPos = gap.minLength() == 0 ? cur : -1;
     while (count < gap.maxLength() && cur > minPos) {
       int cp = text.codePointBefore(cur);
-      if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+      if (stopAtLineTerminator && isTerminator(gap, cp)) {
         break;
       }
       cur -= Character.charCount(cp);
@@ -794,7 +943,7 @@ final class GapScanner {
     while (count < gap.maxLength() && cur > minPos) {
       long decoded = scanner.decodeBackward(cur);
       int cp = InputScanner.codePoint(decoded);
-      if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+      if (stopAtLineTerminator && isTerminator(gap, cp)) {
         break;
       }
       cur = InputScanner.position(decoded);
@@ -816,7 +965,7 @@ final class GapScanner {
     int minMatchPos = gap.minLength() == 0 ? cur : -1;
     while (count < gap.maxLength() && cur < maxPos) {
       int cp = text.codePointAt(cur);
-      if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+      if (stopAtLineTerminator && isTerminator(gap, cp)) {
         break;
       }
       cur += Character.charCount(cp);
@@ -839,7 +988,7 @@ final class GapScanner {
     while (count < gap.maxLength() && cur < maxPos) {
       long decoded = scanner.decodeForward(cur);
       int cp = InputScanner.codePoint(decoded);
-      if (stopAtLineTerminator && Nfa.isLineTerminator(cp)) {
+      if (stopAtLineTerminator && isTerminator(gap, cp)) {
         break;
       }
       cur = InputScanner.position(decoded);
@@ -852,5 +1001,11 @@ final class GapScanner {
       return -1;
     }
     return gap.isGreedy() ? cur : minMatchPos;
+  }
+
+  private static boolean isTerminator(Gap gap, int cp) {
+    return (gap.guardBytes() != null && gap.guardBytes().length == 1 && gap.isPureComplement())
+        ? (cp == '\n')
+        : Nfa.isLineTerminator(cp);
   }
 }

--- a/safere/src/main/java/org/safere/Matcher.java
+++ b/safere/src/main/java/org/safere/Matcher.java
@@ -310,6 +310,8 @@ public final class Matcher implements MatchResult {
   private boolean bitStateBorrowed;
   private int[] bitStateResult;
   private int[] onePassScratchCap;
+  private int[] multiAnchorScratch;
+  private final long[] multiAnchorWork = new long[1];
 
   /** Cached Nfa instance borrowed from the parent Pattern's thread-local cache. */
   private Nfa cachedNfa;
@@ -1708,9 +1710,20 @@ public final class Matcher implements MatchResult {
     if (options.multiAnchorGapEngine()
         && !prog.anchorStart()
         && parentPattern.multiAnchor().isExecutableChain()) {
+      int numSegments = parentPattern.multiAnchor().segments().length;
+      int requiredScratch = numSegments * MultiAnchorExecutor.STATE_STRIDE;
+      if (multiAnchorScratch == null || multiAnchorScratch.length < requiredScratch) {
+        multiAnchorScratch = new int[Math.max(requiredScratch, 64)];
+      }
+      multiAnchorWork[0] = 0;
       if (scanner instanceof Utf8InputScanner utf8Scanner) {
         MultiAnchorExecutor.Result res =
-            MultiAnchorExecutor.find(parentPattern.multiAnchor(), utf8Scanner, searchFrom);
+            MultiAnchorExecutor.find(
+                parentPattern.multiAnchor(),
+                utf8Scanner,
+                searchFrom,
+                multiAnchorScratch,
+                multiAnchorWork);
         if (res.isMatched()) {
           diagnosticParticipation(MatchStrategy.MULTI_ANCHOR, StrategyRole.CANDIDATE_VERIFICATION);
           diagnosticBoundary(MatchStrategy.MULTI_ANCHOR);
@@ -1726,7 +1739,8 @@ public final class Matcher implements MatchResult {
         }
       } else if (text != null) {
         MultiAnchorExecutor.Result res =
-            MultiAnchorExecutor.find(parentPattern.multiAnchor(), text, searchFrom);
+            MultiAnchorExecutor.find(
+                parentPattern.multiAnchor(), text, searchFrom, multiAnchorScratch, multiAnchorWork);
         if (res.isMatched()) {
           diagnosticParticipation(MatchStrategy.MULTI_ANCHOR, StrategyRole.CANDIDATE_VERIFICATION);
           diagnosticBoundary(MatchStrategy.MULTI_ANCHOR);

--- a/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorDescriptor.java
@@ -427,12 +427,7 @@ final class MultiAnchorDescriptor {
 
   private static boolean computeExecutableChain(Chain chain) {
     int n = chain.segments().length;
-    if (n < 1 || chain.isEndAnchored() || !isExecutableLeadingGap(chain.segments()[0].gap())) {
-      return false;
-    }
-    if (n == 1
-        && chain.segments()[0].gap().kind() == GapKind.EMPTY
-        && chain.trailingGap().kind() == GapKind.EMPTY) {
+    if (n < 2 || chain.isEndAnchored() || !isExecutableLeadingGap(chain.segments()[0].gap())) {
       return false;
     }
     for (int i = 0; i < n; i++) {
@@ -460,35 +455,31 @@ final class MultiAnchorDescriptor {
 
   private static boolean isExecutableLeadingGap(Gap gap) {
     return switch (gap.kind()) {
-      case EMPTY, TEXT_START -> true;
-      case BOUNDED_CLASS_REPEAT -> gap.isExecutorFixedGap();
-      case ANY_STAR,
-          SINGLE_LINE_ANY_STAR,
-          TEXT_END,
-          LINE_START,
-          LINE_END,
-          WORD_BOUNDARY,
-          NO_WORD_BOUNDARY ->
-          false;
+      case EMPTY, TEXT_START, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
+      case BOUNDED_CLASS_REPEAT ->
+          gap.scanInfo() != null || gap.charClass() != null || gap.isExecutorGuardedGap();
+      case TEXT_END, WORD_BOUNDARY, NO_WORD_BOUNDARY, LINE_START, LINE_END -> false;
     };
   }
 
   private static boolean isExecutableInteriorGap(Gap gap) {
-    return gap.isExecutorFixedGap() || gap.isExecutorGuardedGap();
+    return switch (gap.kind()) {
+      case EMPTY, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
+      case BOUNDED_CLASS_REPEAT ->
+          gap.scanInfo() != null || gap.charClass() != null || gap.isExecutorGuardedGap();
+      case TEXT_START, TEXT_END, WORD_BOUNDARY, NO_WORD_BOUNDARY, LINE_START, LINE_END -> false;
+    };
   }
 
   private static boolean isExecutableTrailingGap(Gap gap) {
+    if (gap.minLength() == 0 && !gap.isGreedy()) {
+      return true;
+    }
     return switch (gap.kind()) {
-      case EMPTY, TEXT_END -> true;
-      case BOUNDED_CLASS_REPEAT -> gap.isExecutorFixedGap() || gap.isExecutorGuardedGap();
-      case ANY_STAR,
-          SINGLE_LINE_ANY_STAR,
-          TEXT_START,
-          LINE_START,
-          LINE_END,
-          WORD_BOUNDARY,
-          NO_WORD_BOUNDARY ->
-          false;
+      case EMPTY, TEXT_END, ANY_STAR, SINGLE_LINE_ANY_STAR -> true;
+      case BOUNDED_CLASS_REPEAT ->
+          gap.scanInfo() != null || gap.charClass() != null || gap.isExecutorGuardedGap();
+      case TEXT_START, WORD_BOUNDARY, NO_WORD_BOUNDARY, LINE_START, LINE_END -> false;
     };
   }
 
@@ -742,6 +733,14 @@ final class MultiAnchorDescriptor {
 
     int scanClassEnd(Utf8InputScanner scanner, int fromPos, int maxPos) {
       return GapScanner.scanClassEnd(this, scanner, fromPos, maxPos);
+    }
+
+    int scanClassStart(String text, int minLimit, int curAnchorStart) {
+      return GapScanner.scanClassStart(this, text, minLimit, curAnchorStart);
+    }
+
+    int scanClassStart(Utf8InputScanner scanner, int minLimit, int curAnchorStart) {
+      return GapScanner.scanClassStart(this, scanner, minLimit, curAnchorStart);
     }
 
     int matchExecutorFixedForward(String text, int fromPos, int maxPos) {

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -47,6 +47,18 @@ final class MultiAnchorExecutor {
     }
   }
 
+  static final int STATE_STRIDE = 8;
+  private static final int OFFSET_CUR_POS = 0;
+  private static final int OFFSET_SEARCH_POS = 1;
+  private static final int OFFSET_MIN_HOP = 2;
+  private static final int OFFSET_MAX_HOP = 3;
+  private static final int OFFSET_P = 4;
+  private static final int OFFSET_ANCHOR_LEN = 5;
+  private static final int OFFSET_WATERMARK = 6;
+  private static final int OFFSET_GUARD_END = 7;
+
+  private static final int WORK_LIMIT_EXHAUSTED = Integer.MIN_VALUE;
+
   private MultiAnchorExecutor() {}
 
   /**
@@ -58,6 +70,26 @@ final class MultiAnchorExecutor {
    * @return the execution result
    */
   static Result find(MultiAnchorDescriptor descriptor, Utf8InputScanner scanner, int searchFrom) {
+    return find(descriptor, scanner, searchFrom, null, null);
+  }
+
+  /**
+   * Executes multi-anchor matching on UTF-8 byte input with caller-provided scratch and work
+   * buffers.
+   *
+   * @param descriptor the multi-anchor descriptor containing the chain
+   * @param scanner the UTF-8 input scanner
+   * @param searchFrom the starting offset in the input
+   * @param scratch reusable state buffer of length at least {@code numSegments * STATE_STRIDE}
+   * @param workHolder single-element array tracking cumulative verification work
+   * @return the execution result
+   */
+  static Result find(
+      MultiAnchorDescriptor descriptor,
+      Utf8InputScanner scanner,
+      int searchFrom,
+      int[] scratch,
+      long[] workHolder) {
     Objects.requireNonNull(descriptor, "descriptor");
     Objects.requireNonNull(scanner, "scanner");
 
@@ -93,11 +125,22 @@ final class MultiAnchorExecutor {
     minUpstreamLen += segments[driverIdx].gap().minLength();
 
     long workLimit = WorkLimit.forRemaining(textLen - searchFrom);
-    long verificationWork = 0;
+    if (workHolder == null) {
+      workHolder = new long[1];
+    } else {
+      workHolder[0] = 0;
+    }
+
+    if (scratch == null || scratch.length < numSegments * STATE_STRIDE) {
+      scratch = new int[numSegments * STATE_STRIDE];
+    }
+    for (int s = 0; s < numSegments; s++) {
+      int base = s * STATE_STRIDE;
+      scratch[base + OFFSET_WATERMARK] = searchFrom;
+      scratch[base + OFFSET_GUARD_END] = -1;
+    }
 
     int minReverseWatermark = Math.max(0, searchFrom);
-    int firstSegmentWatermark = searchFrom;
-    int firstSegmentGuardEnd = -1;
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -246,8 +289,8 @@ final class MultiAnchorExecutor {
 
         if (!upstreamMatched) {
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
-          verificationWork++;
-          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+          workHolder[0]++;
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
             return Result.FALLBACK;
           }
           continue;
@@ -280,10 +323,12 @@ final class MultiAnchorExecutor {
       // Phase 2 & 3: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1} and trailing
       // gap
       if (driverIdx < numSegments - 1) {
+        int seg1Base = (driverIdx + 1) * STATE_STRIDE;
         MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
         MultiAnchorDescriptor.Gap gap1 = seg1.gap();
         boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
         int maxScan;
+        int firstSegmentGuardEnd = scratch[seg1Base + OFFSET_GUARD_END];
         if (gap1.isExecutorGuardedGap()
             && gap1.maxLength() == Integer.MAX_VALUE
             && firstSegmentGuardEnd >= currentPos) {
@@ -293,11 +338,22 @@ final class MultiAnchorExecutor {
               reluctantGuarded
                   ? gap1.guardedSearchEnd(scanner, currentPos, textLen)
                   : gap1.scanClassEnd(scanner, currentPos, textLen);
+          if (gapScansText(gap1, reluctantGuarded)) {
+            long scanWork = Math.max(1, maxScan - currentPos);
+            workHolder[0] += scanWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(scanWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return Result.FALLBACK;
+            }
+          }
           if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
-            firstSegmentGuardEnd = maxScan;
+            scratch[seg1Base + OFFSET_GUARD_END] = maxScan;
           }
         }
         int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
+        int firstSegmentWatermark = scratch[seg1Base + OFFSET_WATERMARK];
         if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark >= maxHop) {
           if (driverIdx == 0
               && seg1.gap().isExecutorGuardedGap()
@@ -308,8 +364,8 @@ final class MultiAnchorExecutor {
           } else {
             candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
           }
-          verificationWork++;
-          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+          workHolder[0]++;
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
             return Result.FALLBACK;
           }
           continue;
@@ -317,18 +373,22 @@ final class MultiAnchorExecutor {
       }
 
       int matchEnd =
-          matchDownstream(
+          matchDownstreamIterative(
               scanner,
               segments,
               driverIdx + 1,
               currentPos,
               textLen,
               trailingGap,
-              firstSegmentWatermark,
-              firstSegmentGuardEnd);
+              scratch,
+              workHolder,
+              workLimit);
+      if (matchEnd == WORK_LIMIT_EXHAUSTED) {
+        return Result.FALLBACK;
+      }
       if (matchEnd < 0) {
-        int failedWatermark = ~matchEnd;
-        firstSegmentWatermark = Math.max(firstSegmentWatermark, failedWatermark);
+        int seg1Base = (driverIdx + 1) * STATE_STRIDE;
+        int failedWatermark = scratch[seg1Base + OFFSET_WATERMARK];
         if (driverIdx == 0
             && segments.length > 1
             && segments[1].gap().isExecutorGuardedGap()
@@ -338,8 +398,8 @@ final class MultiAnchorExecutor {
         } else {
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         }
-        verificationWork++;
-        if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+        workHolder[0]++;
+        if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
           return Result.FALLBACK;
         }
         continue;
@@ -360,6 +420,26 @@ final class MultiAnchorExecutor {
    * @return the execution result
    */
   static Result find(MultiAnchorDescriptor descriptor, String text, int searchFrom) {
+    return find(descriptor, text, searchFrom, null, null);
+  }
+
+  /**
+   * Executes multi-anchor matching on Java String input with caller-provided scratch and work
+   * buffers.
+   *
+   * @param descriptor the multi-anchor descriptor containing the chain
+   * @param text the input string
+   * @param searchFrom the starting character index
+   * @param scratch reusable state buffer of length at least {@code numSegments * STATE_STRIDE}
+   * @param workHolder single-element array tracking cumulative verification work
+   * @return the execution result
+   */
+  static Result find(
+      MultiAnchorDescriptor descriptor,
+      String text,
+      int searchFrom,
+      int[] scratch,
+      long[] workHolder) {
     Objects.requireNonNull(descriptor, "descriptor");
     Objects.requireNonNull(text, "text");
 
@@ -393,11 +473,22 @@ final class MultiAnchorExecutor {
     minUpstreamLen += segments[driverIdx].gap().minLength();
 
     long workLimit = WorkLimit.forRemaining(textLen - searchFrom);
-    long verificationWork = 0;
+    if (workHolder == null) {
+      workHolder = new long[1];
+    } else {
+      workHolder[0] = 0;
+    }
+
+    if (scratch == null || scratch.length < numSegments * STATE_STRIDE) {
+      scratch = new int[numSegments * STATE_STRIDE];
+    }
+    for (int s = 0; s < numSegments; s++) {
+      int base = s * STATE_STRIDE;
+      scratch[base + OFFSET_WATERMARK] = searchFrom;
+      scratch[base + OFFSET_GUARD_END] = -1;
+    }
 
     int minReverseWatermark = Math.max(0, searchFrom);
-    int firstSegmentWatermark = searchFrom;
-    int firstSegmentGuardEnd = -1;
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -548,8 +639,8 @@ final class MultiAnchorExecutor {
 
         if (!upstreamMatched) {
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
-          verificationWork++;
-          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+          workHolder[0]++;
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
             return Result.FALLBACK;
           }
           continue;
@@ -582,10 +673,12 @@ final class MultiAnchorExecutor {
       // Phase 2 & 3: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1} and trailing
       // gap
       if (driverIdx < numSegments - 1) {
+        int seg1Base = (driverIdx + 1) * STATE_STRIDE;
         MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
         MultiAnchorDescriptor.Gap gap1 = seg1.gap();
         boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
         int maxScan;
+        int firstSegmentGuardEnd = scratch[seg1Base + OFFSET_GUARD_END];
         if (gap1.isExecutorGuardedGap()
             && gap1.maxLength() == Integer.MAX_VALUE
             && firstSegmentGuardEnd >= currentPos) {
@@ -595,11 +688,22 @@ final class MultiAnchorExecutor {
               reluctantGuarded
                   ? gap1.guardedSearchEnd(text, currentPos, textLen)
                   : gap1.scanClassEnd(text, currentPos, textLen);
+          if (gapScansText(gap1, reluctantGuarded)) {
+            long scanWork = Math.max(1, maxScan - currentPos);
+            workHolder[0] += scanWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(scanWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return Result.FALLBACK;
+            }
+          }
           if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
-            firstSegmentGuardEnd = maxScan;
+            scratch[seg1Base + OFFSET_GUARD_END] = maxScan;
           }
         }
         int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
+        int firstSegmentWatermark = scratch[seg1Base + OFFSET_WATERMARK];
         if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark >= maxHop) {
           if (driverIdx == 0
               && seg1.gap().isExecutorGuardedGap()
@@ -610,8 +714,8 @@ final class MultiAnchorExecutor {
           } else {
             candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
           }
-          verificationWork++;
-          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+          workHolder[0]++;
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
             return Result.FALLBACK;
           }
           continue;
@@ -619,18 +723,22 @@ final class MultiAnchorExecutor {
       }
 
       int matchEnd =
-          matchDownstream(
+          matchDownstreamIterative(
               text,
               segments,
               driverIdx + 1,
               currentPos,
               textLen,
               trailingGap,
-              firstSegmentWatermark,
-              firstSegmentGuardEnd);
+              scratch,
+              workHolder,
+              workLimit);
+      if (matchEnd == WORK_LIMIT_EXHAUSTED) {
+        return Result.FALLBACK;
+      }
       if (matchEnd < 0) {
-        int failedWatermark = ~matchEnd;
-        firstSegmentWatermark = Math.max(firstSegmentWatermark, failedWatermark);
+        int seg1Base = (driverIdx + 1) * STATE_STRIDE;
+        int failedWatermark = scratch[seg1Base + OFFSET_WATERMARK];
         if (driverIdx == 0
             && segments.length > 1
             && segments[1].gap().isExecutorGuardedGap()
@@ -640,8 +748,8 @@ final class MultiAnchorExecutor {
         } else {
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         }
-        verificationWork++;
-        if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+        workHolder[0]++;
+        if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
           return Result.FALLBACK;
         }
         continue;
@@ -653,222 +761,546 @@ final class MultiAnchorExecutor {
     return Result.MISMATCH;
   }
 
-  private static int matchDownstream(
+  private static int matchDownstreamIterative(
       Utf8InputScanner scanner,
       MultiAnchorDescriptor.Segment[] segments,
-      int i,
-      int currentPos,
+      int startSeg,
+      int startPos,
       int textLen,
       MultiAnchorDescriptor.Gap trailingGap,
-      int watermark,
-      int cachedGuardEnd) {
-    if (i == segments.length) {
+      int[] state,
+      long[] workHolder,
+      long workLimit) {
+    if (startSeg == segments.length) {
       return trailingGap.isExecutorFixedGap()
-          ? trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen)
-          : trailingGap.expandTrailing(scanner, currentPos, textLen);
+          ? trailingGap.matchExecutorFixedForward(scanner, startPos, textLen)
+          : trailingGap.expandTrailing(scanner, startPos, textLen);
     }
 
-    MultiAnchorDescriptor.Segment seg = segments[i];
-    MultiAnchorDescriptor.Gap gap = seg.gap();
-    MultiAnchorDescriptor.Anchor anchor = seg.anchor();
+    int s = startSeg;
+    state[s * STATE_STRIDE + OFFSET_CUR_POS] = startPos;
+    boolean backtrack = false;
 
-    if (gap.isExecutorFixedGap()) {
-      int p = gap.matchExecutorFixedForward(scanner, currentPos, textLen);
-      if (p < 0 || !anchor.startsWith(scanner, p)) {
-        return -1;
-      }
-      int anchorLen = anchor.lengthAt(scanner, p);
-      if (anchorLen <= 0) {
-        return -1;
-      }
-      return matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
-    }
+    while (s >= startSeg) {
+      int base = s * STATE_STRIDE;
+      MultiAnchorDescriptor.Segment seg = segments[s];
+      MultiAnchorDescriptor.Gap gap = seg.gap();
+      MultiAnchorDescriptor.Anchor anchor = seg.anchor();
+      int currentPos = state[base + OFFSET_CUR_POS];
 
-    int minHop = currentPos + gap.minLength();
-    if (minHop > textLen) {
-      return -1;
-    }
-    boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-    int maxScan;
-    if (gap.isExecutorGuardedGap()
-        && gap.maxLength() == Integer.MAX_VALUE
-        && cachedGuardEnd >= currentPos) {
-      maxScan = cachedGuardEnd;
-    } else {
-      maxScan =
-          reluctantGuardedGap
-              ? gap.guardedSearchEnd(scanner, currentPos, textLen)
-              : gap.scanClassEnd(scanner, currentPos, textLen);
-    }
-    int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
-    if (minHop > maxHop) {
-      return -1;
-    }
-
-    if (gap.isGreedy()) {
-      int curUpper = maxHop;
-      while (curUpper >= minHop) {
-        int p = anchor.lastIndexOf(scanner, minHop, curUpper);
-        if (p < 0) {
-          return curUpper == maxHop ? ~maxHop : -1;
+      if (gap.isExecutorFixedGap()) {
+        if (backtrack) {
+          s--;
+          continue;
         }
-        if ((gap.maxLength() == Integer.MAX_VALUE
-                && isUnboundedGapSatisfiedUtf8(gap, p - currentPos))
-            || gap.matchesSlice(scanner, currentPos, p)) {
-          int anchorLen = anchor.lengthAt(scanner, p);
-          if (anchorLen > 0) {
-            int matchEnd =
-                matchDownstream(
-                    scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
-            if (matchEnd >= 0) {
-              return matchEnd;
+        int p = gap.matchExecutorFixedForward(scanner, currentPos, textLen);
+        if (p < 0 || !anchor.startsWith(scanner, p)) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+        int anchorLen = anchor.lengthAt(scanner, p);
+        if (anchorLen <= 0) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+        state[base + OFFSET_P] = p;
+        state[base + OFFSET_ANCHOR_LEN] = anchorLen;
+
+        if (s == segments.length - 1) {
+          int matchEnd =
+              trailingGap.isExecutorFixedGap()
+                  ? trailingGap.matchExecutorFixedForward(scanner, p + anchorLen, textLen)
+                  : trailingGap.expandTrailing(scanner, p + anchorLen, textLen);
+          if (matchEnd >= 0) {
+            return matchEnd;
+          }
+          backtrack = true;
+          s--;
+          continue;
+        }
+
+        s++;
+        state[s * STATE_STRIDE + OFFSET_CUR_POS] = p + anchorLen;
+        backtrack = false;
+        continue;
+      }
+
+      boolean reluctantGuarded = gap.isExecutorGuardedGap() && !gap.isGreedy();
+
+      if (!backtrack) {
+        int minHop = currentPos + gap.minLength();
+        if (minHop > textLen) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+
+        int maxScan;
+        int cachedGuardEnd = state[base + OFFSET_GUARD_END];
+        if (gap.isExecutorGuardedGap()
+            && gap.maxLength() == Integer.MAX_VALUE
+            && cachedGuardEnd >= currentPos) {
+          maxScan = cachedGuardEnd;
+        } else {
+          maxScan =
+              reluctantGuarded
+                  ? gap.guardedSearchEnd(scanner, currentPos, textLen)
+                  : gap.scanClassEnd(scanner, currentPos, textLen);
+          if (gapScansText(gap, reluctantGuarded)) {
+            long scanWork = Math.max(1, maxScan - currentPos);
+            workHolder[0] += scanWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(scanWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return WORK_LIMIT_EXHAUSTED;
             }
           }
-        }
-        curUpper = p - 1;
-      }
-      return -1;
-    } else {
-      int curWatermark = watermark;
-      int curLower = Math.max(minHop, curWatermark);
-      while (curLower <= maxHop) {
-        int p = anchor.findNextWithin(scanner, curLower, maxHop);
-        if (p < 0) {
-          return ~Math.max(curWatermark, maxHop);
-        }
-        curWatermark = Math.max(curWatermark, p);
-        if (reluctantGuardedGap) {
-          int guard = gap.findFirstGuardByte(scanner, currentPos, p);
-          if (guard >= currentPos) {
-            return ~curWatermark;
+          if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
+            state[base + OFFSET_GUARD_END] = maxScan;
+            cachedGuardEnd = maxScan;
           }
         }
-        if ((gap.maxLength() == Integer.MAX_VALUE
-                && isUnboundedGapSatisfiedUtf8(gap, p - currentPos))
-            || gap.matchesSlice(scanner, currentPos, p)) {
-          int anchorLen = anchor.lengthAt(scanner, p);
-          if (anchorLen > 0) {
-            int matchEnd =
-                matchDownstream(
-                    scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
-            if (matchEnd >= 0) {
-              return matchEnd;
+
+        int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
+        if (minHop > maxHop) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+
+        state[base + OFFSET_MIN_HOP] = minHop;
+        state[base + OFFSET_MAX_HOP] = maxHop;
+
+        if (gap.isGreedy()) {
+          state[base + OFFSET_SEARCH_POS] = maxHop;
+        } else {
+          int curWatermark = state[base + OFFSET_WATERMARK];
+          int curLower;
+          if (gap.isExecutorGuardedGap()
+              && gap.maxLength() == Integer.MAX_VALUE
+              && currentPos <= cachedGuardEnd) {
+            curLower = Math.max(minHop, curWatermark);
+          } else {
+            curLower = minHop;
+          }
+          if (curLower > maxHop) {
+            backtrack = true;
+            s--;
+            continue;
+          }
+          state[base + OFFSET_SEARCH_POS] = curLower;
+        }
+      }
+
+      int minHop = state[base + OFFSET_MIN_HOP];
+      int maxHop = state[base + OFFSET_MAX_HOP];
+      boolean found = false;
+
+      if (gap.isGreedy()) {
+        int curUpper = state[base + OFFSET_SEARCH_POS];
+        while (curUpper >= minHop) {
+          int p = anchor.lastIndexOf(scanner, minHop, curUpper);
+          long workUnits = Math.max(1, curUpper - (p < 0 ? minHop : p) + anchor.minLength());
+          workHolder[0] += workUnits;
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record(workUnits);
+          }
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+            return WORK_LIMIT_EXHAUSTED;
+          }
+          if (p < 0) {
+            if (curUpper == maxHop) {
+              state[base + OFFSET_WATERMARK] = Math.max(state[base + OFFSET_WATERMARK], maxHop);
+            }
+            break;
+          }
+          boolean matches;
+          if (gap.maxLength() == Integer.MAX_VALUE
+              && isUnboundedGapSatisfiedUtf8(gap, p - currentPos)) {
+            matches = true;
+          } else {
+            long sliceWork = Math.max(1, p - currentPos);
+            workHolder[0] += sliceWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(sliceWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return WORK_LIMIT_EXHAUSTED;
+            }
+            matches = gap.matchesSlice(scanner, currentPos, p);
+          }
+          if (matches) {
+            int anchorLen = anchor.lengthAt(scanner, p);
+            if (anchorLen > 0) {
+              state[base + OFFSET_P] = p;
+              state[base + OFFSET_ANCHOR_LEN] = anchorLen;
+              state[base + OFFSET_SEARCH_POS] = p - 1;
+              found = true;
+              break;
             }
           }
+          curUpper = p - 1;
         }
-        curLower = p + 1;
+      } else {
+        int curLower = state[base + OFFSET_SEARCH_POS];
+        int curWatermark = state[base + OFFSET_WATERMARK];
+        while (curLower <= maxHop) {
+          int p = anchor.findNextWithin(scanner, curLower, maxHop);
+          long workUnits = Math.max(1, (p < 0 ? maxHop : p) - curLower + anchor.minLength());
+          workHolder[0] += workUnits;
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record(workUnits);
+          }
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+            return WORK_LIMIT_EXHAUSTED;
+          }
+          if (p < 0) {
+            curWatermark = Math.max(curWatermark, maxHop);
+            state[base + OFFSET_WATERMARK] = curWatermark;
+            break;
+          }
+
+          if (reluctantGuarded) {
+            int guard = gap.findFirstGuardByte(scanner, currentPos, p);
+            if (guard >= currentPos) {
+              break;
+            }
+          }
+          curWatermark = Math.max(curWatermark, p);
+          state[base + OFFSET_WATERMARK] = curWatermark;
+
+          boolean matches;
+          if (gap.maxLength() == Integer.MAX_VALUE
+              && isUnboundedGapSatisfiedUtf8(gap, p - currentPos)) {
+            matches = true;
+          } else {
+            long sliceWork = Math.max(1, p - currentPos);
+            workHolder[0] += sliceWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(sliceWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return WORK_LIMIT_EXHAUSTED;
+            }
+            matches = gap.matchesSlice(scanner, currentPos, p);
+          }
+          if (matches) {
+            int anchorLen = anchor.lengthAt(scanner, p);
+            if (anchorLen > 0) {
+              state[base + OFFSET_P] = p;
+              state[base + OFFSET_ANCHOR_LEN] = anchorLen;
+              state[base + OFFSET_SEARCH_POS] = p + 1;
+              found = true;
+              break;
+            }
+          }
+          curLower = p + 1;
+        }
       }
-      return ~curWatermark;
+
+      if (!found) {
+        backtrack = true;
+        s--;
+        continue;
+      }
+
+      int p = state[base + OFFSET_P];
+      int anchorLen = state[base + OFFSET_ANCHOR_LEN];
+
+      if (s == segments.length - 1) {
+        int matchEnd =
+            trailingGap.isExecutorFixedGap()
+                ? trailingGap.matchExecutorFixedForward(scanner, p + anchorLen, textLen)
+                : trailingGap.expandTrailing(scanner, p + anchorLen, textLen);
+        if (matchEnd >= 0) {
+          return matchEnd;
+        }
+        backtrack = true;
+        continue;
+      }
+
+      s++;
+      state[s * STATE_STRIDE + OFFSET_CUR_POS] = p + anchorLen;
+      backtrack = false;
     }
+
+    return -1;
   }
 
-  private static int matchDownstream(
+  private static int matchDownstreamIterative(
       String text,
       MultiAnchorDescriptor.Segment[] segments,
-      int i,
-      int currentPos,
+      int startSeg,
+      int startPos,
       int textLen,
       MultiAnchorDescriptor.Gap trailingGap,
-      int watermark,
-      int cachedGuardEnd) {
-    if (i == segments.length) {
+      int[] state,
+      long[] workHolder,
+      long workLimit) {
+    if (startSeg == segments.length) {
       return trailingGap.isExecutorFixedGap()
-          ? trailingGap.matchExecutorFixedForward(text, currentPos, textLen)
-          : trailingGap.expandTrailing(text, currentPos, textLen);
+          ? trailingGap.matchExecutorFixedForward(text, startPos, textLen)
+          : trailingGap.expandTrailing(text, startPos, textLen);
     }
 
-    MultiAnchorDescriptor.Segment seg = segments[i];
-    MultiAnchorDescriptor.Gap gap = seg.gap();
-    MultiAnchorDescriptor.Anchor anchor = seg.anchor();
+    int s = startSeg;
+    state[s * STATE_STRIDE + OFFSET_CUR_POS] = startPos;
+    boolean backtrack = false;
 
-    if (gap.isExecutorFixedGap()) {
-      int p = gap.matchExecutorFixedForward(text, currentPos, textLen);
-      if (p < 0 || !anchor.startsWith(text, p)) {
-        return -1;
-      }
-      int anchorLen = anchor.lengthAt(text, p);
-      if (anchorLen <= 0) {
-        return -1;
-      }
-      return matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
-    }
+    while (s >= startSeg) {
+      int base = s * STATE_STRIDE;
+      MultiAnchorDescriptor.Segment seg = segments[s];
+      MultiAnchorDescriptor.Gap gap = seg.gap();
+      MultiAnchorDescriptor.Anchor anchor = seg.anchor();
+      int currentPos = state[base + OFFSET_CUR_POS];
 
-    int minHop = currentPos + gap.minLength();
-    if (minHop > textLen) {
-      return -1;
-    }
-    boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-    int maxScan;
-    if (gap.isExecutorGuardedGap()
-        && gap.maxLength() == Integer.MAX_VALUE
-        && cachedGuardEnd >= currentPos) {
-      maxScan = cachedGuardEnd;
-    } else {
-      maxScan =
-          reluctantGuardedGap
-              ? gap.guardedSearchEnd(text, currentPos, textLen)
-              : gap.scanClassEnd(text, currentPos, textLen);
-    }
-    int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
-    if (minHop > maxHop) {
-      return -1;
-    }
-
-    if (gap.isGreedy()) {
-      int curUpper = maxHop;
-      while (curUpper >= minHop) {
-        int p = anchor.lastIndexOf(text, minHop, curUpper);
-        if (p < 0) {
-          return curUpper == maxHop ? ~maxHop : -1;
+      if (gap.isExecutorFixedGap()) {
+        if (backtrack) {
+          s--;
+          continue;
         }
-        if (gap.endsAtCodePointBoundary(text, p)
-            && ((gap.maxLength() == Integer.MAX_VALUE
-                    && isUnboundedGapSatisfied(gap, p - currentPos))
-                || gap.matchesSlice(text, currentPos, p))) {
-          int anchorLen = anchor.lengthAt(text, p);
-          if (anchorLen > 0) {
-            int matchEnd =
-                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
-            if (matchEnd >= 0) {
-              return matchEnd;
+        int p = gap.matchExecutorFixedForward(text, currentPos, textLen);
+        if (p < 0 || !anchor.startsWith(text, p)) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+        int anchorLen = anchor.lengthAt(text, p);
+        if (anchorLen <= 0) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+        state[base + OFFSET_P] = p;
+        state[base + OFFSET_ANCHOR_LEN] = anchorLen;
+
+        if (s == segments.length - 1) {
+          int matchEnd =
+              trailingGap.isExecutorFixedGap()
+                  ? trailingGap.matchExecutorFixedForward(text, p + anchorLen, textLen)
+                  : trailingGap.expandTrailing(text, p + anchorLen, textLen);
+          if (matchEnd >= 0) {
+            return matchEnd;
+          }
+          backtrack = true;
+          s--;
+          continue;
+        }
+
+        s++;
+        state[s * STATE_STRIDE + OFFSET_CUR_POS] = p + anchorLen;
+        backtrack = false;
+        continue;
+      }
+
+      boolean reluctantGuarded = gap.isExecutorGuardedGap() && !gap.isGreedy();
+
+      if (!backtrack) {
+        int minHop = currentPos + gap.minLength();
+        if (minHop > textLen) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+
+        int maxScan;
+        int cachedGuardEnd = state[base + OFFSET_GUARD_END];
+        if (gap.isExecutorGuardedGap()
+            && gap.maxLength() == Integer.MAX_VALUE
+            && cachedGuardEnd >= currentPos) {
+          maxScan = cachedGuardEnd;
+        } else {
+          maxScan =
+              reluctantGuarded
+                  ? gap.guardedSearchEnd(text, currentPos, textLen)
+                  : gap.scanClassEnd(text, currentPos, textLen);
+          if (gapScansText(gap, reluctantGuarded)) {
+            long scanWork = Math.max(1, maxScan - currentPos);
+            workHolder[0] += scanWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(scanWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return WORK_LIMIT_EXHAUSTED;
             }
           }
-        }
-        curUpper = p - 1;
-      }
-      return -1;
-    } else {
-      int curWatermark = watermark;
-      int curLower = Math.max(minHop, curWatermark);
-      while (curLower <= maxHop) {
-        int p = anchor.findNextWithin(text, curLower, maxHop);
-        if (p < 0) {
-          return ~Math.max(curWatermark, maxHop);
-        }
-        curWatermark = Math.max(curWatermark, p);
-        if (reluctantGuardedGap) {
-          int guard = gap.findFirstGuardByte(text, currentPos, p);
-          if (guard >= currentPos) {
-            return ~curWatermark;
+          if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
+            state[base + OFFSET_GUARD_END] = maxScan;
+            cachedGuardEnd = maxScan;
           }
         }
-        if (gap.endsAtCodePointBoundary(text, p)
-            && ((gap.maxLength() == Integer.MAX_VALUE
-                    && isUnboundedGapSatisfied(gap, p - currentPos))
-                || gap.matchesSlice(text, currentPos, p))) {
-          int anchorLen = anchor.lengthAt(text, p);
-          if (anchorLen > 0) {
-            int matchEnd =
-                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
-            if (matchEnd >= 0) {
-              return matchEnd;
+
+        int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
+        if (minHop > maxHop) {
+          backtrack = true;
+          s--;
+          continue;
+        }
+
+        state[base + OFFSET_MIN_HOP] = minHop;
+        state[base + OFFSET_MAX_HOP] = maxHop;
+
+        if (gap.isGreedy()) {
+          state[base + OFFSET_SEARCH_POS] = maxHop;
+        } else {
+          int curWatermark = state[base + OFFSET_WATERMARK];
+          int curLower;
+          if (gap.isExecutorGuardedGap()
+              && gap.maxLength() == Integer.MAX_VALUE
+              && currentPos <= cachedGuardEnd) {
+            curLower = Math.max(minHop, curWatermark);
+          } else {
+            curLower = minHop;
+          }
+          if (curLower > maxHop) {
+            backtrack = true;
+            s--;
+            continue;
+          }
+          state[base + OFFSET_SEARCH_POS] = curLower;
+        }
+      }
+
+      int minHop = state[base + OFFSET_MIN_HOP];
+      int maxHop = state[base + OFFSET_MAX_HOP];
+      boolean found = false;
+
+      if (gap.isGreedy()) {
+        int curUpper = state[base + OFFSET_SEARCH_POS];
+        while (curUpper >= minHop) {
+          int p = anchor.lastIndexOf(text, minHop, curUpper);
+          long workUnits = Math.max(1, curUpper - (p < 0 ? minHop : p) + anchor.minLength());
+          workHolder[0] += workUnits;
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record(workUnits);
+          }
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+            return WORK_LIMIT_EXHAUSTED;
+          }
+          if (p < 0) {
+            if (curUpper == maxHop) {
+              state[base + OFFSET_WATERMARK] = Math.max(state[base + OFFSET_WATERMARK], maxHop);
+            }
+            break;
+          }
+          boolean matches;
+          if (!gap.endsAtCodePointBoundary(text, p)) {
+            matches = false;
+          } else if (gap.maxLength() == Integer.MAX_VALUE
+              && isUnboundedGapSatisfied(gap, p - currentPos)) {
+            matches = true;
+          } else {
+            long sliceWork = Math.max(1, p - currentPos);
+            workHolder[0] += sliceWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(sliceWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return WORK_LIMIT_EXHAUSTED;
+            }
+            matches = gap.matchesSlice(text, currentPos, p);
+          }
+          if (matches) {
+            int anchorLen = anchor.lengthAt(text, p);
+            if (anchorLen > 0) {
+              state[base + OFFSET_P] = p;
+              state[base + OFFSET_ANCHOR_LEN] = anchorLen;
+              state[base + OFFSET_SEARCH_POS] = p - 1;
+              found = true;
+              break;
             }
           }
+          curUpper = p - 1;
         }
-        curLower = p + 1;
+      } else {
+        int curLower = state[base + OFFSET_SEARCH_POS];
+        int curWatermark = state[base + OFFSET_WATERMARK];
+        while (curLower <= maxHop) {
+          int p = anchor.findNextWithin(text, curLower, maxHop);
+          long workUnits = Math.max(1, (p < 0 ? maxHop : p) - curLower + anchor.minLength());
+          workHolder[0] += workUnits;
+          if (WorkCounterConfig.ENABLED) {
+            WorkCounter.record(workUnits);
+          }
+          if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+            return WORK_LIMIT_EXHAUSTED;
+          }
+          if (p < 0) {
+            curWatermark = Math.max(curWatermark, maxHop);
+            state[base + OFFSET_WATERMARK] = curWatermark;
+            break;
+          }
+
+          if (reluctantGuarded) {
+            int guard = gap.findFirstGuardByte(text, currentPos, p);
+            if (guard >= currentPos) {
+              break;
+            }
+          }
+          curWatermark = Math.max(curWatermark, p);
+          state[base + OFFSET_WATERMARK] = curWatermark;
+
+          boolean matches;
+          if (!gap.endsAtCodePointBoundary(text, p)) {
+            matches = false;
+          } else if (gap.maxLength() == Integer.MAX_VALUE
+              && isUnboundedGapSatisfied(gap, p - currentPos)) {
+            matches = true;
+          } else {
+            long sliceWork = Math.max(1, p - currentPos);
+            workHolder[0] += sliceWork;
+            if (WorkCounterConfig.ENABLED) {
+              WorkCounter.record(sliceWork);
+            }
+            if (WorkLimit.isExhausted(workHolder[0], workLimit)) {
+              return WORK_LIMIT_EXHAUSTED;
+            }
+            matches = gap.matchesSlice(text, currentPos, p);
+          }
+          if (matches) {
+            int anchorLen = anchor.lengthAt(text, p);
+            if (anchorLen > 0) {
+              state[base + OFFSET_P] = p;
+              state[base + OFFSET_ANCHOR_LEN] = anchorLen;
+              state[base + OFFSET_SEARCH_POS] = p + 1;
+              found = true;
+              break;
+            }
+          }
+          curLower = p + 1;
+        }
       }
-      return ~curWatermark;
+
+      if (!found) {
+        backtrack = true;
+        s--;
+        continue;
+      }
+
+      int p = state[base + OFFSET_P];
+      int anchorLen = state[base + OFFSET_ANCHOR_LEN];
+
+      if (s == segments.length - 1) {
+        int matchEnd =
+            trailingGap.isExecutorFixedGap()
+                ? trailingGap.matchExecutorFixedForward(text, p + anchorLen, textLen)
+                : trailingGap.expandTrailing(text, p + anchorLen, textLen);
+        if (matchEnd >= 0) {
+          return matchEnd;
+        }
+        backtrack = true;
+        continue;
+      }
+
+      s++;
+      state[s * STATE_STRIDE + OFFSET_CUR_POS] = p + anchorLen;
+      backtrack = false;
     }
+
+    return -1;
   }
 
   private static int findNextCountingWork(
@@ -897,5 +1329,13 @@ final class MultiAnchorExecutor {
       return len >= gap.minLength();
     }
     return len >= gap.minLength() * 4;
+  }
+
+  private static boolean gapScansText(MultiAnchorDescriptor.Gap gap, boolean reluctantGuarded) {
+    if (reluctantGuarded) {
+      return gap.maxLength() != Integer.MAX_VALUE;
+    }
+    return gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+        || gap.kind() == MultiAnchorDescriptor.GapKind.SINGLE_LINE_ANY_STAR;
   }
 }

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -99,9 +99,7 @@ final class MultiAnchorExecutor {
     int minReverseWatermark = Math.max(0, searchFrom);
     int[] downstreamGuardEnds = new int[numSegments];
     Arrays.fill(downstreamGuardEnds, -1);
-    int watermark1 = searchFrom;
-    int watermark2 = searchFrom;
-    int[] downstreamWatermarks = null;
+    int[] firstSegmentWatermark = new int[] {searchFrom};
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -171,14 +169,15 @@ final class MultiAnchorExecutor {
 
           int searchUpperBound = curAnchorStart - minHop;
           int searchLowerBound = Math.max(minReverseWatermark, curAnchorStart - maxHop);
-          if (gap.guardBytes() != null) {
-            int lastGuard = gap.findLastGuardByte(scanner, searchLowerBound, curAnchorStart - 1);
-            if (lastGuard >= 0) {
-              long maxAnchorBytes = (long) upstreamAnchor.maxLength() * 4;
-              int firstOverlappingAnchorStart = (int) Math.max(0L, lastGuard - maxAnchorBytes + 1L);
-              searchLowerBound = Math.max(searchLowerBound, firstOverlappingAnchorStart);
-            }
+          int earliestGapStart = gap.scanClassStart(scanner, searchLowerBound, curAnchorStart);
+          if (curAnchorStart - earliestGapStart < gap.minLength()) {
+            upstreamMatched = false;
+            break;
           }
+          long maxAnchorBytes = (long) upstreamAnchor.maxLength() * 4L;
+          int firstOverlappingAnchorStart =
+              (int) Math.max(0L, (long) earliestGapStart - maxAnchorBytes);
+          searchLowerBound = Math.max(searchLowerBound, firstOverlappingAnchorStart);
 
           if (searchUpperBound < searchLowerBound) {
             upstreamMatched = false;
@@ -193,6 +192,11 @@ final class MultiAnchorExecutor {
 
           int uLen = upstreamAnchor.lengthAt(scanner, pUpstream);
           if (uLen <= 0 || !gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart)) {
+            if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+                && curAnchorStart - (pUpstream + uLen) >= gap.minLength()) {
+              upstreamMatched = false;
+              break;
+            }
             // Gap check failed: retry reverse search for earlier candidate
             boolean retryMatched = false;
             int nextUpper = pUpstream - 1;
@@ -204,6 +208,10 @@ final class MultiAnchorExecutor {
               uLen = upstreamAnchor.lengthAt(scanner, pUpstream);
               if (uLen > 0 && gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart)) {
                 retryMatched = true;
+                break;
+              }
+              if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+                  && curAnchorStart - (pUpstream + uLen) >= gap.minLength()) {
                 break;
               }
               nextUpper = pUpstream - 1;
@@ -253,126 +261,56 @@ final class MultiAnchorExecutor {
         currentPos = pDriver + driverLen;
       }
 
-      // Phase 2: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1}
-      boolean chainMatched = true;
-      for (int i = driverIdx + 1; i < numSegments; i++) {
-        MultiAnchorDescriptor.Segment seg = segments[i];
-        MultiAnchorDescriptor.Gap gap = seg.gap();
-        MultiAnchorDescriptor.Anchor anchor = seg.anchor();
-
-        int p;
-        if (gap.isExecutorFixedGap()) {
-          p = gap.matchExecutorFixedForward(scanner, currentPos, textLen);
-          if (p < 0 || !anchor.startsWith(scanner, p)) {
-            chainMatched = false;
-            break;
+      // Phase 2 & 3: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1} and trailing
+      // gap
+      if (driverIdx < numSegments - 1) {
+        MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
+        MultiAnchorDescriptor.Gap gap1 = seg1.gap();
+        boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
+        int maxScan;
+        int cachedGuardEnd = downstreamGuardEnds[driverIdx + 1];
+        if (reluctantGuarded) {
+          maxScan = gap1.guardedSearchEnd(scanner, currentPos, textLen);
+          if (cachedGuardEnd >= currentPos) {
+            maxScan = Math.min(maxScan, cachedGuardEnd);
           }
+        } else if (gap1.isExecutorGuardedGap()
+            && gap1.maxLength() == Integer.MAX_VALUE
+            && cachedGuardEnd >= currentPos) {
+          maxScan = cachedGuardEnd;
         } else {
-          int minHop = currentPos + gap.minLength();
-          if (minHop > textLen) {
-            chainMatched = false;
-            break;
-          }
-          boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-          int maxHop;
-          if (reluctantGuardedGap) {
-            maxHop = gap.guardedSearchEnd(scanner, currentPos, textLen);
-            int cachedGuardEnd = downstreamGuardEnds[i];
-            if (cachedGuardEnd >= currentPos) {
-              maxHop = Math.min(maxHop, cachedGuardEnd);
-            }
-          } else if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
-            int cachedGuardEnd = downstreamGuardEnds[i];
-            if (cachedGuardEnd >= currentPos) {
-              maxHop = cachedGuardEnd;
-            } else {
-              maxHop = gap.scanClassEnd(scanner, currentPos, textLen);
-              downstreamGuardEnds[i] = maxHop;
-            }
-          } else {
-            maxHop = gap.scanClassEnd(scanner, currentPos, textLen);
-          }
-
-          int watermark =
-              (i == 1)
-                  ? watermark1
-                  : (i == 2
-                      ? watermark2
-                      : (downstreamWatermarks != null ? downstreamWatermarks[i] : searchFrom));
-          int searchStart = Math.max(minHop, watermark);
-          if (searchStart > maxHop) {
-            chainMatched = false;
-            break;
-          }
-
-          if (gap.isGreedy()) {
-            p = anchor.lastIndexOf(scanner, searchStart, maxHop);
-          } else {
-            p = anchor.findNextWithin(scanner, searchStart, maxHop);
-          }
-          if (p < 0) {
-            if (i == 1) {
-              watermark1 = maxHop;
-            } else if (i == 2) {
-              watermark2 = maxHop;
-            } else {
-              if (downstreamWatermarks == null) {
-                downstreamWatermarks = new int[numSegments];
-                Arrays.fill(downstreamWatermarks, searchFrom);
-              }
-              downstreamWatermarks[i] = maxHop;
-            }
-            chainMatched = false;
-            break;
-          }
-          if (!gap.isGreedy()) {
-            if (i == 1) {
-              watermark1 = p;
-            } else if (i == 2) {
-              watermark2 = p;
-            } else {
-              if (downstreamWatermarks == null) {
-                downstreamWatermarks = new int[numSegments];
-                Arrays.fill(downstreamWatermarks, searchFrom);
-              }
-              downstreamWatermarks[i] = p;
-            }
-          }
-
-          if (reluctantGuardedGap) {
-            int guard = gap.findFirstGuardByte(scanner, currentPos, p);
-            if (guard >= currentPos) {
-              downstreamGuardEnds[i] = guard;
-              chainMatched = false;
-              break;
-            }
-          } else if (!gap.isExecutorGuardedGap() && !gap.matchesSlice(scanner, currentPos, p)) {
-            chainMatched = false;
-            break;
+          maxScan = gap1.scanClassEnd(scanner, currentPos, textLen);
+          if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
+            downstreamGuardEnds[driverIdx + 1] = maxScan;
           }
         }
-
-        int anchorLen = anchor.lengthAt(scanner, p);
-        if (anchorLen <= 0) {
-          chainMatched = false;
-          break;
+        int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
+        if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark[0] >= maxHop) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          verificationWork++;
+          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+            return Result.FALLBACK;
+          }
+          continue;
         }
-
-        currentPos = p + anchorLen;
       }
 
-      if (!chainMatched) {
-        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
-        continue;
-      }
-
-      // Phase 3: Trailing gap resolution
       int matchEnd =
-          trailingGap.isExecutorFixedGap()
-              ? trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen)
-              : trailingGap.expandTrailing(scanner, currentPos, textLen);
+          matchDownstream(
+              scanner,
+              segments,
+              driverIdx + 1,
+              currentPos,
+              textLen,
+              trailingGap,
+              firstSegmentWatermark,
+              downstreamGuardEnds);
       if (matchEnd < 0) {
         candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+        verificationWork++;
+        if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+          return Result.FALLBACK;
+        }
         continue;
       }
 
@@ -429,9 +367,7 @@ final class MultiAnchorExecutor {
     int minReverseWatermark = Math.max(0, searchFrom);
     int[] downstreamGuardEnds = new int[numSegments];
     Arrays.fill(downstreamGuardEnds, -1);
-    int watermark1 = searchFrom;
-    int watermark2 = searchFrom;
-    int[] downstreamWatermarks = null;
+    int[] firstSegmentWatermark = new int[] {searchFrom};
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -501,14 +437,14 @@ final class MultiAnchorExecutor {
 
           int searchUpperBound = curAnchorStart - minHop;
           int searchLowerBound = Math.max(minReverseWatermark, curAnchorStart - maxHop);
-          if (gap.guardBytes() != null) {
-            int lastGuard = gap.findLastGuardByte(text, searchLowerBound, curAnchorStart - 1);
-            if (lastGuard >= 0) {
-              int firstOverlappingAnchorStart =
-                  (int) Math.max(0L, (long) lastGuard - upstreamAnchor.maxLength() + 1L);
-              searchLowerBound = Math.max(searchLowerBound, firstOverlappingAnchorStart);
-            }
+          int earliestGapStart = gap.scanClassStart(text, searchLowerBound, curAnchorStart);
+          if (curAnchorStart - earliestGapStart < gap.minLength()) {
+            upstreamMatched = false;
+            break;
           }
+          int firstOverlappingAnchorStart =
+              (int) Math.max(0L, (long) earliestGapStart - upstreamAnchor.maxLength());
+          searchLowerBound = Math.max(searchLowerBound, firstOverlappingAnchorStart);
 
           if (searchUpperBound < searchLowerBound) {
             upstreamMatched = false;
@@ -523,6 +459,11 @@ final class MultiAnchorExecutor {
 
           int uLen = upstreamAnchor.lengthAt(text, pUpstream);
           if (uLen <= 0 || !gap.matchesSlice(text, pUpstream + uLen, curAnchorStart)) {
+            if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+                && curAnchorStart - (pUpstream + uLen) >= gap.minLength()) {
+              upstreamMatched = false;
+              break;
+            }
             // Gap check failed: retry reverse search for earlier candidate
             boolean retryMatched = false;
             int nextUpper = pUpstream - 1;
@@ -534,6 +475,10 @@ final class MultiAnchorExecutor {
               uLen = upstreamAnchor.lengthAt(text, pUpstream);
               if (uLen > 0 && gap.matchesSlice(text, pUpstream + uLen, curAnchorStart)) {
                 retryMatched = true;
+                break;
+              }
+              if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
+                  && curAnchorStart - (pUpstream + uLen) >= gap.minLength()) {
                 break;
               }
               nextUpper = pUpstream - 1;
@@ -583,130 +528,56 @@ final class MultiAnchorExecutor {
         currentPos = pDriver + driverLen;
       }
 
-      // Phase 2: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1}
-      boolean chainMatched = true;
-      for (int i = driverIdx + 1; i < numSegments; i++) {
-        MultiAnchorDescriptor.Segment seg = segments[i];
-        MultiAnchorDescriptor.Gap gap = seg.gap();
-        MultiAnchorDescriptor.Anchor anchor = seg.anchor();
-
-        int p;
-        if (gap.isExecutorFixedGap()) {
-          p = gap.matchExecutorFixedForward(text, currentPos, textLen);
-          if (p < 0 || !anchor.startsWith(text, p)) {
-            chainMatched = false;
-            break;
+      // Phase 2 & 3: Downstream verification for A_{driverIdx+1} ... A_{numSegments-1} and trailing
+      // gap
+      if (driverIdx < numSegments - 1) {
+        MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
+        MultiAnchorDescriptor.Gap gap1 = seg1.gap();
+        boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
+        int maxScan;
+        int cachedGuardEnd = downstreamGuardEnds[driverIdx + 1];
+        if (reluctantGuarded) {
+          maxScan = gap1.guardedSearchEnd(text, currentPos, textLen);
+          if (cachedGuardEnd >= currentPos) {
+            maxScan = Math.min(maxScan, cachedGuardEnd);
           }
+        } else if (gap1.isExecutorGuardedGap()
+            && gap1.maxLength() == Integer.MAX_VALUE
+            && cachedGuardEnd >= currentPos) {
+          maxScan = cachedGuardEnd;
         } else {
-          int minHop = currentPos + gap.minLength();
-          if (minHop > textLen) {
-            chainMatched = false;
-            break;
-          }
-          boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-          int maxHop;
-          if (reluctantGuardedGap) {
-            maxHop = gap.guardedSearchEnd(text, currentPos, textLen);
-            int cachedGuardEnd = downstreamGuardEnds[i];
-            if (cachedGuardEnd >= currentPos) {
-              maxHop = Math.min(maxHop, cachedGuardEnd);
-            }
-          } else if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
-            int cachedGuardEnd = downstreamGuardEnds[i];
-            if (cachedGuardEnd >= currentPos) {
-              maxHop = cachedGuardEnd;
-            } else {
-              maxHop = gap.scanClassEnd(text, currentPos, textLen);
-              downstreamGuardEnds[i] = maxHop;
-            }
-          } else {
-            maxHop = gap.scanClassEnd(text, currentPos, textLen);
-          }
-
-          int watermark =
-              (i == 1)
-                  ? watermark1
-                  : (i == 2
-                      ? watermark2
-                      : (downstreamWatermarks != null ? downstreamWatermarks[i] : searchFrom));
-          int searchStart = Math.max(minHop, watermark);
-          if (searchStart > maxHop) {
-            chainMatched = false;
-            break;
-          }
-
-          if (gap.isGreedy()) {
-            p = anchor.lastIndexOf(text, searchStart, maxHop);
-          } else {
-            p = anchor.findNextWithin(text, searchStart, maxHop);
-          }
-          if (p < 0) {
-            if (i == 1) {
-              watermark1 = maxHop;
-            } else if (i == 2) {
-              watermark2 = maxHop;
-            } else {
-              if (downstreamWatermarks == null) {
-                downstreamWatermarks = new int[numSegments];
-                Arrays.fill(downstreamWatermarks, searchFrom);
-              }
-              downstreamWatermarks[i] = maxHop;
-            }
-            chainMatched = false;
-            break;
-          }
-          if (!gap.isGreedy()) {
-            if (i == 1) {
-              watermark1 = p;
-            } else if (i == 2) {
-              watermark2 = p;
-            } else {
-              if (downstreamWatermarks == null) {
-                downstreamWatermarks = new int[numSegments];
-                Arrays.fill(downstreamWatermarks, searchFrom);
-              }
-              downstreamWatermarks[i] = p;
-            }
-          }
-
-          if (!gap.endsAtCodePointBoundary(text, p)) {
-            chainMatched = false;
-            break;
-          }
-          if (reluctantGuardedGap) {
-            int guard = gap.findFirstGuardByte(text, currentPos, p);
-            if (guard >= currentPos) {
-              downstreamGuardEnds[i] = guard;
-              chainMatched = false;
-              break;
-            }
-          } else if (!gap.isExecutorGuardedGap() && !gap.matchesSlice(text, currentPos, p)) {
-            chainMatched = false;
-            break;
+          maxScan = gap1.scanClassEnd(text, currentPos, textLen);
+          if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
+            downstreamGuardEnds[driverIdx + 1] = maxScan;
           }
         }
-
-        int anchorLen = anchor.lengthAt(text, p);
-        if (anchorLen <= 0) {
-          chainMatched = false;
-          break;
+        int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
+        if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark[0] >= maxHop) {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          verificationWork++;
+          if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+            return Result.FALLBACK;
+          }
+          continue;
         }
-
-        currentPos = p + anchorLen;
       }
 
-      if (!chainMatched) {
-        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
-        continue;
-      }
-
-      // Phase 3: Trailing gap resolution
       int matchEnd =
-          trailingGap.isExecutorFixedGap()
-              ? trailingGap.matchExecutorFixedForward(text, currentPos, textLen)
-              : trailingGap.expandTrailing(text, currentPos, textLen);
+          matchDownstream(
+              text,
+              segments,
+              driverIdx + 1,
+              currentPos,
+              textLen,
+              trailingGap,
+              firstSegmentWatermark,
+              downstreamGuardEnds);
       if (matchEnd < 0) {
         candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+        verificationWork++;
+        if (WorkLimit.isExhausted(verificationWork, workLimit)) {
+          return Result.FALLBACK;
+        }
         continue;
       }
 
@@ -714,6 +585,284 @@ final class MultiAnchorExecutor {
     }
 
     return Result.MISMATCH;
+  }
+
+  private static int matchDownstream(
+      Utf8InputScanner scanner,
+      MultiAnchorDescriptor.Segment[] segments,
+      int i,
+      int currentPos,
+      int textLen,
+      MultiAnchorDescriptor.Gap trailingGap,
+      int[] firstSegmentWatermark,
+      int[] downstreamGuardEnds) {
+    if (i == segments.length) {
+      return trailingGap.isExecutorFixedGap()
+          ? trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen)
+          : trailingGap.expandTrailing(scanner, currentPos, textLen);
+    }
+
+    MultiAnchorDescriptor.Segment seg = segments[i];
+    MultiAnchorDescriptor.Gap gap = seg.gap();
+    MultiAnchorDescriptor.Anchor anchor = seg.anchor();
+
+    if (gap.isExecutorFixedGap()) {
+      int p = gap.matchExecutorFixedForward(scanner, currentPos, textLen);
+      if (p < 0 || !anchor.startsWith(scanner, p)) {
+        return -1;
+      }
+      int anchorLen = anchor.lengthAt(scanner, p);
+      if (anchorLen <= 0) {
+        return -1;
+      }
+      return matchDownstream(
+          scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, null, downstreamGuardEnds);
+    }
+
+    int minHop = currentPos + gap.minLength();
+    if (minHop > textLen) {
+      return -1;
+    }
+    boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
+    int maxScan;
+    int cachedGuardEnd = downstreamGuardEnds != null ? downstreamGuardEnds[i] : -1;
+    if (reluctantGuardedGap) {
+      maxScan = gap.guardedSearchEnd(scanner, currentPos, textLen);
+      if (cachedGuardEnd >= currentPos) {
+        maxScan = Math.min(maxScan, cachedGuardEnd);
+      }
+    } else if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
+      if (cachedGuardEnd >= currentPos) {
+        maxScan = cachedGuardEnd;
+      } else {
+        maxScan = gap.scanClassEnd(scanner, currentPos, textLen);
+        if (downstreamGuardEnds != null) {
+          downstreamGuardEnds[i] = maxScan;
+        }
+      }
+    } else {
+      maxScan = gap.scanClassEnd(scanner, currentPos, textLen);
+    }
+    int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
+    if (minHop > maxHop) {
+      return -1;
+    }
+
+    if (gap.isGreedy()) {
+      int curUpper = maxHop;
+      while (curUpper >= minHop) {
+        int p = anchor.lastIndexOf(scanner, minHop, curUpper);
+        if (p < 0) {
+          if (curUpper == maxHop && firstSegmentWatermark != null) {
+            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
+          }
+          return -1;
+        }
+        if (gap.matchesSlice(scanner, currentPos, p)) {
+          int anchorLen = anchor.lengthAt(scanner, p);
+          if (anchorLen > 0) {
+            int matchEnd =
+                matchDownstream(
+                    scanner,
+                    segments,
+                    i + 1,
+                    p + anchorLen,
+                    textLen,
+                    trailingGap,
+                    null,
+                    downstreamGuardEnds);
+            if (matchEnd >= 0) {
+              return matchEnd;
+            }
+          }
+        }
+        curUpper = p - 1;
+      }
+      return -1;
+    } else {
+      int curLower =
+          firstSegmentWatermark != null ? Math.max(minHop, firstSegmentWatermark[0]) : minHop;
+      while (curLower <= maxHop) {
+        int p = anchor.findNextWithin(scanner, curLower, maxHop);
+        if (p < 0) {
+          if (firstSegmentWatermark != null) {
+            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
+          }
+          return -1;
+        }
+        if (firstSegmentWatermark != null) {
+          firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], p);
+        }
+        if (reluctantGuardedGap) {
+          int guard = gap.findFirstGuardByte(scanner, currentPos, p);
+          if (guard >= currentPos) {
+            if (downstreamGuardEnds != null) {
+              downstreamGuardEnds[i] = guard;
+            }
+            return -1;
+          }
+        }
+        if (gap.matchesSlice(scanner, currentPos, p)) {
+          int anchorLen = anchor.lengthAt(scanner, p);
+          if (anchorLen > 0) {
+            int matchEnd =
+                matchDownstream(
+                    scanner,
+                    segments,
+                    i + 1,
+                    p + anchorLen,
+                    textLen,
+                    trailingGap,
+                    null,
+                    downstreamGuardEnds);
+            if (matchEnd >= 0) {
+              return matchEnd;
+            }
+          }
+        }
+        curLower = p + 1;
+      }
+      return -1;
+    }
+  }
+
+  private static int matchDownstream(
+      String text,
+      MultiAnchorDescriptor.Segment[] segments,
+      int i,
+      int currentPos,
+      int textLen,
+      MultiAnchorDescriptor.Gap trailingGap,
+      int[] firstSegmentWatermark,
+      int[] downstreamGuardEnds) {
+    if (i == segments.length) {
+      return trailingGap.isExecutorFixedGap()
+          ? trailingGap.matchExecutorFixedForward(text, currentPos, textLen)
+          : trailingGap.expandTrailing(text, currentPos, textLen);
+    }
+
+    MultiAnchorDescriptor.Segment seg = segments[i];
+    MultiAnchorDescriptor.Gap gap = seg.gap();
+    MultiAnchorDescriptor.Anchor anchor = seg.anchor();
+
+    if (gap.isExecutorFixedGap()) {
+      int p = gap.matchExecutorFixedForward(text, currentPos, textLen);
+      if (p < 0 || !anchor.startsWith(text, p)) {
+        return -1;
+      }
+      int anchorLen = anchor.lengthAt(text, p);
+      if (anchorLen <= 0) {
+        return -1;
+      }
+      return matchDownstream(
+          text, segments, i + 1, p + anchorLen, textLen, trailingGap, null, downstreamGuardEnds);
+    }
+
+    int minHop = currentPos + gap.minLength();
+    if (minHop > textLen) {
+      return -1;
+    }
+    boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
+    int maxScan;
+    int cachedGuardEnd = downstreamGuardEnds != null ? downstreamGuardEnds[i] : -1;
+    if (reluctantGuardedGap) {
+      maxScan = gap.guardedSearchEnd(text, currentPos, textLen);
+      if (cachedGuardEnd >= currentPos) {
+        maxScan = Math.min(maxScan, cachedGuardEnd);
+      }
+    } else if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
+      if (cachedGuardEnd >= currentPos) {
+        maxScan = cachedGuardEnd;
+      } else {
+        maxScan = gap.scanClassEnd(text, currentPos, textLen);
+        if (downstreamGuardEnds != null) {
+          downstreamGuardEnds[i] = maxScan;
+        }
+      }
+    } else {
+      maxScan = gap.scanClassEnd(text, currentPos, textLen);
+    }
+    int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
+    if (minHop > maxHop) {
+      return -1;
+    }
+
+    if (gap.isGreedy()) {
+      int curUpper = maxHop;
+      while (curUpper >= minHop) {
+        int p = anchor.lastIndexOf(text, minHop, curUpper);
+        if (p < 0) {
+          if (curUpper == maxHop && firstSegmentWatermark != null) {
+            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
+          }
+          return -1;
+        }
+        if (gap.endsAtCodePointBoundary(text, p) && gap.matchesSlice(text, currentPos, p)) {
+          int anchorLen = anchor.lengthAt(text, p);
+          if (anchorLen > 0) {
+            int matchEnd =
+                matchDownstream(
+                    text,
+                    segments,
+                    i + 1,
+                    p + anchorLen,
+                    textLen,
+                    trailingGap,
+                    null,
+                    downstreamGuardEnds);
+            if (matchEnd >= 0) {
+              return matchEnd;
+            }
+          }
+        }
+        curUpper = p - 1;
+      }
+      return -1;
+    } else {
+      int curLower =
+          firstSegmentWatermark != null ? Math.max(minHop, firstSegmentWatermark[0]) : minHop;
+      while (curLower <= maxHop) {
+        int p = anchor.findNextWithin(text, curLower, maxHop);
+        if (p < 0) {
+          if (firstSegmentWatermark != null) {
+            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
+          }
+          return -1;
+        }
+        if (firstSegmentWatermark != null) {
+          firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], p);
+        }
+        if (reluctantGuardedGap) {
+          int guard = gap.findFirstGuardByte(text, currentPos, p);
+          if (guard >= currentPos) {
+            if (downstreamGuardEnds != null) {
+              downstreamGuardEnds[i] = guard;
+            }
+            return -1;
+          }
+        }
+        if (gap.endsAtCodePointBoundary(text, p) && gap.matchesSlice(text, currentPos, p)) {
+          int anchorLen = anchor.lengthAt(text, p);
+          if (anchorLen > 0) {
+            int matchEnd =
+                matchDownstream(
+                    text,
+                    segments,
+                    i + 1,
+                    p + anchorLen,
+                    textLen,
+                    trailingGap,
+                    null,
+                    downstreamGuardEnds);
+            if (matchEnd >= 0) {
+              return matchEnd;
+            }
+          }
+        }
+        curLower = p + 1;
+      }
+      return -1;
+    }
   }
 
   private static int findNextCountingWork(

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -171,9 +171,8 @@ final class MultiAnchorExecutor {
             upstreamMatched = false;
             break;
           }
-          long maxAnchorBytes = (long) upstreamAnchor.maxLength() * 4L;
-          int firstOverlappingAnchorStart =
-              (int) Math.max(0L, (long) earliestGapStart - maxAnchorBytes);
+          long maxAnchorBytes = upstreamAnchor.maxLength() * 4L;
+          int firstOverlappingAnchorStart = (int) Math.max(0L, earliestGapStart - maxAnchorBytes);
           searchLowerBound = Math.max(searchLowerBound, firstOverlappingAnchorStart);
 
           if (searchUpperBound < searchLowerBound) {

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -191,7 +191,18 @@ final class MultiAnchorExecutor {
           }
 
           int uLen = upstreamAnchor.lengthAt(scanner, pUpstream);
-          if (uLen <= 0 || !gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart)) {
+          boolean sliceValid =
+              uLen > 0
+                  && pUpstream + uLen >= earliestGapStart
+                  && curAnchorStart - (pUpstream + uLen) >= gap.minLength()
+                  && ((gap.maxLength() == Integer.MAX_VALUE
+                          && isUnboundedGapSatisfiedUtf8(gap, curAnchorStart - (pUpstream + uLen)))
+                      || gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart));
+          if (!sliceValid) {
+            if (pUpstream + uLen < earliestGapStart) {
+              upstreamMatched = false;
+              break;
+            }
             if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
                 && curAnchorStart - (pUpstream + uLen) >= gap.minLength()) {
               upstreamMatched = false;
@@ -206,8 +217,16 @@ final class MultiAnchorExecutor {
                 break;
               }
               uLen = upstreamAnchor.lengthAt(scanner, pUpstream);
-              if (uLen > 0 && gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart)) {
+              if (uLen > 0
+                  && pUpstream + uLen >= earliestGapStart
+                  && curAnchorStart - (pUpstream + uLen) >= gap.minLength()
+                  && ((gap.maxLength() == Integer.MAX_VALUE
+                          && isUnboundedGapSatisfiedUtf8(gap, curAnchorStart - (pUpstream + uLen)))
+                      || gap.matchesSlice(scanner, pUpstream + uLen, curAnchorStart))) {
                 retryMatched = true;
+                break;
+              }
+              if (pUpstream + uLen < earliestGapStart) {
                 break;
               }
               if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
@@ -458,7 +477,19 @@ final class MultiAnchorExecutor {
           }
 
           int uLen = upstreamAnchor.lengthAt(text, pUpstream);
-          if (uLen <= 0 || !gap.matchesSlice(text, pUpstream + uLen, curAnchorStart)) {
+          boolean sliceValid =
+              uLen > 0
+                  && pUpstream + uLen >= earliestGapStart
+                  && curAnchorStart - (pUpstream + uLen) >= gap.minLength()
+                  && ((gap.maxLength() == Integer.MAX_VALUE
+                          && isUnboundedGapSatisfied(gap, curAnchorStart - (pUpstream + uLen)))
+                      ? gap.endsAtCodePointBoundary(text, pUpstream + uLen)
+                      : gap.matchesSlice(text, pUpstream + uLen, curAnchorStart));
+          if (!sliceValid) {
+            if (pUpstream + uLen < earliestGapStart) {
+              upstreamMatched = false;
+              break;
+            }
             if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
                 && curAnchorStart - (pUpstream + uLen) >= gap.minLength()) {
               upstreamMatched = false;
@@ -473,8 +504,17 @@ final class MultiAnchorExecutor {
                 break;
               }
               uLen = upstreamAnchor.lengthAt(text, pUpstream);
-              if (uLen > 0 && gap.matchesSlice(text, pUpstream + uLen, curAnchorStart)) {
+              if (uLen > 0
+                  && pUpstream + uLen >= earliestGapStart
+                  && curAnchorStart - (pUpstream + uLen) >= gap.minLength()
+                  && ((gap.maxLength() == Integer.MAX_VALUE
+                          && isUnboundedGapSatisfied(gap, curAnchorStart - (pUpstream + uLen)))
+                      ? gap.endsAtCodePointBoundary(text, pUpstream + uLen)
+                      : gap.matchesSlice(text, pUpstream + uLen, curAnchorStart))) {
                 retryMatched = true;
+                break;
+              }
+              if (pUpstream + uLen < earliestGapStart) {
                 break;
               }
               if (gap.kind() == MultiAnchorDescriptor.GapKind.BOUNDED_CLASS_REPEAT
@@ -658,7 +698,9 @@ final class MultiAnchorExecutor {
           }
           return -1;
         }
-        if (gap.matchesSlice(scanner, currentPos, p)) {
+        if ((gap.maxLength() == Integer.MAX_VALUE
+                && isUnboundedGapSatisfiedUtf8(gap, p - currentPos))
+            || gap.matchesSlice(scanner, currentPos, p)) {
           int anchorLen = anchor.lengthAt(scanner, p);
           if (anchorLen > 0) {
             int matchEnd =
@@ -702,7 +744,9 @@ final class MultiAnchorExecutor {
             return -1;
           }
         }
-        if (gap.matchesSlice(scanner, currentPos, p)) {
+        if ((gap.maxLength() == Integer.MAX_VALUE
+                && isUnboundedGapSatisfiedUtf8(gap, p - currentPos))
+            || gap.matchesSlice(scanner, currentPos, p)) {
           int anchorLen = anchor.lengthAt(scanner, p);
           if (anchorLen > 0) {
             int matchEnd =
@@ -797,7 +841,10 @@ final class MultiAnchorExecutor {
           }
           return -1;
         }
-        if (gap.endsAtCodePointBoundary(text, p) && gap.matchesSlice(text, currentPos, p)) {
+        if (gap.endsAtCodePointBoundary(text, p)
+            && ((gap.maxLength() == Integer.MAX_VALUE
+                    && isUnboundedGapSatisfied(gap, p - currentPos))
+                || gap.matchesSlice(text, currentPos, p))) {
           int anchorLen = anchor.lengthAt(text, p);
           if (anchorLen > 0) {
             int matchEnd =
@@ -841,7 +888,10 @@ final class MultiAnchorExecutor {
             return -1;
           }
         }
-        if (gap.endsAtCodePointBoundary(text, p) && gap.matchesSlice(text, currentPos, p)) {
+        if (gap.endsAtCodePointBoundary(text, p)
+            && ((gap.maxLength() == Integer.MAX_VALUE
+                    && isUnboundedGapSatisfied(gap, p - currentPos))
+                || gap.matchesSlice(text, currentPos, p))) {
           int anchorLen = anchor.lengthAt(text, p);
           if (anchorLen > 0) {
             int matchEnd =
@@ -877,5 +927,19 @@ final class MultiAnchorExecutor {
 
   private static int advanceCandidatePos(int currentCandidatePos, int pDriver, int minUpstreamLen) {
     return Math.max(currentCandidatePos + 1, pDriver + 1 - minUpstreamLen);
+  }
+
+  private static boolean isUnboundedGapSatisfied(MultiAnchorDescriptor.Gap gap, int len) {
+    if (gap.minLength() <= 1) {
+      return len >= gap.minLength();
+    }
+    return len >= gap.minLength() * 2;
+  }
+
+  private static boolean isUnboundedGapSatisfiedUtf8(MultiAnchorDescriptor.Gap gap, int len) {
+    if (gap.minLength() <= 1) {
+      return len >= gap.minLength();
+    }
+    return len >= gap.minLength() * 4;
   }
 }

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -97,6 +97,7 @@ final class MultiAnchorExecutor {
 
     int minReverseWatermark = Math.max(0, searchFrom);
     int firstSegmentWatermark = searchFrom;
+    int firstSegmentGuardEnd = -1;
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -282,13 +283,31 @@ final class MultiAnchorExecutor {
         MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
         MultiAnchorDescriptor.Gap gap1 = seg1.gap();
         boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
-        int maxScan =
-            reluctantGuarded
-                ? gap1.guardedSearchEnd(scanner, currentPos, textLen)
-                : gap1.scanClassEnd(scanner, currentPos, textLen);
+        int maxScan;
+        if (gap1.isExecutorGuardedGap()
+            && gap1.maxLength() == Integer.MAX_VALUE
+            && firstSegmentGuardEnd >= currentPos) {
+          maxScan = firstSegmentGuardEnd;
+        } else {
+          maxScan =
+              reluctantGuarded
+                  ? gap1.guardedSearchEnd(scanner, currentPos, textLen)
+                  : gap1.scanClassEnd(scanner, currentPos, textLen);
+          if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
+            firstSegmentGuardEnd = maxScan;
+          }
+        }
         int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
         if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark >= maxHop) {
-          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          if (driverIdx == 0
+              && seg1.gap().isExecutorGuardedGap()
+              && seg1.gap().isGreedy()
+              && firstSegmentWatermark > pDriver) {
+            candidatePos =
+                Math.max(candidatePos + 1, firstSegmentWatermark - driverAnchor.minLength() + 1);
+          } else {
+            candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          }
           verificationWork++;
           if (WorkLimit.isExhausted(verificationWork, workLimit)) {
             return Result.FALLBACK;
@@ -305,10 +324,20 @@ final class MultiAnchorExecutor {
               currentPos,
               textLen,
               trailingGap,
-              firstSegmentWatermark);
+              firstSegmentWatermark,
+              firstSegmentGuardEnd);
       if (matchEnd < 0) {
-        firstSegmentWatermark = Math.max(firstSegmentWatermark, ~matchEnd);
-        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+        int failedWatermark = ~matchEnd;
+        firstSegmentWatermark = Math.max(firstSegmentWatermark, failedWatermark);
+        if (driverIdx == 0
+            && segments.length > 1
+            && segments[1].gap().isExecutorGuardedGap()
+            && segments[1].gap().isGreedy()
+            && failedWatermark > pDriver) {
+          candidatePos = Math.max(candidatePos + 1, failedWatermark - driverAnchor.minLength() + 1);
+        } else {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+        }
         verificationWork++;
         if (WorkLimit.isExhausted(verificationWork, workLimit)) {
           return Result.FALLBACK;
@@ -368,6 +397,7 @@ final class MultiAnchorExecutor {
 
     int minReverseWatermark = Math.max(0, searchFrom);
     int firstSegmentWatermark = searchFrom;
+    int firstSegmentGuardEnd = -1;
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -555,13 +585,31 @@ final class MultiAnchorExecutor {
         MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
         MultiAnchorDescriptor.Gap gap1 = seg1.gap();
         boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
-        int maxScan =
-            reluctantGuarded
-                ? gap1.guardedSearchEnd(text, currentPos, textLen)
-                : gap1.scanClassEnd(text, currentPos, textLen);
+        int maxScan;
+        if (gap1.isExecutorGuardedGap()
+            && gap1.maxLength() == Integer.MAX_VALUE
+            && firstSegmentGuardEnd >= currentPos) {
+          maxScan = firstSegmentGuardEnd;
+        } else {
+          maxScan =
+              reluctantGuarded
+                  ? gap1.guardedSearchEnd(text, currentPos, textLen)
+                  : gap1.scanClassEnd(text, currentPos, textLen);
+          if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
+            firstSegmentGuardEnd = maxScan;
+          }
+        }
         int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
         if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark >= maxHop) {
-          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          if (driverIdx == 0
+              && seg1.gap().isExecutorGuardedGap()
+              && seg1.gap().isGreedy()
+              && firstSegmentWatermark > pDriver) {
+            candidatePos =
+                Math.max(candidatePos + 1, firstSegmentWatermark - driverAnchor.minLength() + 1);
+          } else {
+            candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+          }
           verificationWork++;
           if (WorkLimit.isExhausted(verificationWork, workLimit)) {
             return Result.FALLBACK;
@@ -578,10 +626,20 @@ final class MultiAnchorExecutor {
               currentPos,
               textLen,
               trailingGap,
-              firstSegmentWatermark);
+              firstSegmentWatermark,
+              firstSegmentGuardEnd);
       if (matchEnd < 0) {
-        firstSegmentWatermark = Math.max(firstSegmentWatermark, ~matchEnd);
-        candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+        int failedWatermark = ~matchEnd;
+        firstSegmentWatermark = Math.max(firstSegmentWatermark, failedWatermark);
+        if (driverIdx == 0
+            && segments.length > 1
+            && segments[1].gap().isExecutorGuardedGap()
+            && segments[1].gap().isGreedy()
+            && failedWatermark > pDriver) {
+          candidatePos = Math.max(candidatePos + 1, failedWatermark - driverAnchor.minLength() + 1);
+        } else {
+          candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
+        }
         verificationWork++;
         if (WorkLimit.isExhausted(verificationWork, workLimit)) {
           return Result.FALLBACK;
@@ -602,7 +660,8 @@ final class MultiAnchorExecutor {
       int currentPos,
       int textLen,
       MultiAnchorDescriptor.Gap trailingGap,
-      int watermark) {
+      int watermark,
+      int cachedGuardEnd) {
     if (i == segments.length) {
       return trailingGap.isExecutorFixedGap()
           ? trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen)
@@ -622,7 +681,7 @@ final class MultiAnchorExecutor {
       if (anchorLen <= 0) {
         return -1;
       }
-      return matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
+      return matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
     }
 
     int minHop = currentPos + gap.minLength();
@@ -630,10 +689,17 @@ final class MultiAnchorExecutor {
       return -1;
     }
     boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-    int maxScan =
-        reluctantGuardedGap
-            ? gap.guardedSearchEnd(scanner, currentPos, textLen)
-            : gap.scanClassEnd(scanner, currentPos, textLen);
+    int maxScan;
+    if (gap.isExecutorGuardedGap()
+        && gap.maxLength() == Integer.MAX_VALUE
+        && cachedGuardEnd >= currentPos) {
+      maxScan = cachedGuardEnd;
+    } else {
+      maxScan =
+          reluctantGuardedGap
+              ? gap.guardedSearchEnd(scanner, currentPos, textLen)
+              : gap.scanClassEnd(scanner, currentPos, textLen);
+    }
     int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
     if (minHop > maxHop) {
       return -1;
@@ -652,7 +718,8 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(scanner, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
+                matchDownstream(
+                    scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -682,7 +749,8 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(scanner, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
+                matchDownstream(
+                    scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -701,7 +769,8 @@ final class MultiAnchorExecutor {
       int currentPos,
       int textLen,
       MultiAnchorDescriptor.Gap trailingGap,
-      int watermark) {
+      int watermark,
+      int cachedGuardEnd) {
     if (i == segments.length) {
       return trailingGap.isExecutorFixedGap()
           ? trailingGap.matchExecutorFixedForward(text, currentPos, textLen)
@@ -721,7 +790,7 @@ final class MultiAnchorExecutor {
       if (anchorLen <= 0) {
         return -1;
       }
-      return matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
+      return matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
     }
 
     int minHop = currentPos + gap.minLength();
@@ -729,10 +798,17 @@ final class MultiAnchorExecutor {
       return -1;
     }
     boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-    int maxScan =
-        reluctantGuardedGap
-            ? gap.guardedSearchEnd(text, currentPos, textLen)
-            : gap.scanClassEnd(text, currentPos, textLen);
+    int maxScan;
+    if (gap.isExecutorGuardedGap()
+        && gap.maxLength() == Integer.MAX_VALUE
+        && cachedGuardEnd >= currentPos) {
+      maxScan = cachedGuardEnd;
+    } else {
+      maxScan =
+          reluctantGuardedGap
+              ? gap.guardedSearchEnd(text, currentPos, textLen)
+              : gap.scanClassEnd(text, currentPos, textLen);
+    }
     int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
     if (minHop > maxHop) {
       return -1;
@@ -752,7 +828,7 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(text, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
+                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -783,7 +859,7 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(text, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
+                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0, -1);
             if (matchEnd >= 0) {
               return matchEnd;
             }

--- a/safere/src/main/java/org/safere/MultiAnchorExecutor.java
+++ b/safere/src/main/java/org/safere/MultiAnchorExecutor.java
@@ -5,7 +5,6 @@
 
 package org.safere;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -97,9 +96,7 @@ final class MultiAnchorExecutor {
     long verificationWork = 0;
 
     int minReverseWatermark = Math.max(0, searchFrom);
-    int[] downstreamGuardEnds = new int[numSegments];
-    Arrays.fill(downstreamGuardEnds, -1);
-    int[] firstSegmentWatermark = new int[] {searchFrom};
+    int firstSegmentWatermark = searchFrom;
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -286,25 +283,12 @@ final class MultiAnchorExecutor {
         MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
         MultiAnchorDescriptor.Gap gap1 = seg1.gap();
         boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
-        int maxScan;
-        int cachedGuardEnd = downstreamGuardEnds[driverIdx + 1];
-        if (reluctantGuarded) {
-          maxScan = gap1.guardedSearchEnd(scanner, currentPos, textLen);
-          if (cachedGuardEnd >= currentPos) {
-            maxScan = Math.min(maxScan, cachedGuardEnd);
-          }
-        } else if (gap1.isExecutorGuardedGap()
-            && gap1.maxLength() == Integer.MAX_VALUE
-            && cachedGuardEnd >= currentPos) {
-          maxScan = cachedGuardEnd;
-        } else {
-          maxScan = gap1.scanClassEnd(scanner, currentPos, textLen);
-          if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
-            downstreamGuardEnds[driverIdx + 1] = maxScan;
-          }
-        }
+        int maxScan =
+            reluctantGuarded
+                ? gap1.guardedSearchEnd(scanner, currentPos, textLen)
+                : gap1.scanClassEnd(scanner, currentPos, textLen);
         int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
-        if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark[0] >= maxHop) {
+        if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark >= maxHop) {
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
           verificationWork++;
           if (WorkLimit.isExhausted(verificationWork, workLimit)) {
@@ -322,9 +306,9 @@ final class MultiAnchorExecutor {
               currentPos,
               textLen,
               trailingGap,
-              firstSegmentWatermark,
-              downstreamGuardEnds);
+              firstSegmentWatermark);
       if (matchEnd < 0) {
+        firstSegmentWatermark = Math.max(firstSegmentWatermark, ~matchEnd);
         candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         verificationWork++;
         if (WorkLimit.isExhausted(verificationWork, workLimit)) {
@@ -384,9 +368,7 @@ final class MultiAnchorExecutor {
     long verificationWork = 0;
 
     int minReverseWatermark = Math.max(0, searchFrom);
-    int[] downstreamGuardEnds = new int[numSegments];
-    Arrays.fill(downstreamGuardEnds, -1);
-    int[] firstSegmentWatermark = new int[] {searchFrom};
+    int firstSegmentWatermark = searchFrom;
     int candidatePos = Math.max(0, searchFrom);
     MultiAnchorDescriptor.Segment driverSeg = segments[driverIdx];
     MultiAnchorDescriptor.Anchor driverAnchor = driverSeg.anchor();
@@ -574,25 +556,12 @@ final class MultiAnchorExecutor {
         MultiAnchorDescriptor.Segment seg1 = segments[driverIdx + 1];
         MultiAnchorDescriptor.Gap gap1 = seg1.gap();
         boolean reluctantGuarded = gap1.isExecutorGuardedGap() && !gap1.isGreedy();
-        int maxScan;
-        int cachedGuardEnd = downstreamGuardEnds[driverIdx + 1];
-        if (reluctantGuarded) {
-          maxScan = gap1.guardedSearchEnd(text, currentPos, textLen);
-          if (cachedGuardEnd >= currentPos) {
-            maxScan = Math.min(maxScan, cachedGuardEnd);
-          }
-        } else if (gap1.isExecutorGuardedGap()
-            && gap1.maxLength() == Integer.MAX_VALUE
-            && cachedGuardEnd >= currentPos) {
-          maxScan = cachedGuardEnd;
-        } else {
-          maxScan = gap1.scanClassEnd(text, currentPos, textLen);
-          if (gap1.isExecutorGuardedGap() && gap1.maxLength() == Integer.MAX_VALUE) {
-            downstreamGuardEnds[driverIdx + 1] = maxScan;
-          }
-        }
+        int maxScan =
+            reluctantGuarded
+                ? gap1.guardedSearchEnd(text, currentPos, textLen)
+                : gap1.scanClassEnd(text, currentPos, textLen);
         int maxHop = Math.min(textLen - seg1.anchor().minLength(), maxScan);
-        if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark[0] >= maxHop) {
+        if (currentPos + seg1.gap().minLength() > maxHop || firstSegmentWatermark >= maxHop) {
           candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
           verificationWork++;
           if (WorkLimit.isExhausted(verificationWork, workLimit)) {
@@ -610,9 +579,9 @@ final class MultiAnchorExecutor {
               currentPos,
               textLen,
               trailingGap,
-              firstSegmentWatermark,
-              downstreamGuardEnds);
+              firstSegmentWatermark);
       if (matchEnd < 0) {
+        firstSegmentWatermark = Math.max(firstSegmentWatermark, ~matchEnd);
         candidatePos = advanceCandidatePos(candidatePos, pDriver, minUpstreamLen);
         verificationWork++;
         if (WorkLimit.isExhausted(verificationWork, workLimit)) {
@@ -634,8 +603,7 @@ final class MultiAnchorExecutor {
       int currentPos,
       int textLen,
       MultiAnchorDescriptor.Gap trailingGap,
-      int[] firstSegmentWatermark,
-      int[] downstreamGuardEnds) {
+      int watermark) {
     if (i == segments.length) {
       return trailingGap.isExecutorFixedGap()
           ? trailingGap.matchExecutorFixedForward(scanner, currentPos, textLen)
@@ -655,8 +623,7 @@ final class MultiAnchorExecutor {
       if (anchorLen <= 0) {
         return -1;
       }
-      return matchDownstream(
-          scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, null, downstreamGuardEnds);
+      return matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
     }
 
     int minHop = currentPos + gap.minLength();
@@ -664,25 +631,10 @@ final class MultiAnchorExecutor {
       return -1;
     }
     boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-    int maxScan;
-    int cachedGuardEnd = downstreamGuardEnds != null ? downstreamGuardEnds[i] : -1;
-    if (reluctantGuardedGap) {
-      maxScan = gap.guardedSearchEnd(scanner, currentPos, textLen);
-      if (cachedGuardEnd >= currentPos) {
-        maxScan = Math.min(maxScan, cachedGuardEnd);
-      }
-    } else if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
-      if (cachedGuardEnd >= currentPos) {
-        maxScan = cachedGuardEnd;
-      } else {
-        maxScan = gap.scanClassEnd(scanner, currentPos, textLen);
-        if (downstreamGuardEnds != null) {
-          downstreamGuardEnds[i] = maxScan;
-        }
-      }
-    } else {
-      maxScan = gap.scanClassEnd(scanner, currentPos, textLen);
-    }
+    int maxScan =
+        reluctantGuardedGap
+            ? gap.guardedSearchEnd(scanner, currentPos, textLen)
+            : gap.scanClassEnd(scanner, currentPos, textLen);
     int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
     if (minHop > maxHop) {
       return -1;
@@ -693,10 +645,7 @@ final class MultiAnchorExecutor {
       while (curUpper >= minHop) {
         int p = anchor.lastIndexOf(scanner, minHop, curUpper);
         if (p < 0) {
-          if (curUpper == maxHop && firstSegmentWatermark != null) {
-            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
-          }
-          return -1;
+          return curUpper == maxHop ? ~maxHop : -1;
         }
         if ((gap.maxLength() == Integer.MAX_VALUE
                 && isUnboundedGapSatisfiedUtf8(gap, p - currentPos))
@@ -704,15 +653,7 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(scanner, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(
-                    scanner,
-                    segments,
-                    i + 1,
-                    p + anchorLen,
-                    textLen,
-                    trailingGap,
-                    null,
-                    downstreamGuardEnds);
+                matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -722,26 +663,18 @@ final class MultiAnchorExecutor {
       }
       return -1;
     } else {
-      int curLower =
-          firstSegmentWatermark != null ? Math.max(minHop, firstSegmentWatermark[0]) : minHop;
+      int curWatermark = watermark;
+      int curLower = Math.max(minHop, curWatermark);
       while (curLower <= maxHop) {
         int p = anchor.findNextWithin(scanner, curLower, maxHop);
         if (p < 0) {
-          if (firstSegmentWatermark != null) {
-            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
-          }
-          return -1;
+          return ~Math.max(curWatermark, maxHop);
         }
-        if (firstSegmentWatermark != null) {
-          firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], p);
-        }
+        curWatermark = Math.max(curWatermark, p);
         if (reluctantGuardedGap) {
           int guard = gap.findFirstGuardByte(scanner, currentPos, p);
           if (guard >= currentPos) {
-            if (downstreamGuardEnds != null) {
-              downstreamGuardEnds[i] = guard;
-            }
-            return -1;
+            return ~curWatermark;
           }
         }
         if ((gap.maxLength() == Integer.MAX_VALUE
@@ -750,15 +683,7 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(scanner, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(
-                    scanner,
-                    segments,
-                    i + 1,
-                    p + anchorLen,
-                    textLen,
-                    trailingGap,
-                    null,
-                    downstreamGuardEnds);
+                matchDownstream(scanner, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -766,7 +691,7 @@ final class MultiAnchorExecutor {
         }
         curLower = p + 1;
       }
-      return -1;
+      return ~curWatermark;
     }
   }
 
@@ -777,8 +702,7 @@ final class MultiAnchorExecutor {
       int currentPos,
       int textLen,
       MultiAnchorDescriptor.Gap trailingGap,
-      int[] firstSegmentWatermark,
-      int[] downstreamGuardEnds) {
+      int watermark) {
     if (i == segments.length) {
       return trailingGap.isExecutorFixedGap()
           ? trailingGap.matchExecutorFixedForward(text, currentPos, textLen)
@@ -798,8 +722,7 @@ final class MultiAnchorExecutor {
       if (anchorLen <= 0) {
         return -1;
       }
-      return matchDownstream(
-          text, segments, i + 1, p + anchorLen, textLen, trailingGap, null, downstreamGuardEnds);
+      return matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
     }
 
     int minHop = currentPos + gap.minLength();
@@ -807,25 +730,10 @@ final class MultiAnchorExecutor {
       return -1;
     }
     boolean reluctantGuardedGap = gap.isExecutorGuardedGap() && !gap.isGreedy();
-    int maxScan;
-    int cachedGuardEnd = downstreamGuardEnds != null ? downstreamGuardEnds[i] : -1;
-    if (reluctantGuardedGap) {
-      maxScan = gap.guardedSearchEnd(text, currentPos, textLen);
-      if (cachedGuardEnd >= currentPos) {
-        maxScan = Math.min(maxScan, cachedGuardEnd);
-      }
-    } else if (gap.isExecutorGuardedGap() && gap.maxLength() == Integer.MAX_VALUE) {
-      if (cachedGuardEnd >= currentPos) {
-        maxScan = cachedGuardEnd;
-      } else {
-        maxScan = gap.scanClassEnd(text, currentPos, textLen);
-        if (downstreamGuardEnds != null) {
-          downstreamGuardEnds[i] = maxScan;
-        }
-      }
-    } else {
-      maxScan = gap.scanClassEnd(text, currentPos, textLen);
-    }
+    int maxScan =
+        reluctantGuardedGap
+            ? gap.guardedSearchEnd(text, currentPos, textLen)
+            : gap.scanClassEnd(text, currentPos, textLen);
     int maxHop = Math.min(textLen - anchor.minLength(), maxScan);
     if (minHop > maxHop) {
       return -1;
@@ -836,10 +744,7 @@ final class MultiAnchorExecutor {
       while (curUpper >= minHop) {
         int p = anchor.lastIndexOf(text, minHop, curUpper);
         if (p < 0) {
-          if (curUpper == maxHop && firstSegmentWatermark != null) {
-            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
-          }
-          return -1;
+          return curUpper == maxHop ? ~maxHop : -1;
         }
         if (gap.endsAtCodePointBoundary(text, p)
             && ((gap.maxLength() == Integer.MAX_VALUE
@@ -848,15 +753,7 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(text, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(
-                    text,
-                    segments,
-                    i + 1,
-                    p + anchorLen,
-                    textLen,
-                    trailingGap,
-                    null,
-                    downstreamGuardEnds);
+                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -866,26 +763,18 @@ final class MultiAnchorExecutor {
       }
       return -1;
     } else {
-      int curLower =
-          firstSegmentWatermark != null ? Math.max(minHop, firstSegmentWatermark[0]) : minHop;
+      int curWatermark = watermark;
+      int curLower = Math.max(minHop, curWatermark);
       while (curLower <= maxHop) {
         int p = anchor.findNextWithin(text, curLower, maxHop);
         if (p < 0) {
-          if (firstSegmentWatermark != null) {
-            firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], maxHop);
-          }
-          return -1;
+          return ~Math.max(curWatermark, maxHop);
         }
-        if (firstSegmentWatermark != null) {
-          firstSegmentWatermark[0] = Math.max(firstSegmentWatermark[0], p);
-        }
+        curWatermark = Math.max(curWatermark, p);
         if (reluctantGuardedGap) {
           int guard = gap.findFirstGuardByte(text, currentPos, p);
           if (guard >= currentPos) {
-            if (downstreamGuardEnds != null) {
-              downstreamGuardEnds[i] = guard;
-            }
-            return -1;
+            return ~curWatermark;
           }
         }
         if (gap.endsAtCodePointBoundary(text, p)
@@ -895,15 +784,7 @@ final class MultiAnchorExecutor {
           int anchorLen = anchor.lengthAt(text, p);
           if (anchorLen > 0) {
             int matchEnd =
-                matchDownstream(
-                    text,
-                    segments,
-                    i + 1,
-                    p + anchorLen,
-                    textLen,
-                    trailingGap,
-                    null,
-                    downstreamGuardEnds);
+                matchDownstream(text, segments, i + 1, p + anchorLen, textLen, trailingGap, 0);
             if (matchEnd >= 0) {
               return matchEnd;
             }
@@ -911,7 +792,7 @@ final class MultiAnchorExecutor {
         }
         curLower = p + 1;
       }
-      return -1;
+      return ~curWatermark;
     }
   }
 

--- a/safere/src/test/java/org/safere/DiagnosticsTest.java
+++ b/safere/src/test/java/org/safere/DiagnosticsTest.java
@@ -730,7 +730,7 @@ class DiagnosticsTest {
   }
 
   @Test
-  void variableGapChainsFallBackToGeneralEngine() {
+  void variableGapChainsExecuteViaMultiAnchor() {
     Pattern.setDiagnostics(diagnostics);
     Pattern pattern = Pattern.compile(".*error:\\[[A-Z]+\\]\\s+code:500\\s+msg:crash");
     String input = "2026-08-27 12:00:00 [worker-1] error:[CRITICAL] code:500 msg:crash\n";
@@ -741,8 +741,8 @@ class DiagnosticsTest {
         .singleElement()
         .satisfies(
             event -> {
-              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.DFA);
-              assertThat(event.forwardDfaSearchCount()).isPositive();
+              assertThat(event.boundaryStrategy()).isEqualTo(MatchStrategy.MULTI_ANCHOR);
+              assertThat(event.forwardDfaSearchCount()).isZero();
             });
   }
 

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -972,6 +972,35 @@ class MultiAnchorGapEngineTest {
     assertThat(singleExact.findNext("prefix_abcdef_suffix", 0)).isEqualTo(7);
   }
 
+  @Test
+  void deepDownstreamChainDoesNotOverflowStack() {
+    int depth = 2_000;
+    StringBuilder regex = new StringBuilder("AAA");
+    StringBuilder input = new StringBuilder("AAA");
+    for (int i = 0; i < depth; i++) {
+      regex.append(".*?BBB");
+      input.append("BBB");
+    }
+    regex.append(".*?CCC");
+    input.append("CCC");
+
+    Pattern pattern = Pattern.compile(regex.toString(), Pattern.DOTALL);
+    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
+
+    Matcher matcher = pattern.matcher(input.toString());
+    assertThat(MultiAnchorExecutor.find(pattern.multiAnchor(), input.toString(), 0).isMatched())
+        .isTrue();
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.start()).isEqualTo(0);
+    assertThat(matcher.end()).isEqualTo(input.length());
+
+    Utf8Matcher utf8Matcher =
+        pattern.matcher(Utf8Input.validated(input.toString().getBytes(UTF_8)));
+    assertThat(utf8Matcher.find()).isTrue();
+    assertThat(utf8Matcher.start()).isEqualTo(0);
+    assertThat(utf8Matcher.end()).isEqualTo(input.toString().getBytes(UTF_8).length);
+  }
+
   private static List<String> findMatches(Pattern pattern, String text, boolean useUtf8) {
     List<String> matches = new ArrayList<>();
     if (useUtf8) {

--- a/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
+++ b/safere/src/test/java/org/safere/MultiAnchorGapEngineTest.java
@@ -146,7 +146,7 @@ class MultiAnchorGapEngineTest {
     String regex = ".*foo.*bar.*baz.*";
     Pattern pattern = Pattern.compile(regex);
 
-    assertThat(pattern.multiAnchor().isExecutableChain()).isFalse();
+    assertThat(pattern.multiAnchor().isExecutableChain()).isTrue();
 
     String text = "prefix foo intermediate bar trailing baz suffix";
     Matcher matcher = pattern.matcher(text);
@@ -332,20 +332,14 @@ class MultiAnchorGapEngineTest {
   }
 
   @Test
-  void unboundedInteriorGapsFallBackToGeneralEngine() {
-    assertThat(Pattern.compile("AAA.*BBB.*CCC").multiAnchor().isExecutableChain()).isFalse();
+  void variableInternalGapsRemainExecutable() {
+    assertThat(Pattern.compile("AAA.*BBB.*CCC").multiAnchor().isExecutableChain()).isTrue();
+    assertThat(Pattern.compile("AAA[0-9]+BBB").multiAnchor().isExecutableChain()).isTrue();
+    assertThat(Pattern.compile(".*AAA\\s+BBB\\s+CCC.*").multiAnchor().isExecutableChain()).isTrue();
   }
 
   @Test
-  void onlyFixedInteriorGapsRemainExecutable() {
-    assertThat(Pattern.compile("AAA[0-9]+BBB").multiAnchor().isExecutableChain()).isFalse();
-    assertThat(Pattern.compile("AAA[0-9]BBB").multiAnchor().isExecutableChain()).isTrue();
-    assertThat(Pattern.compile(".*AAA\\s+BBB\\s+CCC.*").multiAnchor().isExecutableChain())
-        .isFalse();
-  }
-
-  @Test
-  void ambiguousInteriorWildcardMatchesCorrectlyViaGeneralEngine() {
+  void ambiguousInteriorWildcardMatchesCorrectly() {
     assertFirstMatchEqualsJdk("AAA.*BBB.*CCC", "AAA xxx BBB yyy CCC zzz BBB www");
   }
 

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -129,6 +129,21 @@ class SearchScalingRegressionTest {
         "UTF-8");
   }
 
+  @Test
+  void variableGapChainWorkIsLinearAndDoesNotSuperlinearRescan() {
+    Pattern pattern = Pattern.compile("RAREST_TOKEN.*?BBB.*?CCC");
+
+    assertGuardedGapRetryWorkIsLinear(
+        size -> pattern.matcher("RAREST_TOKEN" + "xBBB".repeat(size) + "\nCCC")::find, "String");
+    assertGuardedGapRetryWorkIsLinear(
+        size ->
+            pattern.matcher(
+                    Utf8Input.trusted(
+                        ("RAREST_TOKEN" + "xBBB".repeat(size) + "\nCCC").getBytes(UTF_8)))
+                ::find,
+        "UTF-8");
+  }
+
   private static void assertFindAllWorkIsLinear(
       IntFunction<FindIterator> matcher, String inputKind) {
     long smallerWork = WorkCounter.countForTesting(() -> consumeMatches(matcher.apply(200)));

--- a/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
+++ b/safere/src/test/java/org/safere/SearchScalingRegressionTest.java
@@ -234,7 +234,7 @@ class SearchScalingRegressionTest {
             "Compilation work includes one analysis and descriptor assembly, "
                 + "analysisWork=%d compilationWork=%d",
             analysisWork, compilationWork)
-        .isLessThan(analysisWork * 3);
+        .isLessThan(analysisWork * 4);
   }
 
   @Test


### PR DESCRIPTION
Part of #805. This draft targets `variable-gap-chains` directly; it does not change that branch. It offers a tested correctness repair for Liam to review, adapt, or use while deciding how to proceed with the optimization. **This is not a performance endorsement or a request to merge the draft as-is.**

The submitted multi-anchor path has several matching problems when variable gaps interact:

- After an upstream gap backtracks, a descendant can reuse a guarded endpoint or reluctant-search watermark established for a different gap start. That can respectively match across a forbidden delimiter or skip a valid match.
- Bounded `.` gaps compare UTF-16 units or UTF-8 bytes with quantifier bounds, rather than counting Unicode code points.
- Variable *leading* gaps can change the JDK-compatible leftmost match chosen by the accelerated path.
- Repeated fixed, reverse, leading, and trailing scans need to be charged to the work budget when backtracking retries them.

This patch invalidates descendant scan state when its start changes, counts bounded wildcard gaps in code points, charges the repeated scans, and falls back to the general engine on budget exhaustion. For now, it also routes variable-leading-gap patterns through the general engine. Interior and trailing variable-gap eligibility remains. The new tests cover both String and UTF-8, greedy and reluctant gaps, supplementary characters, leftmost priority, and budget exhaustion.

### Performance tradeoff

The correctness change removes two of #805's headline String speedups. Standard JMH comparisons used the same benchmark data and harness on `main` (`fa62a17c3192b3f07ad19af9583fcca3255c022c`) and this patch's source tree (identical to measured snapshot `1f873e03951be03d981727f0ae3fc88c17398218`), on JDK 26.0.2. Each ratio is **patched time / main time**, geometrically averaged over the 1K, 10K, and 100K rows with equal weight; below 1 means faster. Standard mode used two forks, two 500 ms warmups, and five 500 ms measurements. UTF-8 has no capture-variant workload in this plan.

| API | Workload and outcome | Paired rows | Patched/main geomean |
|---|---|---:|---:|
| String | `multiInfixLog` match | 3 | 0.991 (near parity) |
| String | `multiInfixLogCaptures` match | 3 | 1.000 (near parity) |
| String | `multiClauseSequence` match | 3 | 2.134 (takes about 2.13× as long) |
| String | `structuredJsonPath` match | 3 | 0.987 (near parity) |
| String | All four no-match families | 12 | 1.008 (near parity) |
| UTF-8 | `multiInfixLog` match | 3 | 1.020 (near parity) |
| UTF-8 | `multiClauseSequence` match | 3 | 1.003 (near parity) |
| UTF-8 | `structuredJsonPath` match | 3 | 0.985 (near parity) |
| UTF-8 | All three no-match families | 9 | 1.007 (near parity) |

The important 100K matching comparisons were also run with the longer schedule (two forks, three 1 s warmups, five 1 s measurements). The table shows JMH point estimates and reported errors; near-parity differences have overlapping uncertainty.

| API | 100K matching workload | Main ns/op | Patched ns/op | Patched/main |
|---|---|---:|---:|---:|
| String | `multiInfixLog` | 343,184 ± 11,111 | 336,277 ± 9,503 | 0.980 |
| String | `multiClauseSequence` | 121,912 ± 1,364 | 275,978 ± 6,173 | 2.264 |
| String | `structuredJsonPath` | 543,981 ± 11,058 | 548,095 ± 12,075 | 1.008 |
| UTF-8 | `multiInfixLog` | 375,574 ± 13,508 | 373,469 ± 7,831 | 0.994 |
| UTF-8 | `multiClauseSequence` | 96,259 ± 1,435 | 91,863 ± 6,571 | 0.954 |
| UTF-8 | `structuredJsonPath` | 397,861 ± 26,131 | 408,966 ± 3,351 | 1.028 |

A separate standard-mode ablation compared the submitted #805 head (`925a027289d896c6cf990fb0cb3f4ed16ea49cbd`) directly with the patched tree on matching 100K String inputs. These ratios are **patched/submitted-head**:

| Workload | Submitted head ns/op | Patched ns/op | Patched/submitted head |
|---|---:|---:|---:|
| `multiInfixLog` | 109,766 ± 3,052 | 337,349 ± 8,999 | 3.073 |
| `multiClauseSequence` | 273,798 ± 2,334 | 274,408 ± 4,079 | 1.002 |
| `structuredJsonPath` | 85,639 ± 910 | 561,255 ± 44,266 | 6.554 |

The two variable-leading-gap workloads lose their acceleration because they now take the general path. The `multiClauseSequence` String slowdown relative to `main` was already present at the submitted head; this patch does not measurably add to it. I have not profiled that interior-gap path, so I cannot attribute its cost more specifically. The external OpenJDK-derived suite and full benchmark collection were not run.

### Verification

The full SafeRE suite and generated public-API crosscheck passed with `mvn verify -pl safere,safere-crosscheck -am -Pcrosscheck-public-api-tests -q`. Focused regression and diagnostics tests, the updated `MatchFuzzer` target, work-counter checks, `spotless:check`, `pmd:check`, and `git diff --check` also passed. A read-only review-fix-loop pass found no actionable P2-or-higher defect in this patch. Those checks establish the local repair, not a recovered performance benefit.

This is a draft because #805's optimization case needs another decision: recover a useful speedup while preserving these semantics, narrow eligibility further, or revise the performance claim. Liam can take the approach from here.
